### PR TITLE
CAMEL-23789: Make component docs multi-DSL friendly (Wave 2)

### DIFF
--- a/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
+++ b/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
@@ -308,6 +308,8 @@ from("jms:queue:cheese").routeId("cheesy")
 
 And in XML DSL you just assign the route id via the id attribute
 
+._XML-only:_
+
 [source,xml]
 ----
 <route id="cheesy">

--- a/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
+++ b/catalog/camel-report-maven-plugin/src/main/docs/camel-report-maven-plugin.adoc
@@ -287,6 +287,7 @@ public class FooApplicationTest {
 However if you are using `camel-test` and your unit tests are extending `CamelTestSupport` then you can
 turn on route coverage as shown:
 
+._Java-only: enabling route coverage in CamelTestSupport_
 [source,java]
 ----
 @Override
@@ -297,8 +298,12 @@ public boolean isDumpRouteCoverage() {
 
 IMPORTANT: Routes that can be route coveraged **MUST** have a unique id assigned, in other words you cannot use anonymous routes.
 
-You do this using `routeId` in Java DSL:
+You do this using `routeId`:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("jms:queue:cheese").routeId("cheesy")
@@ -306,10 +311,8 @@ from("jms:queue:cheese").routeId("cheesy")
   ...
 ----
 
-And in XML DSL you just assign the route id via the id attribute
-
-._XML-only:_
-
+XML::
++
 [source,xml]
 ----
 <route id="cheesy">
@@ -318,6 +321,21 @@ And in XML DSL you just assign the route id via the id attribute
   ...
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: cheesy
+    from:
+      uri: jms:queue:cheese
+      steps:
+        - to:
+            uri: log:foo
+        ...
+----
+====
 
 === Generating route coverage report
 

--- a/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
+++ b/components/camel-ai/camel-openai/src/main/docs/openai-component.adoc
@@ -554,6 +554,11 @@ For full schema validation, integrate with the `camel-json-validator` component 
 === Conversation Memory (Per Exchange)
 
 .Usage example:
+
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:conversation")
@@ -564,6 +569,52 @@ from("direct:conversation")
     .to("openai:chat-completion?conversationMemory=true")
     .log("Second response: ${body}"); // Will remember "Alice"
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:conversation"/>
+  <setBody>
+    <constant>My name is Alice</constant>
+  </setBody>
+  <to uri="openai:chat-completion?conversationMemory=true"/>
+  <log message="First response: ${body}"/>
+  <setBody>
+    <constant>What is my name?</constant>
+  </setBody>
+  <to uri="openai:chat-completion?conversationMemory=true"/>
+  <log message="Second response: ${body}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:conversation
+      steps:
+        - setBody:
+            constant: "My name is Alice"
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              conversationMemory: true
+        - log:
+            message: "First response: ${body}"
+        - setBody:
+            constant: "What is my name?"
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              conversationMemory: true
+        - log:
+            message: "Second response: ${body}"
+----
+====
 
 == Input Handling
 
@@ -722,6 +773,10 @@ YAML::
 
 For two-way authentication, configure both trust store and key store:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -734,10 +789,45 @@ from("direct:chat")
         + "&sslKeyPassword=keypass");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;baseUrl=https://my-llm-server:8443/v1&amp;sslTruststoreLocation=/path/to/truststore.jks&amp;sslTruststorePassword=changeit&amp;sslKeystoreLocation=/path/to/keystore.jks&amp;sslKeystorePassword=changeit&amp;sslKeyPassword=keypass"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              baseUrl: https://my-llm-server:8443/v1
+              sslTruststoreLocation: /path/to/truststore.jks
+              sslTruststorePassword: changeit
+              sslKeystoreLocation: /path/to/keystore.jks
+              sslKeystorePassword: changeit
+              sslKeyPassword: keypass
+----
+====
+
 === Disabling Hostname Verification
 
 In development or test environments, hostname verification can be disabled by setting `sslEndpointAlgorithm` to an empty string or `none`:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -747,6 +837,35 @@ from("direct:chat")
         + "&sslTruststorePassword=changeit"
         + "&sslEndpointAlgorithm=none");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;baseUrl=https://localhost:8443/v1&amp;sslTruststoreLocation=/path/to/truststore.jks&amp;sslTruststorePassword=changeit&amp;sslEndpointAlgorithm=none"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              baseUrl: https://localhost:8443/v1
+              sslTruststoreLocation: /path/to/truststore.jks
+              sslTruststorePassword: changeit
+              sslEndpointAlgorithm: none
+----
+====
 
 WARNING: Disabling hostname verification is insecure and should only be used in non-production environments.
 
@@ -779,6 +898,10 @@ This is independent from the inline `<think>...</think>` tag stripping controlle
 * `CamelOpenAIReasoningContent` — from the API-level `reasoning_content` field
 * `CamelOpenAIThinkingContent` — from inline `<think>` tags in the `content` field (requires `stripThinking=true`)
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -788,6 +911,41 @@ from("direct:chat")
     .log("Thinking: ${header.CamelOpenAIThinkingContent}");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=qwen3&amp;stripThinking=true"/>
+  <log message="Answer: ${body}"/>
+  <log message="Reasoning: ${header.CamelOpenAIReasoningContent}"/>
+  <log message="Thinking: ${header.CamelOpenAIThinkingContent}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: qwen3
+              stripThinking: true
+        - log:
+            message: "Answer: ${body}"
+        - log:
+            message: "Reasoning: ${header.CamelOpenAIReasoningContent}"
+        - log:
+            message: "Thinking: ${header.CamelOpenAIThinkingContent}"
+----
+====
+
 NOTE: Reasoning content extraction is supported in non-streaming mode only (both simple and agentic/MCP tool loop paths). Streaming responses do not extract reasoning content.
 
 === Mapping Additional Response Fields to Headers
@@ -796,6 +954,10 @@ The `additionalResponseHeader` option allows mapping any extra field from the AP
 
 The key is the field name in the API response, and the value is the Camel header name to set:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -804,6 +966,36 @@ from("direct:chat")
         + "&additionalResponseHeader.custom_field=CamelMyCustomField")
     .log("Custom reasoning: ${header.CamelMyReasoning}");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=qwen3&amp;additionalResponseHeader.reasoning_content=CamelMyReasoning&amp;additionalResponseHeader.custom_field=CamelMyCustomField"/>
+  <log message="Custom reasoning: ${header.CamelMyReasoning}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: qwen3
+              additionalResponseHeader.reasoning_content: CamelMyReasoning
+              additionalResponseHeader.custom_field: CamelMyCustomField
+        - log:
+            message: "Custom reasoning: ${header.CamelMyReasoning}"
+----
+====
 
 String-valued fields are set directly. Non-string fields (numbers, booleans, objects) are converted using `toString()`.
 
@@ -871,11 +1063,41 @@ Provider* table below).
 https://lmstudio.ai[LM Studio] serves the model currently loaded in the app. Set `model` to the
 identifier shown in its UI.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
     .to("openai:chat-completion?baseUrl=http://localhost:1234/v1&model=local-model");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?baseUrl=http://localhost:1234/v1&amp;model=local-model"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              baseUrl: http://localhost:1234/v1
+              model: local-model
+----
+====
 
 === vLLM (self-hosted)
 
@@ -887,12 +1109,42 @@ and start the model used in the example below:
 vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
 ----
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
     .to("openai:chat-completion?baseUrl=http://localhost:8000/v1"
         + "&model=meta-llama/Llama-3.1-8B-Instruct");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?baseUrl=http://localhost:8000/v1&amp;model=meta-llama/Llama-3.1-8B-Instruct"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              baseUrl: http://localhost:8000/v1
+              model: meta-llama/Llama-3.1-8B-Instruct
+----
+====
 
 If vLLM was started with `--api-key`, pass the same value via the `apiKey` option.
 
@@ -908,6 +1160,10 @@ vllm-mlx serve mlx-community/Qwen2.5-7B-Instruct-4bit --port 8000
 https://openrouter.ai[OpenRouter] is an OpenAI-compatible gateway that routes requests across many
 model providers. Set `baseUrl` to its endpoint and select a model with a cross-provider identifier:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -915,6 +1171,33 @@ from("direct:chat")
         + "&apiKey={{openrouter.api.key}}"
         + "&model=anthropic/claude-sonnet-4-20250514");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?baseUrl=https://openrouter.ai/api/v1&amp;apiKey={{openrouter.api.key}}&amp;model=anthropic/claude-sonnet-4-20250514"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              baseUrl: https://openrouter.ai/api/v1
+              apiKey: "{{openrouter.api.key}}"
+              model: anthropic/claude-sonnet-4-20250514
+----
+====
 
 ==== Provider Routing
 
@@ -1216,12 +1499,43 @@ The audio transcription operation works with any OpenAI-compatible server that i
 * https://github.com/ml-explore/mlx-audio[MLX Audio] — `python3 -m mlx_audio.server --host 127.0.0.1 --port 8003`
 
 .Example using MLX Audio for local transcription:
+
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:transcribe")
     .to("openai:audio-transcription?audioModel=mlx-community/whisper-large-v3-turbo"
         + "&baseUrl=http://localhost:8003/v1");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:transcribe"/>
+  <to uri="openai:audio-transcription?audioModel=mlx-community/whisper-large-v3-turbo&amp;baseUrl=http://localhost:8003/v1"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:transcribe
+      steps:
+        - to:
+            uri: openai:audio-transcription
+            parameters:
+              audioModel: mlx-community/whisper-large-v3-turbo
+              baseUrl: http://localhost:8003/v1
+----
+====
 
 [NOTE]
 ====
@@ -1238,6 +1552,10 @@ MCP servers are configured inline on the endpoint URI using the `mcpServer.` pre
 
 ==== Streamable HTTP Transport
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -1246,8 +1564,39 @@ from("direct:chat")
         + "&mcpServer.api.url=http://localhost:9090/mcp");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;mcpServer.api.transportType=streamableHttp&amp;mcpServer.api.url=http://localhost:9090/mcp"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              mcpServer.api.transportType: streamableHttp
+              mcpServer.api.url: http://localhost:9090/mcp
+----
+====
+
 ==== SSE Transport (Deprecated)
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -1256,8 +1605,39 @@ from("direct:chat")
         + "&mcpServer.weather.url=http://localhost:8080");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;mcpServer.weather.transportType=sse&amp;mcpServer.weather.url=http://localhost:8080"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              mcpServer.weather.transportType: sse
+              mcpServer.weather.url: http://localhost:8080
+----
+====
+
 ==== Stdio Transport
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -1266,6 +1646,34 @@ from("direct:chat")
         + "&mcpServer.fs.command=npx"
         + "&mcpServer.fs.args=-y,@modelcontextprotocol/server-filesystem,/tmp");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;mcpServer.fs.transportType=stdio&amp;mcpServer.fs.command=npx&amp;mcpServer.fs.args=-y,@modelcontextprotocol/server-filesystem,/tmp"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              mcpServer.fs.transportType: stdio
+              mcpServer.fs.command: npx
+              mcpServer.fs.args: "-y,@modelcontextprotocol/server-filesystem,/tmp"
+----
+====
 
 ==== Multiple MCP Servers
 
@@ -1320,6 +1728,10 @@ The `maxToolIterations` option (default: 50) prevents infinite loops. If exceede
 
 Set `autoToolExecution=false` to disable the agentic loop and receive raw tool calls in the message body instead:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -1329,6 +1741,37 @@ from("direct:chat")
         + "&mcpServer.api.url=http://localhost:9090/mcp")
     .log("Tool calls: ${body}"); // body is the raw tool calls list
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;autoToolExecution=false&amp;mcpServer.api.transportType=streamableHttp&amp;mcpServer.api.url=http://localhost:9090/mcp"/>
+  <log message="Tool calls: ${body}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              autoToolExecution: false
+              mcpServer.api.transportType: streamableHttp
+              mcpServer.api.url: http://localhost:9090/mcp
+        - log:
+            message: "Tool calls: ${body}"
+----
+====
 
 === Manual Tool Loop with `tool-execution` Operation
 
@@ -1513,6 +1956,10 @@ NOTE: When `systemMessage` is set and `conversationMemory` is enabled, the conve
 
 When using the Streamable HTTP transport, the component advertises MCP protocol versions during initialization. By default, the SDK's built-in versions are used. If your MCP server does not support the latest protocol version, you can restrict the advertised versions:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -1521,6 +1968,34 @@ from("direct:chat")
         + "&mcpServer.api.url=http://localhost:9090/mcp"
         + "&mcpProtocolVersions=2024-11-05,2025-03-26,2025-06-18");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;mcpServer.api.transportType=streamableHttp&amp;mcpServer.api.url=http://localhost:9090/mcp&amp;mcpProtocolVersions=2024-11-05,2025-03-26,2025-06-18"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              mcpServer.api.transportType: streamableHttp
+              mcpServer.api.url: http://localhost:9090/mcp
+              mcpProtocolVersions: "2024-11-05,2025-03-26,2025-06-18"
+----
+====
 
 === MCP Connection Recovery
 
@@ -1535,6 +2010,10 @@ This handles scenarios where an MCP server restarts, a network connection drops,
 
 Set `mcpReconnect=false` to disable automatic recovery:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -1543,6 +2022,34 @@ from("direct:chat")
         + "&mcpServer.api.transportType=streamableHttp"
         + "&mcpServer.api.url=http://localhost:9090/mcp");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="openai:chat-completion?model=gpt-4&amp;mcpReconnect=false&amp;mcpServer.api.transportType=streamableHttp&amp;mcpServer.api.url=http://localhost:9090/mcp"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: openai:chat-completion
+            parameters:
+              model: gpt-4
+              mcpReconnect: false
+              mcpServer.api.transportType: streamableHttp
+              mcpServer.api.url: http://localhost:9090/mcp
+----
+====
 
 === Error Handling in the Agentic Loop
 

--- a/components/camel-arangodb/src/main/docs/arangodb-component.adoc
+++ b/components/camel-arangodb/src/main/docs/arangodb-component.adoc
@@ -32,7 +32,6 @@ for this component:
 
 == URI format
 
-[source,java]
 ----
 arangodb:database[?options]
 ----

--- a/components/camel-avro-rpc/camel-avro-rpc-component/src/main/docs/avro-component.adoc
+++ b/components/camel-avro-rpc/camel-avro-rpc-component/src/main/docs/avro-component.adoc
@@ -151,6 +151,19 @@ wrapping.
 
 An example of using camel avro producers via http:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("avro:http:localhost:{{avroport}}?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol")
+    .to("log:avro");
+----
+
+XML::
++
 [source,xml]
 ----
         <route>
@@ -160,10 +173,40 @@ An example of using camel avro producers via http:
         </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: avro:http:localhost:{{avroport}}
+            parameters:
+              protocolClassName: org.apache.camel.avro.generated.KeyValueProtocol
+        - to:
+            uri: log:avro
+----
+====
+
 In the example above you need to fill `CamelAvroMessageName` header.
 
 You can use the following syntax to call constant messages:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("avro:http:localhost:{{avroport}}/put?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol")
+    .to("log:avro");
+----
+
+XML::
++
 [source,xml]
 ----
         <route>
@@ -173,8 +216,41 @@ You can use the following syntax to call constant messages:
         </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: avro:http:localhost:{{avroport}}/put
+            parameters:
+              protocolClassName: org.apache.camel.avro.generated.KeyValueProtocol
+        - to:
+            uri: log:avro
+----
+====
+
 An example of consuming messages using camel avro consumers via netty:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("avro:netty:localhost:{{avroport}}?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol")
+    .choice()
+        .when().el("${in.headers.CamelAvroMessageName == 'put'}")
+            .process("putProcessor")
+        .when().el("${in.headers.CamelAvroMessageName == 'get'}")
+            .process("getProcessor");
+----
+
+XML::
++
 [source,xml]
 ----
         <route>
@@ -192,8 +268,46 @@ An example of consuming messages using camel avro consumers via netty:
         </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: avro:netty:localhost:{{avroport}}
+      parameters:
+        protocolClassName: org.apache.camel.avro.generated.KeyValueProtocol
+      steps:
+        - choice:
+            when:
+              - el: "${in.headers.CamelAvroMessageName == 'put'}"
+                steps:
+                  - process:
+                      ref: putProcessor
+              - el: "${in.headers.CamelAvroMessageName == 'get'}"
+                steps:
+                  - process:
+                      ref: getProcessor
+----
+====
+
 You can set up two distinct routes to perform the same task:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("avro:netty:localhost:{{avroport}}/put?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol")
+    .process("putProcessor");
+
+from("avro:netty:localhost:{{avroport}}/get?protocolClassName=org.apache.camel.avro.generated.KeyValueProtocol&singleParameter=true")
+    .process("getProcessor");
+----
+
+XML::
++
 [source,xml]
 ----
         <route>
@@ -205,6 +319,30 @@ You can set up two distinct routes to perform the same task:
             <process ref="getProcessor"/>
         </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: avro:netty:localhost:{{avroport}}/put
+      parameters:
+        protocolClassName: org.apache.camel.avro.generated.KeyValueProtocol
+      steps:
+        - process:
+            ref: putProcessor
+- route:
+    from:
+      uri: avro:netty:localhost:{{avroport}}/get
+      parameters:
+        protocolClassName: org.apache.camel.avro.generated.KeyValueProtocol
+        singleParameter: true
+      steps:
+        - process:
+            ref: getProcessor
+----
+====
 
 In the example above, get takes only one parameter, so `singleParameter`
 is used and `getProcessor` will receive Value class directly in body,

--- a/components/camel-avro/src/main/docs/avro-dataformat.adoc
+++ b/components/camel-avro/src/main/docs/avro-dataformat.adoc
@@ -60,36 +60,65 @@ from("direct:back").unmarshal(format).to("direct:unmarshal");
 
 Where Value is an Avro Maven Plugin Generated class.
 
-or in XML
+The same route can be expressed in XML or YAML:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:in")
+    .marshal().avro("org.apache.camel.dataformat.avro.Message")
+    .to("log:out");
+----
+
+XML::
++
 [source,xml]
 ----
-    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
-        <route>
-            <from uri="direct:in"/>
-            <marshal>
-                <avro instanceClass="org.apache.camel.dataformat.avro.Message" library="ApacheAvro"/>
-            </marshal>
-            <to uri="log:out"/>
-        </route>
-    </camelContext>
+<route>
+    <from uri="direct:in"/>
+    <marshal>
+        <avro instanceClass="org.apache.camel.dataformat.avro.Message" library="ApacheAvro"/>
+    </marshal>
+    <to uri="log:out"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:in
+      steps:
+        - marshal:
+            avro:
+              instanceClass: org.apache.camel.dataformat.avro.Message
+              library: ApacheAvro
+        - to:
+            uri: log:out
+----
+====
 
 An alternative can be to specify the dataformat inside the context and
 reference it from your route.
 
+._XML-only: Spring XML data format configuration_
 [source,xml]
 ----
-    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
-         <dataFormats>
-            <avro id="avro" instanceClass="org.apache.camel.dataformat.avro.Message" library="ApacheAvro"/>
-        </dataFormats>
-        <route>
-            <from uri="direct:in"/>
-            <marshal><custom ref="avro"/></marshal>
-            <to uri="log:out"/>
-        </route>
-    </camelContext>
+<camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+     <dataFormats>
+        <avro id="avro" instanceClass="org.apache.camel.dataformat.avro.Message" library="ApacheAvro"/>
+    </dataFormats>
+    <route>
+        <from uri="direct:in"/>
+        <marshal><custom ref="avro"/></marshal>
+        <to uri="log:out"/>
+    </route>
+</camelContext>
 ----
 
 In the same manner, you can unmarshal using the avro data format.

--- a/components/camel-aws/camel-aws-parameter-store/src/main/docs/aws-parameter-store-component.adoc
+++ b/components/camel-aws/camel-aws-parameter-store/src/main/docs/aws-parameter-store-component.adoc
@@ -121,6 +121,18 @@ When using the `operation` option to create, get, list parameters etc., you shou
 
 At this point, you'll be able to reference a property in the following way:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{aws-parameterstore:/myapp/config/endpoint}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -131,10 +143,35 @@ At this point, you'll be able to reference a property in the following way:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{aws-parameterstore:/myapp/config/endpoint}}"
+----
+====
+
 Where `/myapp/config/endpoint` will be the name (path) of the parameter stored in the AWS Systems Manager Parameter Store.
 
 You could specify a default value in case the parameter is not present on AWS Parameter Store:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{aws-parameterstore:/myapp/config/endpoint:http://localhost:8080}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -145,12 +182,39 @@ You could specify a default value in case the parameter is not present on AWS Pa
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{aws-parameterstore:/myapp/config/endpoint:http://localhost:8080}}"
+----
+====
+
 In this case, if the parameter doesn't exist, the property will fall back to "http://localhost:8080" as value.
 
 === Parameter Store Hierarchies
 
 AWS Parameter Store supports hierarchical parameter names. You can organize parameters into hierarchies using forward slashes:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Database host is {{aws-parameterstore:/myapp/database/host}}")
+    .log("Database port is {{aws-parameterstore:/myapp/database/port}}")
+    .log("Database user is {{aws-parameterstore:/myapp/database/username}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -163,10 +227,39 @@ AWS Parameter Store supports hierarchical parameter names. You can organize para
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Database host is {{aws-parameterstore:/myapp/database/host}}"
+        - log:
+            message: "Database port is {{aws-parameterstore:/myapp/database/port}}"
+        - log:
+            message: "Database user is {{aws-parameterstore:/myapp/database/username}}"
+----
+====
+
 === SecureString Parameters
 
 AWS Parameter Store supports SecureString parameters which are encrypted using AWS KMS. The Parameter Store properties function automatically decrypts SecureString parameters:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("API Key is {{aws-parameterstore:/myapp/secrets/api-key}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -176,6 +269,19 @@ AWS Parameter Store supports SecureString parameters which are encrypted using A
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "API Key is {{aws-parameterstore:/myapp/secrets/api-key}}"
+----
+====
 
 The only requirement is adding the camel-aws-parameter-store jar to your Camel application.
 

--- a/components/camel-aws/camel-aws-secrets-manager/src/main/docs/aws-secrets-manager-component.adoc
+++ b/components/camel-aws/camel-aws-secrets-manager/src/main/docs/aws-secrets-manager-component.adoc
@@ -121,6 +121,18 @@ When using the `operation` option to create, get, list secrets etc., you should 
 
 At this point, you'll be able to reference a property in the following way:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{aws:route}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -131,10 +143,35 @@ At this point, you'll be able to reference a property in the following way:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{aws:route}}"
+----
+====
+
 Where route will be the name of the secret stored in the AWS Secrets Manager Service.
 
 You could specify a default value in case the secret is not present on AWS Secret Manager:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{aws:route:default}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -144,6 +181,19 @@ You could specify a default value in case the secret is not present on AWS Secre
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{aws:route:default}}"
+----
+====
 
 In this case, if the secret doesn't exist, the property will fall back to "default" as value.
 
@@ -163,6 +213,18 @@ Also, you are able to get a particular field of the secret, if you have, for exa
 
 You're able to do get single secret value in your route, like for example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{aws:database#username}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -173,10 +235,35 @@ You're able to do get single secret value in your route, like for example:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{aws:database#username}}"
+----
+====
+
 Or re-use the property as part of an endpoint.
 
 You could specify a default value in case the particular field of secret is not present on AWS Secret Manager:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{aws:database#username:admin}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -187,10 +274,35 @@ You could specify a default value in case the particular field of secret is not 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{aws:database#username:admin}}"
+----
+====
+
 In this case, if the secret doesn't exist or the secret exists, but the username field is not part of the secret, the property will fall back to "admin" as value.
 
 There is also the syntax to get a particular version of the secret for both the approach, with field/default value specified or only with secret:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{aws:route@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -201,8 +313,33 @@ There is also the syntax to get a particular version of the secret for both the 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{aws:route@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}"
+----
+====
+
 This approach will return the RAW route secret with the version 'bf9b4f4b-8e63-43fd-a73c-3e2d3748b451'.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{aws:route:default@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -213,8 +350,33 @@ This approach will return the RAW route secret with the version 'bf9b4f4b-8e63-4
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{aws:route:default@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}"
+----
+====
+
 This approach will return the route secret value with version 'bf9b4f4b-8e63-43fd-a73c-3e2d3748b451' or default value in case the secret doesn't exist or the version doesn't exist.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{aws:database#username:admin@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -224,6 +386,19 @@ This approach will return the route secret value with version 'bf9b4f4b-8e63-43f
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{aws:database#username:admin@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}"
+----
+====
 
 This approach will return the username field of the database secret with version 'bf9b4f4b-8e63-43fd-a73c-3e2d3748b451' or admin in case the secret doesn't exist or the version doesn't exist.
 

--- a/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-firehose-component.adoc
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-firehose-component.adoc
@@ -25,7 +25,7 @@ at https://aws.amazon.com/kinesis/firehose/[AWS Kinesis Firehose]
 
 == URI Format
 
-[source,java]
+[source,text]
 ----
 aws2-kinesis-firehose://delivery-stream-name[?options]
 ----

--- a/components/camel-azure/camel-azure-key-vault/src/main/docs/azure-key-vault-component.adoc
+++ b/components/camel-azure/camel-azure-key-vault/src/main/docs/azure-key-vault-component.adoc
@@ -96,6 +96,18 @@ When using the `operation` option to create, get, list secrets etc., you should 
 
 At this point, you'll be able to reference a property in the following way:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{azure:route}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -106,10 +118,35 @@ At this point, you'll be able to reference a property in the following way:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{azure:route}}"
+----
+====
+
 Where route will be the name of the secret stored in the Azure Key Vault Service.
 
 You could specify a default value in case the secret is not present on Azure Key Vault Service:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{azure:route:default}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -119,6 +156,19 @@ You could specify a default value in case the secret is not present on Azure Key
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{azure:route:default}}"
+----
+====
 
 In this case, if the secret doesn't exist, the property will fall back to "default" as value.
 
@@ -138,6 +188,18 @@ Also, you are able to get a particular field of the secret, if you have, for exa
 
 You're able to do get single secret value in your route, like for example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{azure:database#username}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -148,10 +210,35 @@ You're able to do get single secret value in your route, like for example:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{azure:database#username}}"
+----
+====
+
 Or re-use the property as part of an endpoint.
 
 You could specify a default value in case the particular field of secret is not present on Azure Key Vault:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{azure:database#username:admin}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -162,10 +249,35 @@ You could specify a default value in case the particular field of secret is not 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{azure:database#username:admin}}"
+----
+====
+
 In this case, if the secret doesn't exist or the secret exists, but the username field is not part of the secret, the property will fall back to "admin" as value.
 
 There is also the syntax to get a particular version of the secret for both the approach, with field/default value specified or only with secret:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{azure:route@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -176,8 +288,33 @@ There is also the syntax to get a particular version of the secret for both the 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{azure:route@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}"
+----
+====
+
 This approach will return the RAW route secret with the version 'bf9b4f4b-8e63-43fd-a73c-3e2d3748b451'.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{azure:route:default@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -188,8 +325,33 @@ This approach will return the RAW route secret with the version 'bf9b4f4b-8e63-4
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{azure:route:default@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}"
+----
+====
+
 This approach will return the route secret value with version 'bf9b4f4b-8e63-43fd-a73c-3e2d3748b451' or default value in case the secret doesn't exist or the version doesn't exist.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{azure:database#username:admin@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -199,6 +361,19 @@ This approach will return the route secret value with version 'bf9b4f4b-8e63-43f
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{azure:database#username:admin@bf9b4f4b-8e63-43fd-a73c-3e2d3748b451}}"
+----
+====
 
 This approach will return the username field of the database secret with version 'bf9b4f4b-8e63-43fd-a73c-3e2d3748b451' or admin in case the secret doesn't exist or the version doesn't exist.
 

--- a/components/camel-azure/camel-azure-storage-queue/src/main/docs/azure-storage-queue-component.adoc
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/docs/azure-storage-queue-component.adoc
@@ -116,6 +116,7 @@ If your Camel Application is running behind a firewall or if you need to
 have more control over the `QueueServiceClient` instance configuration, you can
 create your own instance:
 
+._Java-only: programmatic Azure SDK client configuration_
 [source,java]
 ----
 StorageSharedKeyCredential credential = new StorageSharedKeyCredential("yourAccountName", "yourAccessKey");

--- a/components/camel-barcode/src/main/docs/barcode-dataformat.adoc
+++ b/components/camel-barcode/src/main/docs/barcode-dataformat.adoc
@@ -26,7 +26,7 @@ If you use maven, you could just add the following to your pom.xml,
 substituting the version number for the latest & greatest release (see
 the download page for the latest versions).
 
-[source,java]
+[source,xml]
 ----
 <dependency>
   <groupId>org.apache.camel</groupId>

--- a/components/camel-base64/src/main/docs/base64-dataformat.adoc
+++ b/components/camel-base64/src/main/docs/base64-dataformat.adoc
@@ -21,6 +21,7 @@ include::partial$dataformat-options.adoc[]
 
 In Spring DSL, you configure the data format using this tag:
 
+._XML-only: Spring XML data format configuration_
 [source,xml]
 ----
 <camelContext>

--- a/components/camel-base64/src/main/docs/base64-dataformat.adoc
+++ b/components/camel-base64/src/main/docs/base64-dataformat.adoc
@@ -35,6 +35,19 @@ In Spring DSL, you configure the data format using this tag:
 
 Then you can use it later by its reference:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:startEncode")
+    .marshal("base64withLineLength64")
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -43,6 +56,21 @@ Then you can use it later by its reference:
      <to uri="mock:result" />
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:startEncode
+      steps:
+        - marshal:
+            ref: base64withLineLength64
+        - to:
+            uri: mock:result
+----
+====
 
 Most of the time, you won't need to declare the data format if you use
 the default options. In that case, you can declare the data format

--- a/components/camel-bean-validator/src/main/docs/bean-validator-component.adoc
+++ b/components/camel-bean-validator/src/main/docs/bean-validator-component.adoc
@@ -328,22 +328,40 @@ Here is the XML syntax for the example route definition where **OrderedChecks** 
 
 Note that the body should include an instance of a class to validate.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("bean-validator://x?group=org.apache.camel.component.bean.validator.OrderedChecks");
+----
+
+XML::
++
 [source,xml]
 ----
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
-  
-    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
-        <route>
-            <from uri="direct:start"/>
-            <to uri="bean-validator://x?group=org.apache.camel.component.bean.validator.OrderedChecks"/>
-        </route>
-    </camelContext>
-</beans>
+<route>
+    <from uri="direct:start"/>
+    <to uri="bean-validator://x?group=org.apache.camel.component.bean.validator.OrderedChecks"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: bean-validator://x
+            parameters:
+              group: org.apache.camel.component.bean.validator.OrderedChecks
+----
+====
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-bean/src/main/docs/bean-component.adoc
+++ b/components/camel-bean/src/main/docs/bean-component.adoc
@@ -39,6 +39,7 @@ Endpoint to the bean endpoint as output, such as the *direct* endpoint as input.
 
 Suppose you have the following POJO class to be used by Camel
 
+._Java-only: POJO bean class used by the route_
 [source,java]
 ----
 package com.foo;

--- a/components/camel-cbor/src/main/docs/cbor-dataformat.adoc
+++ b/components/camel-cbor/src/main/docs/cbor-dataformat.adoc
@@ -68,25 +68,54 @@ When using Data Format in Spring DSL, you need to
 declare the data formats first. This is done in the *DataFormats* XML
 tag.
 
+._XML-only: Spring XML data format configuration_
 [source,xml]
------------------------------------------------------------------------------------------------------------------------------
+----
 <dataFormats>
     <!-- here we define a CBOR data format with the id test, and that it should use the TestPojo as the class type when
     doing unmarshal. -->
     <cbor id="test" unmarshalType="org.apache.camel.component.cbor.TestPojo"/>
 </dataFormats>
------------------------------------------------------------------------------------------------------------------------------
+----
 
 And then you can refer to this id in the route:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:back")
+    .unmarshal("test")
+    .to("mock:reverse");
+----
+
+XML::
++
 [source,xml]
--------------------------------------
+----
 <route>
     <from uri="direct:back"/>
     <unmarshal><custom ref="test"/></unmarshal>
     <to uri="mock:reverse"/>
 </route>
--------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:back
+      steps:
+        - unmarshal:
+            ref: test
+        - to:
+            uri: mock:reverse
+----
+====
 
 == Dependencies
 

--- a/components/camel-crypto/src/main/docs/crypto-component.adoc
+++ b/components/camel-crypto/src/main/docs/crypto-component.adoc
@@ -194,11 +194,12 @@ YAML::
 
 The following code shows how to load the keystore created using the above `keytool` command and bind it into the registry with the name `myKeystore` for use in the above route. The example makes use of the `@Configuration` and `@BindToRegistry` annotations introduced in Camel 3 to instantiate the KeyStore and register it with the name `myKeyStore`.
 
+._Java-only: KeyStore bean configuration with `@BindToRegistry`_
 [source,java]
 ----
 @Configuration
 public class KeystoreConfig {
-    
+
     @BindToRegistry
     public KeyStore myKeystore() throws Exception {
         KeyStore store = KeyStore.getInstance("JKS");
@@ -342,6 +343,7 @@ Add the Bouncy Castle provider dependencies to your project:
 
 Register the Bouncy Castle provider at application startup:
 
+._Java-only: static provider registration_
 [source,java]
 ----
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/components/camel-crypto/src/main/docs/crypto-dataformat.adoc
+++ b/components/camel-crypto/src/main/docs/crypto-dataformat.adoc
@@ -50,6 +50,7 @@ from("direct:basic-encryption")
 
 In Spring the dataformat is configured first and then used in routes
 
+._XML-only: Spring XML data format configuration_
 [source,xml]
 ----
 <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">

--- a/components/camel-csv/src/main/docs/csv-dataformat.adoc
+++ b/components/camel-csv/src/main/docs/csv-dataformat.adoc
@@ -317,7 +317,24 @@ of your own `CSVConfig` and/or `CSVStrategy`. Also note that the default
 value of the `autogenColumns` option is true. The following example
 should illustrate this customization.
 
-._XML-only: Spring XML with custom CSVConfig and CSVStrategy beans_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+CsvDataFormat csv = new CsvDataFormat();
+csv.setDelimiter("|");
+csv.setAutogenColumns(false);
+
+from("direct:start")
+    .marshal(csv)
+    .convertBodyTo(String.class)
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -347,6 +364,24 @@ should illustrate this customization.
   <property name="staticField" value="org.apache.commons.csv.CSVStrategy.EXCEL_STRATEGY" />
 </bean>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: direct:start
+    steps:
+      - marshal:
+          csv:
+            delimiter: "|"
+            autogenColumns: false
+      - convertBodyTo:
+          type: java.lang.String
+      - to:
+          uri: mock:result
+----
+====
 
 === Collecting header record
 

--- a/components/camel-csv/src/main/docs/csv-dataformat.adoc
+++ b/components/camel-csv/src/main/docs/csv-dataformat.adoc
@@ -317,6 +317,7 @@ of your own `CSVConfig` and/or `CSVStrategy`. Also note that the default
 value of the `autogenColumns` option is true. The following example
 should illustrate this customization.
 
+._XML-only: Spring XML with custom CSVConfig and CSVStrategy beans_
 [source,xml]
 ----
 <route>
@@ -368,8 +369,24 @@ from("direct:start")
 
 *For Camel >= 2.16.5 
 The instruction for CSV Data format to skip headers or first line is the following. 
-Usign the Spring/XML DSL:
+Using the DSL:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+CsvDataFormat csv = new CsvDataFormat();
+csv.setSkipHeaderRecord(true);
+
+from("direct:start")
+    .unmarshal(csv)
+    .to("bean:myCsvHandler?method=doHandleCsv");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -380,6 +397,24 @@ Usign the Spring/XML DSL:
   <to uri="bean:myCsvHandler?method=doHandleCsv" />
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - unmarshal:
+            csv:
+              skipHeaderRecord: true
+        - to:
+            uri: bean:myCsvHandler
+            parameters:
+              method: doHandleCsv
+----
+====
 
 *Since Camel 2.10 and deleted for Camel 2.15*
 

--- a/components/camel-csv/src/main/docs/csv-dataformat.adoc
+++ b/components/camel-csv/src/main/docs/csv-dataformat.adoc
@@ -202,15 +202,48 @@ public void doHandleCsvData(List<List<String>> csvData)
 
 ... your route then looks as follows
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file:///some/path/to/pickup/csvfiles?delete=true&delay=10000")
+    .unmarshal().csv()
+    .to("bean:myCsvHandler?method=doHandleCsvData");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
-        <!-- poll every 10 seconds -->
-        <from uri="file:///some/path/to/pickup/csvfiles?delete=true&amp;delay=10000" />
-        <unmarshal><csv /></unmarshal>
-        <to uri="bean:myCsvHandler?method=doHandleCsvData" />
+  <!-- poll every 10 seconds -->
+  <from uri="file:///some/path/to/pickup/csvfiles?delete=true&amp;delay=10000"/>
+  <unmarshal><csv/></unmarshal>
+  <to uri="bean:myCsvHandler?method=doHandleCsvData"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: file:///some/path/to/pickup/csvfiles
+      parameters:
+        delete: true
+        delay: 10000
+      steps:
+        - unmarshal:
+            csv: {}
+        - to:
+            uri: bean:myCsvHandler
+            parameters:
+              method: doHandleCsvData
+----
+====
 
 === Marshaling with a pipe as delimiter
 Considering the following body:

--- a/components/camel-cxf/camel-cxf-soap/src/main/docs/cxf-component.adoc
+++ b/components/camel-cxf/camel-cxf-soap/src/main/docs/cxf-component.adoc
@@ -319,7 +319,7 @@ headers is required, please use `PAYLOAD` mode or plug in a (pretty
 straightforward) CXF interceptor/JAXWS Handler to the CXF endpoint.
 Here is an example of configuring the `CxfHeaderFilterStrategy`.
 
-
+._XML-only: Spring bean definition for CxfHeaderFilterStrategy_
 [source,xml]
 ----
 <bean id="dropAllMessageHeadersStrategy" class="org.apache.camel.component.cxf.transport.header.CxfHeaderFilterStrategy">
@@ -332,6 +332,18 @@ Here is an example of configuring the `CxfHeaderFilterStrategy`.
 
 Then, your endpoint can reference the `CxfHeaderFilterStrategy`:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("cxf:bean:routerNoRelayEndpoint?headerFilterStrategy=#dropAllMessageHeadersStrategy")
+    .to("cxf:bean:serviceNoRelayEndpoint?headerFilterStrategy=#dropAllMessageHeadersStrategy");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -339,6 +351,23 @@ Then, your endpoint can reference the `CxfHeaderFilterStrategy`:
     <to uri="cxf:bean:serviceNoRelayEndpoint?headerFilterStrategy=#dropAllMessageHeadersStrategy"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: cxf:bean:routerNoRelayEndpoint
+      parameters:
+        headerFilterStrategy: "#dropAllMessageHeadersStrategy"
+      steps:
+        - to:
+            uri: cxf:bean:serviceNoRelayEndpoint
+            parameters:
+              headerFilterStrategy: "#dropAllMessageHeadersStrategy"
+----
+====
 
 * You can plug in your own `MessageHeaderFilter` implementations overriding
 or adding additional ones to the list of relays. To override a
@@ -442,6 +471,7 @@ tags. When you are invoking the service endpoint, you can set the
 `CamelCxfOperationName` and `CamelCxfOperationNamespace` headers to explicitly state
 which operation you are calling.
 
+._XML-only: Spring XML configuration with CXF endpoint beans and Camel route_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"

--- a/components/camel-cxf/camel-cxf-soap/src/main/docs/cxf-component.adoc
+++ b/components/camel-cxf/camel-cxf-soap/src/main/docs/cxf-component.adoc
@@ -225,10 +225,7 @@ is removed in `RAW` mode), you have to configure
 `LoggingOutInterceptor` to be run during the `WRITE` phase. The
 following is an example.
 
-[tabs]
-====
-Java (Quarkus)::
-+
+._Java-only: configuring `LoggingOutInterceptor` in the WRITE phase for RAW mode_
 [source,java]
 ----
 import java.util.List;
@@ -256,8 +253,8 @@ CxfEndpoint soapMtomEnabledServerPayloadModeEndpoint() {
 }
 ----
 
-XML (Spring)::
-+
+The same configuration in Spring XML:
+
 [source,xml]
 ----
 <bean id="loggingOutInterceptor" class="org.apache.cxf.interceptor.LoggingOutInterceptor">
@@ -275,7 +272,6 @@ XML (Spring)::
     </cxf:properties>
 </cxf:cxfEndpoint>
 ----
-====
 
 === Description of CxfHeaderFilterStrategy options
 
@@ -411,6 +407,7 @@ Error:sendSms: SoapFault exception: [Client] looks like we got no XML document i
 To resolve this issue, you need to tell `StaxOutInterceptor` to
 write the XML start document for you, as in the https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/WriteXmlDeclarationInterceptor.java[WriteXmlDeclarationInterceptor] below:
 
+._Java-only: CXF interceptor to force XML declaration in response_
 [source,java]
 ----
 public class WriteXmlDeclarationInterceptor extends AbstractPhaseInterceptor<SoapMessage> {
@@ -428,6 +425,7 @@ public class WriteXmlDeclarationInterceptor extends AbstractPhaseInterceptor<Soa
 
 As an alternative, you can add a message header for it as demonstrated in https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerTest.java#L62[CxfConsumerTest]:
 
+._Java-only: forcing XML declaration via response context header_
 [source,java]
 ----
  // set up the response context which force start document
@@ -580,7 +578,7 @@ operation parameters.
 
 Having simple java web service interface:
 
-
+._Java-only: JAX-WS web service interface definition_
 [source,java]
 ----
 package org.apache.camel.component.cxf.soap.server;
@@ -633,6 +631,7 @@ list.
 If you want to get the object array from the message body, you can get
 the body using `message.getBody(Object[].class)`, as shown in https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfProducerRouterTest.java#L117[CxfProducerRouterTest.testInvokingSimpleServerWithParams]:
 
+._Java-only: preparing and sending a POJO mode request with `ProducerTemplate`_
 [source,java]
 ----
 Exchange senderExchange = new DefaultExchange(context, ExchangePattern.InOut);
@@ -666,6 +665,7 @@ for SOAP message headers and the SOAP body.
 
 See https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerPayloadTest.java#L68[CxfConsumerPayloadTest]:
 
+._Java-only: consuming and processing CXF PAYLOAD with `CxfPayload` API_
 [source,java]
 ----
 protected RouteBuilder createRouteBuilder() {
@@ -777,6 +777,7 @@ The only difference between the two processors is setting the direction of the i
 
 You can find the `InsertResponseOutHeaderProcessor` example in https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/soap/headers/CxfMessageHeadersRelayTest.java#L731[CxfMessageHeadersRelayTest]:
 
+._Java-only: Processor that inserts an out-of-band SOAP header into the response_
 [source,java]
 ----
 public static class InsertResponseOutHeaderProcessor implements Processor {
@@ -812,6 +813,7 @@ headers).
 
 For example, see https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfPayLoadSoapHeaderTest.java#L53[CxfPayLoadSoapHeaderTest]:
 
+._Java-only: accessing SOAP headers from `CxfPayload` in PAYLOAD mode_
 [source,java]
 ----
 from(getRouterEndpointURI()).process(new Processor() {
@@ -869,6 +871,7 @@ may need to throw the SOAP Fault from the camel context. +
 `POJO`, `PAYLOAD` and `RAW` data format. +
  You can define the soap fault as shown in https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfCustomizedExceptionTest.java#L65[CxfCustomizedExceptionTest]:
 
+._Java-only: creating a `SoapFault` with detail text_
 [source,java]
 ----
 SOAP_FAULT = new SoapFault(EXCEPTION_MESSAGE, SoapFault.FAULT_CODE_CLIENT);
@@ -880,6 +883,7 @@ detail.appendChild(tn);
 
 Then throw it as you like:
 
+._Java-only: setting a SOAP fault on the route using `setFaultBody`_
 [source,java]
 ----
 from(routerEndpointURI).setFaultBody(constant(SOAP_FAULT));
@@ -912,6 +916,7 @@ If you are using a Camel CXF endpoint producer to
 invoke the outside web service, you can set the request context and get
 response context with the following code:
 
+._Java-only: setting request context and reading response context via `ProducerTemplate`_
 [source,java]
 ----
 CxfExchange exchange = (CxfExchange)template.send(getJaxwsEndpointUri(), new Processor() {
@@ -947,6 +952,7 @@ Since attachments are marshalled and unmarshalled into POJOs, the attachments sh
 retrieved from the Apache Camel message body (as a parameter list), and it isn't
 possible to retrieve attachments by Camel Message API
 
+._Java-only: retrieving an attachment by ID from the exchange_
 [source,java]
 ----
 DataHandler handler = Exchange.getIn(AttachmentMessage.class).getAttachment("id");
@@ -1020,6 +1026,7 @@ XML (Spring)::
 
 You can produce a Camel message with attachment to send to a CXF endpoint in Payload mode.
 
+._Java-only: sending and receiving MTOM attachments via `ProducerTemplate`_
 [source,java]
 ----
 Exchange exchange = context.createProducerTemplate().send("direct:testEndpoint", new Processor() {
@@ -1075,6 +1082,7 @@ assertEquals(300, image.getHeight());
 You can also consume a Camel message received from a CXF endpoint in Payload mode.
 The https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/mtom/CxfMtomConsumerPayloadModeTest.java#L97[CxfMtomConsumerPayloadModeTest] illustrates how this works:
 
+._Java-only: Processor that verifies and responds to MTOM requests_
 [source,java]
 ----
 public static class MyProcessor implements Processor {

--- a/components/camel-cxf/camel-cxf-transport/src/main/docs/cxf-transport.adoc
+++ b/components/camel-cxf/camel-cxf-transport/src/main/docs/cxf-transport.adoc
@@ -143,6 +143,7 @@ endpoint's target namespace was `\http://widgets.widgetvendor.net`.
 
 *camel:destination Element*
 
+._XML-only: CXF transport destination configuration with embedded Camel route_
 [source,xml]
 ----
 ...
@@ -191,6 +192,7 @@ endpoint's target namespace was `\http://widgets.widgetvendor.net`.
 
 *http-conf:conduit Element*
 
+._XML-only: CXF transport conduit configuration with embedded Camel route_
 [source,xml]
 ----
 ...
@@ -202,7 +204,7 @@ endpoint's target namespace was `\http://widgets.widgetvendor.net`.
    </camelContext>
 
   <camel:conduit name="{http://widgets/widgetvendor.net}widgetSOAPPort.camel-conduit" camelContextId="conduit_context" />
-     
+
 
   <camel:conduit name="*.camel-conduit">
   <!-- you can also using the wild card to specify the camel-conduit that you want to configure -->

--- a/components/camel-disruptor/src/main/docs/disruptor-component.adoc
+++ b/components/camel-disruptor/src/main/docs/disruptor-component.adoc
@@ -251,6 +251,7 @@ unit test.
 In this example, we have defined two consumers and registered them as
 spring beans.
 
+._XML-only: Spring bean configuration with shared Disruptor endpoint_
 [source,xml]
 ----
 <!-- define the consumers as spring beans -->

--- a/components/camel-dns/src/main/docs/dns-component.adoc
+++ b/components/camel-dns/src/main/docs/dns-component.adoc
@@ -190,19 +190,55 @@ If you have instances of the same component running in different regions, you ca
 
 For example, you may have an instance in NYC and an instance in SFO. You would configure a service CNAME service.example.com to point to nyc-service.example.com to bring NYC instance up and SFO instance down. When you change the CNAME service.example.com to point to sfo-service.example.com -- nyc instance would stop its routes and sfo will bring its routes up. This allows you to switch regions without restarting actual components.
 
-._XML-only: Spring bean configuration for `DnsActivationPolicy` with route policy reference_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+DnsActivationPolicy policy = new DnsActivationPolicy();
+policy.setHostname("service.example.com");
+policy.setResolvesTo("nyc-service.example.com");
+policy.setTtl(60000);
+policy.setStopRoutesOnException(false);
+
+from("direct:start")
+    .routeId("routeId")
+    .autoStartup(false)
+    .routePolicy(policy)
+    .to("...");
+----
+
+XML::
++
 [source,xml]
 ----
- <bean id="dnsActivationPolicy" class="org.apache.camel.component.dns.policy.DnsActivationPolicy">
-     <property name="hostname" value="service.example.com" />
-     <property name="resolvesTo" value="nyc-service.example.com" />
-     <property name="ttl" value="60000" />
-     <property name="stopRoutesOnException" value="false" />
- </bean>
+<bean id="dnsActivationPolicy" class="org.apache.camel.component.dns.policy.DnsActivationPolicy">
+    <property name="hostname" value="service.example.com" />
+    <property name="resolvesTo" value="nyc-service.example.com" />
+    <property name="ttl" value="60000" />
+    <property name="stopRoutesOnException" value="false" />
+</bean>
 
- <route id="routeId" autoStartup="false" routePolicyRef="dnsActivationPolicy">
- </route>
+<route id="routeId" autoStartup="false" routePolicyRef="dnsActivationPolicy">
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: routeId
+    autoStartup: false
+    routePolicyRef: dnsActivationPolicy
+    from:
+      uri: direct:start
+    steps:
+      - to:
+          uri: "..."
+----
+====
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-dns/src/main/docs/dns-component.adoc
+++ b/components/camel-dns/src/main/docs/dns-component.adoc
@@ -62,6 +62,18 @@ include::partial$component-endpoint-headers.adoc[]
 
 === IP lookup
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("dns:ip");
+----
+
+XML::
++
 [source,xml]
 ----
 <route id="IPCheck">
@@ -70,6 +82,20 @@ include::partial$component-endpoint-headers.adoc[]
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: IPCheck
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: dns:ip
+----
+====
+
 This looks up a domain's IP. For example, _www.example.com_ resolves to
 192.0.32.10.
 
@@ -77,6 +103,18 @@ The IP address to lookup must be provided in the header with key `"CamelDnsDomai
 
 === DNS lookup
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("dns:lookup");
+----
+
+XML::
++
 [source,xml]
 ----
 <route id="IPCheck">
@@ -84,6 +122,20 @@ The IP address to lookup must be provided in the header with key `"CamelDnsDomai
     <to uri="dns:lookup"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: IPCheck
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: dns:lookup
+----
+====
 
 This returns a set of DNS records associated with a domain. +
  The name to lookup must be provided in the header with key
@@ -93,6 +145,18 @@ This returns a set of DNS records associated with a domain. +
 
 Dig is a Unix command-line utility to run DNS queries.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("dns:dig");
+----
+
+XML::
++
 [source,xml]
 ----
 <route id="IPCheck">
@@ -100,6 +164,20 @@ Dig is a Unix command-line utility to run DNS queries.
     <to uri="dns:dig"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: IPCheck
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: dns:dig
+----
+====
 
 The query must be provided in the header with key `"CamelDnsName"`.
 
@@ -112,6 +190,7 @@ If you have instances of the same component running in different regions, you ca
 
 For example, you may have an instance in NYC and an instance in SFO. You would configure a service CNAME service.example.com to point to nyc-service.example.com to bring NYC instance up and SFO instance down. When you change the CNAME service.example.com to point to sfo-service.example.com -- nyc instance would stop its routes and sfo will bring its routes up. This allows you to switch regions without restarting actual components.
 
+._XML-only: Spring bean configuration for `DnsActivationPolicy` with route policy reference_
 [source,xml]
 ----
  <bean id="dnsActivationPolicy" class="org.apache.camel.component.dns.policy.DnsActivationPolicy">

--- a/components/camel-dynamic-router/src/main/docs/dynamic-router-component.adoc
+++ b/components/camel-dynamic-router/src/main/docs/dynamic-router-component.adoc
@@ -438,6 +438,8 @@ The Dynamic Router Control component supports some JMX operations that allow you
 It is beyond the scope of this document to go into detail about JMX, so this is a list of the operations that are
 supported.  For more information about JMX, see the xref:manual::jmx.adoc[JMX] documentation.
 
+._Java-only: JMX operation_
+
 .Subscribing with a predicate expression
 [source,java]
 ----
@@ -454,6 +456,8 @@ as follows:
 - expression language
 - update the subscription (true), or add a new one (false)
 
+._Java-only: JMX operation_
+
 .Subscribing with a predicate bean
 [source,java]
 ----
@@ -468,6 +472,8 @@ registry. The parameters, in order, are as follows:
 - priority
 - predicate bean name
 - update the subscription (true), or add a new one (false)
+
+._Java-only: JMX operation_
 
 .Subscribing with a predicate instance
 [source,java]
@@ -484,6 +490,8 @@ are as follows:
 - predicate instance
 - update the subscription (true), or add a new one (false)
 
+._Java-only: JMX operation_
+
 .Unsubscribing
 [source,java]
 ----
@@ -494,6 +502,8 @@ This operation provides the ability to unsubscribe from a channel. The parameter
 - subscription ID
 - channel name
 
+._Java-only: JMX operation_
+
 .Getting the subscriptions map
 [source,java]
 ----
@@ -501,6 +511,8 @@ Map<String, ConcurrentSkipListSet<PrioritizedFilter>> getSubscriptionsMap()
 ----
 This operation provides the ability to get the subscriptions map.  The map is keyed by channel name, and the values are
 a set of prioritized filters.
+
+._Java-only: JMX operation_
 
 .Getting the subscriptions statistics map
 [source,java]

--- a/components/camel-dynamic-router/src/main/docs/dynamic-router-control-component.adoc
+++ b/components/camel-dynamic-router/src/main/docs/dynamic-router-control-component.adoc
@@ -238,6 +238,8 @@ used to determine the suitability of exchanges for a participating recipient, wh
 predicates.  Although it is advised to view the complete documentation, an example simple predicate might look like the
 following:
 
+._Java-only: Predicate API_
+
 .Example simple predicate
 [source,java]
 ----
@@ -250,6 +252,8 @@ Predicate msgType = header("messageType").isEqualTo("payment");
 The Dynamic Router Control component supports some JMX operations that allow you to control and monitor the component.
 It is beyond the scope of this document to go into detail about JMX, so this is a list of the operations that are
 supported.  For more information about JMX, see the xref:manual::jmx.adoc[JMX] documentation.
+
+._Java-only: JMX operation_
 
 .Subscribing with a predicate expression
 [source,java]
@@ -267,6 +271,8 @@ as follows:
  - expression language
  - update the subscription (true), or add a new one (false)
 
+._Java-only: JMX operation_
+
 .Subscribing with a predicate bean
 [source,java]
 ----
@@ -281,6 +287,8 @@ registry. The parameters, in order, are as follows:
  - priority
  - predicate bean name
  - update the subscription (true), or add a new one (false)
+
+._Java-only: JMX operation_
 
 .Subscribing with a predicate instance
 [source,java]
@@ -297,6 +305,8 @@ are as follows:
  - predicate instance
  - update the subscription (true), or add a new one (false)
 
+._Java-only: JMX operation_
+
 .Unsubscribing
 [source,java]
 ----
@@ -307,6 +317,8 @@ This operation provides the ability to unsubscribe from a channel. The parameter
  - subscription ID
  - channel name
 
+._Java-only: JMX operation_
+
 .Getting the subscriptions map
 [source,java]
 ----
@@ -314,6 +326,8 @@ Map<String, ConcurrentSkipListSet<PrioritizedFilter>> getSubscriptionsMap()
 ----
 This operation provides the ability to get the subscriptions map.  The map is keyed by channel name, and the values are
 a set of prioritized filters.
+
+._Java-only: JMX operation_
 
 .Getting the subscriptions statistics map
 [source,java]

--- a/components/camel-file/src/main/docs/file-component.adoc
+++ b/components/camel-file/src/main/docs/file-component.adoc
@@ -1113,17 +1113,43 @@ the `idempotentRepository` option using the `#` sign in the value to
 indicate it's a referring to a bean in the Registry
 with the specified `id`.
 
-._XML-only: Spring bean definition for custom idempotent repository with route_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file://inbox?idempotent=true&idempotentRepository=#myStore")
+    .to("bean:processInbox");
+----
+
+XML::
++
 [source,xml]
 ----
- <!-- define our store as a plain spring bean -->
- <bean id="myStore" class="com.mycompany.MyIdempotentStore"/>
+<!-- define our store as a plain spring bean -->
+<bean id="myStore" class="com.mycompany.MyIdempotentStore"/>
 
 <route>
   <from uri="file://inbox?idempotent=true&amp;idempotentRepository=#myStore"/>
   <to uri="bean:processInbox"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: file://inbox
+    parameters:
+      idempotent: true
+      idempotentRepository: "#myStore"
+    steps:
+      - to:
+          uri: bean:processInbox
+----
+====
 
 Camel will log at `DEBUG` level if it skips a file because it has been
 consumed before:
@@ -1267,7 +1293,18 @@ And then we can configure our route using the `filter` attribute to
 reference our filter (using `#` notation) that we have defined in the
 spring XML file:
 
-._XML-only: Spring bean definition for custom file filter with route_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file://inbox?filter=#myFilter")
+    .to("bean:processInbox");
+----
+
+XML::
++
 [source,xml]
 ----
 <!-- define our filter as a plain spring bean -->
@@ -1278,6 +1315,20 @@ spring XML file:
   <to uri="bean:processInbox"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: file://inbox
+    parameters:
+      filter: "#myFilter"
+    steps:
+      - to:
+          uri: bean:processInbox
+----
+====
 
 ==== Filtering using ANT path matcher
 
@@ -1340,17 +1391,42 @@ And then we can configure our route using the *sorter* option to
 reference to our sorter (`mySorter`) we have defined in the spring XML
 file:
 
-._XML-only: Spring bean definition for custom file sorter with route_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file://inbox?sorter=#mySorter")
+    .to("bean:processInbox");
+----
+
+XML::
++
 [source,xml]
 ----
- <!-- define our sorter as a plain spring bean -->
- <bean id="mySorter" class="com.mycompany.MyFileSorter"/>
+<!-- define our sorter as a plain spring bean -->
+<bean id="mySorter" class="com.mycompany.MyFileSorter"/>
 
 <route>
   <from uri="file://inbox?sorter=#mySorter"/>
   <to uri="bean:processInbox"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: file://inbox
+    parameters:
+      sorter: "#mySorter"
+    steps:
+      - to:
+          uri: bean:processInbox
+----
+====
 
 [TIP]
 ====

--- a/components/camel-file/src/main/docs/file-component.adoc
+++ b/components/camel-file/src/main/docs/file-component.adoc
@@ -942,6 +942,18 @@ before they are being written to a directory.
 Using a single route, it is possible to write a file to any number of
 subdirectories. If you have a route setup as such:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("bean:myBean")
+    .to("file:/rootDirectory");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -949,6 +961,19 @@ subdirectories. If you have a route setup as such:
   <to uri="file:/rootDirectory"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: bean:myBean
+      steps:
+        - to:
+            uri: file:/rootDirectory
+----
+====
 
 You can have `myBean` set the header `Exchange.FILE_NAME` to values such
 as:
@@ -1044,6 +1069,18 @@ duplicate files. You can customize this key by
 using an expression in the idempotentKey option. For example, to use both
 the name and the file size as the key
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file://inbox?idempotent=true&idempotentKey=${file:name}-${file:size}")
+    .to("bean:processInbox");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -1051,6 +1088,22 @@ the name and the file size as the key
   <to uri="bean:processInbox"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: file://inbox
+      parameters:
+        idempotent: true
+        idempotentKey: "${file:name}-${file:size}"
+      steps:
+        - to:
+            uri: bean:processInbox
+----
+====
 
 By default, Camel uses an in-memory store for keeping track of
 consumed files.
@@ -1060,6 +1113,7 @@ the `idempotentRepository` option using the `#` sign in the value to
 indicate it's a referring to a bean in the Registry
 with the specified `id`.
 
+._XML-only: Spring bean definition for custom idempotent repository with route_
 [source,xml]
 ----
  <!-- define our store as a plain spring bean -->
@@ -1127,6 +1181,7 @@ need to use the class
 Next, we can create our JPA idempotent repository in the spring
 XML file as well:
 
+._XML-only: Spring bean definition for JPA-based idempotent repository_
 [source,xml]
 ----
 <!-- we define our jpa based idempotent repository we want to use in the file consumer -->
@@ -1143,6 +1198,18 @@ And yes then we just need to refer to the *jpaStore* bean in the file
 consumer endpoint using the `idempotentRepository` using the `#` syntax
 option:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file://inbox?idempotent=true&idempotentRepository=#jpaStore")
+    .to("bean:processInbox");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -1150,6 +1217,22 @@ option:
   <to uri="bean:processInbox"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: file://inbox
+      parameters:
+        idempotent: true
+        idempotentRepository: "#jpaStore"
+      steps:
+        - to:
+            uri: bean:processInbox
+----
+====
 
 === Filtering Strategies
 
@@ -1184,6 +1267,7 @@ And then we can configure our route using the `filter` attribute to
 reference our filter (using `#` notation) that we have defined in the
 spring XML file:
 
+._XML-only: Spring bean definition for custom file filter with route_
 [source,xml]
 ----
 <!-- define our filter as a plain spring bean -->
@@ -1256,6 +1340,7 @@ And then we can configure our route using the *sorter* option to
 reference to our sorter (`mySorter`) we have defined in the spring XML
 file:
 
+._XML-only: Spring bean definition for custom file sorter with route_
 [source,xml]
 ----
  <!-- define our sorter as a plain spring bean -->

--- a/components/camel-flatpack/src/main/docs/flatpack-component.adoc
+++ b/components/camel-flatpack/src/main/docs/flatpack-component.adoc
@@ -117,20 +117,52 @@ trailer. You can omit one or both of them if not needed.
 A common use case is sending a file to this endpoint for further
 processing in a separate route. For example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("file://someDirectory")
+    .to("flatpack:foo");
+
+from("flatpack:foo")
+    ...
+----
+
+XML::
++
 [source,xml]
 ----
-  <camelContext xmlns="http://activemq.apache.org/camel/schema/spring">
-    <route>
-      <from uri="file://someDirectory"/>
-      <to uri="flatpack:foo"/>
-    </route>
+<route>
+    <from uri="file://someDirectory"/>
+    <to uri="flatpack:foo"/>
+</route>
 
-    <route>
-      <from uri="flatpack:foo"/>
-      ...
-    </route>
-  </camelContext>
+<route>
+    <from uri="flatpack:foo"/>
+    ...
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: file://someDirectory
+      steps:
+        - to:
+            uri: flatpack:foo
+
+- route:
+    from:
+      uri: flatpack:foo
+      steps:
+        - ...
+----
+====
 
 You can also convert the payload of each message created to a `Map` for
 easy Bean Integration

--- a/components/camel-ftp/src/main/docs/ftp-component.adoc
+++ b/components/camel-ftp/src/main/docs/ftp-component.adoc
@@ -554,6 +554,18 @@ And then we can configure our route using the *filter* attribute to
 reference our filter (using `#` notation) that we have defined in the
 spring XML file:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("ftp://someuser@someftpserver.com?password=secret&filter=#myFilter")
+    .to("bean:processInbox");
+----
+
+XML::
++
 [source,xml]
 ----
    <!-- define our sorter as a plain spring bean -->
@@ -564,6 +576,22 @@ spring XML file:
     <to uri="bean:processInbox"/>
   </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: ftp://someuser@someftpserver.com
+      parameters:
+        password: secret
+        filter: "#myFilter"
+      steps:
+        - to:
+            uri: bean:processInbox
+----
+====
 
 ==== Filtering using ANT path matcher
 
@@ -621,6 +649,18 @@ YAML::
 To use an HTTP proxy to connect to your remote host, you can configure
 your route in the following way:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("sftp://localhost:9999/root?username=admin&password=admin&proxy=#proxy")
+    .to("bean:processFile");
+----
+
+XML::
++
 [source,xml]
 ----
 <!-- define our sorter as a plain spring bean -->
@@ -634,6 +674,23 @@ your route in the following way:
   <to uri="bean:processFile"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: sftp://localhost:9999/root
+      parameters:
+        username: admin
+        password: admin
+        proxy: "#proxy"
+      steps:
+        - to:
+            uri: bean:processFile
+----
+====
 
 You can also assign a username and password to the proxy, if necessary.
 Please consult the documentation for `com.jcraft.jsch.Proxy` to discover

--- a/components/camel-ftp/src/main/docs/sftp-component.adoc
+++ b/components/camel-ftp/src/main/docs/sftp-component.adoc
@@ -46,6 +46,7 @@ WARNING: By default, the SFTP component has `strictHostKeyChecking=no`, which di
 
 You can configure host key verification settings globally on the SFTP component, which will apply to all SFTP endpoints unless overridden at the endpoint level:
 
+._Java-only: programmatic `SftpComponent` configuration via `CamelContext`_
 [source,java]
 ----
 // Configure component for all SFTP endpoints
@@ -295,6 +296,7 @@ If you need to control the CA signature algorithms that JSch will accept, use th
 
 As of Camel 3.17.0, key types and algorithms that use SHA1 have been deprecated. These can be restored, if necessary, by setting JSch configuration directly. E.g.:
 
+._Java-only: restoring deprecated JSch key types and algorithms_
 [source,java]
 ----
 JSch.setConfig("server_host_key",  JSch.getConfig("server_host_key") + ",ssh-rsa");

--- a/components/camel-google/camel-google-firestore/src/main/docs/google-firestore-component.adoc
+++ b/components/camel-google/camel-google-firestore/src/main/docs/google-firestore-component.adoc
@@ -43,6 +43,8 @@ For more information, please refer to https://cloud.google.com/firestore/docs/qu
 When you have the **service account key**, you can provide authentication credentials to your application code.
 Google security credentials can be set through the component endpoint:
 
+._Java-only: constructing the endpoint URI programmatically_
+
 [source,java]
 ----
 String endpoint = "google-firestore://myCollection?serviceAccountKey=/home/user/Downloads/my-key.json&projectId=my-project";
@@ -950,6 +952,8 @@ For write operations (`setDocument`, `createDocument`, `updateDocument`), the co
 
 You can send a JSON string directly as the message body. The component will automatically parse it:
 
+._Java-only: JSON string input with text blocks_
+
 [source,java]
 ----
 // Simple JSON
@@ -981,24 +985,97 @@ from("direct:start")
 
 ==== Reading JSON from Files
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
-// Read JSON files and store in Firestore
 from("file:data/users?noop=true&include=.*\\.json")
     .setHeader("CamelGoogleFirestoreDocumentId", simple("${file:name.noext}"))
     .to("google-firestore://users?operation=setDocument")
     .log("Imported: ${file:name}");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="file:data/users?noop=true&amp;include=.*\.json"/>
+  <setHeader name="CamelGoogleFirestoreDocumentId">
+    <simple>${file:name.noext}</simple>
+  </setHeader>
+  <to uri="google-firestore://users?operation=setDocument"/>
+  <log message="Imported: ${file:name}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: file:data/users
+      parameters:
+        noop: true
+        include: ".*\\.json"
+      steps:
+        - setHeader:
+            name: CamelGoogleFirestoreDocumentId
+            simple: "${file:name.noext}"
+        - to:
+            uri: google-firestore://users
+            parameters:
+              operation: setDocument
+        - log:
+            message: "Imported: ${file:name}"
+----
+====
+
 ==== REST API Integration
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
-// Receive JSON from REST endpoint and store in Firestore
 from("rest:post:/api/users")
     .to("google-firestore://users?operation=createDocument")
     .setBody(simple("{\"id\": \"${header.CamelGoogleFirestoreResponseDocumentId}\"}"));
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="rest:post:/api/users"/>
+  <to uri="google-firestore://users?operation=createDocument"/>
+  <setBody>
+    <simple>{"id": "${header.CamelGoogleFirestoreResponseDocumentId}"}</simple>
+  </setBody>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: rest:post:/api/users
+      steps:
+        - to:
+            uri: google-firestore://users
+            parameters:
+              operation: createDocument
+        - setBody:
+            simple: '{"id": "${header.CamelGoogleFirestoreResponseDocumentId}"}'
+----
+====
 
 === Supported Firestore Data Types
 

--- a/components/camel-google/camel-google-functions/src/main/docs/google-functions-component.adoc
+++ b/components/camel-google/camel-google-functions/src/main/docs/google-functions-component.adoc
@@ -42,6 +42,8 @@ For more information, please refer to https://github.com/googleapis/google-cloud
 When you have the **service account key**, you can provide authentication credentials to your application code.
 Google security credentials can be set through the component endpoint:
 
+._Java-only: constructing the endpoint URI programmatically_
+
 [source,java]
 ----
 String endpoint = "google-functions://myCamelFunction?serviceAccountKey=/home/user/Downloads/my-key.json";

--- a/components/camel-google/camel-google-secret-manager/src/main/docs/google-secret-manager-component.adoc
+++ b/components/camel-google/camel-google-secret-manager/src/main/docs/google-secret-manager-component.adoc
@@ -152,6 +152,18 @@ When using the `operation` option to create, get, list secrets etc., you should 
 
 At this point you'll be able to reference a property in the following way by using `gcp:` as prefix in the `{{ }}` syntax:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{gcp:route}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -162,10 +174,35 @@ At this point you'll be able to reference a property in the following way by usi
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{gcp:route}}"
+----
+====
+
 Where `route` will be the name of the secret stored in the GCP Secret Manager Service.
 
 You could specify a default value in case the secret is not present on GCP Secret Manager:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{gcp:route:default}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -175,6 +212,19 @@ You could specify a default value in case the secret is not present on GCP Secre
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{gcp:route:default}}"
+----
+====
 
 In this case, if the secret doesn't exist, the property will fall back to `default` as value.
 
@@ -194,6 +244,18 @@ Also, you are able to get a particular field of the secret, if you have, for exa
 
 You're able to do get single secret value in your route, like for example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{gcp:database#username}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -204,10 +266,35 @@ You're able to do get single secret value in your route, like for example:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{gcp:database#username}}"
+----
+====
+
 Or re-use the property as part of an endpoint.
 
 You could specify a default value in case the particular field of secret is not present on GCP Secret Manager:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{gcp:database#username:admin}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -218,10 +305,35 @@ You could specify a default value in case the particular field of secret is not 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{gcp:database#username:admin}}"
+----
+====
+
 In this case, if the secret doesn't exist or the secret exists, but the username field is not part of the secret, the property will fall back to "admin" as value.
 
 There is also the syntax to get a particular version of the secret for both the approach, with field/default value specified or only with secret:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{gcp:route@1}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -232,8 +344,33 @@ There is also the syntax to get a particular version of the secret for both the 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{gcp:route@1}}"
+----
+====
+
 This approach will return the RAW route secret with version '1'.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{gcp:route:default@1}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -244,8 +381,33 @@ This approach will return the RAW route secret with version '1'.
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{gcp:route:default@1}}"
+----
+====
+
 This approach will return the route secret value with version '1' or default value in case the secret doesn't exist or the version doesn't exist.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{gcp:database#username:admin@1}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -255,6 +417,19 @@ This approach will return the route secret value with version '1' or default val
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{gcp:database#username:admin@1}}"
+----
+====
 
 This approach will return the username field of the database secret with version '1' or admin in case the secret doesn't exist or the version doesn't exist.
 

--- a/components/camel-google/camel-google-speech-to-text/src/main/docs/google-speech-to-text-component.adoc
+++ b/components/camel-google/camel-google-speech-to-text/src/main/docs/google-speech-to-text-component.adoc
@@ -41,6 +41,8 @@ For more information, please refer to https://github.com/googleapis/google-cloud
 When you have the **service account key**, you can provide authentication credentials to your application code.
 Google security credentials can be set through the component endpoint:
 
+._Java-only: constructing the endpoint URI programmatically_
+
 [source,java]
 ----
 String endpoint = "google-speech-to-text://recognize?serviceAccountKey=/home/user/Downloads/my-key.json";

--- a/components/camel-google/camel-google-storage/src/main/docs/google-storage-component.adoc
+++ b/components/camel-google/camel-google-storage/src/main/docs/google-storage-component.adoc
@@ -41,6 +41,8 @@ For more information, please refer to https://cloud.google.com/storage/docs/refe
 When you have the **service account key**, you can provide authentication credentials to your application code.
 Google security credentials can be set through the component endpoint:
 
+._Java-only: constructing the endpoint URI programmatically_
+
 [source,java]
 ----
 String endpoint = "google-storage://myCamelBucket?serviceAccountKey=/home/user/Downloads/my-key.json";

--- a/components/camel-google/camel-google-text-to-speech/src/main/docs/google-text-to-speech-component.adoc
+++ b/components/camel-google/camel-google-text-to-speech/src/main/docs/google-text-to-speech-component.adoc
@@ -41,6 +41,8 @@ For more information, please refer to https://github.com/googleapis/google-cloud
 When you have the **service account key**, you can provide authentication credentials to your application code.
 Google security credentials can be set through the component endpoint:
 
+._Java-only: constructing the endpoint URI programmatically_
+
 [source,java]
 ----
 String endpoint = "google-text-to-speech://synthesize?serviceAccountKey=/home/user/Downloads/my-key.json";

--- a/components/camel-google/camel-google-vision/src/main/docs/google-vision-component.adoc
+++ b/components/camel-google/camel-google-vision/src/main/docs/google-vision-component.adoc
@@ -41,6 +41,8 @@ For more information, please refer to https://github.com/googleapis/google-cloud
 When you have the **service account key**, you can provide authentication credentials to your application code.
 Google security credentials can be set through the component endpoint:
 
+._Java-only: constructing the endpoint URI programmatically_
+
 [source,java]
 ----
 String endpoint = "google-vision://labelDetection?serviceAccountKey=/home/user/Downloads/my-key.json";

--- a/components/camel-grok/src/main/docs/grok-dataformat.adoc
+++ b/components/camel-grok/src/main/docs/grok-dataformat.adoc
@@ -132,13 +132,9 @@ All https://github.com/thekrakken/java-grok/tree/master/src/main/resources/patte
 Camel Grok DataFormat supports plugable patterns, which are auto loaded from Camel Registry.
 You can register patterns with Java DSL and Spring DSL:
 
-[tabs]
-====
-
-Java DSL::
-+
+._Java-only: registering a custom Grok pattern in a `RouteBuilder`_
 [source,java]
---------------------------------------------------------------------------------
+----
 public class MyRouteBuilder extends RouteBuilder {
 
     @Override
@@ -150,30 +146,19 @@ public class MyRouteBuilder extends RouteBuilder {
             .to("log:out");
     }
 }
---------------------------------------------------------------------------------
+----
 
-Spring XML::
-+
+In Spring XML, you register the custom pattern as a bean:
+
 [source,xml]
---------------------------------------------------------------------------------
+----
 <beans>
     <bean id="myCustomPatternBean" class="org.apache.camel.component.grok.GrokPattern">
         <constructor-arg value="FOOBAR"/>
         <constructor-arg value="foo|bar"/>
     </bean>
-<beans>
-<camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
-    <route>
-        <from uri="direct:in"/>
-        <unmarshal>
-            <grok pattern="%{FOOBAR:fooBar}"/>
-        </unmarshal>
-        <to uri="log:out"/>
-    </route>
-</camelContext>
---------------------------------------------------------------------------------
-
-====
+</beans>
+----
 
 == Grok Data format Options
 

--- a/components/camel-grok/src/main/docs/grok-dataformat.adoc
+++ b/components/camel-grok/src/main/docs/grok-dataformat.adoc
@@ -150,6 +150,7 @@ public class MyRouteBuilder extends RouteBuilder {
 
 In Spring XML, you register the custom pattern as a bean:
 
+._XML-only: Spring XML bean registration_
 [source,xml]
 ----
 <beans>

--- a/components/camel-hashicorp-vault/src/main/docs/hashicorp-vault-component.adoc
+++ b/components/camel-hashicorp-vault/src/main/docs/hashicorp-vault-component.adoc
@@ -112,6 +112,18 @@ When using the `operation` option to create, get, list secrets etc., you should 
 
 At this point, you'll be able to reference a property in the following way:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{hashicorp:secret:route}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -122,10 +134,35 @@ At this point, you'll be able to reference a property in the following way:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{hashicorp:secret:route}}"
+----
+====
+
 Where route will be the name of the secret stored in the Hashicorp Vault instance, in the 'secret' engine.
 
 You could specify a default value in case the secret is not present on Hashicorp Vault instance:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{hashicorp:secret:route:default}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -135,6 +172,19 @@ You could specify a default value in case the secret is not present on Hashicorp
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{hashicorp:secret:route:default}}"
+----
+====
 
 In this case, if the secret doesn't exist in the 'secret' engine, the property will fall back to "default" as value.
 
@@ -154,6 +204,18 @@ Also, you are able to get a particular field of the secret, if you have, for exa
 
 You're able to do get single secret value in your route, in the 'secret' engine, like for example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{hashicorp:secret:database#username}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -164,10 +226,35 @@ You're able to do get single secret value in your route, in the 'secret' engine,
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{hashicorp:secret:database#username}}"
+----
+====
+
 Or re-use the property as part of an endpoint.
 
 You could specify a default value in case the particular field of secret is not present on Hashicorp Vault instance, in the 'secret' engine:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{hashicorp:secret:database#username:admin}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -178,10 +265,35 @@ You could specify a default value in case the particular field of secret is not 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{hashicorp:secret:database#username:admin}}"
+----
+====
+
 In this case, if the secret doesn't exist or the secret exists (in the 'secret' engine) but the username field is not part of the secret, the property will fall back to "admin" as value.
 
 There is also the syntax to get a particular version of the secret for both the approach, with field/default value specified or only with secret:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{hashicorp:secret:route@2}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -192,8 +304,33 @@ There is also the syntax to get a particular version of the secret for both the 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{hashicorp:secret:route@2}}"
+----
+====
+
 This approach will return the RAW route secret with version '2', in the 'secret' engine.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{hashicorp:route:default@2}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -204,8 +341,33 @@ This approach will return the RAW route secret with version '2', in the 'secret'
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{hashicorp:route:default@2}}"
+----
+====
+
 This approach will return the route secret value with version '2' or default value in case the secret doesn't exist or the version doesn't exist (in the 'secret' engine).
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{hashicorp:secret:database#username:admin@2}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -215,6 +377,19 @@ This approach will return the route secret value with version '2' or default val
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{hashicorp:secret:database#username:admin@2}}"
+----
+====
 
 This approach will return the username field of the database secret with version '2' or admin in case the secret doesn't exist or the version doesn't exist (in the 'secret' engine).
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
@@ -51,29 +51,42 @@ The operations for this producer are:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
------------------------------------------------------------------------------------------
+----
 from("direct:set")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE))
-.toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
------------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE))
+    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:set" />
+    <from uri="direct:set"/>
     <setHeader name="hazelcast.operation.type">
         <constant>setvalue</constant>
     </setHeader>
-    <to uri="hazelcast-atomicvalue:foo" />
+    <to uri="hazelcast-atomicvalue:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:set
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: setvalue
+        - to:
+            uri: hazelcast-atomicvalue:foo
+----
 ====
 
 Provide the value to set inside the message body (here the value is 10):
@@ -83,29 +96,42 @@ Provide the value to set inside the message body (here the value is 10):
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
-------------------------------------------------------------------------------------
+----
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-.toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
-------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
+    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:get" />
+    <from uri="direct:get"/>
     <setHeader name="hazelcast.operation.type">
         <constant>get</constant>
     </setHeader>
-    <to uri="hazelcast-atomicvalue:foo" />
+    <to uri="hazelcast-atomicvalue:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: get
+        - to:
+            uri: hazelcast-atomicvalue:foo
+----
 ====
 
 You can get the number with
@@ -115,30 +141,42 @@ You can get the number with
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
-
 [source,java]
-------------------------------------------------------------------------------------------
+----
 from("direct:increment")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
-.toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
-------------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
+    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:increment" />
+    <from uri="direct:increment"/>
     <setHeader name="hazelcast.operation.type">
         <constant>increment</constant>
     </setHeader>
-    <to uri="hazelcast-atomicvalue:foo" />
+    <to uri="hazelcast-atomicvalue:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:increment
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: increment
+        - to:
+            uri: hazelcast-atomicvalue:foo
+----
 ====
 
 The actual value (after increment) will be provided inside the message
@@ -148,30 +186,42 @@ body.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
-
 [source,java]
-------------------------------------------------------------------------------------------
+----
 from("direct:decrement")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
-.toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
-------------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
+    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:decrement" />
+    <from uri="direct:decrement"/>
     <setHeader name="hazelcast.operation.type">
         <constant>decrement</constant>
     </setHeader>
-    <to uri="hazelcast-atomicvalue:foo" />
+    <to uri="hazelcast-atomicvalue:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:decrement
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: decrement
+        - to:
+            uri: hazelcast-atomicvalue:foo
+----
 ====
 
 The actual value (after decrement) will be provided inside the message
@@ -181,30 +231,42 @@ body.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
-
 [source,java]
-----------------------------------------------------------------------------------------
+----
 from("direct:destroy")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
-.toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
-----------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
+    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:destroy" />
+    <from uri="direct:destroy"/>
     <setHeader name="hazelcast.operation.type">
         <constant>destroy</constant>
     </setHeader>
-    <to uri="hazelcast-atomicvalue:foo" />
+    <to uri="hazelcast-atomicvalue:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:destroy
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: destroy
+        - to:
+            uri: hazelcast-atomicvalue:foo
+----
 ====
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
@@ -50,6 +50,7 @@ The map cache producer provides follow operations specified by *CamelHazelcastOp
 
 You can call the samples with:
 
+._Java-only: calling producer operations using ProducerTemplate_
 [source,java]
 ----
 template.sendBodyAndHeader("direct:[put|get|update|delete|query|evict]", "my-foo", HazelcastConstants.OBJECT_ID, "4711");
@@ -59,8 +60,7 @@ template.sendBodyAndHeader("direct:[put|get|update|delete|query|evict]", "my-foo
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
@@ -69,29 +69,41 @@ from("direct:put")
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:put" />
-    <setHeader name="hazelcast.operation.type">
+    <from uri="direct:put"/>
+    <setHeader name="CamelHazelcastOperationType">
         <constant>put</constant>
     </setHeader>
-    <to uri="hazelcast-map:foo" />
+    <to uri="hazelcast-map:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:put
+      steps:
+        - setHeader:
+            name: CamelHazelcastOperationType
+            constant: put
+        - to:
+            uri: hazelcast-map:foo
+----
 ====
 
 Sample for *put* with eviction:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
-
 [source,java]
 ----
 from("direct:put")
@@ -101,33 +113,52 @@ from("direct:put")
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:put" />
-    <setHeader name="hazelcast.operation.type">
+    <from uri="direct:put"/>
+    <setHeader name="CamelHazelcastOperationType">
         <constant>put</constant>
     </setHeader>
-    <setHeader name="HazelcastConstants.TTL_VALUE">
-        <simple resultType="java.lang.Long">1</simple>
+    <setHeader name="CamelHazelcastObjectTtlValue">
+        <constant>1</constant>
     </setHeader>
-    <setHeader name="HazelcastConstants.TTL_UNIT">
-        <simple resultType="java.util.concurrent.TimeUnit">TimeUnit.MINUTES</simple>
+    <setHeader name="CamelHazelcastObjectTtlUnit">
+        <constant>MINUTES</constant>
     </setHeader>
-    <to uri="hazelcast-map:foo" />
+    <to uri="hazelcast-map:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:put
+      steps:
+        - setHeader:
+            name: CamelHazelcastOperationType
+            constant: put
+        - setHeader:
+            name: CamelHazelcastObjectTtlValue
+            constant: 1
+        - setHeader:
+            name: CamelHazelcastObjectTtlUnit
+            constant: MINUTES
+        - to:
+            uri: hazelcast-map:foo
+----
 ====
 
 === Example for *get*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
@@ -137,28 +168,43 @@ from("direct:get")
 .to("seda:out");
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:get" />
-    <setHeader name="hazelcast.operation.type">
+    <from uri="direct:get"/>
+    <setHeader name="CamelHazelcastOperationType">
         <constant>get</constant>
     </setHeader>
-    <to uri="hazelcast-map:foo" />
-    <to uri="seda:out" />
+    <to uri="hazelcast-map:foo"/>
+    <to uri="seda:out"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get
+      steps:
+        - setHeader:
+            name: CamelHazelcastOperationType
+            constant: get
+        - to:
+            uri: hazelcast-map:foo
+        - to:
+            uri: seda:out
+----
 ====
 
 === Example for *update*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
@@ -167,29 +213,41 @@ from("direct:update")
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:update" />
-    <setHeader name="hazelcast.operation.type">
+    <from uri="direct:update"/>
+    <setHeader name="CamelHazelcastOperationType">
         <constant>update</constant>
     </setHeader>
-    <to uri="hazelcast-map:foo" />
+    <to uri="hazelcast-map:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:update
+      steps:
+        - setHeader:
+            name: CamelHazelcastOperationType
+            constant: update
+        - to:
+            uri: hazelcast-map:foo
+----
 ====
 
 === Example for *delete*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
-
 [source,java]
 ----
 from("direct:delete")
@@ -197,27 +255,40 @@ from("direct:delete")
 .toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:delete" />
-    <setHeader name="hazelcast.operation.type">
+    <from uri="direct:delete"/>
+    <setHeader name="CamelHazelcastOperationType">
         <constant>delete</constant>
     </setHeader>
-    <to uri="hazelcast-map:foo" />
+    <to uri="hazelcast-map:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:delete
+      steps:
+        - setHeader:
+            name: CamelHazelcastOperationType
+            constant: delete
+        - to:
+            uri: hazelcast-map:foo
+----
 ====
 
 === Example for *query*
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
@@ -227,25 +298,42 @@ from("direct:query")
 .to("seda:out");
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:query" />
-    <setHeader name="hazelcast.operation.type">
+    <from uri="direct:query"/>
+    <setHeader name="CamelHazelcastOperationType">
         <constant>query</constant>
     </setHeader>
-    <to uri="hazelcast-map:foo" />
-    <to uri="seda:out" />
+    <to uri="hazelcast-map:foo"/>
+    <to uri="seda:out"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:query
+      steps:
+        - setHeader:
+            name: CamelHazelcastOperationType
+            constant: query
+        - to:
+            uri: hazelcast-map:foo
+        - to:
+            uri: seda:out
+----
 ====
 
 For the query operation Hazelcast offers an SQL like syntax to query your
 distributed map.
 
+._Java-only: sending a query predicate using ProducerTemplate_
 [source,java]
 ----
 String q1 = "bar > 1000";

--- a/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
@@ -46,61 +46,86 @@ The  multimap producer provides eight operations:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
-.to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
+    .to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:put" />
+    <from uri="direct:put"/>
     <log message="put.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>put</constant>
     </setHeader>
-    <to uri="hazelcast-multimap:foo" />
+    <to uri="hazelcast-multimap:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:put
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: put
+        - to:
+            uri: hazelcast-multimap:foo
+----
 ====
 
 === Example for *removevalue*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
-
 [source,java]
 ----
 from("direct:removevalue")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
-.toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
+    .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:removevalue" />
+    <from uri="direct:removevalue"/>
     <log message="removevalue..."/>
     <setHeader name="hazelcast.operation.type">
         <constant>removevalue</constant>
     </setHeader>
-    <to uri="hazelcast-multimap:foo" />
+    <to uri="hazelcast-multimap:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:removevalue
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: removevalue
+        - to:
+            uri: hazelcast-multimap:foo
+----
 ====
 
 To remove a value you have to provide the value you want to remove
@@ -112,66 +137,95 @@ inside the message body to remove the `my-foo` value.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-.toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX)
-.to("seda:out");
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
+    .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX)
+    .to("seda:out");
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:get" />
+    <from uri="direct:get"/>
     <log message="get.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>get</constant>
     </setHeader>
-    <to uri="hazelcast-multimap:foo" />
-    <to uri="seda:out" />
+    <to uri="hazelcast-multimap:foo"/>
+    <to uri="seda:out"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: get
+        - to:
+            uri: hazelcast-multimap:foo
+        - to:
+            uri: seda:out
+----
 ====
 
 === Example for *delete*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
 from("direct:delete")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
-.toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
+    .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:delete" />
+    <from uri="direct:delete"/>
     <log message="delete.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>delete</constant>
     </setHeader>
-    <to uri="hazelcast-multimap:foo" />
+    <to uri="hazelcast-multimap:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:delete
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: delete
+        - to:
+            uri: hazelcast-multimap:foo
+----
 ====
 
 You can call them in your test class with:
 
+._Java-only: uses ProducerTemplate API and Java constants_
 [source,java]
 ----
 template.sendBodyAndHeader("direct:[put|get|removevalue|delete]", "my-foo", HazelcastConstants.OBJECT_ID, "4711");

--- a/components/camel-hazelcast/src/main/docs/hazelcast-pncounter-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-pncounter-component.adoc
@@ -44,29 +44,42 @@ NOTE: PNCounter is a CRDT (Conflict-free Replicated Data Type) that provides eve
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
-------------------------------------------------------------------------------------------
+----
 from("direct:increment")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
-.toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
-------------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
+    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:increment" />
+    <from uri="direct:increment"/>
     <setHeader name="hazelcast.operation.type">
         <constant>increment</constant>
     </setHeader>
-    <to uri="hazelcast-pncounter:foo" />
+    <to uri="hazelcast-pncounter:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:increment
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: increment
+        - to:
+            uri: hazelcast-pncounter:foo
+----
 ====
 
 The actual value (after increment) will be provided inside the message body.
@@ -75,29 +88,42 @@ The actual value (after increment) will be provided inside the message body.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
-------------------------------------------------------------------------------------------
+----
 from("direct:decrement")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
-.toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
-------------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
+    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:decrement" />
+    <from uri="direct:decrement"/>
     <setHeader name="hazelcast.operation.type">
         <constant>decrement</constant>
     </setHeader>
-    <to uri="hazelcast-pncounter:foo" />
+    <to uri="hazelcast-pncounter:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:decrement
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: decrement
+        - to:
+            uri: hazelcast-pncounter:foo
+----
 ====
 
 The actual value (after decrement) will be provided inside the message body.
@@ -106,29 +132,42 @@ The actual value (after decrement) will be provided inside the message body.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
-------------------------------------------------------------------------------------
+----
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-.toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
-------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
+    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:get" />
+    <from uri="direct:get"/>
     <setHeader name="hazelcast.operation.type">
         <constant>get</constant>
     </setHeader>
-    <to uri="hazelcast-pncounter:foo" />
+    <to uri="hazelcast-pncounter:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: get
+        - to:
+            uri: hazelcast-pncounter:foo
+----
 ====
 
 You can get the counter value with
@@ -138,29 +177,42 @@ You can get the counter value with
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
-------------------------------------------------------------------------------------
+----
 from("direct:getAndAdd")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET_AND_ADD))
-.toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
-------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET_AND_ADD))
+    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:getAndAdd" />
+    <from uri="direct:getAndAdd"/>
     <setHeader name="hazelcast.operation.type">
         <constant>getAndAdd</constant>
     </setHeader>
-    <to uri="hazelcast-pncounter:foo" />
+    <to uri="hazelcast-pncounter:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:getAndAdd
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: getAndAdd
+        - to:
+            uri: hazelcast-pncounter:foo
+----
 ====
 
 Provide the delta value in the message body (e.g., 5 to add 5 to the counter):
@@ -172,29 +224,42 @@ The previous value (before the add) will be returned in the message body.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
-------------------------------------------------------------------------------------
+----
 from("direct:destroy")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
-.toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
-------------------------------------------------------------------------------------
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
+    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------------------------------------------------------------------
+----
 <route>
-    <from uri="direct:destroy" />
+    <from uri="direct:destroy"/>
     <setHeader name="hazelcast.operation.type">
         <constant>destroy</constant>
     </setHeader>
-    <to uri="hazelcast-pncounter:foo" />
+    <to uri="hazelcast-pncounter:foo"/>
 </route>
------------------------------------------------------------------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:destroy
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: destroy
+        - to:
+            uri: hazelcast-pncounter:foo
+----
 ====
 
 Destroys the PN Counter instance:

--- a/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
@@ -41,90 +41,132 @@ The replicatedmap producer provides 6 operations:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
-.to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
+    .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:put" />
+    <from uri="direct:put"/>
     <log message="put.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>put</constant>
     </setHeader>
-    <to uri="hazelcast-replicatedmap:foo" />
+    <to uri="hazelcast-replicatedmap:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:put
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: put
+        - to:
+            uri: hazelcast-replicatedmap:foo
+----
 ====
 
 === Example for *get*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-.toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX)
-.to("seda:out");
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
+    .toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX)
+    .to("seda:out");
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:get" />
+    <from uri="direct:get"/>
     <log message="get.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>get</constant>
     </setHeader>
-    <to uri="hazelcast-replicatedmap:foo" />
-    <to uri="seda:out" />
+    <to uri="hazelcast-replicatedmap:foo"/>
+    <to uri="seda:out"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: get
+        - to:
+            uri: hazelcast-replicatedmap:foo
+        - to:
+            uri: seda:out
+----
 ====
 
 === Example for *delete*:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
 from("direct:delete")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
-.toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX);
+    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
+    .toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX);
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:delete" />
+    <from uri="direct:delete"/>
     <log message="delete.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>delete</constant>
     </setHeader>
-    <to uri="hazelcast-replicatedmap:foo" />
+    <to uri="hazelcast-replicatedmap:foo"/>
 </route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:delete
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: delete
+        - to:
+            uri: hazelcast-replicatedmap:foo
 ----
 ====
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
@@ -40,8 +40,7 @@ The ringbuffer producer provides 5 operations:
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
 ----
@@ -50,20 +49,34 @@ from("direct:put")
 .to(String.format("hazelcast-%sbar", HazelcastConstants.RINGBUFFER_PREFIX));
 ----
 
-Spring XML::
+XML::
 +
 [source,xml]
 ----
 <route>
-    <from uri="direct:put" />
+    <from uri="direct:put"/>
     <log message="put.."/>
     <setHeader name="hazelcast.operation.type">
         <constant>add</constant>
     </setHeader>
-    <to uri="hazelcast-ringbuffer:foo" />
+    <to uri="hazelcast-ringbuffer:foo"/>
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:put
+      steps:
+        - setHeader:
+            name: hazelcast.operation.type
+            constant: add
+        - to:
+            uri: hazelcast-ringbuffer:foo
+----
 ====
 
 === Example for *readonce from head*:

--- a/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-seda-component.adoc
@@ -33,25 +33,35 @@ specified queue.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
---------------------------
+----
 from("direct:foo")
-.to("hazelcast-seda:foo");
---------------------------
+    .to("hazelcast-seda:foo");
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
-----------------------------------
+----
 <route>
-   <from uri="direct:start" />
-   <to uri="hazelcast-seda:foo" />
+  <from uri="direct:start"/>
+  <to uri="hazelcast-seda:foo"/>
 </route>
-----------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:foo
+      steps:
+        - to:
+            uri: hazelcast-seda:foo
+----
 ====
 
 == SEDA consumer – from(“hazelcast-seda:foo”)
@@ -61,25 +71,35 @@ the specified queue.
 
 [tabs]
 ====
-
-Java DSL::
+Java::
 +
 [source,java]
---------------------------
+----
 from("hazelcast-seda:foo")
-.to("mock:result");
---------------------------
+    .to("mock:result");
+----
 
-Spring XML::
+XML::
 +
 [source,xml]
------------------------------------
+----
 <route>
-  <from uri="hazelcast-seda:foo" />
-  <to uri="mock:result" />
+  <from uri="hazelcast-seda:foo"/>
+  <to uri="mock:result"/>
 </route>
------------------------------------
+----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: hazelcast-seda:foo
+      steps:
+        - to:
+            uri: mock:result
+----
 ====
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-summary.adoc
@@ -46,8 +46,9 @@ for this component:
 
 === By its name
 
+._XML-only: Spring bean configuration with Hazelcast instance by name_
 [source,xml]
---------------------------------------------------------------------------------------------------------
+----
 <bean id="hazelcastLifecycle" class="com.hazelcast.core.LifecycleService"
       factory-bean="hazelcastInstance" factory-method="getLifecycleService"
       destroy-method="shutdown" />
@@ -77,12 +78,13 @@ for this component:
         <to uri="seda:out" />
     </route>
 </camelContext>
---------------------------------------------------------------------------------------------------------
+----
 
 === By instance
 
+._XML-only: Spring bean configuration with Hazelcast instance by reference_
 [source,xml]
-------------------------------------------------------------------------------
+----
 <bean id="hazelcastInstance" class="com.hazelcast.core.Hazelcast"
       factory-method="newHazelcastInstance" />
 <bean id="hazelcastLifecycle" class="com.hazelcast.core.LifecycleService"
@@ -107,7 +109,7 @@ for this component:
         <to uri="seda:out" />
     </route>
 </camelContext>
-------------------------------------------------------------------------------
+----
 
 === Configuring HazelcastInstance on component
 

--- a/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
+++ b/components/camel-hl7/src/main/docs/hl7-dataformat.adoc
@@ -78,6 +78,7 @@ segment terminators. The HAPI library requires the use of `\r`.
 In the Spring XML file, we configure a mina endpoint to listen for HL7
 requests using TCP on port `8888`:
 
+._XML-only: Spring XML endpoint declaration for HL7 Mina listener_
 [source,xml]
 ----
 <endpoint id="hl7MinaListener" uri="mina:tcp://localhost:8888?sync=true&amp;codec=#hl7codec"/>
@@ -89,6 +90,7 @@ will return a HL7 response to the caller. The HL7 codec is set up with
 could be named `mygreatcodecforhl7` or whatever. The codec is also set
 up in the Spring XML file:
 
+._XML-only: Spring bean declaration for HL7 MLLP codec_
 [source,xml]
 ----
 <bean id="hl7codec" class="org.apache.camel.component.hl7.HL7MLLPCodec">
@@ -110,6 +112,7 @@ This is a basic route that will listen for HL7 and route it to a
 service named *patientLookupService*. This is also Spring bean ID,
 configured in the Spring XML as:
 
+._XML-only: Spring bean declaration for the patient lookup service_
 [source,xml]
 ----
 <bean id="patientLookupService" class="com.mycompany.healthcare.service.PatientLookupService"/>
@@ -141,6 +144,7 @@ public class PatientLookupService {
 In the Spring XML file, we configure a netty endpoint to listen for HL7
 requests using TCP on port `8888`:
 
+._XML-only: Spring XML endpoint declaration for HL7 Netty listener_
 [source,xml]
 ----
 <endpoint id="hl7NettyListener" uri="netty:tcp://localhost:8888?sync=true&amp;encoders=#hl7encoder&amp;decoders=#hl7decoder"/>
@@ -152,6 +156,7 @@ will return a HL7 response to the caller. The HL7 codec is set up with
 and `hl7decoder` are just bean IDs, so they could be named differently.
 The beans can be set in the Spring XML file:
 
+._XML-only: Spring bean declarations for HL7 Netty encoder and decoder_
 [source,xml]
 ----
 <bean id="hl7decoder" class="org.apache.camel.component.hl7.HL7MLLPNettyDecoderFactory"/>

--- a/components/camel-http/src/main/docs/http-component.adoc
+++ b/components/camel-http/src/main/docs/http-component.adoc
@@ -429,6 +429,7 @@ context.getGlobalOptions().put("http.proxyPort", "8080");
 
 Spring XML
 
+._XML-only: Spring XML global options configuration (deprecated)_
 [source,xml]
 ----
 <camelContext>
@@ -722,6 +723,7 @@ httpComponent.setSslContextParameters(scp);
 
 Spring DSL based configuration of endpoint
 
+._XML-only: Spring XML SSL context parameters and endpoint reference_
 [source,xml]
 ----
   <camel:sslContextParameters
@@ -779,6 +781,7 @@ httpComponent.setHttpClientConfigurer(new MyHttpClientConfigurer());
 If you are doing this using the Spring DSL, you can specify your
 `HttpClientConfigurer` using the URI. For example:
 
+._XML-only: Spring bean and endpoint reference for `HttpClientConfigurer`_
 [source,xml]
 ----
 <bean id="myHttpClientConfigurer"
@@ -834,6 +837,7 @@ public class HttpContextFactory {
 
 * 2. Declare an` HttpContext` in the Spring application context file:
 
+._XML-only: Spring bean declaration for `HttpContext` factory_
 [source,xml]
 ----
 <bean id="myHttpContext" factory-bean="httpContextFactory" factory-method="getObject"/>
@@ -841,6 +845,7 @@ public class HttpContextFactory {
 
 * 3. Reference the context in the http URL:
 
+._XML-only: endpoint URI referencing the `HttpContext` bean_
 [source,xml]
 ----
 <to uri="https://myhostname.com:443/myURL?httpContext=myHttpContext"/>
@@ -856,6 +861,7 @@ multiple xref:http-component.adoc[HTTP] components as shown below. Where we have
 two components, each using their own instance of `sslContextParameters`
 property.
 
+._XML-only: Spring bean declarations for multiple HTTP components with different SSL contexts_
 [source,xml]
 ----
 <bean id="http-foo" class="org.apache.camel.component.http.HttpComponent">

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/docs/ibm-secrets-manager-component.adoc
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/docs/ibm-secrets-manager-component.adoc
@@ -376,6 +376,18 @@ When using the `operation` option to create, get, list secrets etc., you should 
 
 At this point, you'll be able to reference a property in the following way:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{ibm:default:route}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -386,10 +398,35 @@ At this point, you'll be able to reference a property in the following way:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{ibm:default:route}}"
+----
+====
+
 Where route will be the name of the secret stored in the IBM Secrets Manager Vault instance, in the 'default' secret group.
 
 You could specify a default value in case the secret is not present on IBM Secrets Manager Vault instance:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{ibm:default:route:default}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -399,6 +436,19 @@ You could specify a default value in case the secret is not present on IBM Secre
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{ibm:default:route:default}}"
+----
+====
 
 In this case, if the secret doesn't exist in the 'default' secret group, the property will fall back to "default" as value.
 
@@ -418,6 +468,18 @@ Also, you are able to get a particular field of the secret, if you have, for exa
 
 You're able to do get single secret value in your route, in the 'default' secret group, like for example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{ibm:default:database#username}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -428,10 +490,35 @@ You're able to do get single secret value in your route, in the 'default' secret
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{ibm:default:database#username}}"
+----
+====
+
 Or re-use the property as part of an endpoint.
 
 You could specify a default value in case the particular field of secret is not present on IBM Secrets Manager Vault instance, in the 'secret' engine:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{ibm:default:database#username:admin}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -442,10 +529,35 @@ You could specify a default value in case the particular field of secret is not 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{ibm:default:database#username:admin}}"
+----
+====
+
 In this case, if the secret doesn't exist or the secret exists (in the 'default' secret group) but the username field is not part of the secret, the property will fall back to "admin" as value.
 
 There is also the syntax to get a particular version of the secret for both the approaches, with field/default value specified or only with secret:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{ibm:default:route@2}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -456,8 +568,33 @@ There is also the syntax to get a particular version of the secret for both the 
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{ibm:default:route@2}}"
+----
+====
+
 This approach will return the RAW route secret with version '2', in the 'default' secret group.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("{{ibm:default:route:default@2}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -468,8 +605,33 @@ This approach will return the RAW route secret with version '2', in the 'default
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: "{{ibm:default:route:default@2}}"
+----
+====
+
 This approach will return the route secret value with version '2' or default value in case the secret doesn't exist or the version doesn't exist (in the 'default' secret group).
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("Username is {{ibm:default:database#username:admin@2}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -479,6 +641,19 @@ This approach will return the route secret value with version '2' or default val
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "Username is {{ibm:default:database#username:admin@2}}"
+----
+====
 
 This approach will return the username field of the database secret with version '2' or admin in case the secret doesn't exist or the version doesn't exist (in the 'default' secret group).
 

--- a/components/camel-jackson3xml/src/main/docs/jacksonXml3-dataformat.adoc
+++ b/components/camel-jackson3xml/src/main/docs/jacksonXml3-dataformat.adoc
@@ -98,15 +98,42 @@ declare the data formats first. This is done in the `dataFormats` XML tag:
 
 And then you can refer to this id in the route:
 
-._XML-only: using a named data format reference in a route_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:back")
+    .unmarshal("jack")
+    .to("mock:reverse");
+----
+
+XML::
++
 [source,xml]
 ----
-       <route>
-            <from uri="direct:back"/>
-            <unmarshal><custom ref="jack"/></unmarshal>
-            <to uri="mock:reverse"/>
-        </route>
+<route>
+    <from uri="direct:back"/>
+    <unmarshal><custom ref="jack"/></unmarshal>
+    <to uri="mock:reverse"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:back
+      steps:
+        - unmarshal:
+            ref: jack
+        - to:
+            uri: mock:reverse
+----
+====
 
 === Excluding POJO fields from marshalling
 
@@ -151,18 +178,45 @@ from("direct:inPojoAgeView")
   .marshal().jacksonXml(TestPojoView.class, Views.Age.class);
 ----
 
-And the same in XML DSL:
+And the same in the route DSL:
 
-._XML-only: specifying jsonView attribute on jacksonXml data format_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:inPojoAgeView")
+    .marshal().jacksonXml(TestPojoView.class, Views.Age.class);
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
-<from uri="direct:inPojoAgeView"/>
+    <from uri="direct:inPojoAgeView"/>
     <marshal>
-      <jacksonXml unmarshalType="org.apache.camel.component.jackson3xml.TestPojoView" jsonView="org.apache.camel.component.jackson3xml.Views$Age"/>
+        <jacksonXml unmarshalType="org.apache.camel.component.jackson3xml.TestPojoView"
+                    jsonView="org.apache.camel.component.jackson3xml.Views$Age"/>
     </marshal>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:inPojoAgeView
+      steps:
+        - marshal:
+            jacksonXml:
+              unmarshalType: org.apache.camel.component.jackson3xml.TestPojoView
+              jsonView: org.apache.camel.component.jackson3xml.Views$Age
+----
+====
 
 === Setting serialization include option
 

--- a/components/camel-jackson3xml/src/main/docs/jacksonXml3-dataformat.adoc
+++ b/components/camel-jackson3xml/src/main/docs/jacksonXml3-dataformat.adoc
@@ -86,6 +86,7 @@ include::partial$dataformat-options.adoc[]
 When using Data Format in Spring DSL, you need to
 declare the data formats first. This is done in the `dataFormats` XML tag:
 
+._XML-only: declaring a named data format in Spring XML_
 [source,xml]
 ----
         <dataFormats>
@@ -97,6 +98,7 @@ declare the data formats first. This is done in the `dataFormats` XML tag:
 
 And then you can refer to this id in the route:
 
+._XML-only: using a named data format reference in a route_
 [source,xml]
 ----
        <route>
@@ -151,6 +153,7 @@ from("direct:inPojoAgeView")
 
 And the same in XML DSL:
 
+._XML-only: specifying jsonView attribute on jacksonXml data format_
 [source,xml]
 ----
 <route>
@@ -189,6 +192,7 @@ format.setInclude("NON_NULL");
 
 Or from XML DSL you configure this as
 
+._XML-only: configuring include option in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -217,6 +221,7 @@ format.setAllowJmsType(true);
 
 Or from XML DSL you configure this as:
 
+._XML-only: configuring allowJmsType in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -245,6 +250,7 @@ format.setUnmarshalType(MyPojo.class);
 And if you use XML DSL then you configure to use a list
 using `useList` attribute as shown below:
 
+._XML-only: configuring useList in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -254,6 +260,7 @@ using `useList` attribute as shown below:
 
 And you can specify the POJO type also
 
+._XML-only: configuring useList with unmarshalType in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -266,6 +273,7 @@ And you can specify the POJO type also
 You can use custom Jackson modules by specifying the class names of
 those using the moduleClassNames option as shown below.
 
+._XML-only: configuring moduleClassNames in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -279,12 +287,13 @@ custom module needs any custom configuration, then an instance of the
 module can be created and configured, and then use modulesRefs to refer
 to the module as shown below:
 
+._XML-only: configuring moduleRefs with bean declaration in Spring XML_
 [source,xml]
 ----
 <bean id="myJacksonModule" class="com.foo.MyModule">
   ... // configure the module as you want
 </bean>
- 
+
 <dataFormats>
     <jacksonXml id="jacksonxml" useList="true" unmarshalType="com.foo.MyPojo" moduleRefs="myJacksonModule"/>
 </dataFormats>
@@ -299,6 +308,7 @@ XmlMapper uses.
 For example, to disable failing on unknown properties
 when marshalling, you can configure this using the disableFeatures:
 
+._XML-only: configuring disableFeatures in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -355,6 +365,7 @@ Otherwise, the default mapper will be used.
 Using the `prettyPrint` option one can output a well-formatted XML while
 marshalling:
 
+._XML-only: configuring prettyPrint in Spring XML_
 [source,xml]
 ----
 <dataFormats>

--- a/components/camel-jacksonxml/src/main/docs/jacksonXml2-dataformat.adoc
+++ b/components/camel-jacksonxml/src/main/docs/jacksonXml2-dataformat.adoc
@@ -98,15 +98,42 @@ declare the data formats first. This is done in the `dataFormats` XML tag:
 
 And then you can refer to this id in the route:
 
-._XML-only: using a named data format reference in a route_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:back")
+    .unmarshal("jack")
+    .to("mock:reverse");
+----
+
+XML::
++
 [source,xml]
 ----
-       <route>
-            <from uri="direct:back"/>
-            <unmarshal><custom ref="jack"/></unmarshal>
-            <to uri="mock:reverse"/>
-        </route>
+<route>
+    <from uri="direct:back"/>
+    <unmarshal><custom ref="jack"/></unmarshal>
+    <to uri="mock:reverse"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:back
+      steps:
+        - unmarshal:
+            ref: jack
+        - to:
+            uri: mock:reverse
+----
+====
 
 === Excluding POJO fields from marshalling
 
@@ -151,18 +178,45 @@ from("direct:inPojoAgeView")
   .marshal().jacksonXml(TestPojoView.class, Views.Age.class);
 ----
 
-And the same in XML DSL:
+And the same in the route DSL:
 
-._XML-only: specifying jsonView attribute on jacksonXml data format_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:inPojoAgeView")
+    .marshal().jacksonXml(TestPojoView.class, Views.Age.class);
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
-<from uri="direct:inPojoAgeView"/>
+    <from uri="direct:inPojoAgeView"/>
     <marshal>
-      <jacksonXml unmarshalType="org.apache.camel.component.jacksonxml.TestPojoView" jsonView="org.apache.camel.component.jacksonxml.Views$Age"/>
+        <jacksonXml unmarshalType="org.apache.camel.component.jacksonxml.TestPojoView"
+                    jsonView="org.apache.camel.component.jacksonxml.Views$Age"/>
     </marshal>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:inPojoAgeView
+      steps:
+        - marshal:
+            jacksonXml:
+              unmarshalType: org.apache.camel.component.jacksonxml.TestPojoView
+              jsonView: org.apache.camel.component.jacksonxml.Views$Age
+----
+====
 
 === Setting serialization include option
 

--- a/components/camel-jacksonxml/src/main/docs/jacksonXml2-dataformat.adoc
+++ b/components/camel-jacksonxml/src/main/docs/jacksonXml2-dataformat.adoc
@@ -86,6 +86,7 @@ include::partial$dataformat-options.adoc[]
 When using Data Format in Spring DSL, you need to
 declare the data formats first. This is done in the `dataFormats` XML tag:
 
+._XML-only: declaring a named data format in Spring XML_
 [source,xml]
 ----
         <dataFormats>
@@ -97,6 +98,7 @@ declare the data formats first. This is done in the `dataFormats` XML tag:
 
 And then you can refer to this id in the route:
 
+._XML-only: using a named data format reference in a route_
 [source,xml]
 ----
        <route>
@@ -151,6 +153,7 @@ from("direct:inPojoAgeView")
 
 And the same in XML DSL:
 
+._XML-only: specifying jsonView attribute on jacksonXml data format_
 [source,xml]
 ----
 <route>
@@ -189,6 +192,7 @@ format.setInclude("NON_NULL");
 
 Or from XML DSL you configure this as
 
+._XML-only: configuring include option in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -217,6 +221,7 @@ format.setAllowJmsType(true);
 
 Or from XML DSL you configure this as:
 
+._XML-only: configuring allowJmsType in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -245,6 +250,7 @@ format.setUnmarshalType(MyPojo.class);
 And if you use XML DSL then you configure to use a list
 using `useList` attribute as shown below:
 
+._XML-only: configuring useList in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -254,6 +260,7 @@ using `useList` attribute as shown below:
 
 And you can specify the POJO type also
 
+._XML-only: configuring useList with unmarshalType in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -266,6 +273,7 @@ And you can specify the POJO type also
 You can use custom Jackson modules by specifying the class names of
 those using the moduleClassNames option as shown below.
 
+._XML-only: configuring moduleClassNames in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -279,12 +287,13 @@ custom module needs any custom configuration, then an instance of the
 module can be created and configured, and then use modulesRefs to refer
 to the module as shown below:
 
+._XML-only: configuring moduleRefs with bean declaration in Spring XML_
 [source,xml]
 ----
 <bean id="myJacksonModule" class="com.foo.MyModule">
   ... // configure the module as you want
 </bean>
- 
+
 <dataFormats>
     <jacksonXml id="jacksonxml" useList="true" unmarshalType="com.foo.MyPojo" moduleRefs="myJacksonModule"/>
 </dataFormats>
@@ -299,6 +308,7 @@ XmlMapper uses.
 For example, to disable failing on unknown properties
 when marshalling, you can configure this using the disableFeatures:
 
+._XML-only: configuring disableFeatures in Spring XML_
 [source,xml]
 ----
 <dataFormats>
@@ -355,6 +365,7 @@ Otherwise, the default mapper will be used.
 Using the `prettyPrint` option one can output a well-formatted XML while
 marshalling:
 
+._XML-only: configuring prettyPrint in Spring XML_
 [source,xml]
 ----
 <dataFormats>

--- a/components/camel-jaxb/src/main/docs/jaxb-dataformat.adoc
+++ b/components/camel-jaxb/src/main/docs/jaxb-dataformat.adoc
@@ -54,6 +54,7 @@ from("activemq:My.Queue").
 
 The following example shows how to configure the `JaxbDataFormat` and use it in multiple routes.
 
+._XML-only: Spring XML bean and route configuration_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"

--- a/components/camel-jcache/src/main/docs/jcache-component.adoc
+++ b/components/camel-jcache/src/main/docs/jcache-component.adoc
@@ -190,6 +190,20 @@ is executed as normal, and the returned value is inserted into the cache for fut
 In Camel XML DSL, we need a named reference to the JCachePolicy instance (registered in CamelContext or simply in Spring).
 We have to wrap the route between `<policy>...</policy>` tags after `<from>`.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:get-order")
+    .policy("jCachePolicy")
+        .setBody().method("orderService", "findOrderById(${body})")
+    .end();
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext xmlns="http://camel.apache.org/schema/spring">
@@ -204,8 +218,43 @@ We have to wrap the route between `<policy>...</policy>` tags after `<from>`.
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get-order
+      steps:
+        - policy:
+            ref: jCachePolicy
+            steps:
+              - setBody:
+                  method:
+                    ref: orderService
+                    method: "findOrderById(${body})"
+----
+====
+
 See this example when only a part of the route is wrapped:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:get-order")
+    .log("Start - This is always called. body:${body}")
+    .policy("jCachePolicy")
+        .log("Executing route, not found in cache. body:${body}")
+        .setBody().method("orderService", "findOrderById(${body})")
+    .end()
+    .log("End - This is always called. body:${body}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext xmlns="http://camel.apache.org/schema/spring">
@@ -222,6 +271,30 @@ See this example when only a part of the route is wrapped:
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:get-order
+      steps:
+        - log:
+            message: "Start - This is always called. body:${body}"
+        - policy:
+            ref: jCachePolicy
+            steps:
+              - log:
+                  message: "Executing route, not found in cache. body:${body}"
+              - setBody:
+                  method:
+                    ref: orderService
+                    method: "findOrderById(${body})"
+        - log:
+            message: "End - This is always called. body:${body}"
+----
+====
 
 
 === Define CachePolicy in Spring

--- a/components/camel-jetty/src/main/docs/jetty-component.adoc
+++ b/components/camel-jetty/src/main/docs/jetty-component.adoc
@@ -311,6 +311,18 @@ The session support option, `sessionSupport`, can be used to enable a
 `HttpSession` object and access the session object while processing the
 exchange. For example, the following route enables sessions:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("jetty:http://0.0.0.0/myapp/myservice/?sessionSupport=true")
+    .process("myCode");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -319,9 +331,25 @@ exchange. For example, the following route enables sessions:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: jetty:http://0.0.0.0/myapp/myservice/
+      parameters:
+        sessionSupport: true
+      steps:
+        - process:
+            ref: myCode
+----
+====
+
 The `myCode` Processor can be instantiated by a
 Spring `bean` element:
 
+._XML-only: Spring bean definition for Processor_
 [source,xml]
 ----
 <bean id="myCode" class="com.mycompany.MyCodeProcessor"/>
@@ -375,6 +403,7 @@ jettyComponent.setSslContextParameters(scp);
 [[Jetty-SpringDSLbasedconfigurationofendpoint]]
 Spring DSL based configuration of endpoint
 
+._XML-only: Spring XML configuration for SSL context parameters_
 [source,xml]
 ----
   <camel:sslContextParameters
@@ -397,10 +426,30 @@ Configuring Jetty Directly
 Jetty provides SSL support out of the box. To enable Jetty to run in SSL
 mode, format the URI with the `\https://` prefix---for example:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("jetty:https://0.0.0.0/myapp/myservice/");
+----
+
+XML::
++
 [source,xml]
 ----
 <from uri="jetty:https://0.0.0.0/myapp/myservice/"/>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: jetty:https://0.0.0.0/myapp/myservice/
+----
+====
 
 Jetty also needs to know where to load your keystore from and what
 passwords to use to load the correct SSL certificate. Set the
@@ -428,6 +477,7 @@ properties like needClientAuth for mutual authentication requiring a
 client certificate or wantClientAuth for mutual authentication where a
 client doesn't need a certificate but can have one.
 
+._XML-only: Spring bean configuration for Jetty SSL socket connectors_
 [source,xml]
 ----
 <bean id="jetty" class="org.apache.camel.component.jetty.JettyHttpComponent">
@@ -457,6 +507,7 @@ above), you can now configure general properties that apply for all
 SSL socket connectors (that are not explicitly configured as above with
 the port number as entry).
 
+._XML-only: Spring bean configuration for general Jetty SSL properties_
 [source,xml]
 ----
 <bean id="jetty" class="org.apache.camel.component.jetty.JettyHttpComponent">
@@ -491,6 +542,7 @@ above), you can now configure general properties that apply for all
 HTTP socket connectors (that are not explicitly configured as above with
 the port number as entry).
 
+._XML-only: Spring bean configuration for general Jetty HTTP connector properties_
 [source,xml]
 ----
 <bean id="jetty" class="org.apache.camel.component.jetty.JettyHttpComponent">
@@ -516,6 +568,7 @@ property.  This property is not available directly through the endpoint
 configuration, but it can be easily added using the socketConnectors
 property:
 
+._XML-only: Spring bean configuration for Jetty X-Forwarded-For support_
 [source,xml]
 ----
 <bean id="jetty" class="org.apache.camel.component.jetty.JettyHttpComponent">
@@ -562,6 +615,7 @@ order to change how exceptions are returned:
 We can then create an instance of our binding and register it in the
 Spring registry as follows:
 
+._XML-only: Spring bean definition for custom HttpBinding_
 [source,xml]
 ----
 <bean id="mybinding" class="com.mycompany.MyHttpBinding"/>
@@ -569,6 +623,18 @@ Spring registry as follows:
 
 And then we can reference this binding when we define the route:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("jetty:http://0.0.0.0:8080/myapp/myservice?httpBinding=#mybinding")
+    .to("bean:doSomething");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -577,12 +643,28 @@ And then we can reference this binding when we define the route:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: jetty:http://0.0.0.0:8080/myapp/myservice
+      parameters:
+        httpBinding: "#mybinding"
+      steps:
+        - to:
+            uri: bean:doSomething
+----
+====
+
 === Jetty handlers and security configuration
 
 You can configure a list of Jetty handlers on the endpoint, which can be
 useful for enabling advanced Jetty security features. These handlers are
 configured in Spring XML as follows:
 
+._XML-only: Spring bean definitions for Jetty JAAS security handler_
 [source,xml]
 ----
 <bean id="userRealm" class="org.mortbay.jetty.plus.jaas.JAASUserRealm">
@@ -609,6 +691,7 @@ configured in Spring XML as follows:
 
 You can configure a list of Jetty handlers as follows:
 
+._XML-only: Spring bean definitions for Jetty constraint-based security handler_
 [source,xml]
 ----
 <bean id="constraint" class="org.eclipse.jetty.http.security.Constraint">
@@ -705,15 +788,59 @@ first endpoint to use a protocol/host/port pairing. For example, given
 two routes created from the following XML fragments, JMX support would
 remain enabled for all endpoints listening on `https://0.0.0.0`.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("jetty:https://0.0.0.0/myapp/myservice1/?enableJmx=true");
+----
+
+XML::
++
 [source,xml]
 ----
 <from uri="jetty:https://0.0.0.0/myapp/myservice1/?enableJmx=true"/>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: jetty:https://0.0.0.0/myapp/myservice1/
+    parameters:
+      enableJmx: true
+----
+====
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("jetty:https://0.0.0.0/myapp/myservice2/?enableJmx=false");
+----
+
+XML::
++
 [source,xml]
 ----
 <from uri="jetty:https://0.0.0.0/myapp/myservice2/?enableJmx=false"/>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- from:
+    uri: jetty:https://0.0.0.0/myapp/myservice2/
+    parameters:
+      enableJmx: false
+----
+====
 
 The camel-jetty component also provides for direct configuration of the
 Jetty MBeanContainer. Jetty creates MBean names dynamically. If you are

--- a/components/camel-joor/src/main/docs/java-language.adoc
+++ b/components/camel-joor/src/main/docs/java-language.adoc
@@ -324,6 +324,7 @@ Here the Java code is externalized into the file `src/main/resources/orders.java
 
 In XML DSL it's easier because you can turn off pre-compilation in the `<java>` XML element:
 
+._XML-only:_
 [source,xml]
 ----
 <route>

--- a/components/camel-joor/src/main/docs/java-language.adoc
+++ b/components/camel-joor/src/main/docs/java-language.adoc
@@ -60,6 +60,7 @@ These functions are convenient for getting the message body, header or exchange 
 
 Here we want to get the message body as a `com.foo.MyUser` type we can do as follows:
 
+._Java-only: Java language expression using bodyAs function_
 [source,java]
 ----
 var user = bodyAs(com.foo.MyUser.class);
@@ -67,6 +68,7 @@ var user = bodyAs(com.foo.MyUser.class);
 
 You can omit _.class_ to make the function a little smaller:
 
+._Java-only: Java language expression with simplified bodyAs syntax_
 [source,java]
 ----
 var user = bodyAs(com.foo.MyUser);
@@ -82,6 +84,7 @@ import com.foo.MyUser;
 
 And then the function can be shortened:
 
+._Java-only: Java language expression with imported type_
 [source,java]
 ----
 var user = bodyAs(MyUser);
@@ -97,6 +100,7 @@ In the Java code you declare the injected beans using the syntax `#bean:beanId`.
 
 For example, suppose we have the following bean
 
+._Java-only: bean class used for dependency injection_
 [source,java]
 ----
 public class MyEchoBean {
@@ -115,6 +119,7 @@ And this bean is registered with the name `myEcho` in the Camel registry.
 
 The Java code can then inject this bean directly in the script where the bean is in use:
 
+._Java-only: Java DSL route with bean injection syntax_
 [source,java]
 ----
 from("direct:start")
@@ -126,6 +131,7 @@ Now this code may seem a bit magic, but what happens is that the `myEcho` bean i
 
 Under the hood, Camel Java generates the following source code compiled once:
 
+._Java-only: generated source code showing dependency injection internals_
 [source,java]
 ----
 public class JoorScript1 implements org.apache.camel.language.joor.JoorMethod {
@@ -145,6 +151,7 @@ public class JoorScript1 implements org.apache.camel.language.joor.JoorMethod {
 
 You can also store a reference to the bean in a variable which would more resemble how you would code in Java
 
+._Java-only: Java DSL route with bean variable reference_
 [source,java]
 ----
 from("direct:start")
@@ -160,6 +167,7 @@ Therefore, we use _bean_ as name in the script.
 
 The Java language will automatically import from:
 
+._Java-only: default auto-imported packages_
 [source,java]
 ----
 import java.util.*;
@@ -176,6 +184,7 @@ You can specify a different location with the `configResource` option on the Jav
 
 For example, you can add additional imports in the `camel-joor.properties` file by adding:
 
+._Java-only: custom imports in camel-joor.properties_
 [source,java]
 ----
 import com.foo.MyUser;
@@ -192,6 +201,7 @@ echo()=bodyAs(String) + bodyAs(String)
 
 Which allows using `echo()` in the jOOR language script such as:
 
+._Java-only: Java DSL route using alias function_
 [source,java]
 ----
 from("direct:hello")
@@ -201,6 +211,7 @@ from("direct:hello")
 
 The `echo()` alias will be replaced with its value resulting in a script as:
 
+._Java-only: expanded alias result in Java DSL_
 [source,java]
 ----
 .transform(java("'Hello ' + bodyAs(String) + bodyAs(String)"))
@@ -208,6 +219,7 @@ The `echo()` alias will be replaced with its value resulting in a script as:
 
 You can configure a custom configuration location for the `camel-joor.properties` file or reference to a bean in the registry:
 
+._Java-only: programmatic language configuration_
 [source,java]
 ----
 JavaLanguage joor = (JavaLanguage) context.resolveLanguage("java");
@@ -216,6 +228,7 @@ java.setConfigResource("ref:MyJoorConfig");
 
 And then register a bean in the registry with id `MyJoorConfig` that is a String value with the content.
 
+._Java-only: programmatic registry bean configuration_
 [source,java]
 ----
 String config = "....";
@@ -273,6 +286,7 @@ It is possible to include multiple statements.
 The code below shows an example where the `user` header is retrieved in a first statement.
 And then, in a second statement we return a value whether the user is `null` or not.
 
+._Java-only: Java DSL route with multi-statement expression_
 [source,java]
 ----
 from("seda:orders")
@@ -282,6 +296,7 @@ from("seda:orders")
 
 Notice how we have to quote strings in strings, and that is annoying, so instead we can use single quotes:
 
+._Java-only: Java DSL route using single-quote syntax_
 [source,java]
 ----
 from("seda:orders")
@@ -294,6 +309,7 @@ from("seda:orders")
 You can turn off pre-compilation for the Java language and then Camel will recompile the script for each message.
 You can externalize the code into a resource file, which will be reloaded on each message as shown:
 
+._Java-only: programmatic hot-reload configuration with Java DSL_
 [source,java]
 ----
 JavaLanguage java = (JavaLanguage) context.resolveLanguage("java");
@@ -337,6 +353,7 @@ The lambda syntax is representing a Java util `BiFunction<Exchange, Exchange, Ob
 
 For example, to aggregate message bodies together, we can do this as shown:
 
+._Java-only: lambda-based aggregation strategy expression_
 [source,java]
 ----
 (e1, e2) -> {

--- a/components/camel-joor/src/main/docs/joor-language.adoc
+++ b/components/camel-joor/src/main/docs/joor-language.adoc
@@ -65,6 +65,7 @@ These functions are convenient for getting the message body, header or exchange 
 
 Here we want to get the message body as a `com.foo.MyUser` type we can do as follows:
 
+._Java-only: jOOR type conversion function_
 [source,java]
 ----
 var user = bodyAs(com.foo.MyUser.class);
@@ -72,6 +73,7 @@ var user = bodyAs(com.foo.MyUser.class);
 
 You can omit _.class_ to make the function a little smaller:
 
+._Java-only: jOOR shorthand type conversion_
 [source,java]
 ----
 var user = bodyAs(com.foo.MyUser);
@@ -87,6 +89,7 @@ import com.foo.MyUser;
 
 And then the function can be shortened:
 
+._Java-only: jOOR type conversion with imported class_
 [source,java]
 ----
 var user = bodyAs(MyUser);
@@ -102,6 +105,7 @@ In the jOOR script you declare the injected beans using the syntax `#bean:beanId
 
 For example, suppose we have the following bean
 
+._Java-only: bean class used for dependency injection_
 [source,java]
 ----
 public class MyEchoBean {
@@ -120,6 +124,7 @@ And this bean is registered with the name `myEcho` in the Camel registry.
 
 The jOOR script can then inject this bean directly in the script where the bean is in use:
 
+._Java-only: jOOR bean injection in route_
 [source,java]
 ----
 from("direct:start")
@@ -131,6 +136,7 @@ Now this code may seem a bit magic, but what happens is that the `myEcho` bean i
 
 Under the hood, Camel jOOR generates the following source code compiled once:
 
+._Java-only: generated compiled jOOR script class_
 [source,java]
 ----
 public class JoorScript1 implements org.apache.camel.language.joor.JoorMethod {
@@ -150,6 +156,7 @@ public class JoorScript1 implements org.apache.camel.language.joor.JoorMethod {
 
 You can also store a reference to the bean in a variable which would more resemble how you would code in Java
 
+._Java-only: jOOR bean variable reference in route_
 [source,java]
 ----
 from("direct:start")
@@ -165,6 +172,7 @@ Therefore, we use _bean_ as name in the script.
 
 The jOOR language will automatically import from:
 
+._Java-only: jOOR auto-imported packages_
 [source,java]
 ----
 import java.util.*;
@@ -197,6 +205,7 @@ echo()=bodyAs(String) + bodyAs(String)
 
 Which allows using `echo()` in the jOOR language script such as:
 
+._Java-only: jOOR alias usage in route_
 [source,java]
 ----
 from("direct:hello")
@@ -206,6 +215,7 @@ from("direct:hello")
 
 The `echo()` alias will be replaced with its value resulting in a script as:
 
+._Java-only: jOOR alias expansion result_
 [source,java]
 ----
 .transform(joor("'Hello ' + bodyAs(String) + bodyAs(String)"))
@@ -213,6 +223,7 @@ The `echo()` alias will be replaced with its value resulting in a script as:
 
 You can configure a custom configuration location for the `camel-joor.properties` file or reference to a bean in the registry:
 
+._Java-only: programmatic language configuration_
 [source,java]
 ----
 JoorLanguage joor = (JoorLanguage) context.resolveLanguage("joor");
@@ -221,6 +232,7 @@ joor.setConfigResource("ref:MyJoorConfig");
 
 And then register a bean in the registry with id `MyJoorConfig` that is a String value with the content.
 
+._Java-only: programmatic bean registration_
 [source,java]
 ----
 String config = "....";
@@ -279,6 +291,7 @@ It is possible to include multiple statements.
 The code below shows an example where the `user` header is retrieved in a first statement.
 And then, in a second statement we return a value whether the user is `null` or not.
 
+._Java-only: jOOR multi-statement expression in route_
 [source,java]
 ----
 from("seda:orders")
@@ -288,6 +301,7 @@ from("seda:orders")
 
 Notice how we have to quote strings in strings, and that is annoying, so instead we can use single quotes:
 
+._Java-only: jOOR single-quoted string syntax_
 [source,java]
 ----
 from("seda:orders")
@@ -369,6 +383,7 @@ The lambda syntax is representing a Java util `BiFunction<Exchange, Exchange, Ob
 
 For example, to aggregate message bodies together, we can do this as shown:
 
+._Java-only: jOOR lambda-based aggregation strategy_
 [source,java]
 ----
 (e1, e2) -> {
@@ -393,12 +408,12 @@ To use scripting languages in your camel routes, you need to add a dependency on
 If you use Maven you could add the following to your `pom.xml`, substituting the version number for the latest and greatest release.
 
 [source,xml]
----------------------------------------
+----
 <dependency>
   <groupId>org.apache.camel</groupId>
   <artifactId>camel-joor</artifactId>
   <version>x.x.x</version>
 </dependency>
----------------------------------------
+----
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-jpa/src/main/docs/jpa-component.adoc
+++ b/components/camel-jpa/src/main/docs/jpa-component.adoc
@@ -453,18 +453,49 @@ Index: 20, Size: 20
 
 . Create the JPA idempotent repository in the Spring XML file:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .idempotentConsumer(header("messageId")).idempotentRepository("jpaStore")
+        .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
-<camelContext xmlns="http://camel.apache.org/schema/spring">
-    <route id="JpaMessageIdRepositoryTest">
-        <from uri="direct:start" />
-        <idempotentConsumer idempotentRepository="jpaStore">
-            <header>messageId</header>
-            <to uri="mock:result" />
-        </idempotentConsumer>
-    </route>
-</camelContext>
+<route id="JpaMessageIdRepositoryTest">
+    <from uri="direct:start" />
+    <idempotentConsumer idempotentRepository="jpaStore">
+        <header>messageId</header>
+        <to uri="mock:result" />
+    </idempotentConsumer>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: JpaMessageIdRepositoryTest
+    from:
+      uri: direct:start
+      steps:
+        - idempotentConsumer:
+            idempotentRepository: "#jpaStore"
+            expression:
+              header:
+                expression: messageId
+            steps:
+              - to:
+                  uri: mock:result
+----
+====
 
 == Important Development Notes
 

--- a/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
+++ b/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
@@ -418,6 +418,7 @@ TIP: You can also use `variable:` as source prefix to refer to an Exchange varia
 
 The same example in XML DSL would be easier to do:
 
+._XML-only:_
 [source,xml]
 ----
 <route>

--- a/components/camel-kubernetes/src/main/docs/kubernetes-config-maps-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-config-maps-component.adoc
@@ -193,6 +193,19 @@ first = Carlsberg
 
 Then these values can be used in your Camel routes such as:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .log("What {{configmap:myconfig/drink}} do you want?")
+    .log("I want {{configmap:myconfig/first}}");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -203,6 +216,21 @@ Then these values can be used in your Camel routes such as:
   </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - log:
+            message: "What {{configmap:myconfig/drink}} do you want?"
+        - log:
+            message: "I want {{configmap:myconfig/first}}"
+----
+====
 
 You can also provide a default value in case a key does not exist:
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-secrets-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-secrets-component.adoc
@@ -167,6 +167,24 @@ mypass = tiger
 
 This can be used in Camel with for example the Postrgres Sink Kamelet:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:rome")
+    .setBody(constant("{ \"username\":\"oscerd\", \"city\":\"Rome\"}"))
+    .to("kamelet:postgresql-sink?serverName={{secret:mydb/myhost}}"
+        + "&serverPort={{secret:mydb/myport}}"
+        + "&username={{secret:mydb/myuser}}"
+        + "&password={{secret:mydb/mypass}}"
+        + "&databaseName=cities"
+        + "&query=INSERT INTO accounts (username,city) VALUES (:#username,:#city)");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -185,6 +203,28 @@ This can be used in Camel with for example the Postrgres Sink Kamelet:
 </camelContext>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:rome
+      steps:
+        - setBody:
+            constant: '{ "username":"oscerd", "city":"Rome"}'
+        - to:
+            uri: kamelet:postgresql-sink
+            parameters:
+              serverName: "{{secret:mydb/myhost}}"
+              serverPort: "{{secret:mydb/myport}}"
+              username: "{{secret:mydb/myuser}}"
+              password: "{{secret:mydb/mypass}}"
+              databaseName: cities
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+----
+====
+
 The postgres-sink Kamelet can also be configured in `application.properties` which reduces the configuration
 in the route above:
 
@@ -198,6 +238,20 @@ camel.component.kamelet.postgresql-sink.password={{secret:mydb/mypass}}
 
 Which reduces the route to:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:rome")
+    .setBody(constant("{ \"username\":\"oscerd\", \"city\":\"Rome\"}"))
+    .to("kamelet:postgresql-sink?databaseName=cities"
+        + "&query=INSERT INTO accounts (username,city) VALUES (:#username,:#city)");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -211,6 +265,24 @@ Which reduces the route to:
   </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:rome
+      steps:
+        - setBody:
+            constant: '{ "username":"oscerd", "city":"Rome"}'
+        - to:
+            uri: kamelet:postgresql-sink
+            parameters:
+              databaseName: cities
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+----
+====
 
 == Automatic Camel context reloading on Secret Refresh
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
@@ -39,21 +39,23 @@ Here we show some examples of producer using camel-kubernetes.
 
 === Create a pod
 
+._Java-only: uses toF() with runtime variables for host and auth token_
 [source,java]
--------------------------------------------------------------
+----
 from("direct:createPod")
     .toF("kubernetes-pods://%s?oauthToken=%s&operation=createPod", host, authToken);
--------------------------------------------------------------
+----
 
 By using the `KubernetesConstants.KUBERNETES_POD_SPEC` header, you can specify your PodSpec and pass it to this operation.
 
 === Delete a pod
 
+._Java-only: uses toF() with runtime variables for host and auth token_
 [source,java]
--------------------------------------------------------------
+----
 from("direct:createPod")
     .toF("kubernetes-pods://%s?oauthToken=%s&operation=deletePod", host, authToken);
--------------------------------------------------------------
+----
 
 By using the `KubernetesConstants.KUBERNETES_POD_NAME` header, you can specify your Pod name and pass it to this operation.
 

--- a/components/camel-log/src/main/docs/log-component.adoc
+++ b/components/camel-log/src/main/docs/log-component.adoc
@@ -274,6 +274,8 @@ camelContext.setLogMask(true);
 ----
 
 And in XML:
+
+._XML-only: enabling log masking on `CamelContext`_
 [source,xml]
 ----
 <camelContext logMask="true">
@@ -356,6 +358,7 @@ in either of two ways:
 
 *Explicitly instantiating the LogComponent in your Registry:*
 
+._XML-only: Spring bean declaration for custom `LogComponent` with `ExchangeFormatter`_
 [source,xml]
 ----
 <bean name="log" class="org.apache.camel.component.log.LogComponent">
@@ -368,6 +371,7 @@ in either of two ways:
 Simply by registering a bean with the name `logFormatter`; the Log
 Component is intelligent enough to pick it up automatically.
 
+._XML-only: Spring bean registration for auto-detected `ExchangeFormatter`_
 [source,xml]
 ----
 <bean name="logFormatter" class="com.xyz.MyCustomExchangeFormatter" />
@@ -388,6 +392,7 @@ custom log formatter. Though when you do that, you should define the
 "logFormatter" as prototype scoped, so it's not shared if you have
 different parameters, e.g.:
 
+._XML-only: Spring bean with prototype scope for per-endpoint `ExchangeFormatter`_
 [source,xml]
 ----
 <bean name="logFormatter" class="com.xyz.MyCustomExchangeFormatter" scope="prototype"/>
@@ -396,6 +401,7 @@ different parameters, e.g.:
 And then we can have Camel routes using the log uri with different
 options:
 
+._XML-only: example `<to>` elements showing different log endpoint URIs_
 [source,xml]
 ----
 <to uri="log:foo?param1=foo&amp;param2=100"/>

--- a/components/camel-mail/src/main/docs/mail-component.adoc
+++ b/components/camel-mail/src/main/docs/mail-component.adoc
@@ -655,6 +655,7 @@ Expression in the route as shown below:
 If you use XML DSL, then you need to declare a method call expression in
 the Splitter as shown below
 
+._XML-only: `method` expression with `beanType` attribute is XML DSL specific_
 [source,xml]
 ----
 <split>
@@ -683,6 +684,18 @@ to filter out unwanted mails.
 For example, to filter mails to contain Camel in either Subject or Text,
 you can do as follows:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("imaps://mymailseerver?username=foo&password=secret&searchTerm.subjectOrBody=Camel")
+    .to("bean:myBean");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -690,6 +703,23 @@ you can do as follows:
   <to uri="bean:myBean"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: imaps://mymailseerver
+      parameters:
+        username: foo
+        password: secret
+        searchTerm.subjectOrBody: Camel
+      steps:
+        - to:
+            uri: bean:myBean
+----
+====
 
 Notice we use the `"searchTerm.subjectOrBody"` as a parameter key to
 indicate that we want to search on mail subject or body, to contain the
@@ -700,6 +730,18 @@ number of options you can configure:
 Or to get the new unseen emails going 24 hours back in time, you can do.
 Notice the "now-24h" syntax. See the table below for more details.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("imaps://mymailseerver?username=foo&password=secret&searchTerm.fromSentDate=now-24h")
+    .to("bean:myBean");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -708,11 +750,40 @@ Notice the "now-24h" syntax. See the table below for more details.
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: imaps://mymailseerver
+      parameters:
+        username: foo
+        password: secret
+        searchTerm.fromSentDate: now-24h
+      steps:
+        - to:
+            uri: bean:myBean
+----
+====
+
 You can have multiple searchTerm in the endpoint uri configuration. They
 would then be combined using the `AND` operator, e.g., so both
 conditions must match. For example, to get the last unseen emails going
 back 24 hours which has Camel in the mail subject you can do:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("imaps://mymailseerver?username=foo&password=secret&searchTerm.subject=Camel&searchTerm.fromSentDate=now-24h")
+    .to("bean:myBean");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -721,9 +792,28 @@ back 24 hours which has Camel in the mail subject you can do:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: imaps://mymailseerver
+      parameters:
+        username: foo
+        password: secret
+        searchTerm.subject: Camel
+        searchTerm.fromSentDate: now-24h
+      steps:
+        - to:
+            uri: bean:myBean
+----
+====
+
 The `SimpleSearchTerm` is designed to be easily configurable from a
 POJO, so you can also configure it using a <bean> style in XML
 
+._XML-only: Spring `<bean>` configuration for `SimpleSearchTerm`_
 [source,xml]
 ----
 <bean id="mySearchTerm" class="org.apache.camel.component.mail.SimpleSearchTerm">
@@ -736,6 +826,18 @@ POJO, so you can also configure it using a <bean> style in XML
 You can then refer to this bean, using #beanId in your Camel route as
 shown:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("imaps://mymailseerver?username=foo&password=secret&searchTerm=#mySearchTerm")
+    .to("bean:myBean");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -743,6 +845,23 @@ shown:
   <to uri="bean:myBean"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: imaps://mymailseerver
+      parameters:
+        username: foo
+        password: secret
+        searchTerm: "#mySearchTerm"
+      steps:
+        - to:
+            uri: bean:myBean
+----
+====
 
 In Java there is a builder class to build compound
 `SearchTerms` using the `org.apache.camel.component.mail.SearchTermBuilder`

--- a/components/camel-metrics/src/main/docs/metrics-component.adoc
+++ b/components/camel-metrics/src/main/docs/metrics-component.adoc
@@ -531,15 +531,52 @@ component URI.
 |CamelMetricsHistogramValue |Override histogram value in URI |Long
 |=================================================================
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // adds value 992 to simple.histogram
 from("direct:in")
     .setHeader(MetricsConstants.HEADER_HISTOGRAM_VALUE, constant(992L))
     .to("metrics:histogram:simple.histogram?value=700")
-    .to("direct:out")
-
+    .to("direct:out");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:in"/>
+  <setHeader name="CamelMetricsHistogramValue">
+    <constant resultType="java.lang.Long">992</constant>
+  </setHeader>
+  <to uri="metrics:histogram:simple.histogram?value=700"/>
+  <to uri="direct:out"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:in
+      steps:
+        - setHeader:
+            name: CamelMetricsHistogramValue
+            constant: 992
+        - to:
+            uri: metrics:histogram:simple.histogram
+            parameters:
+              value: 700
+        - to:
+            uri: direct:out
+----
+====
 
 [[MetricsComponent-meter]]
 === Metric type meter
@@ -647,6 +684,10 @@ component URI.
 |CamelMetricsMeterMark |Override mark value in URI |Long
 |=======================================================
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // updates meter simple.meter with value 345
@@ -655,6 +696,40 @@ from("direct:in")
     .to("metrics:meter:simple.meter?mark=123")
     .to("direct:out");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:in"/>
+  <setHeader name="CamelMetricsMeterMark">
+    <constant resultType="java.lang.Long">345</constant>
+  </setHeader>
+  <to uri="metrics:meter:simple.meter?mark=123"/>
+  <to uri="direct:out"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:in
+      steps:
+        - setHeader:
+            name: CamelMetricsMeterMark
+            constant: 345
+        - to:
+            uri: metrics:meter:simple.meter
+            parameters:
+              mark: 123
+        - to:
+            uri: direct:out
+----
+====
 
 [[MetricsComponent-timer]]
 === Metrics type timer
@@ -914,6 +989,7 @@ want to instrument a few selected routes.
 
 From Java, you add the factory to the `CamelContext` as shown below:
 
+._Java-only: adding MetricsRoutePolicyFactory to CamelContext_
 [source,java]
 ----
 context.addRoutePolicyFactory(new MetricsRoutePolicyFactory());
@@ -970,6 +1046,7 @@ the `com.codahale.metrics.MetricRegistry` from the
 `org.apache.camel.component.metrics.routepolicy.MetricsRegistryService`
 as shown below:
 
+._Java-only: accessing MetricRegistry from MetricsRegistryService_
 [source,java]
 ----
 MetricRegistryService registryService = context.hasService(MetricsRegistryService.class);
@@ -989,6 +1066,7 @@ the examples below demonstrates.
 
 From Java, you set the factory to the `CamelContext` as shown below:
 
+._Java-only: setting MetricsMessageHistoryFactory on CamelContext_
 [source,java]
 ----
 context.setMessageHistoryFactory(new MetricsMessageHistoryFactory());
@@ -1044,6 +1122,7 @@ to gather the data as json output.
 From Java code, you can get the service from the CamelContext as
 shown:
 
+._Java-only: dumping message history statistics as JSON_
 [source,java]
 ----
 MetricsMessageHistoryService service = context.hasService(MetricsMessageHistoryService.class);

--- a/components/camel-micrometer/src/main/docs/micrometer-component.adoc
+++ b/components/camel-micrometer/src/main/docs/micrometer-component.adoc
@@ -99,6 +99,8 @@ To use the legacy naming, then you can use the `LEGACY` naming from the `xxxNami
 
 For example:
 
+._Java-only: configuring legacy naming strategy on the route policy factory_
+
 [source,java]
 ----
 MicrometerRoutePolicyFactory factory = new MicrometerRoutePolicyFactory();
@@ -740,6 +742,8 @@ want to instrument a few selected routes.
 
 From Java, you add the factory to the `CamelContext` as shown below:
 
+._Java-only: adding MicrometerRoutePolicyFactory to the CamelContext_
+
 [source,java]
 ----
 context.addRoutePolicyFactory(new MicrometerRoutePolicyFactory());
@@ -798,6 +802,8 @@ the examples below demonstrates.
 
 From Java, you set the factory to the `CamelContext` as shown below:
 
+._Java-only: setting MicrometerMessageHistoryFactory on the CamelContext_
+
 [source,java]
 ----
 context.setMessageHistoryFactory(new MicrometerMessageHistoryFactory());
@@ -827,6 +833,8 @@ to gather the data as json output.
 From Java code, you can get the service from the CamelContext as
 shown:
 
+._Java-only: accessing MicrometerMessageHistoryService from the CamelContext_
+
 [source,java]
 ----
 MicrometerMessageHistoryService service = context.hasService(MicrometerMessageHistoryService.class);
@@ -843,6 +851,8 @@ There is a `MicrometerRouteEventNotifier` (counting added and running routes) an
 
 EventNotifiers can be added to the CamelContext, e.g.:
 
+._Java-only: adding MicrometerExchangeEventNotifier to the CamelContext_
+
 [source,java]
 ----
 camelContext.getManagementStrategy().addEventNotifier(new MicrometerExchangeEventNotifier());
@@ -853,6 +863,8 @@ to gather the data as json output.
 
 From Java code, you can get the service from the CamelContext as
 shown:
+
+._Java-only: accessing MicrometerEventNotifierService from the CamelContext_
 
 [source,java]
 ----

--- a/components/camel-mina-sftp/src/main/docs/mina-sftp-component.adoc
+++ b/components/camel-mina-sftp/src/main/docs/mina-sftp-component.adoc
@@ -342,11 +342,42 @@ This behavior matches the JSch-based sftp component.
 
 You can customize the authentication order using the `preferredAuthentications` option:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&privateKeyFile=/path/to/key&preferredAuthentications=password,publickey")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;privateKeyFile=/path/to/key&amp;preferredAuthentications=password,publickey"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        privateKeyFile: /path/to/key
+        preferredAuthentications: "password,publickey"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 ==== Available Authentication Methods
 
@@ -370,11 +401,41 @@ If `preferredAuthentications` is not specified, the default order from Apache MI
 
 You can restrict which public key algorithms are accepted for authentication using the `publicKeyAcceptedAlgorithms` option:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?privateKeyFile=/path/to/key&publicKeyAcceptedAlgorithms=ssh-ed25519,rsa-sha2-256,rsa-sha2-512")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?privateKeyFile=/path/to/key&amp;publicKeyAcceptedAlgorithms=ssh-ed25519,rsa-sha2-256,rsa-sha2-512"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        privateKeyFile: /path/to/key
+        publicKeyAcceptedAlgorithms: "ssh-ed25519,rsa-sha2-256,rsa-sha2-512"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 ==== Available Public Key Algorithms
 
@@ -411,11 +472,41 @@ from("mina-sftp://user@host/path?privateKeyFile=/path/to/key&publicKeyAcceptedAl
 
 For security-conscious deployments, restrict to modern algorithms only:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?privateKeyFile=/path/to/key&publicKeyAcceptedAlgorithms=ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?privateKeyFile=/path/to/key&amp;publicKeyAcceptedAlgorithms=ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        privateKeyFile: /path/to/key
+        publicKeyAcceptedAlgorithms: "ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 If `publicKeyAcceptedAlgorithms` is not specified, the default list from Apache MINA SSHD is used.
 
@@ -934,11 +1025,42 @@ When migrating from `sftp` to `mina-sftp`, verify the following:
 
 === Connection Retry
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&maximumReconnectAttempts=5&reconnectDelay=2000")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;maximumReconnectAttempts=5&amp;reconnectDelay=2000"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        maximumReconnectAttempts: 5
+        reconnectDelay: 2000
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 === Error Messages
 
@@ -976,11 +1098,41 @@ The mina-sftp component supports SSH data compression to reduce bandwidth usage 
 
 To enable compression, set the `compression` option to a value between 1 and 10:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&compression=5")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;compression=5"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        compression: 5
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 The compression level is advisory; the actual compression behavior depends on the SSH library's implementation. When compression is enabled, the component configures the following algorithms in order of preference:
 
@@ -1035,11 +1187,41 @@ The mina-sftp component allows you to specify which SSH cipher algorithms to use
 
 To specify a custom list of ciphers, use the `ciphers` option with a comma-separated list of cipher names:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&ciphers=aes256-ctr,aes256-gcm@openssh.com")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;ciphers=aes256-ctr,aes256-gcm@openssh.com"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        ciphers: "aes256-ctr,aes256-gcm@openssh.com"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 Ciphers are offered to the server in the order specified. The first mutually supported cipher will be used.
 
@@ -1111,12 +1293,44 @@ The following ciphers are supported by Apache MINA SSHD:
 
 For security-hardened environments, use only modern authenticated encryption modes:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Recommended secure configuration
 from("mina-sftp://user@host/path?password=secret&ciphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Recommended secure configuration -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;ciphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Recommended secure configuration
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        ciphers: "aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 === Default Cipher Behavior
 
@@ -1132,11 +1346,41 @@ The mina-sftp component allows you to specify which SSH key exchange algorithms 
 
 To specify a custom list of key exchange protocols, use the `keyExchangeProtocols` option with a comma-separated list:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&keyExchangeProtocols=curve25519-sha256,ecdh-sha2-nistp256")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;keyExchangeProtocols=curve25519-sha256,ecdh-sha2-nistp256"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        keyExchangeProtocols: "curve25519-sha256,ecdh-sha2-nistp256"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 Key exchange protocols are offered to the server in the order specified. The first mutually supported algorithm will be used.
 
@@ -1221,11 +1465,41 @@ The mina-sftp component allows you to specify which server host key algorithms a
 
 To specify a custom list of server host key algorithms, use the `serverHostKeys` option with a comma-separated list:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&serverHostKeys=ssh-ed25519,rsa-sha2-512")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;serverHostKeys=ssh-ed25519,rsa-sha2-512"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        serverHostKeys: "ssh-ed25519,rsa-sha2-512"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 Server host key algorithms are offered to the server in the order specified. The first mutually supported algorithm will be used for server authentication.
 
@@ -1391,6 +1665,10 @@ NOTE: Under the hood, these settings are mapped to Apache MINA SSHD's `CoreModul
 
 For routes with long idle periods between file transfers, configure keep-alive to prevent firewalls or servers from terminating the connection:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Send keep-alive every 30 seconds
@@ -1398,16 +1676,77 @@ from("mina-sftp://user@host/path?password=secret&serverAliveInterval=30000")
     .to("file:local");
 ----
 
+XML::
++
+[source,xml]
+----
+<!-- Send keep-alive every 30 seconds -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;serverAliveInterval=30000"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Send keep-alive every 30 seconds
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        serverAliveInterval: 30000
+      steps:
+        - to:
+            uri: file:local
+----
+====
+
 === Detecting Unresponsive Servers
 
 Configure `serverAliveCountMax` to control how quickly the component detects an unresponsive server:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Terminate connection after 3 unanswered keep-alives (90 seconds max)
 from("mina-sftp://user@host/path?password=secret&serverAliveInterval=30000&serverAliveCountMax=3")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Terminate connection after 3 unanswered keep-alives (90 seconds max) -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;serverAliveInterval=30000&amp;serverAliveCountMax=3"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Terminate connection after 3 unanswered keep-alives (90 seconds max)
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        serverAliveInterval: 30000
+        serverAliveCountMax: 3
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 With this configuration:
 
@@ -1462,11 +1801,41 @@ The MINA SFTP component supports comprehensive host key verification to protect 
 
 When `strictHostKeyChecking=yes`, the server's host key must match an entry in the known hosts source. If the key is unknown or mismatches, the connection is rejected.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&strictHostKeyChecking=yes")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;strictHostKeyChecking=yes"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        strictHostKeyChecking: "yes"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 === Known Hosts Sources (Priority Order)
 
@@ -1479,49 +1848,203 @@ The component checks for known hosts in this priority order:
 
 ==== Using Custom Known Hosts File
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&strictHostKeyChecking=yes&knownHostsFile=/path/to/known_hosts")
     .to("file:local");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;strictHostKeyChecking=yes&amp;knownHostsFile=/path/to/known_hosts"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        strictHostKeyChecking: "yes"
+        knownHostsFile: /path/to/known_hosts
+      steps:
+        - to:
+            uri: file:local
+----
+====
+
 ==== Using Known Hosts from Classpath
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&strictHostKeyChecking=yes&knownHostsUri=classpath:ssh/known_hosts")
     .to("file:local");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;strictHostKeyChecking=yes&amp;knownHostsUri=classpath:ssh/known_hosts"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        strictHostKeyChecking: "yes"
+        knownHostsUri: "classpath:ssh/known_hosts"
+      steps:
+        - to:
+            uri: file:local
+----
+====
+
 ==== Using User's Default Known Hosts
 
 By default, `useUserKnownHostsFile=true` which uses `~/.ssh/known_hosts`:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&strictHostKeyChecking=yes")
     .to("file:local");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;strictHostKeyChecking=yes"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        strictHostKeyChecking: "yes"
+      steps:
+        - to:
+            uri: file:local
+----
+====
+
 === Auto-Create Known Hosts File (Development Only)
 
 For development environments, you can enable automatic trust-on-first-use:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&autoCreateKnownHostsFile=true&knownHostsFile=/tmp/dev_known_hosts")
     .to("file:local");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;autoCreateKnownHostsFile=true&amp;knownHostsFile=/tmp/dev_known_hosts"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        autoCreateKnownHostsFile: true
+        knownHostsFile: /tmp/dev_known_hosts
+      steps:
+        - to:
+            uri: file:local
+----
+====
+
 CAUTION: Auto-create is only recommended for development environments. It weakens security by automatically trusting new hosts.
 
 === Disable Host Key Checking (Testing Only)
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@localhost/test?password=secret&strictHostKeyChecking=no&useUserKnownHostsFile=false")
     .to("mock:result");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@localhost/test?password=secret&amp;strictHostKeyChecking=no&amp;useUserKnownHostsFile=false"/>
+  <to uri="mock:result"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@localhost/test
+      parameters:
+        password: secret
+        strictHostKeyChecking: "no"
+        useUserKnownHostsFile: false
+      steps:
+        - to:
+            uri: mock:result
+----
+====
 
 CAUTION: Disabling host key checking is insecure and should only be used for testing.
 
@@ -1544,11 +2067,42 @@ The standard OpenSSH known_hosts format supports `@cert-authority` entries that 
 
 ==== Example Configuration
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host.example.com/path?password=secret&strictHostKeyChecking=yes&knownHostsFile=/path/to/known_hosts")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host.example.com/path?password=secret&amp;strictHostKeyChecking=yes&amp;knownHostsFile=/path/to/known_hosts"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host.example.com/path
+      parameters:
+        password: secret
+        strictHostKeyChecking: "yes"
+        knownHostsFile: /path/to/known_hosts
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 Where the known_hosts file contains:
 [source]
@@ -1666,11 +2220,41 @@ In multi-homed environments (servers with multiple network interfaces), you may 
 
 Use the `bindAddress` option to specify the local IP address or hostname to bind the outgoing connection:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mina-sftp://user@host/path?password=secret&bindAddress=192.168.1.100")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;bindAddress=192.168.1.100"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        bindAddress: "192.168.1.100"
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 === Bind Address Formats
 
@@ -1771,6 +2355,7 @@ The mina-sftp component's `bindAddress` parameter has an enhanced format compare
 
 If you are migrating from the `sftp` component to `mina-sftp`, your existing `bindAddress` configurations will work without changes. The port specification is an optional enhancement.
 
+._Java-only: bindAddress configuration values_
 [source,java]
 ----
 // Works in both sftp and mina-sftp
@@ -1788,6 +2373,10 @@ The mina-sftp component allows you to configure buffer sizes for SFTP read and w
 
 Use `readBufferSize` and `writeBufferSize` to control the buffer allocation for SFTP transfers:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Configure 64KB read buffer and 32KB write buffer
@@ -1798,6 +2387,53 @@ from("mina-sftp://user@host/path?password=secret&readBufferSize=65536&writeBuffe
 from("mina-sftp://user@host/path?password=secret&readBufferSize=65536&writeBufferSize=65536")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Configure 64KB read buffer and 32KB write buffer -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;readBufferSize=65536&amp;writeBufferSize=32768"/>
+  <to uri="file:local"/>
+</route>
+
+<!-- Configure symmetric buffer sizes for balanced transfers -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;readBufferSize=65536&amp;writeBufferSize=65536"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Configure 64KB read buffer and 32KB write buffer
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        readBufferSize: 65536
+        writeBufferSize: 32768
+      steps:
+        - to:
+            uri: file:local
+
+# Configure symmetric buffer sizes for balanced transfers
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        readBufferSize: 65536
+        writeBufferSize: 65536
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 === Buffer Size Options
 
@@ -2070,6 +2706,10 @@ The mina-sftp component supports reading and writing through symbolic links on S
 
 When consuming files, the consumer follows symbolic links to their target files:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Will consume files through symlinks
@@ -2077,16 +2717,74 @@ from("mina-sftp://user@host/data?password=secret")
     .to("file:local");
 ----
 
+XML::
++
+[source,xml]
+----
+<!-- Will consume files through symlinks -->
+<route>
+  <from uri="mina-sftp://user@host/data?password=secret"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Will consume files through symlinks
+- route:
+    from:
+      uri: mina-sftp://user@host/data
+      parameters:
+        password: secret
+      steps:
+        - to:
+            uri: file:local
+----
+====
+
 === Producer Behavior
 
 When producing files, you can write to paths that are symbolic links. The file will be written to the symlink's target:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Can write to symlink targets
 from("file:local")
     .to("mina-sftp://user@host/upload-link?password=secret");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Can write to symlink targets -->
+<route>
+  <from uri="file:local"/>
+  <to uri="mina-sftp://user@host/upload-link?password=secret"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Can write to symlink targets
+- route:
+    from:
+      uri: file:local
+      steps:
+        - to:
+            uri: mina-sftp://user@host/upload-link
+            parameters:
+              password: secret
+----
+====
 
 === Symlink Limitations
 
@@ -2198,6 +2896,10 @@ By default, MINA SSHD uses UTF-8 encoding for filenames, which is the standard f
 
 Use the `filenameEncoding` option to specify the charset:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Connect to a legacy server using GBK encoding for Chinese filenames
@@ -2208,6 +2910,51 @@ from("mina-sftp://user@host/path?password=secret&filenameEncoding=GBK")
 from("mina-sftp://user@host/path?password=secret&filenameEncoding=Shift-JIS")
     .to("file:local");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Connect to a legacy server using GBK encoding for Chinese filenames -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;filenameEncoding=GBK"/>
+  <to uri="file:local"/>
+</route>
+
+<!-- Connect to a Japanese server -->
+<route>
+  <from uri="mina-sftp://user@host/path?password=secret&amp;filenameEncoding=Shift-JIS"/>
+  <to uri="file:local"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Connect to a legacy server using GBK encoding for Chinese filenames
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        filenameEncoding: GBK
+      steps:
+        - to:
+            uri: file:local
+
+# Connect to a Japanese server
+- route:
+    from:
+      uri: mina-sftp://user@host/path
+      parameters:
+        password: secret
+        filenameEncoding: Shift-JIS
+      steps:
+        - to:
+            uri: file:local
+----
+====
 
 === Default Behavior
 
@@ -2253,6 +3000,7 @@ WARN  The 'jschLoggingLevel' parameter is specific to the JSch-based sftp compon
 
 === Migration Example
 
+._Java-only: before and after migration from JSch-specific parameters_
 [source,java]
 ----
 // Before (sftp component with JSch-specific parameters)
@@ -2403,6 +3151,8 @@ If you are migrating from the `sftp` component and were using `loggingLevel` or 
 4. The standard SLF4J approach provides more flexibility and follows Java logging best practices
 
 .Before (JSch sftp component)
+
+._Java-only: JSch sftp component with logging parameters_
 [source,java]
 ----
 from("sftp://user@host/path?password=secret&loggingLevel=DEBUG&serverMessageLoggingLevel=INFO")
@@ -2410,6 +3160,8 @@ from("sftp://user@host/path?password=secret&loggingLevel=DEBUG&serverMessageLogg
 ----
 
 .After (MINA SSHD mina-sftp component)
+
+._Java-only: mina-sftp component with logging parameters removed_
 [source,java]
 ----
 // Remove logging parameters from URI

--- a/components/camel-mina/src/main/docs/mina-component.adoc
+++ b/components/camel-mina/src/main/docs/mina-component.adoc
@@ -161,13 +161,40 @@ assertEquals("Bye World", response);
 Spring DSL can also be used for xref:mina-component.adoc[MINA].
 In the sample below, we expose a TCP server on port 5555:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("mina:tcp://localhost:5555?textline=true")
+    .to("bean:myTCPOrderHandler");
+----
+
+XML::
++
 [source,xml]
 ----
-   <route>
-     <from uri="mina:tcp://localhost:5555?textline=true"/>
-     <to uri="bean:myTCPOrderHandler"/>
-  </route>
+<route>
+  <from uri="mina:tcp://localhost:5555?textline=true"/>
+  <to uri="bean:myTCPOrderHandler"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina:tcp://localhost:5555
+      parameters:
+        textline: true
+      steps:
+        - to:
+            uri: bean:myTCPOrderHandler
+----
+====
 
 In the route above, we expose a TCP server on port 5555 using the
 textline codec. We let the Spring bean with ID, `myTCPOrderHandler`,

--- a/components/camel-minio/src/main/docs/minio-component.adoc
+++ b/components/camel-minio/src/main/docs/minio-component.adoc
@@ -695,6 +695,7 @@ Sometimes build a Minio Request can be complex because of multiple options.
 We introduce the possibility to use a POJO as the body.
 In Minio, there are multiple operations you can submit, as an example for List brokers request, you can do something like:
 
+._Java-only: uses Minio Java SDK builder API for POJO request body_
 [source,java]
 ----
 from("direct:minio")

--- a/components/camel-mock/src/main/docs/mock-component.adoc
+++ b/components/camel-mock/src/main/docs/mock-component.adoc
@@ -96,6 +96,7 @@ Here's a simple example of Mock endpoint in use. First, the endpoint is
 resolved on the context. Then we set an expectation, and then, after the
 test has run, we assert that our expectations have been met:
 
+._Java-only: MockEndpoint assertion API_
 [source,java]
 ----
 MockEndpoint resultEndpoint = context.getEndpoint("mock:foo", MockEndpoint.class);
@@ -126,6 +127,7 @@ will not affect the outcome of the assertion. Suppose you do want to
 test that no new messages arrives after a period thereafter, then you
 can do that by setting the `setAssertPeriod` method, for example:
 
+._Java-only: programmatic mock expectations with assert period_
 [source,java]
 ----
 MockEndpoint resultEndpoint = context.getEndpoint("mock:foo", MockEndpoint.class);
@@ -177,6 +179,7 @@ JMS, or some unique reference number within the message.
 
 Here's another example:
 
+._Java-only: MockEndpoint assertion API_
 [source,java]
 ----
 resultEndpoint.expectedBodiesReceived("firstMessageBody", "secondMessageBody", "thirdMessageBody");
@@ -193,6 +196,7 @@ For example, to add expectations of the headers or body of the first
 message (using zero-based indexing like `java.util.List`), you can use
 the following code:
 
+._Java-only: programmatic mock expectations on specific messages_
 [source,java]
 ----
 resultEndpoint.message(0).header("foo").isEqualTo("bar");
@@ -212,6 +216,7 @@ See next section for how to use all the Camel languages using the language build
 
 You can use regular expressions as expectations, as follows:
 
+._Java-only: mock endpoint regex expectations_
 [source,java]
 ----
 mock.message(1).header("cheese").regex("value[2,3]");
@@ -226,6 +231,7 @@ coding this easier. There are a limited set of functions out of the box.
 
 You can also use XPath as follows:
 
+._Java-only: mock endpoint XPath expectations_
 [source,java]
 ----
 String filter = "/person[@name='James']";
@@ -237,6 +243,7 @@ mock.message(2).header("cheese").xpath(filter).isFalse();
 
 You can also use xpath to check if it matches a given value such as:
 
+._Java-only: mock endpoint XPath value expectations_
 [source,java]
 ----
 String name = "/person/@name";
@@ -255,6 +262,7 @@ then you can use the Camel languages to perform the validation.
 
 For example to check whether a header matches a XPath you can do as follows:
 
+._Java-only: mock endpoint language builder expectations_
 [source,java]
 ----
 // setup the xpath once
@@ -271,6 +279,7 @@ you to use any of the many Camel languages, and to configure every option you ma
 
 If you only need to use the expectation once, you can inline this directly in the mock as follows:
 
+._Java-only: inline mock endpoint language builder expectation_
 [source,java]
 ----
 mock.message(1).predicate(expression().xpath("/person[@name='James']").source("header:cheese").end());
@@ -289,6 +298,7 @@ to use Java programming to compute the returned value.
 For example, you can write a custom function that takes an int as input and return the double value.
 And then use this in mock as follows:
 
+._Java-only: custom Function for mock expectations_
 [source,java]
 ----
 mock.message(0).header("num").expression(o -> {
@@ -313,6 +323,7 @@ can view this as a kind of intercept and delegate or endpoint listener.
 
 Suppose you have the given route below:
 
+._Java-only: Java test route definition_
 [source,java]
 .*Route*
 ----
@@ -322,6 +333,7 @@ include::{examplesdir}/core/camel-core/src/test/java/org/apache/camel/processor/
 You can then use the `adviceWith` feature in Camel to mock all the
 endpoints in a given route from your unit test, as shown below:
 
+._Java-only: adviceWith mock endpoint test pattern_
 [source,java]
 .*`adviceWith` mocking all endpoints*
 ----
@@ -346,6 +358,7 @@ removed.
 It's also possible to only mock certain endpoints using a pattern. For
 example to mock all `log` endpoints you do as shown:
 
+._Java-only: adviceWith mock endpoint test pattern with URI filter_
 [source,java]
 .*`adviceWith` mocking only log endpoints using a pattern*
 ----
@@ -376,6 +389,7 @@ endpoints.
 If you only want to mock all `log` endpoints you can return `"log*"`
 instead.
 
+._Java-only: camel-test kit mock endpoint test pattern_
 [source,java]
 .*`isMockEndpoints` using camel-test kit*
 ----
@@ -432,6 +446,7 @@ only. You can now use the `mockEndpointsAndSkip`
 method using AdviceWith. The example below will skip sending to the two endpoints
 `"direct:foo"`, and `"direct:bar"`.
 
+._Java-only: adviceWith mock and skip endpoint test pattern_
 [source,java]
 .*adviceWith mock and skip sending to endpoints*
 ----
@@ -440,6 +455,7 @@ include::{examplesdir}/core/camel-core/src/test/java/org/apache/camel/processor/
 
 The same example using the Test Kit
 
+._Java-only: camel-test kit mock and skip endpoint test pattern_
 [source,java]
 .*isMockEndpointsAndSkip using camel-test kit*
 ----
@@ -458,6 +474,7 @@ and/or last Exchanges.
 For example, in the code below, we only want to retain a copy of the
 first five and last five Exchanges the mock receives.
 
+._Java-only: programmatic mock expectations with retain limits_
 [source,java]
 ----
   MockEndpoint mock = getMockEndpoint("mock:data");
@@ -484,6 +501,7 @@ expectations on the 10 retained messages.
 The xref:mock-component.adoc[Mock] endpoint stores the arrival time of the message
 as a property on the Exchange.
 
+._Java-only: Exchange property access API_
 [source,java]
 ----
 Date time = exchange.getProperty(Exchange.RECEIVED_TIMESTAMP, Date.class);
@@ -498,6 +516,7 @@ endpoint.
 For example, to say that the first message should arrive between 0 and 2
 seconds before the next you can do:
 
+._Java-only: mock endpoint arrival time expectations_
 [source,java]
 ----
 mock.message(0).arrives().noLaterThan(2).seconds().beforeNext();
@@ -506,6 +525,7 @@ mock.message(0).arrives().noLaterThan(2).seconds().beforeNext();
 You can also define this as that second message (0 index based) should
 arrive no later than 0 and 2 seconds after the previous:
 
+._Java-only: mock endpoint arrival time expectations_
 [source,java]
 ----
 mock.message(1).arrives().noLaterThan(2).seconds().afterPrevious();
@@ -514,6 +534,7 @@ mock.message(1).arrives().noLaterThan(2).seconds().afterPrevious();
 You can also use between to set a lower bound. For example, suppose that
 it should be between 1 and 4 seconds:
 
+._Java-only: mock endpoint arrival time range expectations_
 [source,java]
 ----
 mock.message(1).arrives().between(1, 4).seconds().afterPrevious();
@@ -522,6 +543,7 @@ mock.message(1).arrives().between(1, 4).seconds().afterPrevious();
 You can also set the expectation on all messages, for example, to say
 that the gap between them should be at most 1 second:
 
+._Java-only: mock endpoint arrival time expectations for all messages_
 [source,java]
 ----
 mock.allMessages().arrives().noLaterThan(1).seconds().beforeNext();

--- a/components/camel-mongodb-gridfs/src/main/docs/mongodb-gridfs-component.adoc
+++ b/components/camel-mongodb-gridfs/src/main/docs/mongodb-gridfs-component.adoc
@@ -134,6 +134,19 @@ xref:mongodb-gridfs-component.adoc[*findOne*] on a collection.
 
 *Get a file from GridFS*
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("mongodb-gridfs:mongoBean?database=${mongodb.database}&operation=findOne")
+    .to("direct:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -143,6 +156,24 @@ xref:mongodb-gridfs-component.adoc[*findOne*] on a collection.
   <to uri="direct:result" />
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: mongodb-gridfs:mongoBean
+            parameters:
+              database: "${mongodb.database}"
+              operation: findOne
+        - to:
+            uri: direct:result
+----
+====
 
 === Configuration of a database in Spring XML
 

--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -158,6 +158,10 @@ YAML::
 
 Please note that the default _id is treated by Mongo as and `ObjectId` type, so you may need to convert it properly.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:findById")
@@ -165,6 +169,39 @@ from("direct:findById")
     .to("mongodb:myDb?database=flights&collection=tickets&operation=findById")
     .to("mock:resultFindById");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:findById"/>
+  <convertBodyTo type="org.bson.types.ObjectId"/>
+  <to uri="mongodb:myDb?database=flights&amp;collection=tickets&amp;operation=findById"/>
+  <to uri="mock:resultFindById"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:findById
+      steps:
+        - convertBodyTo:
+            type: org.bson.types.ObjectId
+        - to:
+            uri: mongodb:myDb
+            parameters:
+              database: flights
+              collection: tickets
+              operation: findById
+        - to:
+            uri: mock:resultFindById
+----
+====
 
 [TIP]
 ====
@@ -825,6 +862,8 @@ which displays useful statistic figures about the database. +
 
 Usage example:
 
+._Java-only: Java test API (ProducerTemplate)_
+
 [source,java]
 ----
 // from("direct:getDbStats").to("mongodb:myDb?database=flights&collection=tickets&operation=getDbStats");
@@ -864,6 +903,8 @@ shell, which displays useful statistic figures about the collection. +
 
 Usage example:
 
+._Java-only: Java test API (ProducerTemplate)_
+
 [source,java]
 ----
 // from("direct:getColStats").to("mongodb:myDb?database=flights&collection=tickets&operation=getColStats");
@@ -880,6 +921,8 @@ Run the body as a command on the database. Useful for admin operation as
 getting host information, replication or sharding status.
 
 Collection parameter is not used for this operation.
+
+._Java-only: Java test API (ProducerTemplate)_
 
 [source,java]
 ----
@@ -973,6 +1016,10 @@ value of 1000ms.), which you can modify to suit your needs.
 
 An example:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasingField=departureTime")
@@ -980,6 +1027,35 @@ from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasing
     .autoStartup(false)
     .to("mock:test");
 ----
+
+XML::
++
+[source,xml]
+----
+<route id="tailableCursorConsumer1" autoStartup="false">
+  <from uri="mongodb:myDb?database=flights&amp;collection=cancellations&amp;tailTrackIncreasingField=departureTime"/>
+  <to uri="mock:test"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: tailableCursorConsumer1
+    autoStartup: false
+    from:
+      uri: mongodb:myDb
+      parameters:
+        database: flights
+        collection: cancellations
+        tailTrackIncreasingField: departureTime
+      steps:
+        - to:
+            uri: mock:test
+----
+====
 
 The above route will consume from the `flights.cancellations` capped
 collection, using `departureTime` as the increasing field, with a
@@ -1027,29 +1103,102 @@ with persistent tail tracking turned on, and persisting under the
 the last processed value under the "lastTrackingValue" field
 (`camelTailTracking` and `lastTrackingValue` are defaults).
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
-from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasingField=departureTime&persistentTailTracking=true" + 
+from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasingField=departureTime&persistentTailTracking=true" +
      "&persistentId=cancellationsTracker")
     .id("tailableCursorConsumer2")
     .autoStartup(false)
     .to("mock:test");
 ----
 
+XML::
++
+[source,xml]
+----
+<route id="tailableCursorConsumer2" autoStartup="false">
+  <from uri="mongodb:myDb?database=flights&amp;collection=cancellations&amp;tailTrackIncreasingField=departureTime&amp;persistentTailTracking=true&amp;persistentId=cancellationsTracker"/>
+  <to uri="mock:test"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: tailableCursorConsumer2
+    autoStartup: false
+    from:
+      uri: mongodb:myDb
+      parameters:
+        database: flights
+        collection: cancellations
+        tailTrackIncreasingField: departureTime
+        persistentTailTracking: true
+        persistentId: cancellationsTracker
+      steps:
+        - to:
+            uri: mock:test
+----
+====
+
 Below is another example identical to the one above, but where the
 persistent tail tracking runtime information will be stored under the
 "trackers.camelTrackers" collection, in the "lastProcessedDepartureTime"
 field:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
-from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasingField=departureTime&persistentTailTracking=true" + 
-     "&persistentId=cancellationsTracker&tailTrackDb=trackers&tailTrackCollection=camelTrackers" + 
+from("mongodb:myDb?database=flights&collection=cancellations&tailTrackIncreasingField=departureTime&persistentTailTracking=true" +
+     "&persistentId=cancellationsTracker&tailTrackDb=trackers&tailTrackCollection=camelTrackers" +
      "&tailTrackField=lastProcessedDepartureTime")
     .id("tailableCursorConsumer3")
     .autoStartup(false)
     .to("mock:test");
 ----
+
+XML::
++
+[source,xml]
+----
+<route id="tailableCursorConsumer3" autoStartup="false">
+  <from uri="mongodb:myDb?database=flights&amp;collection=cancellations&amp;tailTrackIncreasingField=departureTime&amp;persistentTailTracking=true&amp;persistentId=cancellationsTracker&amp;tailTrackDb=trackers&amp;tailTrackCollection=camelTrackers&amp;tailTrackField=lastProcessedDepartureTime"/>
+  <to uri="mock:test"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: tailableCursorConsumer3
+    autoStartup: false
+    from:
+      uri: mongodb:myDb
+      parameters:
+        database: flights
+        collection: cancellations
+        tailTrackIncreasingField: departureTime
+        persistentTailTracking: true
+        persistentId: cancellationsTracker
+        tailTrackDb: trackers
+        tailTrackCollection: camelTrackers
+        tailTrackField: lastProcessedDepartureTime
+      steps:
+        - to:
+            uri: mock:test
+----
+====
 
 ==== Change Streams Consumer
 
@@ -1061,22 +1210,46 @@ The exchange body will contain the full document of any change.
 To configure Change Streams Consumer you need to specify `consumerType`, `database`, `collection`
 and optional JSON property `streamFilter` to filter events.
 That JSON property is standard MongoDB `$match` aggregation.
-It could be easily specified using XML DSL configuration:
+It could be easily specified using the DSL configuration:
 
-[source,xml]
-----
-<route id="filterConsumer">
-    <from uri="mongodb:myDb?consumerType=changeStreams&amp;database=flights&amp;collection=tickets&amp;streamFilter={ '$match':{'$or':[{'fullDocument.stringValue': 'specificValue'}]} }"/>
-    <to uri="mock:test"/>
-</route>
-----
-
-Java configuration:
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("mongodb:myDb?consumerType=changeStreams&database=flights&collection=tickets&streamFilter={ '$match':{'$or':[{'fullDocument.stringValue': 'specificValue'}]} }")
     .to("mock:test");
 ----
+
+XML::
++
+[source,xml]
+----
+<route id="filterConsumer">
+  <from uri="mongodb:myDb?consumerType=changeStreams&amp;database=flights&amp;collection=tickets&amp;streamFilter={ '$match':{'$or':[{'fullDocument.stringValue': 'specificValue'}]} }"/>
+  <to uri="mock:test"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: filterConsumer
+    from:
+      uri: mongodb:myDb
+      parameters:
+        consumerType: changeStreams
+        database: flights
+        collection: tickets
+        streamFilter: "{ '$match':{'$or':[{'fullDocument.stringValue': 'specificValue'}]} }"
+      steps:
+        - to:
+            uri: mock:test
+----
+====
 
 TIP: You can externalize the streamFilter value into a property placeholder which allows the endpoint
 URI parameters to be _cleaner_ and easier to read.

--- a/components/camel-mongodb/src/main/docs/mongodb-component.adoc
+++ b/components/camel-mongodb/src/main/docs/mongodb-component.adoc
@@ -1283,6 +1283,19 @@ The following route defined in Spring XML executes the operation
 
 *Get DB stats for specified collection*
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .to("mongodb:mongoBean?database=${mongodb.database}&collection=${mongodb.collection}&operation=getDbStats")
+    .to("direct:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -1292,6 +1305,25 @@ The following route defined in Spring XML executes the operation
   <to uri="direct:result" />
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: mongodb:mongoBean
+            parameters:
+              database: "${mongodb.database}"
+              collection: "${mongodb.collection}"
+              operation: getDbStats
+        - to:
+            uri: direct:result
+----
+====
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-mybatis/src/main/docs/mybatis-component.adoc
+++ b/components/camel-mybatis/src/main/docs/mybatis-component.adoc
@@ -622,6 +622,7 @@ proxy. This proxy enables non-Spring use of the `DataSource` to
 participate in Spring transactions (the MyBatis `SqlSessionFactory` does
 just this).
 
+._XML-only: Spring bean declaration for transaction-aware `DataSource` proxy_
 [source,xml]
 ----
 <bean id="dataSource" class="org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy">
@@ -642,6 +643,7 @@ to be externalised using property placeholders.
 A transaction manager is then configured to manage the outermost
 `DataSource`:
 
+._XML-only: Spring bean declaration for `DataSourceTransactionManager`_
 [source,xml]
 ----
 <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
@@ -653,6 +655,7 @@ A http://www.mybatis.org/spring/index.html[mybatis-spring]
 http://www.mybatis.org/spring/factorybean.html[`SqlSessionFactoryBean`]
 then wraps that same `DataSource`:
 
+._XML-only: Spring bean declaration for MyBatis `SqlSessionFactoryBean`_
 [source,xml]
 ----
 <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
@@ -666,6 +669,7 @@ then wraps that same `DataSource`:
 
 The camel-mybatis component is then configured with that factory:
 
+._XML-only: Spring bean declaration for `MyBatisComponent` with `SqlSessionFactory`_
 [source,xml]
 ----
 <bean id="mybatis" class="org.apache.camel.component.mybatis.MyBatisComponent">
@@ -675,6 +679,7 @@ The camel-mybatis component is then configured with that factory:
 
 Finally, a transaction policy is defined over the top of the transaction manager, which can then be used as usual:
 
+._XML-only: Spring transaction policy bean and transacted route_
 [source,xml]
 ----
 <bean id="PROPAGATION_REQUIRED" class="org.apache.camel.spring.spi.SpringTransactionPolicy">

--- a/components/camel-mybatis/src/main/docs/mybatis-component.adoc
+++ b/components/camel-mybatis/src/main/docs/mybatis-component.adoc
@@ -679,7 +679,19 @@ The camel-mybatis component is then configured with that factory:
 
 Finally, a transaction policy is defined over the top of the transaction manager, which can then be used as usual:
 
-._XML-only: Spring transaction policy bean and transacted route_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:insert")
+    .policy("PROPAGATION_REQUIRED")
+    .to("mybatis:myModel.insert?statementType=Insert");
+----
+
+XML::
++
 [source,xml]
 ----
 <bean id="PROPAGATION_REQUIRED" class="org.apache.camel.spring.spi.SpringTransactionPolicy">
@@ -695,6 +707,24 @@ Finally, a transaction policy is defined over the top of the transaction manager
     </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:insert
+      steps:
+        - policy:
+            ref: PROPAGATION_REQUIRED
+            steps:
+              - to:
+                  uri: mybatis:myModel.insert
+                  parameters:
+                    statementType: Insert
+----
+====
 
 == MyBatis Spring Boot Starter integration
 

--- a/components/camel-netty-http/src/main/docs/netty-http-component.adoc
+++ b/components/camel-netty-http/src/main/docs/netty-http-component.adoc
@@ -198,13 +198,40 @@ io.netty.handler.codec.http.HttpRequest request = exchange.getIn(NettyHttpMessag
 The Netty HTTP consumer supports HTTP basic authentication by specifying
 the security realm name to use, as shown below
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("netty-http:http://0.0.0.0:{{port}}/foo?securityConfiguration.realm=someRealm")
+    .to("direct:secured");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
    <from uri="netty-http:http://0.0.0.0:{{port}}/foo?securityConfiguration.realm=someRealm"/>
-   ...
+   <to uri="direct:secured"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: netty-http:http://0.0.0.0:{{port}}/foo
+      parameters:
+        securityConfiguration.realm: someRealm
+      steps:
+        - to:
+            uri: direct:secured
+----
+====
 
 The realm name is mandatory to enable basic authentication. By default,
 the JAAS based authenticator is used, which will use the realm name
@@ -255,13 +282,42 @@ necessary, and is therefore public for everyone without logging in
 To use this constraint, we just need to refer to the bean id as shown
 below:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("netty-http:http://0.0.0.0:{{port}}/foo?matchOnUriPrefix=true&securityConfiguration.realm=someRealm&securityConfiguration.securityConstraint=#constraint")
+    .to("direct:secured");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
    <from uri="netty-http:http://0.0.0.0:{{port}}/foo?matchOnUriPrefix=true&amp;securityConfiguration.realm=someRealm&amp;securityConfiguration.securityConstraint=#constraint"/>
-   ...
+   <to uri="direct:secured"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: netty-http:http://0.0.0.0:{{port}}/foo
+      parameters:
+        matchOnUriPrefix: true
+        securityConfiguration.realm: someRealm
+        securityConfiguration.securityConstraint: "#constraint"
+      steps:
+        - to:
+            uri: direct:secured
+----
+====
 
 == Examples
 
@@ -551,23 +607,72 @@ consumers to refer and reuse the same options across all consumers.
 
 And in the routes you refer to this option as shown below
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("netty-http:http://0.0.0.0:{{port}}/foo?bootstrapConfiguration=#nettyHttpBootstrapOptions")
+    .to("direct:foo");
+
+from("netty-http:http://0.0.0.0:{{port}}/bar?bootstrapConfiguration=#nettyHttpBootstrapOptions")
+    .to("direct:bar");
+
+from("netty-http:http://0.0.0.0:{{port}}/beer?bootstrapConfiguration=#nettyHttpBootstrapOptions")
+    .to("direct:beer");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
   <from uri="netty-http:http://0.0.0.0:{{port}}/foo?bootstrapConfiguration=#nettyHttpBootstrapOptions"/>
-  ...
+  <to uri="direct:foo"/>
 </route>
 
 <route>
   <from uri="netty-http:http://0.0.0.0:{{port}}/bar?bootstrapConfiguration=#nettyHttpBootstrapOptions"/>
-  ...
+  <to uri="direct:bar"/>
 </route>
 
 <route>
   <from uri="netty-http:http://0.0.0.0:{{port}}/beer?bootstrapConfiguration=#nettyHttpBootstrapOptions"/>
-  ...
+  <to uri="direct:beer"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: netty-http:http://0.0.0.0:{{port}}/foo
+      parameters:
+        bootstrapConfiguration: "#nettyHttpBootstrapOptions"
+      steps:
+        - to:
+            uri: direct:foo
+- route:
+    from:
+      uri: netty-http:http://0.0.0.0:{{port}}/bar
+      parameters:
+        bootstrapConfiguration: "#nettyHttpBootstrapOptions"
+      steps:
+        - to:
+            uri: direct:bar
+- route:
+    from:
+      uri: netty-http:http://0.0.0.0:{{port}}/beer
+      parameters:
+        bootstrapConfiguration: "#nettyHttpBootstrapOptions"
+      steps:
+        - to:
+            uri: direct:beer
+----
+====
 
 === Implementing a reverse proxy
 

--- a/components/camel-netty-http/src/main/docs/netty-http-component.adoc
+++ b/components/camel-netty-http/src/main/docs/netty-http-component.adoc
@@ -519,6 +519,7 @@ This will cause Camel to fail on startup.
 *Two routes are sharing the same port, but the second route is misconfigured
 and will fail on starting*
 
+._Java-only: demonstrates a misconfiguration that causes startup failure_
 [source,java]
 ----
 from("netty-http:http://0.0.0.0:{{port}}/foo")

--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -436,25 +436,83 @@ Netty producers.
 Then in the Camel routes we can refer to this worker pools by
 configuring the `workerPool` option in the URI as shown below:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("netty:tcp://0.0.0.0:5021?textline=true&sync=true&workerPool=#sharedPool&usingExecutorService=false")
+    .to("log:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
   <from uri="netty:tcp://0.0.0.0:5021?textline=true&amp;sync=true&amp;workerPool=#sharedPool&amp;usingExecutorService=false"/>
   <to uri="log:result"/>
-  ...
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: netty:tcp://0.0.0.0:5021
+      parameters:
+        textline: true
+        sync: true
+        workerPool: "#sharedPool"
+        usingExecutorService: false
+      steps:
+        - to:
+            uri: log:result
+----
+====
+
 And if we have another route, we can refer to the shared worker pool:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("netty:tcp://0.0.0.0:5022?textline=true&sync=true&workerPool=#sharedPool&usingExecutorService=false")
+    .to("log:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
   <from uri="netty:tcp://0.0.0.0:5022?textline=true&amp;sync=true&amp;workerPool=#sharedPool&amp;usingExecutorService=false"/>
   <to uri="log:result"/>
-  ...
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: netty:tcp://0.0.0.0:5022
+      parameters:
+        textline: true
+        sync: true
+        workerPool: "#sharedPool"
+        usingExecutorService: false
+      steps:
+        - to:
+            uri: log:result
+----
+====
 
 And so forth.
 

--- a/components/camel-pqc/src/main/docs/pqc-component.adoc
+++ b/components/camel-pqc/src/main/docs/pqc-component.adoc
@@ -115,16 +115,57 @@ TIP: To combine a classical signature (ECDSA, Ed25519, RSA) with a PQC signature
 
 - ML-DSA
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-    from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
-      .to("mock:verify");
---------------------------------------------------------------------------------
+----
+from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
+    .to("mock:verify");
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+      - to:
+          uri: mock:verify
+----
+====
 
 With the following beans registered in the Registry
 
+._Java-only: registering ML-DSA KeyPair and Signature beans_
 [source,java]
---------------------------------------------------------------------------------    
+--------------------------------------------------------------------------------
     @BindToRegistry("Keypair")
     public KeyPair setKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         KeyPairGenerator kpGen = KeyPairGenerator.getInstance("ML-DSA", "BC");
@@ -142,12 +183,54 @@ With the following beans registered in the Registry
 
 This could be done even without the Registry beans, by specifying the `signatureAlgorithm` parameter in the following way
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-  from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=MLDSA").to("mock:sign")
+----
+from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=MLDSA").to("mock:sign")
     .to("pqc:verify?operation=verify&signatureAlgorithm=MLDSA")
     .to("mock:verify");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign&amp;signatureAlgorithm=MLDSA"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify&amp;signatureAlgorithm=MLDSA"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+            signatureAlgorithm: MLDSA
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+            signatureAlgorithm: MLDSA
+      - to:
+          uri: mock:verify
+----
+====
 
 With this approach the component will use the class `org.apache.camel.component.pqc.crypto.PQCDefaultMLDSAMaterial`, which will create the Signature and KeyPair objects to be used.
 
@@ -155,16 +238,57 @@ The Spec used for the KeyPair will be, in this case, `ML-DSA-65`.
 
 - SLH-DSA
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-    from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
-      .to("mock:verify");
---------------------------------------------------------------------------------
+----
+from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
+    .to("mock:verify");
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+      - to:
+          uri: mock:verify
+----
+====
 
 With the following beans registered in the Registry
 
+._Java-only: registering SLH-DSA KeyPair and Signature beans_
 [source,java]
---------------------------------------------------------------------------------    
+--------------------------------------------------------------------------------
     @BindToRegistry("Keypair")
     public KeyPair setKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         KeyPairGenerator kpGen = KeyPairGenerator.getInstance("SLH-DSA", "BC");
@@ -182,12 +306,54 @@ With the following beans registered in the Registry
 
 This could be done even without the Registry beans, by specifying the `signatureAlgorithm` parameter in the following way
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-  from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=SLHDSA").to("mock:sign")
+----
+from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=SLHDSA").to("mock:sign")
     .to("pqc:verify?operation=verify&signatureAlgorithm=SLHDSA")
     .to("mock:verify");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign&amp;signatureAlgorithm=SLHDSA"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify&amp;signatureAlgorithm=SLHDSA"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+            signatureAlgorithm: SLHDSA
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+            signatureAlgorithm: SLHDSA
+      - to:
+          uri: mock:verify
+----
+====
 
 With this approach the component will use the class `org.apache.camel.component.pqc.crypto.PQCDefaultSLHDSAMaterial`, which will create the Signature and KeyPair objects to be used.
 
@@ -195,16 +361,57 @@ The Spec used for the KeyPair will be, in this case, `SLH-DSA-SHA2-128s`.
 
 - LMS
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-    from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
-      .to("mock:verify");
---------------------------------------------------------------------------------
+----
+from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
+    .to("mock:verify");
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+      - to:
+          uri: mock:verify
+----
+====
 
 With the following beans registered in the Registry
 
+._Java-only: registering LMS KeyPair and Signature beans_
 [source,java]
---------------------------------------------------------------------------------    
+--------------------------------------------------------------------------------
     @BindToRegistry("Keypair")
     public KeyPair setKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         KeyPairGenerator kpGen = KeyPairGenerator.getInstance("LMS", "BC");
@@ -222,12 +429,54 @@ With the following beans registered in the Registry
 
 This could be done even without the Registry beans, by specifying the `signatureAlgorithm` parameter in the following way
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-  from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=LMS").to("mock:sign")
+----
+from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=LMS").to("mock:sign")
     .to("pqc:verify?operation=verify&signatureAlgorithm=LMS")
     .to("mock:verify");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign&amp;signatureAlgorithm=LMS"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify&amp;signatureAlgorithm=LMS"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+            signatureAlgorithm: LMS
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+            signatureAlgorithm: LMS
+      - to:
+          uri: mock:verify
+----
+====
 
 With this approach the component will use the class `org.apache.camel.component.pqc.crypto.PQCDefaultLMSMaterial`, which will create the Signature and KeyPair objects to be used.
 
@@ -235,16 +484,57 @@ The Parameters used will be `LMS-SHA256-N32-H5` for the signature and `SHA256-n3
 
 - XMSS
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-    from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
-      .to("mock:verify");
---------------------------------------------------------------------------------
+----
+from("direct:sign").to("pqc:sign?operation=sign").to("mock:sign").to("pqc:verify?operation=verify")
+    .to("mock:verify");
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+      - to:
+          uri: mock:verify
+----
+====
 
 With the following beans registered in the Registry
 
+._Java-only: registering XMSS KeyPair and Signature beans_
 [source,java]
---------------------------------------------------------------------------------    
+--------------------------------------------------------------------------------
     @BindToRegistry("Keypair")
     public KeyPair setKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         KeyPairGenerator kpGen = KeyPairGenerator.getInstance("XMSS", "BCPQC");
@@ -262,12 +552,54 @@ With the following beans registered in the Registry
 
 This could be done even without the Registry beans, by specifying the `signatureAlgorithm` parameter in the following way
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-  from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=XMSS").to("mock:sign")
+----
+from("direct:sign").to("pqc:sign?operation=sign&signatureAlgorithm=XMSS").to("mock:sign")
     .to("pqc:verify?operation=verify&signatureAlgorithm=XMSS")
     .to("mock:verify");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:sign?operation=sign&amp;signatureAlgorithm=XMSS"/>
+  <to uri="mock:sign"/>
+  <to uri="pqc:verify?operation=verify&amp;signatureAlgorithm=XMSS"/>
+  <to uri="mock:verify"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:sign
+          parameters:
+            operation: sign
+            signatureAlgorithm: XMSS
+      - to:
+          uri: mock:sign
+      - to:
+          uri: pqc:verify
+          parameters:
+            operation: verify
+            signatureAlgorithm: XMSS
+      - to:
+          uri: mock:verify
+----
+====
 
 With this approach the component will use the class `org.apache.camel.component.pqc.crypto.PQCDefaultXMSSMaterial`, which will create the Signature and KeyPair objects to be used.
 
@@ -317,17 +649,60 @@ A possible flow of the operation could be the following:
 
 - ML-KEM
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
+----
 from("direct:encapsulate").to("pqc:keyenc?operation=generateSecretKeyEncapsulation&symmetricKeyAlgorithm=AES")
-  .to("mock:encapsulate")
-  .to("pqc:keyenc?operation=extractSecretKeyEncapsulation&symmetricKeyAlgorithm=AES").to("mock:extract");
---------------------------------------------------------------------------------
+    .to("mock:encapsulate")
+    .to("pqc:keyenc?operation=extractSecretKeyEncapsulation&symmetricKeyAlgorithm=AES").to("mock:extract");
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:encapsulate"/>
+  <to uri="pqc:keyenc?operation=generateSecretKeyEncapsulation&amp;symmetricKeyAlgorithm=AES"/>
+  <to uri="mock:encapsulate"/>
+  <to uri="pqc:keyenc?operation=extractSecretKeyEncapsulation&amp;symmetricKeyAlgorithm=AES"/>
+  <to uri="mock:extract"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:encapsulate
+    steps:
+      - to:
+          uri: pqc:keyenc
+          parameters:
+            operation: generateSecretKeyEncapsulation
+            symmetricKeyAlgorithm: AES
+      - to:
+          uri: mock:encapsulate
+      - to:
+          uri: pqc:keyenc
+          parameters:
+            operation: extractSecretKeyEncapsulation
+            symmetricKeyAlgorithm: AES
+      - to:
+          uri: mock:extract
+----
+====
 
 With the following beans registered in the Registry
 
+._Java-only: registering ML-KEM KeyPair and KeyGenerator beans_
 [source,java]
---------------------------------------------------------------------------------    
+--------------------------------------------------------------------------------
     @BindToRegistry("Keypair")
     public KeyPair setKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(PQCKeyEncapsulationAlgorithms.MLKEM.getAlgorithm(),
@@ -348,14 +723,58 @@ With the following beans registered in the Registry
 
 This could be done even without the Registry beans, by specifying the `symmetricKeyAlgorithm` and `keyEncapsulationAlgorithm` parameters in the following way
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
-   from("direct:encapsulate").to(
-     "pqc:keyenc?operation=generateSecretKeyEncapsulation&symmetricKeyAlgorithm=AES&keyEncapsulationAlgorithm=MLKEM")
-     .to("mock:encapsulate")
-     .to("pqc:keyenc?operation=extractSecretKeyEncapsulation&symmetricKeyAlgorithm=AES&keyEncapsulationAlgorithm=MLKEM")
-     .to("mock:extract");
---------------------------------------------------------------------------------
+----
+from("direct:encapsulate").to(
+    "pqc:keyenc?operation=generateSecretKeyEncapsulation&symmetricKeyAlgorithm=AES&keyEncapsulationAlgorithm=MLKEM")
+    .to("mock:encapsulate")
+    .to("pqc:keyenc?operation=extractSecretKeyEncapsulation&symmetricKeyAlgorithm=AES&keyEncapsulationAlgorithm=MLKEM")
+    .to("mock:extract");
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:encapsulate"/>
+  <to uri="pqc:keyenc?operation=generateSecretKeyEncapsulation&amp;symmetricKeyAlgorithm=AES&amp;keyEncapsulationAlgorithm=MLKEM"/>
+  <to uri="mock:encapsulate"/>
+  <to uri="pqc:keyenc?operation=extractSecretKeyEncapsulation&amp;symmetricKeyAlgorithm=AES&amp;keyEncapsulationAlgorithm=MLKEM"/>
+  <to uri="mock:extract"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:encapsulate
+    steps:
+      - to:
+          uri: pqc:keyenc
+          parameters:
+            operation: generateSecretKeyEncapsulation
+            symmetricKeyAlgorithm: AES
+            keyEncapsulationAlgorithm: MLKEM
+      - to:
+          uri: mock:encapsulate
+      - to:
+          uri: pqc:keyenc
+          parameters:
+            operation: extractSecretKeyEncapsulation
+            symmetricKeyAlgorithm: AES
+            keyEncapsulationAlgorithm: MLKEM
+      - to:
+          uri: mock:extract
+----
+====
 
 With this approach the component will use the class `org.apache.camel.component.pqc.crypto.kem.PQCDefaultMLKEMMaterial`, which will create the KeyGenerator and KeyPair objects to be used.
 
@@ -369,6 +788,7 @@ All of this could be done to use the secret key coming from the encapsulation in
 
 As example you could use the secret key to dynamically instruct the CryptoDataFormat to use it, like in the following route.
 
+._Java-only: extracting secret key from encapsulation for downstream CryptoDataFormat usage_
 [source,java]
 --------------------------------------------------------------------------------
         CryptoDataFormat cryptoFormat = new CryptoDataFormat("AES", null);
@@ -437,6 +857,7 @@ A production-ready implementation that persists keys and metadata to disk.
 
 **Example:**
 
+._Java-only: FileBasedKeyLifecycleManager usage_
 [source,java]
 --------------------------------------------------------------------------------
 KeyLifecycleManager keyManager = new FileBasedKeyLifecycleManager("/secure/keys");
@@ -471,6 +892,7 @@ A lightweight implementation that stores keys in memory only.
 
 **Example:**
 
+._Java-only: InMemoryKeyLifecycleManager usage_
 [source,java]
 --------------------------------------------------------------------------------
 InMemoryKeyLifecycleManager keyManager = new InMemoryKeyLifecycleManager();
@@ -539,6 +961,7 @@ To use HashicorpVaultKeyLifecycleManager, add the following optional dependency:
 
 **Example with VaultTemplate:**
 
+._Java-only: HashicorpVaultKeyLifecycleManager with VaultTemplate_
 [source,java]
 --------------------------------------------------------------------------------
 // Option 1: Using existing VaultTemplate (recommended when using camel-hashicorp-vault)
@@ -570,6 +993,7 @@ KeyPair keyPair = keyManager.generateKeyPair("DILITHIUM", "app-signing-key",
 
 **Example with Direct Configuration:**
 
+._Java-only: HashicorpVaultKeyLifecycleManager with direct configuration_
 [source,java]
 --------------------------------------------------------------------------------
 // Option 2: Direct configuration with connection parameters
@@ -590,6 +1014,7 @@ KeyPair keyPair = keyManager.generateKeyPair("DILITHIUM", "vault-key",
 
 **Example with HashiCorp Cloud Platform (HCP) Vault:**
 
+._Java-only: HashicorpVaultKeyLifecycleManager with HCP Vault_
 [source,java]
 --------------------------------------------------------------------------------
 // Option 3: Configuration for HCP Vault with namespace
@@ -748,6 +1173,7 @@ admin/                                     # Namespace
 
 HashicorpVaultKeyLifecycleManager can share the same VaultTemplate with the camel-hashicorp-vault component:
 
+._Java-only: reusing VaultTemplate from camel-hashicorp-vault_
 [source,java]
 --------------------------------------------------------------------------------
 // Reuse VaultTemplate from camel-hashicorp-vault
@@ -962,6 +1388,7 @@ To use AwsSecretsManagerKeyLifecycleManager, add the following optional dependen
 
 **Example with SecretsManagerClient:**
 
+._Java-only: AwsSecretsManagerKeyLifecycleManager with SecretsManagerClient_
 [source,java]
 --------------------------------------------------------------------------------
 // Option 1: Using existing SecretsManagerClient (recommended when using camel-aws-secrets-manager)
@@ -989,6 +1416,7 @@ KeyPair keyPair = keyManager.generateKeyPair("DILITHIUM", "app-signing-key",
 
 **Example with Direct Configuration:**
 
+._Java-only: AwsSecretsManagerKeyLifecycleManager with direct configuration_
 [source,java]
 --------------------------------------------------------------------------------
 // Option 2: Direct configuration with AWS credentials
@@ -1007,6 +1435,7 @@ KeyPair keyPair = keyManager.generateKeyPair("DILITHIUM", "aws-key",
 
 **Example with LocalStack (Testing):**
 
+._Java-only: AwsSecretsManagerKeyLifecycleManager with LocalStack_
 [source,java]
 --------------------------------------------------------------------------------
 // Option 3: Configuration for LocalStack testing
@@ -1305,6 +1734,7 @@ Limit access to specific key IDs only:
 
 AwsSecretsManagerKeyLifecycleManager can share the same SecretsManagerClient with the camel-aws-secrets-manager component:
 
+._Java-only: reusing SecretsManagerClient from camel-aws-secrets-manager_
 [source,java]
 --------------------------------------------------------------------------------
 // Reuse SecretsManagerClient from camel-aws-secrets-manager
@@ -1405,6 +1835,7 @@ The key lifecycle manager supports all PQC algorithms with sensible default para
 
 ==== Signature Algorithms
 
+._Java-only: generating key pairs for various PQC signature algorithms_
 [source,java]
 --------------------------------------------------------------------------------
 // ML-DSA (uses default ML-DSA-65)
@@ -1429,6 +1860,7 @@ KeyPair lmsKey = keyManager.generateKeyPair("LMS", "lms-key");
 
 ==== Key Encapsulation Algorithms
 
+._Java-only: generating key pairs for various PQC KEM algorithms_
 [source,java]
 --------------------------------------------------------------------------------
 // ML-KEM (uses default)
@@ -1448,6 +1880,7 @@ KeyPair bikeKey = keyManager.generateKeyPair("BIKE", "bike-key");
 
 Each key is associated with metadata that tracks its lifecycle:
 
+._Java-only: retrieving and inspecting key metadata_
 [source,java]
 --------------------------------------------------------------------------------
 KeyMetadata metadata = keyManager.getKeyMetadata("my-key");
@@ -1474,6 +1907,7 @@ System.out.println("Next rotation: " + metadata.getNextRotationAt());
 
 Key rotation is essential for maintaining security. The lifecycle manager supports automated rotation:
 
+._Java-only: checking rotation need and rotating a key_
 [source,java]
 --------------------------------------------------------------------------------
 // Check if key needs rotation
@@ -1504,6 +1938,7 @@ Keys can be exported and imported in multiple formats:
 
 **Export Example:**
 
+._Java-only: exporting keys in PEM and DER formats_
 [source,java]
 --------------------------------------------------------------------------------
 KeyPair keyPair = keyManager.getKey("my-key");
@@ -1526,6 +1961,7 @@ byte[] fullExport = keyManager.exportKey(keyPair, KeyFormat.DER, true);
 
 **Import Example:**
 
+._Java-only: importing a key from PEM format_
 [source,java]
 --------------------------------------------------------------------------------
 // Import from PEM format
@@ -1541,6 +1977,7 @@ keyManager.storeKey("imported-key", imported, metadata);
 
 **Expire a Key:**
 
+._Java-only: setting expiration and manually expiring a key_
 [source,java]
 --------------------------------------------------------------------------------
 // Set expiration time
@@ -1559,6 +1996,7 @@ if (metadata.isExpired()) {
 
 **Revoke a Key:**
 
+._Java-only: revoking a compromised key_
 [source,java]
 --------------------------------------------------------------------------------
 // Revoke a compromised key
@@ -1571,6 +2009,7 @@ assert metadata.getDescription().contains("Revoked: Private key exposed");
 
 === Listing and Managing Keys
 
+._Java-only: listing, filtering, and deleting keys_
 [source,java]
 --------------------------------------------------------------------------------
 // List all keys
@@ -1727,6 +2166,7 @@ The lifecycle manager provides sensible defaults for all algorithms:
 
 Implement automated key rotation policies:
 
+._Java-only: automated key rotation policy_
 [source,java]
 --------------------------------------------------------------------------------
 // Rotate keys every 90 days or after 10,000 uses
@@ -1751,6 +2191,7 @@ For FileBasedKeyLifecycleManager:
 
 Always update metadata when using keys:
 
+._Java-only: updating key usage metadata_
 [source,java]
 --------------------------------------------------------------------------------
 KeyMetadata metadata = keyManager.getKeyMetadata(keyId);
@@ -1780,6 +2221,7 @@ When exporting keys:
 
 Use InMemoryKeyLifecycleManager for tests:
 
+._Java-only: test setup and cleanup with InMemoryKeyLifecycleManager_
 [source,java]
 --------------------------------------------------------------------------------
 @BeforeEach
@@ -1802,6 +2244,7 @@ Both implementations are thread-safe:
 
 Concurrent key operations are safe:
 
+._Java-only: concurrent key generation with thread pool_
 [source,java]
 --------------------------------------------------------------------------------
 ExecutorService executor = Executors.newFixedThreadPool(10);
@@ -1826,6 +2269,7 @@ executor.awaitTermination(1, TimeUnit.MINUTES);
 
 To migrate from InMemoryKeyLifecycleManager to FileBasedKeyLifecycleManager:
 
+._Java-only: migrating keys between lifecycle manager implementations_
 [source,java]
 --------------------------------------------------------------------------------
 InMemoryKeyLifecycleManager memoryManager = new InMemoryKeyLifecycleManager();
@@ -1871,8 +2315,12 @@ The component supports hybrid signatures that combine a classical signature (e.g
 
 **Example - Hybrid Signature with ECDSA P-256 + ML-DSA:**
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
+----
 from("direct:sign")
     .to("pqc:hybrid?operation=hybridSign"
         + "&signatureAlgorithm=MLDSA"
@@ -1884,18 +2332,99 @@ from("direct:verify")
         + "&signatureAlgorithm=MLDSA"
         + "&classicalSignatureAlgorithm=ECDSA_P256")
     .to("mock:verified");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:hybrid?operation=hybridSign&amp;signatureAlgorithm=MLDSA&amp;classicalSignatureAlgorithm=ECDSA_P256"/>
+  <to uri="mock:signed"/>
+</route>
+<route>
+  <from uri="direct:verify"/>
+  <to uri="pqc:hybrid?operation=hybridVerify&amp;signatureAlgorithm=MLDSA&amp;classicalSignatureAlgorithm=ECDSA_P256"/>
+  <to uri="mock:verified"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:hybrid
+          parameters:
+            operation: hybridSign
+            signatureAlgorithm: MLDSA
+            classicalSignatureAlgorithm: ECDSA_P256
+      - to:
+          uri: mock:signed
+- route:
+    from:
+      uri: direct:verify
+    steps:
+      - to:
+          uri: pqc:hybrid
+          parameters:
+            operation: hybridVerify
+            signatureAlgorithm: MLDSA
+            classicalSignatureAlgorithm: ECDSA_P256
+      - to:
+          uri: mock:verified
+----
+====
 
 **Example - Hybrid Signature with Ed25519 + ML-DSA:**
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
+----
 from("direct:sign")
     .to("pqc:hybrid?operation=hybridSign"
         + "&signatureAlgorithm=MLDSA"
         + "&classicalSignatureAlgorithm=ED25519")
     .to("mock:signed");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:sign"/>
+  <to uri="pqc:hybrid?operation=hybridSign&amp;signatureAlgorithm=MLDSA&amp;classicalSignatureAlgorithm=ED25519"/>
+  <to uri="mock:signed"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:sign
+    steps:
+      - to:
+          uri: pqc:hybrid
+          parameters:
+            operation: hybridSign
+            signatureAlgorithm: MLDSA
+            classicalSignatureAlgorithm: ED25519
+      - to:
+          uri: mock:signed
+----
+====
 
 **Hybrid Signature Wire Format:**
 
@@ -1934,8 +2463,12 @@ The component supports hybrid Key Encapsulation Mechanisms that combine classica
 
 **Example - Hybrid KEM with X25519 + ML-KEM:**
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
+----
 from("direct:encapsulate")
     .to("pqc:hybridkem?operation=hybridGenerateSecretKeyEncapsulation"
         + "&keyEncapsulationAlgorithm=MLKEM"
@@ -1951,12 +2484,67 @@ from("direct:extract")
         + "&symmetricKeyAlgorithm=AES"
         + "&symmetricKeyLength=256")
     .to("mock:extracted");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:encapsulate"/>
+  <to uri="pqc:hybridkem?operation=hybridGenerateSecretKeyEncapsulation&amp;keyEncapsulationAlgorithm=MLKEM&amp;classicalKEMAlgorithm=X25519&amp;symmetricKeyAlgorithm=AES&amp;symmetricKeyLength=256"/>
+  <to uri="mock:encapsulated"/>
+</route>
+<route>
+  <from uri="direct:extract"/>
+  <to uri="pqc:hybridkem?operation=hybridExtractSecretKeyEncapsulation&amp;keyEncapsulationAlgorithm=MLKEM&amp;classicalKEMAlgorithm=X25519&amp;symmetricKeyAlgorithm=AES&amp;symmetricKeyLength=256"/>
+  <to uri="mock:extracted"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:encapsulate
+    steps:
+      - to:
+          uri: pqc:hybridkem
+          parameters:
+            operation: hybridGenerateSecretKeyEncapsulation
+            keyEncapsulationAlgorithm: MLKEM
+            classicalKEMAlgorithm: X25519
+            symmetricKeyAlgorithm: AES
+            symmetricKeyLength: 256
+      - to:
+          uri: mock:encapsulated
+- route:
+    from:
+      uri: direct:extract
+    steps:
+      - to:
+          uri: pqc:hybridkem
+          parameters:
+            operation: hybridExtractSecretKeyEncapsulation
+            keyEncapsulationAlgorithm: MLKEM
+            classicalKEMAlgorithm: X25519
+            symmetricKeyAlgorithm: AES
+            symmetricKeyLength: 256
+      - to:
+          uri: mock:extracted
+----
+====
 
 **Example - Hybrid KEM with ECDH P-256 + ML-KEM:**
 
+[tabs]
+====
+Java::
++
 [source,java]
---------------------------------------------------------------------------------
+----
 from("direct:encapsulate")
     .to("pqc:hybridkem?operation=hybridGenerateSecretKeyEncapsulation"
         + "&keyEncapsulationAlgorithm=MLKEM"
@@ -1965,7 +2553,40 @@ from("direct:encapsulate")
         + "&symmetricKeyLength=128"
         + "&hybridKdfAlgorithm=HKDF-SHA256")
     .to("mock:encapsulated");
---------------------------------------------------------------------------------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:encapsulate"/>
+  <to uri="pqc:hybridkem?operation=hybridGenerateSecretKeyEncapsulation&amp;keyEncapsulationAlgorithm=MLKEM&amp;classicalKEMAlgorithm=ECDH_P256&amp;symmetricKeyAlgorithm=AES&amp;symmetricKeyLength=128&amp;hybridKdfAlgorithm=HKDF-SHA256"/>
+  <to uri="mock:encapsulated"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:encapsulate
+    steps:
+      - to:
+          uri: pqc:hybridkem
+          parameters:
+            operation: hybridGenerateSecretKeyEncapsulation
+            keyEncapsulationAlgorithm: MLKEM
+            classicalKEMAlgorithm: ECDH_P256
+            symmetricKeyAlgorithm: AES
+            symmetricKeyLength: 128
+            hybridKdfAlgorithm: HKDF-SHA256
+      - to:
+          uri: mock:encapsulated
+----
+====
 
 **Hybrid KEM Wire Format:**
 
@@ -2077,6 +2698,7 @@ The `PQCAlgorithmId` enum maps every supported algorithm — classical signature
 
 **Lookup by JCA name:**
 
+._Java-only: resolving PQCAlgorithmId from JCA algorithm names_
 [source,java]
 --------------------------------------------------------------------------------
 // Resolve from a JCA algorithm string (case-insensitive)
@@ -2090,6 +2712,7 @@ PQCAlgorithmId unknown = PQCAlgorithmId.fromJcaName("FutureAlg"); // UNKNOWN
 
 **Lookup by wire format ID:**
 
+._Java-only: resolving PQCAlgorithmId from wire format identifier_
 [source,java]
 --------------------------------------------------------------------------------
 // Resolve from a 16-bit identifier read from the wire
@@ -2100,6 +2723,7 @@ String jca = alg.getJcaName();  // "ML-DSA"
 
 **Inspecting algorithm metadata from a parsed hybrid output:**
 
+._Java-only: parsing and inspecting v2 hybrid signature components_
 [source,java]
 --------------------------------------------------------------------------------
 // After parsing a v2 hybrid signature
@@ -2199,6 +2823,7 @@ This format allows the receiver to identify the algorithms used, extract the enc
 
 ==== Java DSL
 
+._Java-only: PQC DataFormat basic encrypt and decrypt routes_
 [source,java]
 --------------------------------------------------------------------------------
 // Create PQC DataFormat
@@ -2299,6 +2924,7 @@ The DataFormat requires a KeyPair to be available either:
 
 ==== Option 1: Registry-based Configuration
 
+._Java-only: registering ML-KEM KeyPair in Camel registry_
 [source,java]
 --------------------------------------------------------------------------------
 @BindToRegistry("pqcKeyPair")
@@ -2316,6 +2942,7 @@ pqcFormat.setSymmetricKeyAlgorithm("AES");
 
 ==== Option 2: Direct Configuration
 
+._Java-only: configuring PQCDataFormat with KeyPair directly_
 [source,java]
 --------------------------------------------------------------------------------
 KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", "BCPQC");
@@ -2330,6 +2957,7 @@ pqcFormat.setSymmetricKeyAlgorithm("AES");
 
 ==== Option 3: Header-based Configuration
 
+._Java-only: providing KeyPair via message header_
 [source,java]
 --------------------------------------------------------------------------------
 from("direct:encrypt")
@@ -2377,6 +3005,7 @@ from("direct:encrypt")
 
 ==== Secure File Transfer
 
+._Java-only: PQC DataFormat for secure file encrypt and decrypt_
 [source,java]
 --------------------------------------------------------------------------------
 PQCDataFormat pqcFormat = new PQCDataFormat();
@@ -2399,6 +3028,7 @@ from("file:encrypted?noop=true")
 
 ==== API Message Encryption
 
+._Java-only: PQC DataFormat for API message encrypt and decrypt_
 [source,java]
 --------------------------------------------------------------------------------
 from("direct:secure-api")
@@ -2413,6 +3043,7 @@ from("direct:secure-api")
 
 ==== Multiple Algorithm Support
 
+._Java-only: PQC DataFormat with multiple security levels_
 [source,java]
 --------------------------------------------------------------------------------
 // Different algorithms for different security levels
@@ -2440,6 +3071,7 @@ from("direct:classify")
 
 ==== Dynamic Algorithm Selection via Headers
 
+._Java-only: PQC DataFormat with dynamic algorithm selection_
 [source,java]
 --------------------------------------------------------------------------------
 PQCDataFormat pqcFormat = new PQCDataFormat();
@@ -2455,6 +3087,7 @@ from("direct:dynamic-encrypt")
 
 The PQC DataFormat can be integrated with the Key Lifecycle Manager for automated key management:
 
+._Java-only: integrating PQC DataFormat with Key Lifecycle Manager_
 [source,java]
 --------------------------------------------------------------------------------
 @BindToRegistry("keyLifecycleManager")
@@ -2489,6 +3122,7 @@ public KeyPair createKeyPair() throws Exception {
 
 **Manual Approach (using PQC component endpoints):**
 
+._Java-only: manual KEM encrypt with multiple endpoint steps_
 [source,java]
 --------------------------------------------------------------------------------
 from("direct:manual-encrypt")
@@ -2503,6 +3137,7 @@ from("direct:manual-encrypt")
 
 **DataFormat Approach (simplified):**
 
+._Java-only: simplified encrypt using PQCDataFormat_
 [source,java]
 --------------------------------------------------------------------------------
 from("direct:dataformat-encrypt")
@@ -2547,6 +3182,7 @@ The DataFormat approach is significantly simpler and handles all KEM operations 
 
 Adjust bufferSize based on message size:
 
+._Java-only: configuring PQCDataFormat buffer size_
 [source,java]
 --------------------------------------------------------------------------------
 PQCDataFormat pqcFormat = new PQCDataFormat();
@@ -2557,6 +3193,7 @@ pqcFormat.setBufferSize(8192);  // Larger buffer for big files
 
 Configure a KeyGenerator once to avoid repeated initialization:
 
+._Java-only: caching a KeyGenerator to avoid repeated initialization_
 [source,java]
 --------------------------------------------------------------------------------
 @BindToRegistry("kemKeyGenerator")
@@ -2572,6 +3209,7 @@ pqcFormat.setKeyGenerator(kemKeyGenerator);
 
 The DataFormat supports streaming for large payloads, avoiding memory issues:
 
+._Java-only: streaming large files with PQCDataFormat_
 [source,java]
 --------------------------------------------------------------------------------
 from("file:large-files?noop=true")
@@ -2584,6 +3222,7 @@ from("file:large-files?noop=true")
 
 Example test demonstrating round-trip encryption/decryption:
 
+._Java-only: JUnit 5 test for PQC DataFormat round-trip encryption_
 [source,java]
 --------------------------------------------------------------------------------
 @Test
@@ -2641,6 +3280,7 @@ void testPQCDataFormatRoundTrip() throws Exception {
 
 * **Solution**: Add Bouncy Castle providers:
 +
+._Java-only: adding Bouncy Castle security providers_
 [source,java]
 --------------------------------------------------------------------------------
 Security.addProvider(new BouncyCastleProvider());
@@ -2656,6 +3296,7 @@ Security.addProvider(new BouncyCastlePQCProvider());
 
 * **Solution**: Increase buffer size or enable stream caching:
 +
+._Java-only: increasing buffer size or enabling stream caching_
 [source,java]
 --------------------------------------------------------------------------------
 pqcFormat.setBufferSize(16384);

--- a/components/camel-quickfix/src/main/docs/quickfix-component.adoc
+++ b/components/camel-quickfix/src/main/docs/quickfix-component.adoc
@@ -293,6 +293,7 @@ QuickFIX/J session ID strings is also included. The following example
 shows a simple configuration of an acceptor and initiator session with
 default settings for both sessions.
 
+._XML-only: Spring XML configuration with QuickFIX/J component and session settings_
 [source,xml]
 ----
 <!--  camel route  -->

--- a/components/camel-reactive-streams/src/main/docs/reactive-streams-component.adoc
+++ b/components/camel-reactive-streams/src/main/docs/reactive-streams-component.adoc
@@ -258,11 +258,39 @@ Flowable.just(new File("file1.txt"), new File("file2.txt"))
 
 In order this to work, a route like the following should be defined in the Camel context:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("reactive-streams:readAndMarshal")
     .marshal() // ... other details
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="reactive-streams:readAndMarshal"/>
+  <marshal>
+    <!-- ... other details -->
+  </marshal>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: reactive-streams:readAndMarshal
+      steps:
+        - marshal: {}
+----
+====
 
 ==== Request a transformation to Camel using the direct API
 
@@ -286,11 +314,39 @@ route using `reactive-streams:` endpoints (although they are used under the hood
 
 In this case, the Camel transformation can be just:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:process")
     .marshal() // ... other details
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:process"/>
+  <marshal>
+    <!-- ... other details -->
+  </marshal>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:process
+      steps:
+        - marshal: {}
+----
+====
 
 
 === Process Camel data into the reactive framework

--- a/components/camel-ref/src/main/docs/ref-component.adoc
+++ b/components/camel-ref/src/main/docs/ref-component.adoc
@@ -60,6 +60,7 @@ producer.process(exchange);
 With Spring XML, you could have a list of endpoints defined in the
 Registry such as:
 
+._XML-only: Spring XML endpoint registry definitions_
 [source,xml]
 ----
 <camelContext id="camel" xmlns="http://activemq.apache.org/camel/schema/spring">

--- a/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-component.adoc
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-component.adoc
@@ -124,6 +124,7 @@ As a general example on using the operations in this salesforce component, the f
 the upsertSObject API, with the sObjectIdName parameter specifying 'Name' as the external id field.
 The request message body should be an SObject DTO generated using the maven plugin.
 
+._Java-only: endpoint URI snippet_
 [source,java]
 ----
 ...to("salesforce:upsertSObject?sObjectIdName=Name")...
@@ -1891,6 +1892,7 @@ type, which can be XML, CSV, ZIP_XML or ZIP_CSV. The put message body
 will contain `BatchInfo` on success, or throw a `SalesforceException` on
 error.
 
+._Java-only: endpoint URI snippet_
 [source,java]
 ----
 ...to("salesforce:createBatch")..

--- a/components/camel-saxon/src/main/docs/xquery-component.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-component.adoc
@@ -112,6 +112,19 @@ key name *foo* then it is added as *foo*.
 If you prefer to configure your routes in your Spring
 XML file, then you can use XPath expressions as follows
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("activemq:MyQueue")
+    .filter().xquery("/foo:person[@name='James']")
+        .to("mqseries:SomeOtherQueue");
+----
+
+XML::
++
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -132,6 +145,23 @@ XML file, then you can use XPath expressions as follows
   </camelContext>
 </beans>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:MyQueue
+      steps:
+        - filter:
+            xquery:
+              expression: "/foo:person[@name='James']"
+            steps:
+              - to:
+                  uri: mqseries:SomeOtherQueue
+----
+====
 
 Notice how we can reuse the namespace prefixes, *foo* in this case, in
 the XPath expression for easier namespace-based XQuery expressions!
@@ -156,16 +186,44 @@ templates.
 The following example shows how to take a message of an ActiveMQ queue
 (MyQueue) and transform it using XQuery and send it to MQSeries.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("activemq:MyQueue")
+    .to("xquery:com/acme/someTransform.xquery")
+    .to("mqseries:SomeOtherQueue");
+----
+
+XML::
++
 [source,xml]
 ----
-  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
-    <route>
-      <from uri="activemq:MyQueue"/>
-      <to uri="xquery:com/acme/someTransform.xquery"/>
-      <to uri="mqseries:SomeOtherQueue"/>
-    </route>
-  </camelContext>
+<camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+  <route>
+    <from uri="activemq:MyQueue"/>
+    <to uri="xquery:com/acme/someTransform.xquery"/>
+    <to uri="mqseries:SomeOtherQueue"/>
+  </route>
+</camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:MyQueue
+      steps:
+        - to:
+            uri: xquery:com/acme/someTransform.xquery
+        - to:
+            uri: mqseries:SomeOtherQueue
+----
+====
 
 === Loading script from external resource
 

--- a/components/camel-saxon/src/main/docs/xquery-language.adoc
+++ b/components/camel-saxon/src/main/docs/xquery-language.adoc
@@ -176,6 +176,7 @@ in the XML root tag (or one of the `camelContext`, `routes`, `route` tags).
 In the XML example below we use Spring XML where the namespace is declared in the root tag `beans`,
 in the line with `xmlns:foo="http://example.com/person"`:
 
+._XML-only:_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"

--- a/components/camel-seda/src/main/docs/seda-component.adoc
+++ b/components/camel-seda/src/main/docs/seda-component.adoc
@@ -62,6 +62,7 @@ By default, the SEDA component always instantiates a `LinkedBlockingQueue`,
 but you can use different implementation, you can reference your own
 `BlockingQueue` implementation, in this case the size option is not used:
 
+._XML-only: Spring bean definition for custom BlockingQueue_
 [source,xml]
 ----
 <bean id="arrayQueue" class="java.util.ArrayBlockingQueue">
@@ -80,6 +81,7 @@ Three implementations are provided:
 * `ArrayBlockingQueueFactory`
 * `PriorityBlockingQueueFactory`
 
+._XML-only: Spring bean definition for custom BlockingQueueFactory_
 [source,xml]
 ----
 <bean id="priorityQueueFactory" class="org.apache.camel.component.seda.PriorityBlockingQueueFactory">

--- a/components/camel-seda/src/main/docs/seda-component.adoc
+++ b/components/camel-seda/src/main/docs/seda-component.adoc
@@ -196,6 +196,7 @@ number of concurrent consumers is always fixed.
 Be aware that adding a thread pool to a SEDA endpoint by doing something
 like:
 
+._Java-only: thread pool added to SEDA endpoint_
 [source,java]
 ----
 from("seda:stageName").thread(5).process(...)
@@ -207,6 +208,7 @@ Instead, you might wish to configure a xref:direct-component.adoc[Direct] endpoi
 with a thread pool, which can process messages both synchronously and
 asynchronously. For example:
 
+._Java-only: thread pool on a Direct endpoint_
 [source,java]
 ----
 from("direct:stageName").thread(5).process(...)

--- a/components/camel-servlet/src/main/docs/servlet-component.adoc
+++ b/components/camel-servlet/src/main/docs/servlet-component.adoc
@@ -171,6 +171,7 @@ If you're running Camel standalone on a Servlet container or application server,
 
 For example, to define a route that exposes an HTTP service under the path `/services`.
 
+._XML-only: web.xml servlet configuration_
 [source,xml]
 ----
 <web-app>
@@ -228,6 +229,7 @@ On the Camel Quarkus runtime, these init parameters can be set via configuration
 
 On other runtimes you can configure these parameters in `web.xml` as follows.
 
+._XML-only: web.xml with async servlet init parameters_
 [source,xml]
 ----
 <web-app>
@@ -260,6 +262,7 @@ WARNING: Having Camel JARs on the boot classpath of the application server is no
 
 In this scenario, you *must* define a custom and unique servlet name in each of your Camel applications. For example, in `web.xml`:
 
+._XML-only: web.xml with custom servlet name_
 [source,xml]
 ----
 <web-app>
@@ -317,6 +320,7 @@ start the application. You can control and ignore such duplicates by
 setting the servlet init parameter `ignoreDuplicateServletName` to `true` as
 follows:
 
+._XML-only: web.xml init parameter to ignore duplicate servlet names_
 [source,xml]
 ----
   <servlet>

--- a/components/camel-snakeyaml/src/main/docs/snakeYaml-dataformat.adoc
+++ b/components/camel-snakeyaml/src/main/docs/snakeYaml-dataformat.adoc
@@ -130,24 +130,65 @@ tag.
 
 And then you can refer to those ids in the route:
 
-._XML-only: routes referencing pre-defined data format beans_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:unmarshal")
+    .unmarshal("snake")
+    .to("mock:unmarshal");
+
+from("direct:unmarshal-safe")
+    .unmarshal("snake-safe")
+    .to("mock:unmarshal-safe");
+----
+
+XML::
++
 [source,xml]
 ----
-  <route>
-    <from uri="direct:unmarshal"/>
-    <unmarshal>
-      <custom ref="snake"/>
-    </unmarshal>
-    <to uri="mock:unmarshal"/>
-  </route>
-  <route>
-    <from uri="direct:unmarshal-safe"/>
-    <unmarshal>
-      <custom ref="snake-safe"/>
-    </unmarshal>
-    <to uri="mock:unmarshal-safe"/>
-  </route>
+<route>
+  <from uri="direct:unmarshal"/>
+  <unmarshal>
+    <custom ref="snake"/>
+  </unmarshal>
+  <to uri="mock:unmarshal"/>
+</route>
+<route>
+  <from uri="direct:unmarshal-safe"/>
+  <unmarshal>
+    <custom ref="snake-safe"/>
+  </unmarshal>
+  <to uri="mock:unmarshal-safe"/>
+</route>
 ----
+
+YAML DSL::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:unmarshal
+      steps:
+        - unmarshal:
+            custom:
+              ref: snake
+        - to:
+            uri: mock:unmarshal
+- route:
+    from:
+      uri: direct:unmarshal-safe
+      steps:
+        - unmarshal:
+            custom:
+              ref: snake-safe
+        - to:
+            uri: mock:unmarshal-safe
+----
+====
 
 
 == Dependencies for SnakeYAML

--- a/components/camel-snakeyaml/src/main/docs/snakeYaml-dataformat.adoc
+++ b/components/camel-snakeyaml/src/main/docs/snakeYaml-dataformat.adoc
@@ -102,6 +102,7 @@ When using Data Format in Spring DSL, you need to
 declare the data formats first. This is done in the *DataFormats* XML
 tag.
 
+._XML-only: Spring XML data format definitions with type filters_
 [source,xml]
 ----
 <dataFormats>
@@ -129,6 +130,7 @@ tag.
 
 And then you can refer to those ids in the route:
 
+._XML-only: routes referencing pre-defined data format beans_
 [source,xml]
 ----
   <route>

--- a/components/camel-soap/src/main/docs/soap-dataformat.adoc
+++ b/components/camel-soap/src/main/docs/soap-dataformat.adoc
@@ -108,6 +108,7 @@ from("direct:start")
 When using XML DSL, there is a version attribute you can set on the
 <soap> element.
 
+._XML-only: Spring bean definition for ServiceInterfaceStrategy_
 [source,xml]
 ----
     <!-- Defining a ServiceInterfaceStrategy for retrieving the element name when marshalling -->
@@ -119,6 +120,21 @@ When using XML DSL, there is a version attribute you can set on the
 
 And in the Camel route
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+SoapDataFormat soap = new SoapDataFormat("com.example.customerservice", new ServiceInterfaceStrategy(CustomerService.class));
+soap.setVersion("1.2");
+from("direct:start")
+    .marshal(soap)
+    .to("jms:myQueue");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -129,6 +145,24 @@ And in the Camel route
   <to uri="jms:myQueue"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - marshal:
+            soap:
+              contextPath: com.example.customerservice
+              version: "1.2"
+              elementNameStrategyRef: myNameStrategy
+        - to:
+            uri: jms:myQueue
+----
+====
 
 == Multi-part Messages
 

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/docs/spring-ai-chat-component.adoc
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/docs/spring-ai-chat-component.adoc
@@ -234,16 +234,48 @@ String response = template.requestBodyAndHeader(
 
 ==== Via Endpoint Configuration
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
     .to("spring-ai-chat:test?chatModel=#chatModel&temperature=0.8&maxTokens=500");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:test?chatModel=#chatModel&amp;temperature=0.8&amp;maxTokens=500"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:test
+            parameters:
+              chatModel: "#chatModel"
+              temperature: 0.8
+              maxTokens: 500
+----
+====
+
 === Adding System Messages
 
 System messages provide instructions or context to the LLM. You can configure them via endpoint parameters for default behavior:
 
+._Java-only: route definition with ProducerTemplate usage_
 [source,java]
 ----
 from("direct:chat")
@@ -258,6 +290,7 @@ String response = template.requestBody("direct:chat",
 
 The component automatically tracks token usage and response metadata, providing them via headers. You can access these headers in your Camel routes:
 
+._Java-only: route with `.log()` header interpolation and ProducerTemplate usage_
 [source,java]
 ----
 from("direct:chat")
@@ -297,6 +330,10 @@ The component supports attaching metadata to both user and system messages. This
 
 You can attach metadata to user messages via headers or endpoint configuration:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Using URL parameters - nested property syntax
@@ -307,10 +344,42 @@ from("direct:chat")
         + "&userMetadata.priority=high");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:test?chatModel=#chatModel&amp;userMetadata.messageId=msg-123&amp;userMetadata.userId=user-456&amp;userMetadata.priority=high"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:test
+            parameters:
+              chatModel: "#chatModel"
+              userMetadata.messageId: msg-123
+              userMetadata.userId: user-456
+              userMetadata.priority: high
+----
+====
+
 ==== System Message Metadata
 
 Similarly, you can attach metadata to system messages:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Using URL parameters - nested property syntax
@@ -320,6 +389,34 @@ from("direct:chat")
         + "&systemMetadata.model=gpt-4"
         + "&systemMetadata.promptVersion=2024-01");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:test?chatModel=#chatModel&amp;systemMetadata.version=1.0&amp;systemMetadata.model=gpt-4&amp;systemMetadata.promptVersion=2024-01"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:test
+            parameters:
+              chatModel: "#chatModel"
+              systemMetadata.version: "1.0"
+              systemMetadata.model: gpt-4
+              systemMetadata.promptVersion: "2024-01"
+----
+====
 
 === Conversation Memory
 
@@ -409,6 +506,10 @@ The component integrates with the xref:spring-ai-tools-component.adoc[Spring AI 
 
 When you configure the `tags` parameter, the chat component discovers all matching tools from `spring-ai-tools` routes, registers them with Spring AI's ChatClient, and allows the LLM to call them during conversation.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Define tools
@@ -431,6 +532,111 @@ from("direct:mathChat")
 from("direct:multiToolChat")
     .to("spring-ai-chat:chat?tags=weather,math,finance&chatClient=#chatClient");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Define tools -->
+<route>
+  <from uri="spring-ai-tools:weather?tags=weather&amp;description=Get current weather for a location"/>
+  <setBody><constant>Sunny</constant></setBody>
+</route>
+
+<route>
+  <from uri="spring-ai-tools:calculator?tags=math&amp;description=Evaluate mathematical expressions"/>
+  <setBody><constant>42</constant></setBody>
+</route>
+
+<route>
+  <from uri="spring-ai-tools:stock?tags=finance&amp;description=Get current stock price"/>
+  <setBody><constant>42</constant></setBody>
+</route>
+
+<!-- Chat endpoints with different tool combinations -->
+<route>
+  <from uri="direct:weatherChat"/>
+  <to uri="spring-ai-chat:chat?tags=weather&amp;chatClient=#chatClient"/>
+</route>
+
+<route>
+  <from uri="direct:mathChat"/>
+  <to uri="spring-ai-chat:chat?tags=math&amp;chatClient=#chatClient"/>
+</route>
+
+<route>
+  <from uri="direct:multiToolChat"/>
+  <to uri="spring-ai-chat:chat?tags=weather,math,finance&amp;chatClient=#chatClient"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Define tools
+- route:
+    from:
+      uri: spring-ai-tools:weather
+      parameters:
+        tags: weather
+        description: Get current weather for a location
+      steps:
+        - setBody:
+            constant: Sunny
+
+- route:
+    from:
+      uri: spring-ai-tools:calculator
+      parameters:
+        tags: math
+        description: Evaluate mathematical expressions
+      steps:
+        - setBody:
+            constant: "42"
+
+- route:
+    from:
+      uri: spring-ai-tools:stock
+      parameters:
+        tags: finance
+        description: Get current stock price
+      steps:
+        - setBody:
+            constant: "42"
+
+# Chat endpoints with different tool combinations
+- route:
+    from:
+      uri: direct:weatherChat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              tags: weather
+              chatClient: "#chatClient"
+
+- route:
+    from:
+      uri: direct:mathChat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              tags: math
+              chatClient: "#chatClient"
+
+- route:
+    from:
+      uri: direct:multiToolChat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              tags: weather,math,finance
+              chatClient: "#chatClient"
+----
+====
 
 **How it works:**
 
@@ -521,6 +727,10 @@ template.requestBody("direct:scan-analyzer", message, String.class);
 
 To prevent out-of-memory errors with large media files, the component validates file sizes before loading them into memory. The default maximum file size is 1MB, configurable via:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Configure via endpoint parameter (in bytes)
@@ -537,6 +747,73 @@ from("file:trusted")
     .to("spring-ai-chat:vision?chatModel=#chatModel&maxFileSize=0");
 ----
 
+XML::
++
+[source,xml]
+----
+<!-- Configure via endpoint parameter (in bytes) - 5MB -->
+<route>
+  <from uri="file:uploads"/>
+  <to uri="spring-ai-chat:vision?chatModel=#chatModel&amp;maxFileSize=5242880"/>
+</route>
+
+<!-- Override via header for dynamic control - 10MB -->
+<route>
+  <from uri="direct:upload"/>
+  <setHeader name="CamelSpringAiChatMaxFileSize">
+    <constant>10485760</constant>
+  </setHeader>
+  <to uri="spring-ai-chat:vision?chatModel=#chatModel"/>
+</route>
+
+<!-- Disable size checking (not recommended) -->
+<route>
+  <from uri="file:trusted"/>
+  <to uri="spring-ai-chat:vision?chatModel=#chatModel&amp;maxFileSize=0"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Configure via endpoint parameter (in bytes) - 5MB
+- route:
+    from:
+      uri: file:uploads
+      steps:
+        - to:
+            uri: spring-ai-chat:vision
+            parameters:
+              chatModel: "#chatModel"
+              maxFileSize: 5242880
+
+# Override via header for dynamic control - 10MB
+- route:
+    from:
+      uri: direct:upload
+      steps:
+        - setHeader:
+            name: CamelSpringAiChatMaxFileSize
+            constant: "10485760"
+        - to:
+            uri: spring-ai-chat:vision
+            parameters:
+              chatModel: "#chatModel"
+
+# Disable size checking (not recommended)
+- route:
+    from:
+      uri: file:trusted
+      steps:
+        - to:
+            uri: spring-ai-chat:vision
+            parameters:
+              chatModel: "#chatModel"
+              maxFileSize: 0
+----
+====
+
 Files exceeding the configured limit will be rejected with an `IllegalArgumentException`.
 
 === SafeGuard - Content Filtering
@@ -549,6 +826,10 @@ This feature is useful for:
 * Compliance with data protection requirements
 * Filtering inappropriate or restricted topics
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Configure safeguard with sensitive words
@@ -557,6 +838,33 @@ from("direct:safeguard")
         + "&safeguardSensitiveWords=password,secret,confidential,api-key"
         + "&safeguardFailureResponse=I cannot provide information containing sensitive words");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:safeguard"/>
+  <to uri="spring-ai-chat:test?chatModel=#chatModel&amp;safeguardSensitiveWords=password,secret,confidential,api-key&amp;safeguardFailureResponse=I cannot provide information containing sensitive words"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:safeguard
+      steps:
+        - to:
+            uri: spring-ai-chat:test
+            parameters:
+              chatModel: "#chatModel"
+              safeguardSensitiveWords: "password,secret,confidential,api-key"
+              safeguardFailureResponse: "I cannot provide information containing sensitive words"
+----
+====
 
 **Configuration Options:**
 
@@ -675,6 +983,7 @@ from("direct:chat")
 Select specific tools by name using the `toolNames` parameter, instead of (or in addition to) tag-based discovery.
 This is useful for selecting individual `@Tool` methods or controlling which tools are available per endpoint:
 
+._Java-only: route definition with dynamic tool selection via ProducerTemplate header_
 [source,java]
 ----
 // Select only the getCapital tool by name
@@ -728,6 +1037,10 @@ Enable automatic validation of structured output with retry on failure.
 When the LLM produces invalid output (doesn't match the expected JSON Schema),
 the advisor re-prompts the LLM with validation errors:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -738,8 +1051,41 @@ from("direct:chat")
         + "&structuredOutputValidationMaxAttempts=3");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:chat?chatModel=#chatModel&amp;outputFormat=BEAN&amp;outputClass=com.example.ActorFilms&amp;structuredOutputValidation=true&amp;structuredOutputValidationMaxAttempts=3"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              chatModel: "#chatModel"
+              outputFormat: BEAN
+              outputClass: com.example.ActorFilms
+              structuredOutputValidation: true
+              structuredOutputValidationMaxAttempts: 3
+----
+====
+
 If all retry attempts fail, the exception propagates to Camel's error handler:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -752,6 +1098,52 @@ from("direct:chat")
         .to("direct:fallback")
     .end();
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <doTry>
+    <to uri="spring-ai-chat:chat?chatModel=#chatModel&amp;outputFormat=BEAN&amp;outputClass=com.example.ActorFilms&amp;structuredOutputValidation=true&amp;structuredOutputValidationMaxAttempts=2"/>
+    <doCatch>
+      <exception>java.lang.Exception</exception>
+      <log message="Structured output validation failed: ${exception.message}"/>
+      <to uri="direct:fallback"/>
+    </doCatch>
+  </doTry>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - doTry:
+            steps:
+              - to:
+                  uri: spring-ai-chat:chat
+                  parameters:
+                    chatModel: "#chatModel"
+                    outputFormat: BEAN
+                    outputClass: com.example.ActorFilms
+                    structuredOutputValidation: true
+                    structuredOutputValidationMaxAttempts: 2
+            doCatch:
+              - exception:
+                  - java.lang.Exception
+                steps:
+                  - log:
+                      message: "Structured output validation failed: ${exception.message}"
+                  - to:
+                      uri: direct:fallback
+----
+====
 
 The advisor requires `outputClass` or `entityClass` to be set so it can generate a JSON Schema
 for validation. A warning is logged if neither is configured.
@@ -766,6 +1158,10 @@ Configure MCP servers using the `mcpServer.<name>.<property>` prefix notation:
 
 ==== Stdio Transport
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Connect to MCP filesystem server via stdio
@@ -776,8 +1172,40 @@ from("direct:chat")
         + "&mcpServer.fs.args=-y,@modelcontextprotocol/server-filesystem,/tmp");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:chat?chatModel=#chatModel&amp;mcpServer.fs.transportType=stdio&amp;mcpServer.fs.command=npx&amp;mcpServer.fs.args=-y,@modelcontextprotocol/server-filesystem,/tmp"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              chatModel: "#chatModel"
+              mcpServer.fs.transportType: stdio
+              mcpServer.fs.command: npx
+              mcpServer.fs.args: "-y,@modelcontextprotocol/server-filesystem,/tmp"
+----
+====
+
 ==== SSE Transport
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Connect to MCP server via SSE
@@ -787,8 +1215,39 @@ from("direct:chat")
         + "&mcpServer.weather.url=http://mcp-server:3001/sse");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:chat?chatModel=#chatModel&amp;mcpServer.weather.transportType=sse&amp;mcpServer.weather.url=http://mcp-server:3001/sse"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              chatModel: "#chatModel"
+              mcpServer.weather.transportType: sse
+              mcpServer.weather.url: "http://mcp-server:3001/sse"
+----
+====
+
 ==== Multiple MCP Servers
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -800,11 +1259,45 @@ from("direct:chat")
         + "&mcpServer.weather.url=http://weather-mcp:3001/sse");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:chat?chatModel=#chatModel&amp;mcpServer.fs.transportType=stdio&amp;mcpServer.fs.command=npx&amp;mcpServer.fs.args=-y,@modelcontextprotocol/server-filesystem,/tmp&amp;mcpServer.weather.transportType=sse&amp;mcpServer.weather.url=http://weather-mcp:3001/sse"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              chatModel: "#chatModel"
+              mcpServer.fs.transportType: stdio
+              mcpServer.fs.command: npx
+              mcpServer.fs.args: "-y,@modelcontextprotocol/server-filesystem,/tmp"
+              mcpServer.weather.transportType: sse
+              mcpServer.weather.url: "http://weather-mcp:3001/sse"
+----
+====
+
 ==== OAuth Authentication for MCP Servers
 
 For MCP servers requiring authentication, configure an OAuth profile per server.
 This requires `camel-oauth` on the classpath:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:chat")
@@ -813,6 +1306,34 @@ from("direct:chat")
         + "&mcpServer.api.url=http://secure-mcp:3001/sse"
         + "&mcpServer.api.oauthProfile=keycloak");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:chat"/>
+  <to uri="spring-ai-chat:chat?chatModel=#chatModel&amp;mcpServer.api.transportType=sse&amp;mcpServer.api.url=http://secure-mcp:3001/sse&amp;mcpServer.api.oauthProfile=keycloak"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:chat
+      steps:
+        - to:
+            uri: spring-ai-chat:chat
+            parameters:
+              chatModel: "#chatModel"
+              mcpServer.api.transportType: sse
+              mcpServer.api.url: "http://secure-mcp:3001/sse"
+              mcpServer.api.oauthProfile: keycloak
+----
+====
 
 With corresponding properties:
 

--- a/components/camel-spring-parent/camel-spring-batch/src/main/docs/spring-batch-component.adoc
+++ b/components/camel-spring-parent/camel-spring-batch/src/main/docs/spring-batch-component.adoc
@@ -181,6 +181,7 @@ infrastructure.
 For example, the snippet below is configuring Spring Batch to read data from
 JMS queue.
 
+._XML-only: Spring Batch job with CamelItemReader bean_
 [source,xml]
 ----
 <bean id="camelReader" class="org.apache.camel.component.spring.batch.support.CamelItemReader">
@@ -205,6 +206,7 @@ dedicated to write chunk of the processed data.
 For example, the snippet below is configuring Spring Batch to read data from
 JMS queue.
 
+._XML-only: Spring Batch job with CamelItemWriter bean_
 [source,xml]
 ----
 <bean id="camelwriter" class="org.apache.camel.component.spring.batch.support.CamelItemWriter">
@@ -235,6 +237,7 @@ For example, the snippet below performs simple processing of the batch
 item using the http://camel.apache.org/direct.html[Direct endpoint] and
 the http://camel.apache.org/simple.html[Simple expression language].
 
+._XML-only: Spring Batch job with CamelItemProcessor and Camel route_
 [source,xml]
 ----
 <camel:camelContext>
@@ -275,6 +278,7 @@ is set to the `BEFORE` or `AFTER` value.
 The example snippet below sends Spring Batch job execution events to the
 JMS queue.
 
+._XML-only: Spring Batch job with CamelJobExecutionListener_
 [source,xml]
 ----
 <bean id="camelJobExecutionListener" class="org.apache.camel.component.spring.batch.support.CamelJobExecutionListener">

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
@@ -81,10 +81,32 @@ The `ConnectionFactory` is auto-detected by default, so you can do:
 To use default exchange name (which would be an empty exchange name in RabbitMQ) then you should use `default` as name
 in the endpoint uri, such as:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 to("spring-rabbitmq:default?routingKey=foo")
 ----
+
+XML::
++
+[source,xml]
+----
+<to uri="spring-rabbitmq:default?routingKey=foo"/>
+----
+
+YAML::
++
+[source,yaml]
+----
+- to:
+    uri: spring-rabbitmq:default
+    parameters:
+      routingKey: foo
+----
+====
 
 === Auto declare exchanges, queues and bindings
 
@@ -153,6 +175,7 @@ So if we send `World` as message body to _direct:start_ then, we will se the mes
 - `log:input -> World`
 - `log:response -> Hello World`
 
+._Java-only: Java DSL with ExchangePattern.InOut and body().prepend()_
 [source,java]
 ----
 from("direct:start")

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
@@ -66,6 +66,18 @@ TIP: It is recommended to use `CachingConnectionFactory` from spring-rabbit as i
 
 The `ConnectionFactory` is auto-detected by default, so you can do:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:cheese")
+    .to("spring-rabbitmq:foo?routingKey=cheese");
+----
+
+XML::
++
 [source,xml]
 ----
 <camelContext>
@@ -75,6 +87,21 @@ The `ConnectionFactory` is auto-detected by default, so you can do:
   </route>
 </camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:cheese
+      steps:
+        - to:
+            uri: spring-rabbitmq:foo
+            parameters:
+              routingKey: cheese
+----
+====
 
 === Default Exchange Name
 

--- a/components/camel-spring-parent/camel-spring-security/src/main/docs/spring-security.adoc
+++ b/components/camel-spring-parent/camel-spring-security/src/main/docs/spring-security.adoc
@@ -72,6 +72,7 @@ are required to use this component. Here is an example of how to
 configure these objects in Spring XML using the Spring Security
 namespace:
 
+._XML-only: Spring Security authentication and authorization manager configuration_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -100,6 +101,7 @@ Now that the underlying security objects are set up, we can use them to
 configure an authorization policy and use that policy to control access
 to a route:
 
+._XML-only: Spring XML authorization policy with Camel route_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -220,6 +222,22 @@ The `CamelAuthorizationException` will have a reference to the ID of the
 policy which threw the exception, so you can handle errors based on the
 policy as well as the type of exception:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+onException(AccessDeniedException.class)
+    .choice()
+        .when(simple("${exception.policyId} == 'user'"))
+            .transform(constant("You do not have ROLE_USER access!"))
+        .when(simple("${exception.policyId} == 'admin'"))
+            .transform(constant("You do not have ROLE_ADMIN access!"));
+----
+
+XML::
++
 [source,xml]
 ----
 <onException>
@@ -240,5 +258,26 @@ policy as well as the type of exception:
   </choice>
 </onException>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- onException:
+    exception:
+      - org.springframework.security.authentication.AccessDeniedException
+    steps:
+      - choice:
+          when:
+            - simple: "${exception.policyId} == 'user'"
+              steps:
+                - transform:
+                    constant: "You do not have ROLE_USER access!"
+            - simple: "${exception.policyId} == 'admin'"
+              steps:
+                - transform:
+                    constant: "You do not have ROLE_ADMIN access!"
+----
+====
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-spring-parent/camel-spring-ws/src/main/docs/spring-ws-component.adoc
+++ b/components/camel-spring-parent/camel-spring-ws/src/main/docs/spring-ws-component.adoc
@@ -281,6 +281,7 @@ all Spring-WS endpoints
 
 - the local messageFilter directly on the endpoint as follows:
 
+._Java-only: endpoint URI fragment with bean reference_
 [source,java]
 ----
 to("spring-ws:http://yourdomain.com?messageFilter=#myEndpointSpecificMessageFilter");
@@ -428,39 +429,168 @@ define what web service requests are handled by your endpoint:
 The following route will receive all web service requests that have a
 root element named "GetFoo" within the `\http://example.com/` namespace.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("spring-ws:rootqname:{http://example.com/}GetFoo?endpointMapping=#endpointMapping")
     .convertBodyTo(String.class).to("mock:example");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="spring-ws:rootqname:{http://example.com/}GetFoo?endpointMapping=#endpointMapping"/>
+  <convertBodyTo type="String"/>
+  <to uri="mock:example"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: "spring-ws:rootqname:{http://example.com/}GetFoo"
+      parameters:
+        endpointMapping: "#endpointMapping"
+      steps:
+        - convertBodyTo:
+            type: String
+        - to:
+            uri: mock:example
+----
+====
+
 The following route will receive web service requests containing the
 `\http://example.com/GetFoo` SOAP action.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("spring-ws:soapaction:http://example.com/GetFoo?endpointMapping=#endpointMapping")
     .convertBodyTo(String.class).to("mock:example");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="spring-ws:soapaction:http://example.com/GetFoo?endpointMapping=#endpointMapping"/>
+  <convertBodyTo type="String"/>
+  <to uri="mock:example"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: "spring-ws:soapaction:http://example.com/GetFoo"
+      parameters:
+        endpointMapping: "#endpointMapping"
+      steps:
+        - convertBodyTo:
+            type: String
+        - to:
+            uri: mock:example
+----
+====
+
 The following route will receive all requests sent to
 `\http://example.com/foobar`.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("spring-ws:uri:http://example.com/foobar?endpointMapping=#endpointMapping")
     .convertBodyTo(String.class).to("mock:example");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="spring-ws:uri:http://example.com/foobar?endpointMapping=#endpointMapping"/>
+  <convertBodyTo type="String"/>
+  <to uri="mock:example"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: "spring-ws:uri:http://example.com/foobar"
+      parameters:
+        endpointMapping: "#endpointMapping"
+      steps:
+        - convertBodyTo:
+            type: String
+        - to:
+            uri: mock:example
+----
+====
+
 The route below will receive requests that contain the element
 `<foobar>abc</foobar>` anywhere inside the message (and the default
 namespace).
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("spring-ws:xpathresult:abc?expression=//foobar&endpointMapping=#endpointMapping")
     .convertBodyTo(String.class).to("mock:example");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="spring-ws:xpathresult:abc?expression=//foobar&amp;endpointMapping=#endpointMapping"/>
+  <convertBodyTo type="String"/>
+  <to uri="mock:example"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: "spring-ws:xpathresult:abc"
+      parameters:
+        expression: "//foobar"
+        endpointMapping: "#endpointMapping"
+      steps:
+        - convertBodyTo:
+            type: String
+        - to:
+            uri: mock:example
+----
+====
 
 === Alternative configuration, using existing endpoint mappings
 

--- a/components/camel-spring-parent/camel-spring-ws/src/main/docs/spring-ws-component.adoc
+++ b/components/camel-spring-parent/camel-spring-ws/src/main/docs/spring-ws-component.adoc
@@ -243,21 +243,51 @@ The header transformation filter (`HeaderTransformationMessageFilter`)
 can be used to transform the soap header for a soap request. If you want to use 
 the header transformation filter, see the below example:
 
+._XML-only: Spring bean definition for HeaderTransformationMessageFilter_
 [source,xml]
 ----
 <bean id="headerTransformationFilter" class="org.apache.camel.component.spring.ws.filter.impl.HeaderTransformationMessageFilter">
     <constructor-arg index="0" value="org/apache/camel/component/spring/ws/soap-header-transform.xslt"/>
 </bean>
 ----
-Use the bead defined above in the camel endpoint
+Use the bean defined above in the camel endpoint
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:stockQuoteWebserviceHeaderTransformation")
+    .to("spring-ws:http://localhost?webServiceTemplate=#webServiceTemplate&soapAction=http://www.stockquotes.edu/GetQuote&messageFilter=#headerTransformationFilter");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
     <from uri="direct:stockQuoteWebserviceHeaderTransformation"/>
     <to uri="spring-ws:http://localhost?webServiceTemplate=#webServiceTemplate&amp;soapAction=http://www.stockquotes.edu/GetQuote&amp;messageFilter=#headerTransformationFilter"/>
-</route> 
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:stockQuoteWebserviceHeaderTransformation
+      steps:
+        - to:
+            uri: spring-ws:http://localhost
+            parameters:
+              webServiceTemplate: "#webServiceTemplate"
+              soapAction: "http://www.stockquotes.edu/GetQuote"
+              messageFilter: "#headerTransformationFilter"
+----
+====
 
 
 === The custom header and attachment filtering
@@ -616,6 +646,7 @@ of annotations.
 
 An example of a route using `beanname`:
 
+._XML-only: Spring XML with legacy endpoint mapping and CamelEndpointDispatcher beans_
 [source,xml]
 ----
 <camelContext xmlns="http://camel.apache.org/schema/spring">

--- a/components/camel-spring-parent/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring-parent/camel-spring/src/main/docs/spring-summary.adoc
@@ -364,7 +364,18 @@ protected Class<?>[] excludeRoutes() {
 You can use Spring XML configuration to specify your XML Configuration for
 Routes such as in the following
 
-._XML-only: Spring XML file with CamelContext containing a route definition_
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("seda:start")
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -383,6 +394,19 @@ Routes such as in the following
 
 </beans>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:start
+      steps:
+        - to:
+            uri: mock:result
+----
+====
 
 == Configuring Components and Endpoints
 

--- a/components/camel-spring-parent/camel-spring/src/main/docs/spring-summary.adoc
+++ b/components/camel-spring-parent/camel-spring/src/main/docs/spring-summary.adoc
@@ -52,6 +52,7 @@ http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/came
 
 So the XML file looks like this:
 
+._XML-only: Spring XML schema declaration for Camel_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -72,6 +73,7 @@ xmlns:camel="http://camel.apache.org/schema/spring"
 
 ... so the declaration is:
 
+._XML-only: Spring XML schema declaration with camel namespace prefix_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -85,6 +87,7 @@ xmlns:camel="http://camel.apache.org/schema/spring"
 ... and then use the camel: namespace prefix, and you can omit the
 inline namespace declaration:
 
+._XML-only: using camel namespace prefix for CamelContext configuration_
 [source,xml]
 ----
 <camel:camelContext>
@@ -111,6 +114,7 @@ definition, specifying the packages to be recursively searched for
 `<package></package>` tag specifying a comma-separated list of
 packages that should be searched e.g.
 
+._XML-only: CamelContext with package scanning for RouteBuilder classes_
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/spring">
@@ -144,6 +148,7 @@ contain one or more 'package' elements, and optionally
 one or more 'includes' or 'excludes' elements specifying patterns to be
 applied to the fully qualified names of the discovered classes. e.g.
 
+._XML-only: CamelContext with packageScan including include/exclude patterns_
 [source,xml]
 ----
   <camelContext xmlns="http://camel.apache.org/schema/spring">
@@ -236,6 +241,7 @@ other words the `<routeContext>` is currently isolated.
 For example, we could have a file named `myCoolRoutes.xml` which contains
 a couple of routes as shown:
 
+._XML-only: Spring XML file with routeContext for externalized route definitions_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -265,6 +271,7 @@ to import the `myCoolRoute.xml` file.
 And then inside `<camelContext/>` you can refer to the
 `<routeContext/>` by its id as shown below:
 
+._XML-only: importing routeContext and combining with inline routes in CamelContext_
 [source,xml]
 ----
  <!-- import the routes from another XML file -->
@@ -357,6 +364,7 @@ protected Class<?>[] excludeRoutes() {
 You can use Spring XML configuration to specify your XML Configuration for
 Routes such as in the following
 
+._XML-only: Spring XML file with CamelContext containing a route definition_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -381,6 +389,7 @@ Routes such as in the following
 You can configure your Component or Endpoint instances in your Spring
 XML as follows:
 
+._XML-only: Spring bean configuration for CamelContext and JMS component_
 [source,xml]
 ----
   <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
@@ -432,6 +441,18 @@ Maven users will need to add the following additional dependency to their `pom.x
 
 Users can then use the cron component inside routes of their Spring or Spring Boot application:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("cron:tab?schedule=0/1+*+*+*+*+?")
+    .to("log:info");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -439,6 +460,21 @@ Users can then use the cron component inside routes of their Spring or Spring Bo
   <to uri="log:info"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: cron:tab
+      parameters:
+        schedule: "0/1+*+*+*+*+?"
+      steps:
+        - to:
+            uri: log:info
+----
+====
 
 :camel-spring-boot-name: spring
 

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -482,6 +482,7 @@ YAML::
 
 And the bean has the following method:
 
+._Java-only: bean class used as expression parameter_
 [source,java]
 ----
 public static class MyIdGenerator {

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -858,6 +858,7 @@ CREATE TABLE aggregationRepo3_completed (
 
 And then configure the repository to enable this behavior as shown below:
 
+._XML-only: Spring bean declaration for `JdbcAggregationRepository` with text storage_
 [source,xml]
 ----
 <bean id="repo3"
@@ -915,6 +916,7 @@ your database system, it can be injected with the `lobHandler` property.
 
 Here is the declaration for Oracle:
 
+._XML-only: Spring bean declarations for Oracle `LobHandler` and `JdbcAggregationRepository`_
 [source,xml]
 ----
 <bean id="lobHandler" class="org.springframework.jdbc.support.lob.OracleLobHandler">
@@ -968,6 +970,7 @@ optimistic locking error.
 Here is an example, where we define two extra FQN class names from the
 JDBC vendor.
 
+._XML-only: Spring bean declarations for `JdbcAggregationRepository` with custom optimistic locking exception mapper_
 [source,xml]
 ----
 <bean id="repo"
@@ -998,6 +1001,8 @@ common `PlatformTransactionManager` used, there may be a need to configure _prop
 transaction templates inside `JdbcAggregationRepository`.
 
 Here's a way to do it:
+
+._XML-only: Spring bean declaration for `JdbcAggregationRepository` with propagation behavior_
 [source,xml]
 ----
 <bean id="repo"

--- a/components/camel-sql/src/main/docs/sql-stored-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-stored-component.adoc
@@ -83,6 +83,7 @@ The template is declared using a syntax that would be similar to a Java
 method signature. The name of the stored procedure, and then the
 arguments enclosed in parentheses. An example explains this well:
 
+._XML-only: stored procedure call with IN, INOUT and OUT parameters_
 [source,xml]
 ----
 <to uri="sql-stored:STOREDSAMPLE(INTEGER ${headers.num1},INTEGER ${headers.num2},INOUT INTEGER ${headers.num3} result1,OUT INTEGER result2)"/>
@@ -128,6 +129,7 @@ When using named parameters, Camel will look up the names in the given precedenc
 3. from message headers
 4. from exchange variables
 
+._XML-only: stored procedure call with named parameter, custom SQL type and scale_
 [source,xml]
 ----
 <to uri="sql-stored:MYFUNC('param1' org.example.Types.INTEGER(10) ${header.srcValue})"/>
@@ -137,10 +139,11 @@ URI means that the stored procedure will be called with parameter name `param1`,
 it's SQL type is read from field `INTEGER` of class `org.example.Types` and scale will be set to 10.
 The input value for the parameter is passed from the header `srcValue`.
 
+._XML-only: stored procedure call with explicit SQL type number and type name_
 [source,xml]
-----------------------------------------------------------------------------------------------------------
+----
 <to uri="sql-stored:MYFUNC('param1' 100 'mytypename' ${header.srcValue})"/>
-----------------------------------------------------------------------------------------------------------
+----
 URI is identical to previous on except SQL-type is 100 and type name is _mytypename_.
 
 Actual call will be done using org.springframework.jdbc.core.SqlParameter.
@@ -155,6 +158,7 @@ Type name is optional and also works the same as IN parameters.
 
 Output parameter name is used for the OUT parameter name, as well as the header name where the result will be stored.
 
+._XML-only: stored procedure call with OUT parameter_
 [source,xml]
 ----
 <to uri="sql-stored:MYFUNC(OUT org.example.Types.DECIMAL(10) outheader1)"/>
@@ -162,6 +166,7 @@ Output parameter name is used for the OUT parameter name, as well as the header 
 
 URI means that the OUT parameter's name is `outheader1` and result will be but into header `outheader1`.
 
+._XML-only: stored procedure call with OUT parameter and custom type name_
 [source,xml]
 ----
 <to uri="sql-stored:MYFUNC(OUT org.example.Types.NUMERIC(10) 'mytype' outheader1)"/>
@@ -177,6 +182,7 @@ INOUT parameters are a combination of all of the above.  They receive a value fr
 result as a message header.  The only caveat is that the IN parameter's "name" is skipped.  Instead, the OUT
 parameter's _name_ defines both the SQL parameter name, and the result header name.
 
+._XML-only: stored procedure call with INOUT parameter_
 [source,xml]
 ----
 <to uri="sql-stored:MYFUNC(INOUT DECIMAL(10) ${headers.inheader} outheader)"/>
@@ -188,6 +194,7 @@ Actual call will be done using org.springframework.jdbc.core.SqlInOutParameter.
 
 You can configure query timeout (via `template.queryTimeout`) on statements used for query processing as shown:
 
+._XML-only: stored procedure call with query timeout_
 [source,xml]
 ----
 <to uri="sql-stored:MYFUNC(INOUT DECIMAL(10) ${headers.inheader} outheader)?template.queryTimeout=5000"/>

--- a/components/camel-stax/src/main/docs/stax-component.adoc
+++ b/components/camel-stax/src/main/docs/stax-component.adoc
@@ -192,6 +192,7 @@ from("file:target/in")
 
 Alternatively, the example above could be implemented as follows in Spring XML
 
+._XML-only: Spring bean configuration with StAXBuilder factory method_
 [source,xml]
 ----
   <!-- use STaXBuilder to create the expression we want to use in the route below for splitting the XML file -->

--- a/components/camel-swift/src/main/docs/swiftMt-dataformat.adoc
+++ b/components/camel-swift/src/main/docs/swiftMt-dataformat.adoc
@@ -21,6 +21,7 @@ include::partial$dataformat-options.adoc[]
 
 In Spring DSL, you configure the data format using this tag:
 
+._XML-only: Spring XML data format configuration_
 [source,xml]
 ----
 <camelContext>

--- a/components/camel-swift/src/main/docs/swiftMt-dataformat.adoc
+++ b/components/camel-swift/src/main/docs/swiftMt-dataformat.adoc
@@ -33,6 +33,19 @@ In Spring DSL, you configure the data format using this tag:
 
 Then you can use it later by its reference:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:startEncode")
+    .marshal("swiftInJson")
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -42,10 +55,38 @@ Then you can use it later by its reference:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:startEncode
+      steps:
+        - marshal:
+            ref: swiftInJson
+        - to:
+            uri: mock:result
+----
+====
+
 Most of the time, you won't need to declare the data format if you use
 the default options. In that case, you can declare the data format
 inline as shown below:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:startEncode")
+    .marshal().swiftMt()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -56,6 +97,21 @@ inline as shown below:
     <to uri="mock:result" />
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:startEncode
+      steps:
+        - marshal:
+            swiftMt: {}
+        - to:
+            uri: mock:result
+----
+====
 
 == Marshal
 

--- a/components/camel-swift/src/main/docs/swiftMx-dataformat.adoc
+++ b/components/camel-swift/src/main/docs/swiftMx-dataformat.adoc
@@ -21,6 +21,7 @@ include::partial$dataformat-options.adoc[]
 
 In Spring DSL, you configure the data format using this tag:
 
+._XML-only: Spring XML data format configuration_
 [source,xml]
 ----
 <camelContext>

--- a/components/camel-swift/src/main/docs/swiftMx-dataformat.adoc
+++ b/components/camel-swift/src/main/docs/swiftMx-dataformat.adoc
@@ -33,6 +33,19 @@ In Spring DSL, you configure the data format using this tag:
 
 Then you can use it later by its reference:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:startEncode")
+    .marshal("swiftInJson")
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -42,10 +55,38 @@ Then you can use it later by its reference:
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:startEncode
+      steps:
+        - marshal:
+            ref: swiftInJson
+        - to:
+            uri: mock:result
+----
+====
+
 Most of the time, you won't need to declare the data format if you use
 the default options. In that case, you can declare the data format
 inline as shown below:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:startEncode")
+    .marshal().swiftMx()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -56,6 +97,21 @@ inline as shown below:
     <to uri="mock:result" />
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:startEncode
+      steps:
+        - marshal:
+            swiftMx: {}
+        - to:
+            uri: mock:result
+----
+====
 
 == Marshal
 

--- a/components/camel-syslog/src/main/docs/syslog-dataformat.adoc
+++ b/components/camel-syslog/src/main/docs/syslog-dataformat.adoc
@@ -75,8 +75,21 @@ this  +
  will allow a fallback to a NettyTypeConverter and delivers the message
 as an InputStream:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("netty:udp://localhost:10514?sync=false&allowDefaultCodec=false")
+    .unmarshal(new SyslogDataFormat())
+    .to("mock:stop1");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------
+----
 <camelContext id="myCamel" xmlns="http://camel.apache.org/schema/spring">
 
     <dataFormats>
@@ -90,12 +103,43 @@ as an InputStream:
     </route>
 
 </camelContext>
-------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: netty:udp://localhost:10514
+      parameters:
+        sync: false
+        allowDefaultCodec: false
+      steps:
+        - unmarshal:
+            syslog: {}
+        - to:
+            uri: mock:stop1
+----
+====
 
 The same route using xref:ROOT:mina-component.adoc[Mina Component]
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("mina:udp://localhost:10514")
+    .unmarshal(new SyslogDataFormat())
+    .to("mock:stop1");
+----
+
+XML::
++
 [source,xml]
--------------------------------------------------------------------------
+----
 <camelContext id="myCamel" xmlns="http://camel.apache.org/schema/spring">
 
     <dataFormats>
@@ -109,12 +153,40 @@ The same route using xref:ROOT:mina-component.adoc[Mina Component]
     </route>
 
 </camelContext>
--------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: mina:udp://localhost:10514
+      steps:
+        - unmarshal:
+            syslog: {}
+        - to:
+            uri: mock:stop1
+----
+====
 
 === Sending syslog messages to a remote destination
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:syslogMessages")
+    .marshal(new SyslogDataFormat())
+    .to("mina:udp://remotehost:10514");
+----
+
+XML::
++
 [source,xml]
--------------------------------------------------------------------------
+----
 <camelContext id="myCamel" xmlns="http://camel.apache.org/schema/spring">
 
     <dataFormats>
@@ -128,7 +200,22 @@ The same route using xref:ROOT:mina-component.adoc[Mina Component]
     </route>
 
 </camelContext>
--------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:syslogMessages
+      steps:
+        - marshal:
+            syslog: {}
+        - to:
+            uri: mina:udp://remotehost:10514
+----
+====
 
 
 

--- a/components/camel-test/camel-test-junit5/src/main/docs/test-junit5.adoc
+++ b/components/camel-test/camel-test-junit5/src/main/docs/test-junit5.adoc
@@ -21,6 +21,7 @@ for build the routes to be tested. Then the methods with `@Test` annotations are
 will be executed. The base class `CamelTestSupport` has a number of helper methods to configure testing,
 see more at the Javadoc of this class.
 
+._Java-only: CamelTestSupport is a Java test framework class._
 [source,java]
 ----
 import org.apache.camel.RoutesBuilder;
@@ -112,6 +113,7 @@ configuration is done inside them.
 
 Consider, for instance, a test enabling JMX. Previously, that test would be written like this:
 
+._Java-only: overriding CamelTestSupport methods is Java-specific._
 [source,java]
 ----
 public class MyTestClass extends CamelTestSupport {
@@ -128,6 +130,7 @@ public class MyTestClass extends CamelTestSupport {
 
 This test can be migrated to the new API like this:
 
+._Java-only: CamelTestSupport configuration API is Java-specific._
 [source,java]
 ----
 public class MyTestClass extends CamelTestSupport {

--- a/components/camel-test/camel-test-main-junit5/src/main/docs/test-main-junit5.adoc
+++ b/components/camel-test/camel-test-main-junit5/src/main/docs/test-main-junit5.adoc
@@ -704,6 +704,7 @@ In the next example,
 the property `some-property` is set to `foo` for all the tests in `SomeTest` including the tests in `SomeNestedTest`.
 Additionally, the property `some-other-property` is set to `bar` but only for all the tests in `SomeNestedTest`.
 
+._Java-only: annotation-based nested test configuration_
 [source,java]
 ----
 @CamelMainTest(properties = { "some-property=foo" })
@@ -727,6 +728,7 @@ but also the tests in the `@Nested` test class `SomeOtherNestedTest` as it is no
 `SomeOtherMainClass` is used as the main class for all the tests directly inside `SomeNestedTest`,
 but also the tests in the `@Nested` test class `SomeDeeplyNestedTest` as it is not redefined.
 
+._Java-only: annotation-based nested test class hierarchy_
 [source,java]
 ----
 @CamelMainTest(mainClass = SomeMainClass.class)

--- a/components/camel-test/camel-test-main-junit6/src/main/docs/test-main-junit6.adoc
+++ b/components/camel-test/camel-test-main-junit6/src/main/docs/test-main-junit6.adoc
@@ -704,6 +704,7 @@ In the next example,
 the property `some-property` is set to `foo` for all the tests in `SomeTest` including the tests in `SomeNestedTest`.
 Additionally, the property `some-other-property` is set to `bar` but only for all the tests in `SomeNestedTest`.
 
+._Java-only: JUnit 6 nested test class with @CamelMainTest annotation_
 [source,java]
 ----
 @CamelMainTest(properties = { "some-property=foo" })
@@ -727,6 +728,7 @@ but also the tests in the `@Nested` test class `SomeOtherNestedTest` as it is no
 `SomeOtherMainClass` is used as the main class for all the tests directly inside `SomeNestedTest`,
 but also the tests in the `@Nested` test class `SomeDeeplyNestedTest` as it is not redefined.
 
+._Java-only: JUnit 6 nested test class with mono-valued @CamelMainTest attribute override_
 [source,java]
 ----
 @CamelMainTest(mainClass = SomeMainClass.class)

--- a/components/camel-test/camel-test-spring-junit5/src/main/docs/test-spring-junit5.adoc
+++ b/components/camel-test/camel-test-spring-junit5/src/main/docs/test-spring-junit5.adoc
@@ -26,6 +26,7 @@ The Spring test context may be specified in one of three ways:
 * a class annotated with `SpringBootConfiguration` accessible in the package of the test class or a parent package.
 
 
+._Java-only: Spring Boot test using annotations, dependency injection, and inner configuration class._
 [source,java]
 ----
 package com.foo;
@@ -82,6 +83,7 @@ class CamelSpringBootSimpleTest {
 There are multiple approaches to test Camel Spring 5.x based routes with JUnit 5.
 An approach is to extend `org.apache.camel.test.spring.junit5.CamelSpringTestSupport`, for instance:
 
+._Java-only: extends CamelSpringTestSupport which is a Java test base class._
 [source,java]
 ----
 public class SimpleMockTest extends CamelSpringTestSupport {
@@ -118,6 +120,7 @@ Instead of instantiating the `CamelContext` and routes programmatically,
 this class relies on a Spring context to wire the needed components together.
 If your test extends this class, you must provide the Spring context by implementing the following method:
 
+._Java-only: abstract method to override in Java test subclasses._
 [source,java]
 ----
 protected abstract AbstractApplicationContext createApplicationContext();
@@ -128,6 +131,7 @@ protected abstract AbstractApplicationContext createApplicationContext();
 A better and recommended approach involves the usage of the
 `org.apache.camel.test.spring.junit5.CamelSpringTest` annotation, as shown:
 
+._Java-only: Spring test using annotations and dependency injection._
 [source,java]
 ----
 package com.foo;

--- a/components/camel-test/camel-test-spring-junit5/src/main/docs/test-spring-junit5.adoc
+++ b/components/camel-test/camel-test-spring-junit5/src/main/docs/test-spring-junit5.adoc
@@ -172,6 +172,7 @@ the example above loads the file `com/foo/CamelSpringPlainTest-context.xml`.
 
 This XML file is Spring XML file as shown:
 
+._XML-only: Spring XML context file with Camel route definition_
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>

--- a/components/camel-test/camel-test-spring-junit6/src/main/docs/test-spring-junit6.adoc
+++ b/components/camel-test/camel-test-spring-junit6/src/main/docs/test-spring-junit6.adoc
@@ -26,6 +26,7 @@ The Spring test context may be specified in one of three ways:
 * a class annotated with `SpringBootConfiguration` accessible in the package of the test class or a parent package.
 
 
+._Java-only: uses Java test annotations and Spring Boot configuration class._
 [source,java]
 ----
 package com.foo;
@@ -82,6 +83,7 @@ class CamelSpringBootSimpleTest {
 There are multiple approaches to test Camel Spring 4.x based routes with JUnit 6.
 An approach is to extend `org.apache.camel.test.spring.junit6.CamelSpringTestSupport`, for instance:
 
+._Java-only: extends CamelSpringTestSupport, a Java test base class._
 [source,java]
 ----
 public class SimpleMockTest extends CamelSpringTestSupport {
@@ -117,6 +119,7 @@ Instead of instantiating the `CamelContext` and routes programmatically,
 this class relies on a Spring context to wire the needed components together.
 If your test extends this class, you must provide the Spring context by implementing the following method:
 
+._Java-only: Java method signature for Spring context creation._
 [source,java]
 ----
 protected abstract AbstractApplicationContext createApplicationContext();
@@ -127,6 +130,7 @@ protected abstract AbstractApplicationContext createApplicationContext();
 A better and recommended approach involves the usage of the
 `org.apache.camel.test.spring.junit6.CamelSpringTest` annotation, as shown:
 
+._Java-only: uses Java test annotations and Spring dependency injection._
 [source,java]
 ----
 package com.foo;

--- a/components/camel-test/camel-test-spring-junit6/src/main/docs/test-spring-junit6.adoc
+++ b/components/camel-test/camel-test-spring-junit6/src/main/docs/test-spring-junit6.adoc
@@ -171,6 +171,7 @@ the example above loads the file `com/foo/CamelSpringPlainTest-context.xml`.
 
 This XML file is Spring XML file as shown:
 
+._XML-only: Spring XML context file with Camel route definition_
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>

--- a/components/camel-undertow/src/main/docs/undertow-component.adoc
+++ b/components/camel-undertow/src/main/docs/undertow-component.adoc
@@ -385,6 +385,18 @@ YAML::
 In this sample we define a route that exposes a HTTP service at
 `\http://localhost:8080/myapp/myservice`:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("undertow:http://localhost:8080/myapp/myservice")
+    .to("bean:myBean");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -393,11 +405,37 @@ In this sample we define a route that exposes a HTTP service at
 </route>
 ----
 
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: undertow:http://localhost:8080/myapp/myservice
+      steps:
+        - to:
+            uri: bean:myBean
+----
+====
+
 === WebSocket Example
 
 In this sample we define a route that exposes a WebSocket service at
 `\http://localhost:8080/myapp/mysocket` and returns back a response to the same channel:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("undertow:ws://localhost:8080/myapp/mysocket")
+    .transform(simple("Echo ${body}"))
+    .to("undertow:ws://localhost:8080/myapp/mysocket");
+----
+
+XML::
++
 [source,xml]
 ----
 <route>
@@ -406,5 +444,20 @@ In this sample we define a route that exposes a WebSocket service at
   <to uri="undertow:ws://localhost:8080/myapp/mysocket"/>
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: undertow:ws://localhost:8080/myapp/mysocket
+      steps:
+        - transform:
+            simple: "Echo ${body}"
+        - to:
+            uri: undertow:ws://localhost:8080/myapp/mysocket
+----
+====
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-univocity-parsers/src/main/docs/univocityCsv-dataformat.adoc
+++ b/components/camel-univocity-parsers/src/main/docs/univocityCsv-dataformat.adoc
@@ -66,8 +66,21 @@ Any other body will throw an exception.
 
 === Usage example: marshalling a Map into CSV format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityCsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -75,12 +88,40 @@ Any other body will throw an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityCsv: {}
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: marshalling a Map into fixed-width format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityFixed()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -92,12 +133,41 @@ Any other body will throw an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityFixed:
+              padding: "_"
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: marshalling a Map into TSV format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityTsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -105,7 +175,22 @@ Any other body will throw an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityTsv: {}
+        - to:
+            uri: mock:result
+----
+====
 
 == Unmarshalling usages
 
@@ -124,8 +209,21 @@ All the rows can either:
 
 === Usage example: unmarshalling a CSV format into maps with automatic headers
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .unmarshal().univocityCsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <unmarshal>
@@ -133,12 +231,42 @@ All the rows can either:
     </unmarshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - unmarshal:
+            univocityCsv:
+              headerExtractionEnabled: true
+              asMap: true
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: unmarshalling a fixed-width format into lists
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .unmarshal().univocityFixed()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <unmarshal>
@@ -150,7 +278,22 @@ All the rows can either:
     </unmarshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - unmarshal:
+            univocityFixed: {}
+        - to:
+            uri: mock:result
+----
+====
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-univocity-parsers/src/main/docs/univocityFixed-dataformat.adoc
+++ b/components/camel-univocity-parsers/src/main/docs/univocityFixed-dataformat.adoc
@@ -66,8 +66,21 @@ Any other body will throws an exception.
 
 === Usage example: marshalling a Map into CSV format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityCsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -75,12 +88,40 @@ Any other body will throws an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityCsv: {}
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: marshalling a Map into fixed-width format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityFixed()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -92,12 +133,41 @@ Any other body will throws an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityFixed:
+              padding: "_"
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: marshalling a Map into TSV format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityTsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -105,7 +175,22 @@ Any other body will throws an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityTsv: {}
+        - to:
+            uri: mock:result
+----
+====
 
 == Unmarshalling usages
 
@@ -124,8 +209,21 @@ All the rows can either:
 
 === Usage example: unmarshalling a CSV format into maps with automatic headers
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .unmarshal().univocityCsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <unmarshal>
@@ -133,12 +231,42 @@ All the rows can either:
     </unmarshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - unmarshal:
+            univocityCsv:
+              headerExtractionEnabled: true
+              asMap: true
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: unmarshalling a fixed-width format into lists
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .unmarshal().univocityFixed()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <unmarshal>
@@ -150,7 +278,22 @@ All the rows can either:
     </unmarshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - unmarshal:
+            univocityFixed: {}
+        - to:
+            uri: mock:result
+----
+====
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-univocity-parsers/src/main/docs/univocityTsv-dataformat.adoc
+++ b/components/camel-univocity-parsers/src/main/docs/univocityTsv-dataformat.adoc
@@ -66,8 +66,21 @@ Any other body will throws an exception.
 
 === Usage example: marshalling a Map into CSV format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityCsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -75,12 +88,40 @@ Any other body will throws an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityCsv: {}
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: marshalling a Map into fixed-width format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityFixed()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -92,12 +133,41 @@ Any other body will throws an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityFixed:
+              padding: "_"
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: marshalling a Map into TSV format
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .marshal().univocityTsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <marshal>
@@ -105,7 +175,22 @@ Any other body will throws an exception.
     </marshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - marshal:
+            univocityTsv: {}
+        - to:
+            uri: mock:result
+----
+====
 
 == Unmarshalling usages
 
@@ -124,8 +209,21 @@ All the rows can either:
 
 === Usage example: unmarshalling a CSV format into maps with automatic headers
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .unmarshal().univocityCsv()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <unmarshal>
@@ -133,12 +231,42 @@ All the rows can either:
     </unmarshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - unmarshal:
+            univocityCsv:
+              headerExtractionEnabled: true
+              asMap: true
+        - to:
+            uri: mock:result
+----
+====
 
 === Usage example: unmarshalling a fixed-width format into lists
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:input")
+    .unmarshal().univocityFixed()
+    .to("mock:result");
+----
+
+XML::
++
 [source,xml]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
 <route>
     <from uri="direct:input"/>
     <unmarshal>
@@ -150,7 +278,22 @@ All the rows can either:
     </unmarshal>
     <to uri="mock:result"/>
 </route>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:input
+      steps:
+        - unmarshal:
+            univocityFixed: {}
+        - to:
+            uri: mock:result
+----
+====
 
 
 include::spring-boot:partial$starter.adoc[]

--- a/components/camel-xmlsecurity/src/main/docs/xmlSecurity-dataformat.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/xmlSecurity-dataformat.adoc
@@ -159,59 +159,133 @@ A namespace prefix defined as part of the `camelContext`
 definition can be re-used in context within the data format `secureTag`
 attribute of the `xmlSecurity` element.
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .marshal().xmlSecurity("//cheese:cheesesites/italy", true)
+    .to("...");
+----
+
+XML::
++
 [source,xml]
 ----
-<camelContext id="springXmlSecurityDataFormatTestCamelContext" 
+<camelContext id="springXmlSecurityDataFormatTestCamelContext"
               xmlns="http://camel.apache.org/schema/spring"
-              xmlns:cheese="http://cheese.xmlsecurity.camel.apache.org/">        
+              xmlns:cheese="http://cheese.xmlsecurity.camel.apache.org/">
     <route>
         <from uri="direct://start"/>
             <marshal>
                 <xmlSecurity secureTag="//cheese:cheesesites/italy"
                            secureTagContents="true"/>
-            </marshal> 
+            </marshal>
             ...
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - marshal:
+            xmlSecurity:
+              secureTag: "//cheese:cheesesites/italy"
+              secureTagContents: true
+----
+====
 
 === Asymmetric Key Encryption
 
 [[XMLSecurityDataFormat-SpringXMLSender]]
 Spring XML Sender
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .marshal().xmlSecurity("//cheese:cheesesites/italy", namespaces, true,
+            "recipient", XMLCipher.AES_128_CBC, XMLCipher.RSA_v1dot5, trustStoreParams)
+    .to("...");
+----
+
+XML::
++
 [source,xml]
 ----
-<!--  trust store configuration -->                          
+<!--  trust store configuration -->
 <camel:keyStoreParameters id="trustStoreParams" resource="./sender.truststore" password="password"/>
 
-<camelContext id="springXmlSecurityDataFormatTestCamelContext" 
+<camelContext id="springXmlSecurityDataFormatTestCamelContext"
               xmlns="http://camel.apache.org/schema/spring"
-              xmlns:cheese="http://cheese.xmlsecurity.camel.apache.org/">        
+              xmlns:cheese="http://cheese.xmlsecurity.camel.apache.org/">
     <route>
         <from uri="direct://start"/>
             <marshal>
                 <xmlSecurity secureTag="//cheese:cheesesites/italy"
                            secureTagContents="true"
-                           xmlCipherAlgorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"       
+                           xmlCipherAlgorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"
                            keyCipherAlgorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"
                            recipientKeyAlias="recipient"
                            keyOrTrustStoreParametersRef="trustStoreParams"/>
-            </marshal> 
+            </marshal>
             ...
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - marshal:
+            xmlSecurity:
+              secureTag: "//cheese:cheesesites/italy"
+              secureTagContents: true
+              xmlCipherAlgorithm: "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
+              keyCipherAlgorithm: "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+              recipientKeyAlias: recipient
+              keyOrTrustStoreParametersRef: "#trustStoreParams"
+----
+====
 
 [[XMLSecurityDataFormat-SpringXMLRecipient]]
 Spring XML Recipient
 
-[source,xml]
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:encrypted")
+    .unmarshal().xmlSecurity("//cheese:cheesesites/italy", namespaces, true,
+            "recipient", XMLCipher.AES_128_CBC, XMLCipher.RSA_v1dot5, keyStoreParams)
+    .to("...");
 ----
 
+XML::
++
+[source,xml]
+----
 <!--  key store configuration -->
 <camel:keyStoreParameters id="keyStoreParams" resource="./recipient.keystore" password="password" />
 
-<camelContext id="springXmlSecurityDataFormatTestCamelContext" 
+<camelContext id="springXmlSecurityDataFormatTestCamelContext"
               xmlns="http://camel.apache.org/schema/spring"
               xmlns:cheese="http://cheese.xmlsecurity.camel.apache.org/">
-    <route>    
+    <route>
         <from uri="direct://encrypted"/>
             <unmarshal>
                 <xmlSecurity secureTag="//cheese:cheesesites/italy"
@@ -224,6 +298,26 @@ Spring XML Recipient
             </unmarshal>
             ...
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:encrypted
+      steps:
+        - unmarshal:
+            xmlSecurity:
+              secureTag: "//cheese:cheesesites/italy"
+              secureTagContents: true
+              xmlCipherAlgorithm: "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
+              keyCipherAlgorithm: "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+              recipientKeyAlias: recipient
+              keyOrTrustStoreParametersRef: "#keyStoreParams"
+              keyPassword: privateKeyPassword
+----
+====
 
 == Dependencies
 

--- a/components/camel-xmlsecurity/src/main/docs/xmlsecurity-sign-component.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/xmlsecurity-sign-component.adoc
@@ -599,6 +599,7 @@ from("direct:xades").to("xmlsecurity-sign://xades?keyAccessor=#keyAccessorDefaul
 
 *XAdES-BES/EPES Example in Spring XML*
 
+._XML-only: Spring bean configuration for XAdES signature properties_
 [source,xml]
 ----
 ...
@@ -609,7 +610,7 @@ from("direct:xades").to("xmlsecurity-sign://xades?keyAccessor=#keyAccessorDefaul
 ...
 <bean id="xadesProperties"
     class="org.apache.camel.component.xmlsecurity.api.XAdESSignatureProperties">
-    <!-- For more properties see the previous Java DSL example. 
+    <!-- For more properties see the previous Java DSL example.
          If you want to have a signing certificate then use the bean class DefaultXAdESSignatureProperties (see the previous Java DSL example). -->
     <property name="signaturePolicy" value="ExplicitId" />
     <property name="sigPolicyId" value="http://www.test.com/policy.pdf" />

--- a/components/camel-xmlsecurity/src/main/docs/xmlsecurity-verify-component.adoc
+++ b/components/camel-xmlsecurity/src/main/docs/xmlsecurity-verify-component.adoc
@@ -378,9 +378,9 @@ YAML::
 
 *Spring Example*
 
+._XML-only: Spring bean configuration for detached XML signature verification_
 [source,xml]
 ----
-   
 <bean id="xpathsToIdAttributesBean" class="java.util.ArrayList">
       <constructor-arg type="java.util.Collection">
           <list>
@@ -549,6 +549,7 @@ from("direct:xades").to("xmlsecurity-sign://xades?keyAccessor=#keyAccessorDefaul
 
 *XAdES-BES/EPES Example in Spring XML*
 
+._XML-only: Spring bean configuration for XAdES signature properties_
 [source,xml]
 ----
 ...
@@ -559,7 +560,7 @@ from("direct:xades").to("xmlsecurity-sign://xades?keyAccessor=#keyAccessorDefaul
 ...
 <bean id="xadesProperties"
     class="org.apache.camel.component.xmlsecurity.api.XAdESSignatureProperties">
-    <!-- For more properties see the previous Java DSL example. 
+    <!-- For more properties see the previous Java DSL example.
          If you want to have a signing certificate then use the bean class DefaultXAdESSignatureProperties (see the previous Java DSL example). -->
     <property name="signaturePolicy" value="ExplicitId" />
     <property name="sigPolicyId" value="http://www.test.com/policy.pdf" />

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -116,6 +116,21 @@ Here's an example showing some of these functions in use.
 If you prefer to configure your routes in your Spring
 XML file, then you can use XPath expressions as follows
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+Namespaces ns = new Namespaces("foo", "http://example.com/person");
+
+from("activemq:MyQueue")
+    .filter(xpath("/foo:person[@name='James']", ns))
+        .to("mqseries:SomeOtherQueue");
+----
+
+XML::
++
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -136,6 +151,24 @@ XML file, then you can use XPath expressions as follows
   </camelContext>
 </beans>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:MyQueue
+      steps:
+        - filter:
+            expression:
+              xpath:
+                expression: "/foo:person[@name='James']"
+            steps:
+              - to:
+                  uri: mqseries:SomeOtherQueue
+----
+====
 
 Notice how we can reuse the namespace prefixes, *foo* in this case, in
 the XPath expression for easier namespace-based XPath expressions.

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -255,6 +255,8 @@ XPath which result type to use.
 
 In Java DSL:
 
+._Java-only: XPath expression builder API_
+
 [source,java]
 ----
 xpath("/foo:person/@id", String.class)
@@ -293,6 +295,8 @@ header's value, you can do this by defining the 'headerName' attribute.
 ----
 
 And in Java DSL you specify the headerName as the second parameter as shown:
+
+._Java-only: XPath expression builder API_
 
 [source,java]
 ----
@@ -616,6 +620,8 @@ scopes. For each discovered prefix, all associated URIs are listed.
 You can enable this option in Java DSL and XML DSL:
 
 Java DSL:
+
+._Java-only: XPathBuilder API_
 
 [source,java]
 ----

--- a/components/camel-xpath/src/main/docs/xpath-language.adoc
+++ b/components/camel-xpath/src/main/docs/xpath-language.adoc
@@ -429,6 +429,7 @@ in the XML root tag (or one of the `camelContext`, `routes`, `route` tags).
 In the XML example below we use Spring XML where the namespace is declared in the root tag `beans`,
 in the line with `xmlns:foo="http://example.com/person"`:
 
+._XML-only:_
 [source,xml]
 ----
 <beans xmlns="http://www.springframework.org/schema/beans"

--- a/components/camel-xslt-saxon/src/main/docs/xslt-saxon-component.adoc
+++ b/components/camel-xslt-saxon/src/main/docs/xslt-saxon-component.adoc
@@ -140,19 +140,83 @@ To make the parameters usable, you will need to declare them.
 
 - Header
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .setHeader("myParam", constant("42"))
+    .to("xslt-saxon:MyTransform.xsl");
+----
+
+XML::
++
 [source,xml]
 ----
-<setHeader name="myParam"><constant>42</constant></setHeader>
-<to uri="xslt-saxon:MyTransform.xsl"/>
+<route>
+  <from uri="direct:start"/>
+  <setHeader name="myParam"><constant>42</constant></setHeader>
+  <to uri="xslt-saxon:MyTransform.xsl"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setHeader:
+            name: myParam
+            constant: "42"
+        - to:
+            uri: xslt-saxon:MyTransform.xsl
+----
+====
 
 - Variable
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .setVariable("myParam", constant("42"))
+    .to("xslt-saxon:MyTransform.xsl");
+----
+
+XML::
++
 [source,xml]
 ----
-<setVariable name="myParam"><constant>42</constant></setVariable>
-<to uri="xslt-saxon:MyTransform.xsl"/>
+<route>
+  <from uri="direct:start"/>
+  <setVariable name="myParam"><constant>42</constant></setVariable>
+  <to uri="xslt-saxon:MyTransform.xsl"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setVariable:
+            name: myParam
+            constant: "42"
+        - to:
+            uri: xslt-saxon:MyTransform.xsl
+----
+====
 
 The parameter also needs to be declared in the top level of the XSLT for it to be
 available:
@@ -170,16 +234,44 @@ available:
 
 To use the above examples in Spring XML, you would use something like the following code:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("activemq:My.Queue")
+    .to("xslt-saxon:org/apache/camel/spring/processor/example.xsl")
+    .to("activemq:Another.Queue");
+----
+
+XML::
++
 [source,xml]
 ----
-  <camelContext xmlns="http://activemq.apache.org/camel/schema/spring">
-    <route>
-      <from uri="activemq:My.Queue"/>
-      <to uri="xslt-saxon:org/apache/camel/spring/processor/example.xsl"/>
-      <to uri="activemq:Another.Queue"/>
-    </route>
-  </camelContext>
+<camelContext xmlns="http://activemq.apache.org/camel/schema/spring">
+  <route>
+    <from uri="activemq:My.Queue"/>
+    <to uri="xslt-saxon:org/apache/camel/spring/processor/example.xsl"/>
+    <to uri="activemq:Another.Queue"/>
+  </route>
+</camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:My.Queue
+      steps:
+        - to:
+            uri: xslt-saxon:org/apache/camel/spring/processor/example.xsl
+        - to:
+            uri: activemq:Another.Queue
+----
+====
 
 === Using `xsl:include`
 
@@ -241,6 +333,7 @@ context.addRoutes(new RouteBuilder() {
 
 With Spring XML:
 
+._XML-only: registering Saxon extension functions as Spring beans_
 [source,xml]
 ----
 <bean id="function1" class="org.apache.camel.component.xslt.extensions.MyExtensionFunction1"/>

--- a/components/camel-xslt/src/main/docs/xslt-component.adoc
+++ b/components/camel-xslt/src/main/docs/xslt-component.adoc
@@ -137,19 +137,83 @@ To make the parameters usable, you will need to declare them.
 
 - Header
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .setHeader("myParam", constant("42"))
+    .to("xslt:MyTransform.xsl");
+----
+
+XML::
++
 [source,xml]
 ----
-<setHeader name="myParam"><constant>42</constant></setHeader>
-<to uri="xslt:MyTransform.xsl"/>
+<route>
+  <from uri="direct:start"/>
+  <setHeader name="myParam"><constant>42</constant></setHeader>
+  <to uri="xslt:MyTransform.xsl"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setHeader:
+            name: myParam
+            constant: "42"
+        - to:
+            uri: xslt:MyTransform.xsl
+----
+====
 
 - Variable
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("direct:start")
+    .setVariable("myParam", constant("42"))
+    .to("xslt:MyTransform.xsl");
+----
+
+XML::
++
 [source,xml]
 ----
-<setVariable name="myParam"><constant>42</constant></setVariable>
-<to uri="xslt:MyTransform.xsl"/>
+<route>
+  <from uri="direct:start"/>
+  <setVariable name="myParam"><constant>42</constant></setVariable>
+  <to uri="xslt:MyTransform.xsl"/>
+</route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setVariable:
+            name: myParam
+            constant: "42"
+        - to:
+            uri: xslt:MyTransform.xsl
+----
+====
 
 The parameter also needs to be declared in the top level of the XSLT for it to be
 available:
@@ -167,16 +231,44 @@ available:
 
 To use the above examples in Spring XML, you would use something like the following code:
 
+[tabs]
+====
+Java::
++
+[source,java]
+----
+from("activemq:My.Queue")
+    .to("xslt:org/apache/camel/spring/processor/example.xsl")
+    .to("activemq:Another.Queue");
+----
+
+XML::
++
 [source,xml]
 ----
-  <camelContext xmlns="http://activemq.apache.org/camel/schema/spring">
-    <route>
-      <from uri="activemq:My.Queue"/>
-      <to uri="xslt:org/apache/camel/spring/processor/example.xsl"/>
-      <to uri="activemq:Another.Queue"/>
-    </route>
-  </camelContext>
+<camelContext xmlns="http://activemq.apache.org/camel/schema/spring">
+  <route>
+    <from uri="activemq:My.Queue"/>
+    <to uri="xslt:org/apache/camel/spring/processor/example.xsl"/>
+    <to uri="activemq:Another.Queue"/>
+  </route>
+</camelContext>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:My.Queue
+      steps:
+        - to:
+            uri: xslt:org/apache/camel/spring/processor/example.xsl
+        - to:
+            uri: activemq:Another.Queue
+----
+====
 
 == Using xsl:include
 

--- a/core/camel-base/src/main/docs/properties-component.adoc
+++ b/core/camel-base/src/main/docs/properties-component.adoc
@@ -90,6 +90,7 @@ Or you can use the `<propertyPlaceholder>` tag.
 
 Using the `<propertyPlaceholder>` allows to configure this within the `<camelContext>` tag.
 
+._XML-only:_
 [source,xml]
 ----
 <camelContext>
@@ -99,6 +100,7 @@ Using the `<propertyPlaceholder>` allows to configure this within the `<camelCon
 
 For fine-grained configuration of the location, then this can be done as follows:
 
+._XML-only:_
 [source,xml]
 ----
 <camelContext>

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/aggregate-eip.adoc
@@ -68,6 +68,7 @@ favor returning the old exchange whenever possible.
 Here are a few example `AggregationStrategy` implementations that should
 help you create your own custom strategy.
 
+._Java-only: example AggregationStrategy implementations_
 [source,java]
 ----
 //simply combines Exchange String body values using '+' as a delimiter
@@ -113,6 +114,7 @@ be used for creating commonly used aggregation strategies without having to crea
 In the route below we group all the exchanges together using
 `GroupedExchangeAggregationStrategy`:
 
+._Java-only: using GroupedExchangeAggregationStrategy_
 [source,java]
 ----
 from("direct:start")
@@ -131,6 +133,7 @@ containing all the incoming Exchanges.
 The output of the aggregator will then contain the exchanges grouped
 together in a list as shown below:
 
+._Java-only: retrieving grouped exchanges from message body_
 [source,java]
 ----
 List<Exchange> grouped = exchange.getMessage().getBody(List.class);
@@ -149,6 +152,7 @@ the message body.
 For example, to aggregate a `List<Integer>` you can extend this class as
 shown below, and implement the `getValue` method:
 
+._Java-only: extending AbstractListAggregationStrategy_
 [source,java]
 ----
 public class MyListOfNumbersStrategy extends AbstractListAggregationStrategy<Integer> {
@@ -166,6 +170,7 @@ be used for creating commonly used aggregation strategies without having to crea
 
 The previous example can also be built using the builder as shown:
 
+._Java-only: using AggregationStrategies builder_
 [source,java]
 ----
 AggregationStrategy agg = AggregationStrategies.flexible(Integer.class)
@@ -245,6 +250,7 @@ to return a `true` value.
 
 When pre-completion is enabled then the `preComplete` method is invoked:
 
+._Java-only: preComplete method signature_
 [source,java]
 ----
 /**
@@ -299,6 +305,7 @@ For example, the following logic will complete the
 group if the message body size is larger than 5. This is done by setting
 the exchange property `Exchange.AGGREGATION_COMPLETE_CURRENT_GROUP` to `true`.
 
+._Java-only: completing current group from AggregationStrategy_
 [source,java]
 ----
 public final class MyCompletionStrategy implements AggregationStrategy {
@@ -333,6 +340,7 @@ previous groups, and start a new aggregation group.
 This is done by setting the property `Exchange.AGGREGATION_COMPLETE_ALL_GROUPS` to `true`
 on the returned exchange.
 
+._Java-only: completing all previous groups from AggregationStrategy_
 [source,java]
 ----
 public final class MyCompletionStrategy implements AggregationStrategy {
@@ -437,6 +445,7 @@ YAML::
 Then there is API on `AggregateController` to force completion. For
 example, to complete a group with key foo:
 
+._Java-only: forcing completion of a group via AggregateController_
 [source,java]
 ----
 int groups = controller.forceCompletionOfGroup("foo");
@@ -447,6 +456,7 @@ A value of 1 is returned if the foo group existed, otherwise 0 is returned.
 
 There is also a method to complete all groups:
 
+._Java-only: forcing completion of all groups_
 [source,java]
 ----
 int groups = controller.forceCompletionOfAllGroups();
@@ -482,6 +492,7 @@ In the method below, we have only two parameters, so the first parameter is
 the body of the `oldExchange`, and the second is paired to the body of the
 `newExchange`:
 
+._Java-only: bean method with two parameters_
 [source,java]
 ----
 public String append(String existing, String next) {
@@ -494,6 +505,7 @@ the body of the `oldExchange`, and the second is the `Map` of the
 `oldExchange` headers, and the third is paired to the body of the `newExchange`,
 and the fourth parameter is the `Map` of the `newExchange` headers:
 
+._Java-only: bean method with four parameters_
 [source,java]
 ----
 public String append(String existing, Map existingHeaders, String next, Map nextHeaders) {
@@ -503,6 +515,7 @@ public String append(String existing, Map existingHeaders, String next, Map next
 
 And finally, if we have six parameters, that includes the exchange properties:
 
+._Java-only: bean method with six parameters_
 [source,java]
 ----
 public String append(String existing, Map existingHeaders, Map existingProperties,
@@ -513,6 +526,7 @@ public String append(String existing, Map existingHeaders, Map existingPropertie
 
 To use this with the aggregate EIP, we can use a bean with the aggregate logic as follows:
 
+._Java-only: bean class for aggregation_
 [source,java]
 ----
 public class MyBodyAppender {
@@ -587,6 +601,7 @@ YAML::
 
 In Java DSL, you can also provide the bean class type directly:
 
+._Java-only: using AggregationStrategies.bean with class type_
 [source,java]
 ----
 public void configure() throws Exception {
@@ -600,6 +615,7 @@ public void configure() throws Exception {
 And if the bean has only one method, we do not need to specify the name
 of the method:
 
+._Java-only: using AggregationStrategies.bean without method name_
 [source,java]
 ----
 public void configure() throws Exception {
@@ -612,6 +628,7 @@ public void configure() throws Exception {
 
 And the `append` method could be static:
 
+._Java-only: bean class with static method_
 [source,java]
 ----
 public class MyBodyAppender {
@@ -675,6 +692,7 @@ then set the `strategyMethodAllowNull` to `true`.
 When using beans, this can be configured a bit easier using the `beanAllowNull` method
 from `AggregationStrategies` as shown:
 
+._Java-only: using AggregationStrategies.beanAllowNull_
 [source,java]
 ----
 public void configure() throws Exception {
@@ -687,6 +705,7 @@ public void configure() throws Exception {
 Then the `append` method in the bean would need to deal with the
 situation that `newExchange` can be `null`:
 
+._Java-only: bean class handling null values_
 [source,java]
 ----
 public class MyBodyAppender {
@@ -767,6 +786,7 @@ parameter type of the message bodies does not have to be the same.
 For example suppose we want to aggregate from a `com.foo.User` type to a
 `List<String>` that contains the name of the user. We could code a bean as follows:
 
+._Java-only: bean class aggregating different body types_
 [source,java]
 ----
 public final class MyUserAppender {

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/choice-eip.adoc
@@ -108,6 +108,7 @@ xref:loadBalance-eip.adoc[Load Balancer] EIP inside the Choice EIP in the first 
 
 *Code will not compile*
 
+._Java-only: incorrect use of loadBalance inside choice_
 [source,java]
 ----
 from("direct:start")
@@ -122,6 +123,7 @@ Well, the first issue is that the xref:loadBalance-eip.adoc[Load Balancer] EIP
 uses the additional routing to know what to use in the load balancing.
 In this example, that would be:
 
+._Java-only: load balancer routing snippet_
 [source,java]
 ----
 .to("mock:foo").to("mock:bar")
@@ -133,6 +135,7 @@ So the route is updated as follows:
 
 *Code will still not compile*
 
+._Java-only: using end() does not fix the compilation issue_
 [source,java]
 ----
 from("direct:start")
@@ -156,6 +159,7 @@ to the scope of the Choice EIP.
 
 *Code compiles*
 
+._Java-only: using endChoice() to fix the compilation issue_
 [source,java]
 ----
 from("direct:start")

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-enricher.adoc
@@ -67,6 +67,7 @@ xref:manual::expression.adoc[Expression].
 In the example below, the message
 is enriched by appending ` World!` to the message body:
 
+._Java-only: fluent builder to append to the message body_
 [source,java]
 ----
 from("direct:start")
@@ -127,6 +128,7 @@ YAML::
 In this example, we add our own xref:manual::processor.adoc[Processor] using
 explicit Java to enrich the message:
 
+._Java-only: using an inline Processor to enrich the message_
 [source,java]
 ----
 from("direct:start")
@@ -142,6 +144,7 @@ from("direct:start")
 In the Java code above we used an inlined `Processor` which is harder to do with XML or YAML DSL.
 A good practice is to use a class for your custom `Processor` which can then be referenced in the DSL:
 
+._Java-only: custom Processor class registered in the Registry_
 [source,java]
 ----
 @BindToRegistry("myProcessor")

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/content-filter-eip.adoc
@@ -20,6 +20,7 @@ image::eip/ContentFilter.gif[image]
 In this example, we add our own xref:manual::processor.adoc[Processor] using
 explicit Java to filter the message:
 
+._Java-only: using an inline Processor to filter the message_
 [source,java]
 ----
 from("direct:start")
@@ -37,6 +38,7 @@ from("direct:start")
 In the Java code above we used an inlined `Processor` which is harder to do with XML or YAML DSL.
 A good practice is to use a class for your custom `Processor` which can then be referenced in the DSL:
 
+._Java-only: custom Processor class registered in the Registry_
 [source,java]
 ----
 @BindToRegistry("myProcessor")

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
@@ -63,6 +63,7 @@ The id must then be enabled on either the `<camelContext>` (global scope), or pe
 
 The following listing is an equivalent of the prior Java DSL listing:
 
+._XML-only:_
 [source,xml]
 ----
 <camelContext errorHandlerRef="myErrorHandler">

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/dead-letter-channel.adoc
@@ -198,13 +198,46 @@ The option `useOriginalMessage` is used for routing the original input message i
 
 For instance, if you have this route:
 
+[tabs]
+====
+Java::
++
 [source,java]
------
+----
 from("jms:queue:order:input")
    .to("bean:validateOrder")
    .to("bean:transformOrder")
    .to("bean:handleOrder");
------
+----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="jms:queue:order:input"/>
+  <to uri="bean:validateOrder"/>
+  <to uri="bean:transformOrder"/>
+  <to uri="bean:handleOrder"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: jms:queue:order:input
+      steps:
+        - to:
+            uri: bean:validateOrder
+        - to:
+            uri: bean:transformOrder
+        - to:
+            uri: bean:handleOrder
+----
+====
 
 The route listens for JMS messages and validates, transforms and handles it.
 During this the xref:manual::exchange.adoc[Exchange] payload is transformed/modified in the various bean stages.
@@ -333,6 +366,7 @@ Before the exchange is sent to the dead letter queue, you can use `onPrepare` to
 
 For example, the following processor adds a header with the exception message:
 
+._Java-only: custom Processor to prepare the Exchange before sending to the dead letter queue_
 [source,java]
 ----
 public static class MyPrepareProcessor implements Processor {
@@ -389,6 +423,7 @@ In other words, this happens right after the exception was thrown, where you may
 
 For example, you may have a `Processor` that does some special logging:
 
+._Java-only: custom Processor for logging when an exception occurs_
 [source,java]
 ----
 public static class OnErrorLogger implements Processor {
@@ -511,6 +546,7 @@ will append the following headers to the message with the state of the redeliver
 During routing messages, Camel will store an exchange property
 with the most recent endpoint in use (send to):
 
+._Java-only: accessing the last endpoint URI from the Exchange_
 [source,java]
 ----
 String lastEndpointUri = exchange.getProperty(Exchange.TO_ENDPOINT, String.class);
@@ -523,6 +559,7 @@ This information is updated when Apache Camel sends a message to any endpoint.
 When, for example, processing the xref:manual::exchange.adoc[Exchange] at a given
 xref:manual::endpoint.adoc[Endpoint] and the message is to be moved into the dead letter queue, then Camel also decorates the Exchange with another property that contains that *last* endpoint:
 
+._Java-only: accessing the failure endpoint URI from the Exchange_
 [source,java]
 ----
 String failedEndpointUri = exchange.getProperty(Exchange.FAILURE_ENDPOINT, String.class);
@@ -539,12 +576,42 @@ This information is kept on the Exchange even if the message was successfully pr
 and then later fails, for example, in local xref:bean-eip.adoc[Bean] EIP processing instead.
 So beware that this is a hint that helps pinpoint errors to xref:manual::endpoint.adoc[Endpoints], and not EIPs.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("activemq:queue:foo")
     .to("http://someserver/somepath")
     .bean("foo");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="activemq:queue:foo"/>
+  <to uri="http://someserver/somepath"/>
+  <bean ref="foo"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: activemq:queue:foo
+      steps:
+        - to:
+            uri: http://someserver/somepath
+        - bean:
+            ref: foo
+----
+====
 
 Now suppose the route above, and a failure happens in the `foo` bean.
 Then the `Exchange.TO_ENDPOINT` and `Exchange.FAILURE_ENDPOINT` will still contain the value of `\http://someserver/somepath`.
@@ -555,6 +622,7 @@ Then the `Exchange.TO_ENDPOINT` and `Exchange.FAILURE_ENDPOINT` will still conta
 When a message is moved into the dead letter queue, then Camel will store the id of the route,
 where the message failed. This information can be obtained in Java via:
 
+._Java-only: accessing the failure route id from the Exchange_
 [source,java]
 ----
 String failedRouteId = exchange.getProperty(Exchange.FAILURE_ROUTE_ID, String.class);

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/delay-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/delay-eip.adoc
@@ -65,6 +65,8 @@ YAML::
 ====
 
 Note that delay creates its own block, so some DSLs (including Java) require the delay block be closed:
+
+._Java-only: closing the delay block with end() in Java DSL_
 [source,java]
 ----
 .from("direct:delayBlockExample")
@@ -176,6 +178,7 @@ YAML::
 
 Then the bean would look something like this:
 
+._Java-only: bean class to compute the delay value_
 [source,java]
 ----
 public class SomeBean {

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/kamelet-eip.adoc
@@ -24,6 +24,7 @@ In special situations like these, then you **must** use this Kamelet EIP instead
 
 Given the following Kamelet (as a route template):
 
+._Java-only: defining a route template (Kamelet) with an aggregation strategy_
 [source,java]
 ----
 routeTemplate("my-aggregate")

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/log-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/log-eip.adoc
@@ -214,6 +214,7 @@ YAML::
 
 In Java DSL the logger instance may be used as well:
 
+._Java-only: using a logger instance directly in Java DSL_
 [source,java]
 ----
 from("direct:start")
@@ -503,6 +504,7 @@ At this time of writing, there are more than 65 different keywords.
 
 Custom keywords can be added as shown:
 
+._Java-only: registering a custom masking formatter with additional keywords_
 [source,java]
 ----
 DefaultMaskingFormatter formatter = new DefaultMaskingFormatter();

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/message-history.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/message-history.adoc
@@ -82,8 +82,12 @@ the history in a critical route to help pinpoint where the route is slow.
 
 A route level configuration overrides the global configuration.
 
-To enable in Java:
+To enable per route:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("jms:cheese")
@@ -92,6 +96,36 @@ from("jms:cheese")
   .to("bean:transform")
   .to("jms:wine");
 ----
+
+XML::
++
+[source,xml]
+----
+<route messageHistory="true">
+  <from uri="jms:cheese"/>
+  <to uri="bean:validate"/>
+  <to uri="bean:transform"/>
+  <to uri="jms:wine"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    messageHistory: "true"
+    from:
+      uri: jms:cheese
+      steps:
+        - to:
+            uri: bean:validate
+        - to:
+            uri: bean:transform
+        - to:
+            uri: jms:wine
+----
+====
 
 You can also turn off message history per route:
 
@@ -288,6 +322,7 @@ In this case we can see its the `MyJavaRouteBuilder` class on line 35 that is th
 You can turn off logging Message History with `logExhaustedMessageHistory`
 from the xref:manual::error-handler.adoc[Error Handler] using:
 
+._Java-only: disabling message history logging on the error handler_
 [source,java]
 ----
 errorHandler(defaultErrorHandler().logExhaustedMessageHistory(false));
@@ -362,6 +397,7 @@ route id, processor id, timestamp, and elapsed time it took to process the `Exch
 
 You can access the message history from Java code:
 
+._Java-only: accessing the message history from the Exchange_
 [source,java]
 ----
 List<MessageHistory> list = exchange.getProperty(Exchange.MESSAGE_HISTORY, List.class);
@@ -376,6 +412,7 @@ The  Message History format in Camel is controlled by `Java String.format` patte
 
 The defaults are defined in https://github.com/apache/camel/blob/main/core/camel-support/src/main/java/org/apache/camel/support/MessageHelper.java[`MessageHelper.java`]:
 
+._Java-only: default message history format patterns_
 [source,java]
 ----
 private static final String MESSAGE_HISTORY_HEADER = "%-40s %-30s %-50s %-12s";
@@ -392,6 +429,7 @@ camel.main.global-options[CamelMessageHistoryOutputFormat] = %-40.40s %-30.30s %
 
 If you want to configure the message format for a specific exchange, you can do it programmatically:
 
+._Java-only: configuring custom message history format on the CamelContext_
 [source,java]
 ----
 camelContext.getGlobalOptions().put(Exchange.MESSAGE_HISTORY_HEADER_FORMAT,

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/process-eip.adoc
@@ -31,6 +31,7 @@ step and return it.
 The `Processor` interface is a central API in Camel.
 Its API is purposely designed to be both straightforward and flexible in the form of a single functional method:
 
+._Java-only: the Processor interface_
 [source,java]
 ----
 @FunctionalInterface
@@ -53,6 +54,7 @@ the xref:enterprise-integration-patterns.adoc[EIP patterns].
 
 Once you have written a class which implements `Processor` like this:
 
+._Java-only: implementing a custom Processor class_
 [source,java]
 ----
 public class MyProcessor implements Processor {
@@ -64,6 +66,7 @@ public class MyProcessor implements Processor {
 
 Then in Camel you can call this processor:
 
+._Java-only: calling a Processor by instantiating it directly_
 [source,java]
 ----
 from("activemq:myQueue")
@@ -135,6 +138,7 @@ YAML::
 
 The process can be used in routes as an anonymous inner class such:
 
+._Java-only: using an anonymous inner class as a Processor_
 [source,java]
 ----
     from("activemq:myQueue").process(new Processor() {

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
@@ -146,6 +146,7 @@ The dynamic list of recipients that are defined in the header must be iterable s
 In XML DSL you can set the delimiter attribute for setting a delimiter to be used if the header value is a single `String` with multiple separated endpoints.
 By default, Camel uses comma as delimiter, but this option lets you specify a custom delimiter to use instead.
 
+._XML-only:_
 [source,xml]
 ----
 <route>

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/recipientList-eip.adoc
@@ -180,6 +180,7 @@ You can use spaces between the endpoints as Camel will trim the value when it lo
 
 In Java DSL, you specify the delimiter as second parameter as shown below:
 
+._Java-only: the delimiter is passed as a second parameter to recipientList_
 [source,java]
 ----
 from("direct:a")
@@ -417,6 +418,7 @@ For example, in the unit test below, you can see that we multicast the message t
 We have a timeout of 2 seconds, which means only the last two messages can be completed within the timeframe.
 This means we will only aggregate the last two which yields a result aggregation which outputs "BC".
 
+._Java-only: multicast with inline AggregationStrategy and timeout_
 [source,java]
 ----
 from("direct:start")

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/resume-strategies.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/resume-strategies.adoc
@@ -40,6 +40,7 @@ the heavy-lifting for you.
 
 Using the resume API with the configuration should look like this:
 
+._Java-only: configuring resume strategy with KafkaResumeStrategyConfigurationBuilder_
 [source,java]
 ----
 KafkaResumeStrategyConfigurationBuilder kafkaConfigurationBuilder = KafkaResumeStrategyConfigurationBuilder.newBuilder()
@@ -58,6 +59,7 @@ from("some:component")
 
 This instance can be bound in the Context registry as follows:
 
+._Java-only: binding resume strategy to the registry_
 [source,java]
 ----
 getCamelContext().getRegistry().bind("testResumeStrategy", new MyTestResumeStrategy());
@@ -70,6 +72,7 @@ from("some:component")
 
 Or the instance can be constructed as follows:
 
+._Java-only: constructing resume strategy inline_
 [source,java]
 ----
 getCamelContext().getRegistry().bind("resumeCache", new MyChoiceOfResumeCache<>(100));
@@ -90,6 +93,7 @@ In some circumstances, such as when dealing with File I/O, it may be necessary t
 In some cases, it may be necessary to avoid updating the offset for every exchange.
 You can enable the intermittent mode to modify the route behavior so that missing offsets will not cause an exception:
 
+._Java-only: enabling intermittent mode on resumable_
 [source,java]
 ----
 from("some:component")
@@ -110,6 +114,7 @@ Some of the builtin strategies may need additional configuration. This can be do
 available for each strategy. For instance, to configure either one of the Kafka strategies mentioned earlier, the
 `KafkaResumeStrategyConfiguration` needs to be used. It can be created using a code similar to the following:
 
+._Java-only: building KafkaResumeStrategyConfiguration_
 [source,java]
 ----
     KafkaResumeStrategyConfiguration resumeStrategyConfiguration = KafkaResumeStrategyConfigurationBuilder.newBuilder()
@@ -134,6 +139,7 @@ When using the converters with the file component, beware of the differences in 
 
 For instance, the behavior of:
 
+._Java-only: resumable with Reader body type_
 [source,java]
 ----
 from("file:{{input.dir}}?noop=true&fileName={{input.file}}")
@@ -144,6 +150,7 @@ from("file:{{input.dir}}?noop=true&fileName={{input.file}}")
 
 It is different from the behavior of:
 
+._Java-only: resumable with InputStream body type_
 [source,java]
 ----
 from("file:{{input.dir}}?noop=true&fileName={{input.file}}")
@@ -172,6 +179,7 @@ To use the API, it needs an instance of a Consumer listener along with a predica
 
 Usage example:
 
+._Java-only: using pausable consumer API_
 [source,java]
 ----
 from(from)
@@ -190,6 +198,7 @@ On success, it shuts down the scheduled check.
 
 An example implementation of this approach would be similar to this:
 
+._Java-only: integrating pausable consumer with circuit breaker_
 [source,java]
 ----
 CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("pausable");

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/scatter-gather.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/scatter-gather.adoc
@@ -201,6 +201,7 @@ public class MyVendor {
 
 And are loaded up in Spring XML like this:
 
+._XML-only: Spring XML bean definitions for vendor and aggregation strategy_
 [source,xml]
 ----
 <camelContext>

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/scatter-gather.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/scatter-gather.adoc
@@ -111,6 +111,8 @@ from("seda:quoteAggregator")
     .end();
 ----
 
+XML::
++
 [source,xml]
 ----
   <route>

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/setHeaders-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/setHeaders-eip.adoc
@@ -192,29 +192,24 @@ YAML::
 It's also possible to build a Map and pass it as the single argument to `setHeaders().`
 If the order in which the headers should be set is important, use a `LinkedHashMap`.
 
-====
-Java::
-+
+._Java-only: using a LinkedHashMap to set headers in order_
 [source,java]
 ----
 private Map<String, Expression> headerMap = new java.util.LinkedHashMap<>();
 headerMap.put("foo", ConstantLanguage.constant("ABC"));
 headerMap.put("bar", ConstantLanguage.constant("XYZ"));
-        
+
 from("direct:startMap")
     .setHeaders(headerMap)
     .to("direct:b");
 ----
-====
 
 If the ordering is not critical, then `Map.of(name1, expr1, name2, expr2...)` can be used.
-====
-Java::
-+
+
+._Java-only: using Map.of for unordered headers_
 [source,java]
 ----
 from("direct:startMap")
     .setHeaders(Map.of("foo", "ABC", "bar", "XYZ"))
     .to("direct:b");
 ----
-====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/setVariables-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/setVariables-eip.adoc
@@ -192,29 +192,24 @@ YAML::
 It's also possible to build a Map and pass it as the single argument to `setVariables().`
 If the order in which the variables should be set is important, use a `LinkedHashMap`.
 
-====
-Java::
-+
+._Java-only: using a LinkedHashMap to set variables in order_
 [source,java]
 ----
 private Map<String, Expression> variableMap = new java.util.LinkedHashMap<>();
 variableMap.put("foo", ConstantLanguage.constant("ABC"));
 variableMap.put("bar", ConstantLanguage.constant("XYZ"));
-        
+
 from("direct:startMap")
     .setVariables(variableMap)
     .to("direct:b");
 ----
-====
 
 If the ordering is not critical, then `Map.of(name1, expr1, name2, expr2...)` can be used.
-====
-Java::
-+
+
+._Java-only: using Map.of for unordered variables_
 [source,java]
 ----
 from("direct:startMap")
     .setVariables(Map.of("foo", "ABC", "bar", "XYZ"))
     .to("direct:b");
 ----
-====

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/split-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/split-eip.adoc
@@ -935,6 +935,10 @@ aggregate and return a combined response to the original caller.
 The route below illustrates this and how the split supports a custom `AggregationStrategy`
 to build up the combined response message.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // this routes starts from the direct:start endpoint
@@ -954,6 +958,41 @@ from("direct:start")
     // this bean will receive the result of the aggregate strategy: MyOrderStrategy
     .to("bean:MyOrderService?method=buildCombinedResponse")
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="direct:start"/>
+    <split aggregationStrategy="#class:com.foo.MyOrderStrategy">
+        <tokenize token="@"/>
+        <to uri="bean:MyOrderService?method=handleOrder"/>
+    </split>
+    <to uri="bean:MyOrderService?method=buildCombinedResponse"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - split:
+            aggregationStrategy: "#class:com.foo.MyOrderStrategy"
+            expression:
+              tokenize:
+                token: "@"
+            steps:
+              - to:
+                  uri: bean:MyOrderService?method=handleOrder
+        - to:
+            uri: bean:MyOrderService?method=buildCombinedResponse
+----
+====
 
 And the OrderService bean is as follows:
 

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/split-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/split-eip.adoc
@@ -835,6 +835,7 @@ In Spring XML, the equivalent route would be written as follows:
 
 NOTE: Notice how the namespace in XML can also be defined in the root tag such as `<camelContext>`.
 
+._XML-only:_
 [source,xml]
 ----
 <camelContext xmlns:ns1="urn:shop">

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/toD-eip.adoc
@@ -171,11 +171,40 @@ which results in an overhead of resources in use, by each dynamic endpoint uri, 
 
 For example, HTTP-based endpoints where you may have dynamic values in URI parameters when calling the HTTP service, such as:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:login")
   .toD("http:myloginserver:8080/login?userid=${header.userName}");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:login"/>
+  <toD uri="http:myloginserver:8080/login?userid=${header.userName}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:login
+      steps:
+        - toD:
+            uri: http:myloginserver:8080/login
+            parameters:
+              userid: "${header.userName}"
+----
+====
 
 In the example above then the parameter `userid` is dynamically computed, and would result in one instance of endpoint and producer
 for each different userid. To avoid having too many dynamic endpoints you can configure `toD` to reduce its cache size, for example,
@@ -359,6 +388,7 @@ YAML::
 
 This will essentially be optimized to (**internally** pseudo route):
 
+._Java-only: pseudo code showing the internal optimization_
 [source,java]
 ----
 from("direct:login")

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/csimple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/csimple-language.adoc
@@ -245,6 +245,10 @@ echo()=${bodyAs(String)} ${bodyAs(String)}
 
 Which allows to use _echo()_ in the csimple language script such as:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:hello")
@@ -252,8 +256,37 @@ from("direct:hello")
     .log("You said ${body}");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:hello"/>
+  <transform>
+    <csimple>Hello echo()</csimple>
+  </transform>
+  <log message="You said ${body}"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:hello
+      steps:
+        - transform:
+            csimple: "Hello echo()"
+        - log:
+            message: "You said ${body}"
+----
+====
+
 The _echo()_ alias will be replaced with its value resulting in a script as:
 
+._Java-only: expanded echo() alias_
 [source,java]
 ----
     .transform(csimple("Hello ${bodyAs(String)} ${bodyAs(String)}"))

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
@@ -779,6 +779,10 @@ Then `${jq(.id)}` will return `123`.
 
 You can also use this for basic data mapping such as:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:map")
@@ -791,11 +795,52 @@ from("direct:map")
         .to("log:data");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:map"/>
+  <transform>
+    <simple>{
+              "roll": ${jq(.id)},
+              "country": "${jq(.country // constant(sweden))}",
+              "fullname": "${jq(.name)}"
+            }</simple>
+  </transform>
+  <to uri="log:data"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:map
+      steps:
+        - transform:
+            simple: |-
+              {
+                "roll": ${jq(.id)},
+                "country": "${jq(.country // constant(sweden))}",
+                "fullname": "${jq(.name)}"
+              }
+        - to:
+            uri: log:data
+----
+====
+
 The `jsonpath` function works similar to `jq` but uses JSONPath.
 When using `${jsonpath($.id)}` will also return `123`.
 
 And the data mapping can be done as follows with JSonPath instead of JQ:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:map")
@@ -808,11 +853,52 @@ from("direct:map")
         .to("log:data");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:map"/>
+  <transform>
+    <simple>{
+              "roll": ${jsonpath($.id)},
+              "years": ${jsonpath($.age)},
+              "fullname": "${jsonpath($.name)}"
+            }</simple>
+  </transform>
+  <to uri="log:data"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:map
+      steps:
+        - transform:
+            simple: |-
+              {
+                "roll": ${jsonpath($.id)},
+                "years": ${jsonpath($.age)},
+                "fullname": "${jsonpath($.name)}"
+              }
+        - to:
+            uri: log:data
+----
+====
+
 The `simpleJsonpath` function is using Camel's built in JSON library from `camel-util-json` that is a basic JSON parser.
 The syntax for the path is similar to Camel's bean OGNL syntax to use a dot notation to walk down a nested structure.
 
 Because the input JSON is not nested then the mapping example is just:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:map")
@@ -824,6 +910,43 @@ from("direct:map")
             }""")
         .to("log:data");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:map"/>
+  <transform>
+    <simple>{
+              "roll": ${simpleJsonpath(id)},
+              "years": ${simpleJsonpath(age)},
+              "fullname": "${simpleJsonpath(name)}"
+            }</simple>
+  </transform>
+  <to uri="log:data"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:map
+      steps:
+        - transform:
+            simple: |-
+              {
+                "roll": ${simpleJsonpath(id)},
+                "years": ${simpleJsonpath(age)},
+                "fullname": "${simpleJsonpath(name)}"
+              }
+        - to:
+            uri: log:data
+----
+====
 
 However, if there are nested JSON such as:
 
@@ -929,6 +1052,10 @@ Then `${xpath(/order/@id)}` will return `123`.
 
 And the data mapping can be done with XPath as follows:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:map")
@@ -940,6 +1067,43 @@ from("direct:map")
         }""")
     .to("log:data");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:map"/>
+  <transform>
+    <simple>{
+          "id": ${xpath(/order/@id)},
+          "item": "${xpath(/order/item)}",
+          "fullname": "${xpath(/order/first)} ${xpath(/order/last)}"
+        }</simple>
+  </transform>
+  <to uri="log:data"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:map
+      steps:
+        - transform:
+            simple: |-
+              {
+                "id": ${xpath(/order/@id)},
+                "item": "${xpath(/order/item)}",
+                "fullname": "${xpath(/order/first)} ${xpath(/order/last)}"
+              }
+        - to:
+            uri: log:data
+----
+====
 
 The `pretty` function is used for pretty printing JSON or XML data as a String value.
 For example given the following JSON payload (in a single line): `{"id": 123, "age": 42, "name": "scott"}`
@@ -1849,27 +2013,12 @@ simple("${body.address.zip} > 1000")
 
 == EIP Examples
 
-In the XML DSL sample below, we filter based on a header value:
+Below we filter based on a header value:
 
-._XML-only:_
-[source,xml]
-----
-<from uri="seda:orders">
-   <filter>
-       <simple>${header.foo}</simple>
-       <to uri="mock:fooOrders"/>
-   </filter>
-</from>
-----
-
-The Simple language can be used for the predicate test above in the
-Message Filter pattern, where we test if the
-in message has a `foo` header (a header with the key `foo` exists). If
-the expression evaluates to `*true*`, then the message is routed to the
-`mock:fooOrders` endpoint, otherwise the message is dropped.
-
-The same example in Java DSL:
-
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("seda:orders")
@@ -1877,8 +2026,47 @@ from("seda:orders")
         .to("seda:fooOrders");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="seda:orders"/>
+  <filter>
+    <simple>${header.foo}</simple>
+    <to uri="seda:fooOrders"/>
+  </filter>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:orders
+      steps:
+        - filter:
+            simple: "${header.foo}"
+            steps:
+              - to:
+                  uri: seda:fooOrders
+----
+====
+
+The Simple language can be used for the predicate test above in the
+Message Filter pattern, where we test if the
+in message has a `foo` header (a header with the key `foo` exists). If
+the expression evaluates to `*true*`, then the message is routed to the
+`seda:fooOrders` endpoint, otherwise the message is dropped.
+
 You can also use the simple language for simple text concatenations such as:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:hello")
@@ -1886,11 +2074,43 @@ from("direct:hello")
     .to("mock:reply");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:hello"/>
+  <transform>
+    <simple>Hello ${header.user} how are you?</simple>
+  </transform>
+  <to uri="mock:reply"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:hello
+      steps:
+        - transform:
+            simple: "Hello ${header.user} how are you?"
+        - to:
+            uri: mock:reply
+----
+====
+
 Notice that we must use `${ }` placeholders in the expression now to
 allow Camel to parse it correctly.
 
 And this sample uses the date command to output current date.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:hello")
@@ -1898,15 +2118,75 @@ from("direct:hello")
     .to("mock:reply");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:hello"/>
+  <transform>
+    <simple>The today is ${date:now:yyyyMMdd} and it is a great day.</simple>
+  </transform>
+  <to uri="mock:reply"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:hello
+      steps:
+        - transform:
+            simple: "The today is ${date:now:yyyyMMdd} and it is a great day."
+        - to:
+            uri: mock:reply
+----
+====
+
 And in the sample below, we invoke the bean language to invoke a method
 on a bean to be included in the returned string:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:order")
     .transform().simple("OrderId: ${bean:orderIdGenerator}")
     .to("mock:reply");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:order"/>
+  <transform>
+    <simple>OrderId: ${bean:orderIdGenerator}</simple>
+  </transform>
+  <to uri="mock:reply"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:order
+      steps:
+        - transform:
+            simple: "OrderId: ${bean:orderIdGenerator}"
+        - to:
+            uri: mock:reply
+----
+====
 
 Where `orderIdGenerator` is the id of the bean registered in the
 Registry. If using Spring, then it is the Spring bean
@@ -1916,6 +2196,10 @@ If we want to declare which method to invoke on the order id generator
 bean we must prepend `.method name` such as below where we invoke the
 `generateId` method.
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:order")
@@ -1923,15 +2207,75 @@ from("direct:order")
     .to("mock:reply");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:order"/>
+  <transform>
+    <simple>OrderId: ${bean:orderIdGenerator.generateId}</simple>
+  </transform>
+  <to uri="mock:reply"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:order
+      steps:
+        - transform:
+            simple: "OrderId: ${bean:orderIdGenerator.generateId}"
+        - to:
+            uri: mock:reply
+----
+====
+
 We can use the `?method=methodname` option that we are familiar with the
 xref:components::bean-component.adoc[Bean] component itself:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:order")
     .transform().simple("OrderId: ${bean:orderIdGenerator?method=generateId}")
     .to("mock:reply");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:order"/>
+  <transform>
+    <simple>OrderId: ${bean:orderIdGenerator?method=generateId}</simple>
+  </transform>
+  <to uri="mock:reply"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:order
+      steps:
+        - transform:
+            simple: "OrderId: ${bean:orderIdGenerator?method=generateId}"
+        - to:
+            uri: mock:reply
+----
+====
 
 You can also convert the body to a given
 type, for example, to ensure that it is a String you can do:
@@ -2009,12 +2353,44 @@ syntax where double quote is `\&quot;` and single quote is `\&apos;` (yeah that 
 
 For example, to replace all double quotes with single quotes:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:order")
   .transform().simple("${replace(&quot; , &apos;)}")
   .to("mock:reply");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:order"/>
+  <transform>
+    <simple>${replace(&amp;quot; , &amp;apos;)}</simple>
+  </transform>
+  <to uri="mock:reply"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:order
+      steps:
+        - transform:
+            simple: "${replace(&quot; , &apos;)}"
+        - to:
+            uri: mock:reply
+----
+====
 
 And to replace all single quotes with double quotes:
 
@@ -2043,6 +2419,7 @@ booleans, integers, etc.
 
 For example, to set a header as a boolean type, you can do:
 
+._Java-only: setting result type on a simple expression_
 [source,java]
 ----
 .setHeader("cool", simple("true", Boolean.class))
@@ -2091,6 +2468,7 @@ such as `"classpath:"`, `"file:"`, or `"http:"`.
 This is done using the following syntax: `"resource:scheme:location"`,
 e.g., to refer to a file on the classpath you can do:
 
+._Java-only: loading a simple script from an external resource_
 [source,java]
 ----
 .setHeader("myHeader").simple("resource:classpath:mysimple.txt")
@@ -2166,6 +2544,7 @@ A custom function should either be an `Expression` or a `org.apache.camel.spi.Si
 You may want to use `Expression` when you build custom functions from the built-in functions in Camel.
 This can be done programmatically such as:
 
+._Java-only: registering a custom function with SimpleFunctionRegistry_
 [source,java]
 ----
 SimpleFunctionRegistry reg = PluginHelper.getSimpleFunctionRegistry(getCamelContext());
@@ -2183,6 +2562,10 @@ can be done by using the `org.apache.camel.support.ExpressionAdapter` class as a
 
 The foo function can now be used in simple such as:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:start")
@@ -2190,11 +2573,40 @@ from("direct:start")
         .to("mock:result");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:start"/>
+  <setBody>
+    <simple>Hello ${foo}</simple>
+  </setBody>
+  <to uri="mock:result"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setBody:
+            simple: "Hello ${foo}"
+        - to:
+            uri: mock:result
+----
+====
+
 Notice how the foo function is used just like it was a built-in function using `$\{foo}` syntax.
 
 Since a custom function is just an `Expression` then it's possible to build custom functions from
 all the Camel languages such as Groovy, JSonPath and even Simple as well.
 
+._Java-only: building a custom function from Simple expressions_
 [source,java]
 ----
 var bar = context.resolveLanguage("simple").createExpression("${trim()} ~> ${normalizeWhitespace()} ~> ${capitalize()} ~> ${quote()}");
@@ -2208,6 +2620,10 @@ which allows to provide the input as fixed value such as a string literal or to 
 
 For example the foo function uses variable with name `msg` as the input:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:start")
@@ -2216,8 +2632,46 @@ from("direct:start")
         .to("mock:result");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:start"/>
+  <setVariable name="msg">
+    <constant>Moon</constant>
+  </setVariable>
+  <setBody>
+    <simple>Bye ${foo(${variable.msg})}</simple>
+  </setBody>
+  <to uri="mock:result"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setVariable:
+            name: msg
+            constant: "Moon"
+        - setBody:
+            simple: "Bye ${foo(${variable.msg})}"
+        - to:
+            uri: mock:result
+----
+====
+
 And instead of nesting the variable inside the foo function, we can also use the `~>` chain operator:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:start")
@@ -2226,8 +2680,43 @@ from("direct:start")
         .to("mock:result");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:start"/>
+  <setVariable name="msg">
+    <constant>Moon</constant>
+  </setVariable>
+  <setBody>
+    <simple>Bye ${variable.msg} ~> ${foo}</simple>
+  </setBody>
+  <to uri="mock:result"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setVariable:
+            name: msg
+            constant: "Moon"
+        - setBody:
+            simple: "Bye ${variable.msg} ~> ${foo}"
+        - to:
+            uri: mock:result
+----
+====
+
 You can also build custom functions as a Java class as below:
 
+._Java-only: implementing SimpleFunction interface_
 [source,java]
 ----
 public class FooSimpleFunction implements SimpleFunction {
@@ -2248,6 +2737,7 @@ This gives you the full power to implement the function logic in standard Java.
 
 This function can be added programmatically:
 
+._Java-only: adding a SimpleFunction to the registry_
 [source,java]
 ----
 SimpleFunctionRegistry reg = PluginHelper.getSimpleFunctionRegistry(getCamelContext());

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
@@ -1420,6 +1420,7 @@ languages for testing with simple operators. Now you can do this with the simple
 language. In the sample below, we want to test it if the header is a widget
 order:
 
+._XML-only:_
 [source,xml]
 ----
 <from uri="seda:orders">
@@ -1850,6 +1851,7 @@ simple("${body.address.zip} > 1000")
 
 In the XML DSL sample below, we filter based on a header value:
 
+._XML-only:_
 [source,xml]
 ----
 <from uri="seda:orders">

--- a/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
+++ b/core/camel-core-languages/src/main/docs/modules/languages/pages/simple-language.adoc
@@ -2100,41 +2100,21 @@ e.g., to refer to a file on the classpath you can do:
 
 From *Camel 4.18* onwards then the Simple language can _pretty format_ the output.
 
-In Java DSL you turn this on via the `boolean` parameter that is set as `true` below:
+You turn this on via the `pretty` option set to `true`:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
-from("direct:xml")
-    .setBody().simple("<person><name>Jack</name></person>", true)
-    .to("mock:result");
-
 from("direct:json")
     .setBody().simple("{ \"name\": \"Jack\", \"age\": 44 }", true)
     .to("mock:result");
-
-from("direct:text")
-    .setBody().simple("Hello ${body}", true)
-    .to("mock:result");
 ----
 
-In YAML DSL you specific `pretty: true` as follows:
-
-[source,yaml]
-----
-route:
-  from:
-    uri: direct:xml
-    steps:
-      - setBody:
-          simple:
-            expression: "<person><name>Jack</name></person>"
-            pretty: true
-      - to:
-          uri: mock:result
-----
-
-And in XML DSL you use the pretty attribute to true as show below:
-
+XML::
++
 [source,xml]
 ----
 <route>
@@ -2144,6 +2124,37 @@ And in XML DSL you use the pretty attribute to true as show below:
   </setBody>
   <to uri="mock:result"/>
 </route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:json
+      steps:
+        - setBody:
+            simple:
+              expression: "{ \"name\": \"Jack\", \"age\": 44 }"
+              pretty: true
+        - to:
+            uri: mock:result
+----
+====
+
+This works with XML, JSON and text content:
+
+._Java-only: pretty formatting with different content types_
+[source,java]
+----
+from("direct:xml")
+    .setBody().simple("<person><name>Jack</name></person>", true)
+    .to("mock:result");
+
+from("direct:text")
+    .setBody().simple("Hello ${body}", true)
+    .to("mock:result");
 ----
 
 == Adding custom functions to Simple language

--- a/docs/user-manual/modules/ROOT/pages/Endpoint-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/Endpoint-dsl.adoc
@@ -11,6 +11,7 @@ The DSL can be accessed in several ways, but the main one is to switch to using 
 
 The following is an example of an FTP route using the standard `RouteBuilder` Java DSL:
 
+._Java-only: FTP route using standard string-based URI_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {
@@ -27,6 +28,7 @@ public class MyRoutes extends RouteBuilder {
 The same Java statement can be rewritten in the following more type-safe and readable way using
 the new `EndpointRouteBuilder` that allows using the Endpoint-DSL:
 
+._Java-only: same FTP route rewritten with type-safe Endpoint DSL_
 [source,java]
 ----
 public class MyRoutes extends EndpointRouteBuilder {
@@ -56,6 +58,7 @@ Then you can set up two Camel JMS components with unique names such as: `myAMQ` 
 
 The Endpoint-DSL can use these names with the `jms` fluent builder as shown:
 
+._Java-only: using custom component names with Endpoint DSL_
 [source,java]
 ----
 from(jms("myWMQ", "cheese").concurrentConsumers(5))
@@ -73,6 +76,7 @@ the target component.
 
 In the example below the method `file()` available from `EndpointRouteBuilder`, gives access to the methods corresponding to the name of the headers of the file component. Here the method `fileName()` is called to get the name of the header for the name of the file.
 
+._Java-only: using type-safe header name builder_
 [source,java]
 ----
 public class MyRoutes extends EndpointRouteBuilder {
@@ -96,6 +100,7 @@ You can use the type-safe endpoint-dsl outside route builders with:
 
 For example to send a message to Kafka you can use the `FluentProducerTemplate`
 
+._Java-only: sending a message using FluentProducerTemplate with Endpoint DSL_
 [source,java]
 ----
 import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.kafka;
@@ -111,6 +116,7 @@ To use the endpoint-dsl with kafka you need to static import `kafka` from the cl
 
 An endpoint can also be created in Java code via the endpoint-dsl as shown:
 
+._Java-only: creating an endpoint using Endpoint DSL and resolving it_
 [source,java]
 ----
 import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.paho;
@@ -125,6 +131,7 @@ by calling `resolve` with `CamelContext` as parameter.
 If you want to inject an endpoint into your POJO or `RouteBuilder` class using endpoint-dsl, then
 this can be done similar to the previous example, but with one important difference:
 
+._Java-only: injecting an Endpoint DSL builder into a POJO_
 [source,java]
 ----
 import org.apache.camel.BindToRegistry;

--- a/docs/user-manual/modules/ROOT/pages/advice-with.adoc
+++ b/docs/user-manual/modules/ROOT/pages/advice-with.adoc
@@ -54,6 +54,7 @@ For example, using `mockEndpointsAndSkip("activemq:queue:foo?*")` To match the f
 To _advice_ you need to use the `AdviceWithRouteBuilder` for manipulating the route.
 But first, you need to select which route to manipulate which you can do by the route ID or the route index.
 
+._Java-only: advising a route using AdviceWithRouteBuilder_
 [source,java]
 ----
 AdviceWith.adviceWith("myRoute", context, new AdviceWithRouteBuilder() {
@@ -68,6 +69,7 @@ We introduce a more modern API for _advicing_ routes using Java lambda style.
 
 Below, we are _advicing_ the route with ID myRoute:
 
+._Java-only: advising a route using lambda style_
 [source,java]
 ----
 AdviceWith.adviceWith(context, "myRoute", a ->
@@ -102,6 +104,7 @@ This is solved by following the following steps:
 When using xref:components:others:test-junit5.adoc[camel-test-junit5] for unit testing, then you can tell Camel that advice is in use by either
 overriding the `isUsedAdviceWith` method from `CamelTestSupport` as shown:
 
+._Java-only: enabling AdviceWith in CamelTestSupport_
 [source,java]
 ----
 public class MyAdviceWithTest extends CamelTestSupport {
@@ -114,6 +117,7 @@ public class MyAdviceWithTest extends CamelTestSupport {
 
 Or when using xref:components:others:test-spring-junit5.adoc[camel-test-spring-junit5] for unit testing you can use the `@UseAdviceWith` annotation as shown:
 
+._Java-only: enabling AdviceWith using @UseAdviceWith annotation_
 [source,java]
 ----
 @UseAdviceWith
@@ -123,6 +127,7 @@ public class MyAdviceWithTest extends CamelSpringTestSupport {
 
 Then you advise the routes followed by starting Camel:
 
+._Java-only: advising a route and then starting CamelContext_
 [source,java]
 ----
 @Test
@@ -156,6 +161,7 @@ However, this requires to have `camel-xml-jaxb` as dependency, which you can add
 
 It is possible to turn of logging as XML, by setting the logging to `false` as shown:
 
+._Java-only: disabling XML logging when advising routes_
 [source,java]
 ----
 AdviceWith.adviceWith(context, "myRoute", false, a ->
@@ -174,6 +180,7 @@ xref:components::seda-component.adoc[seda], xref:components::stub-component.adoc
 
 The following illustrates how to do this:
 
+._Java-only: replacing the route input endpoint for testing_
 [source,java]
 ----
 @Test
@@ -206,6 +213,7 @@ Here Camel have _adviced_ two endpoints:
 
 This allows using the mock endpoints in your unit tests for testing, such as:
 
+._Java-only: using auto-mocked endpoints in unit tests_
 [source,java]
 ----
 public void testMockEndpoints() throws Exception {
@@ -242,6 +250,7 @@ The following methods are available for the `weave` methods:
 
 For example, given the following route:
 
+._Java-only: example route used for weave demonstrations_
 [source,java]
 ----
 from("direct:start")
@@ -254,6 +263,7 @@ Then let's go over the four methods to see how you can use them in unit tests
 
 ==== Replace
 
+._Java-only: weaving a node by ID and replacing it_
 [source,java]
 ----
 AdviceWith.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
@@ -273,6 +283,7 @@ That means instead of sending the message to a mock:bar endpoint, we do a Multic
 
 In the example below, we simply just remove the `.to("mock:bar").id("bar")` from the route:
 
+._Java-only: weaving a node by ID and removing it_
 [source,java]
 ----
 AdviceWith.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
@@ -288,6 +299,7 @@ AdviceWith.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceW
 
 In the example below, we add the following nodes `to("mock:a").transform(constant("Bye World"))` before the node with the id bar.
 
+._Java-only: weaving nodes before a specific node_
 [source,java]
 ----
 AdviceWith.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
@@ -306,6 +318,7 @@ That means the message being sent before to mock:bar would have been transformed
 
 In the example below, we add the following nodes `to("mock:a").transform(constant("Bye World"))` after the node with the id bar.
 
+._Java-only: weaving nodes after a specific node_
 [source,java]
 ----
 AdviceWith.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
@@ -328,6 +341,7 @@ as criteria to select one or more nodes in the route graph.
 Suppose you use the xref:components:eips:split-eip.adoc[Split] EIP in a route; then you can use `weaveByType` to select this EIP.
 Given the following route:
 
+._Java-only: route with a Split EIP used for weaveByType example_
 [source,java]
 ----
 from("file:inbox").routeId("inbox")
@@ -342,6 +356,7 @@ Due to that route has only one xref:components:eips:split-eip.adoc[Split] EIP, y
 splitter in the route. Using `weaveByType` requires you to pass in the model type of
 the EIP. The name of the model type is using the pattern _name_Definition.
 
+._Java-only: using weaveByType to insert a node before the Split EIP_
 [source,java]
 ----
 weaveByType(SplitDefinition.class)
@@ -359,6 +374,7 @@ send messages to a given endpoint URI or pattern.
 
 Given the following route having two branches in the xref:components:eips:choice-eip.adoc[Content Based Router] EIP:
 
+._Java-only: route with content-based router for weaveByToUri example_
 [source,java]
 ----
 from("direct:start")
@@ -371,6 +387,7 @@ from("direct:start")
 Then we want to easily unit test this route, that messages are sent branch-1 or branch-2.
 This can be done with the `weaveByToUri` as shown:
 
+._Java-only: using weaveByToUri with wildcard matching_
 [source,java]
 ----
 weaveByToUri("direct:branch*").replace().to("mock:cheese");
@@ -404,6 +421,7 @@ the selection to a specific node. This can be done by using the select methods:
 Given the following route which has multiple xref:components:eips:filter-eip.adoc[Filter] EIP,
 then we want to only advise the second filter.
 
+._Java-only: route with multiple Filter EIPs for selectIndex example_
 [source,java]
 ----
 from("file:inbox").routeId("inbox")
@@ -423,6 +441,7 @@ from("file:inbox").routeId("inbox")
 
 You can then use `weaveByType` to match the Filter EIPs and selectIndex to match the second found:
 
+._Java-only: using selectIndex to target a specific matched node_
 [source,java]
 ----
 weaveByType(FilterDefinition.class).selectIndex(1).replace().to("mock:changed");

--- a/docs/user-manual/modules/ROOT/pages/bean-binding.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-binding.adoc
@@ -61,6 +61,7 @@ Examples:
 
 Simple asynchronous processor, modifying message body.
 
+._Java-only: async method signature_
 [source,java]
 ----
 public CompletableFuture<String> doSomethingAsync(String body)
@@ -68,10 +69,11 @@ public CompletableFuture<String> doSomethingAsync(String body)
 
 Composite processor that do not modify exchange
 
+._Java-only: composite async method_
 [source,java]
 ----
  public CompletableFuture<Void> doSomethingAsync(String body) {
-     return CompletableFuture.allOf(doA(body), doB(body), doC()); 
+     return CompletableFuture.allOf(doA(body), doB(body), doC());
  }
 ----
 
@@ -106,6 +108,7 @@ Let's review some examples:
 Below is a simple method with a body binding. Camel will bind the IN
 body to the `body` parameter and convert it to a `String`.
 
+._Java-only: method signature with body binding_
 [source,java]
 ----
 public String doSomething(String body)
@@ -114,31 +117,35 @@ public String doSomething(String body)
 In the following sample we got one of the automatically bound types as
 well. For instance, a `Registry` that we can use to lookup beans.
 
+._Java-only: method signature with Registry parameter_
 [source,java]
 ----
-public String doSomething(String body, Registry registry) 
+public String doSomething(String body, Registry registry)
 ----
 
 We can use xref:exchange.adoc[Exchange] as well:
 
+._Java-only: method signature with Exchange parameter_
 [source,java]
 ----
-public String doSomething(String body, Exchange exchange) 
+public String doSomething(String body, Exchange exchange)
 ----
 
 You can also have multiple types:
 
+._Java-only: method signature with multiple parameter types_
 [source,java]
 ----
-public String doSomething(String body, Exchange exchange, TypeConverter converter) 
+public String doSomething(String body, Exchange exchange, TypeConverter converter)
 ----
 
 And imagine you use a xref:components::bean-component.adoc[Pojo] to handle a given custom
 exception `InvalidOrderException` - we can then bind that as well:
 
+._Java-only: method signature with exception binding_
 [source,java]
 ----
-public String badOrder(String body, InvalidOrderException invalid) 
+public String badOrder(String body, InvalidOrderException invalid)
 ----
 
 Notice that we can bind to it even if we use a subtype of
@@ -160,6 +167,7 @@ the xref:components:eips:message.adoc[Message]
 
 For example, a xref:components:eips:bean-eip.adoc[Bean] such as:
 
+._Java-only: bean class with method binding_
 [source,java]
 ----
 public class Bar {
@@ -174,11 +182,12 @@ Or the Exchange example. Notice that the return type must be *void* when
 there is only a single parameter of the type
 `org.apache.camel.Exchange`:
 
+._Java-only: bean class with Exchange parameter_
 [source,java]
 ----
  public class Bar {
      public void doSomething(Exchange exchange) {
-         // process the exchange 
+         // process the exchange
          exchange.getIn().setBody("Bye World");
      }
  }
@@ -194,15 +203,16 @@ This has an advantage as you don't need to specify a method name in the Camel
 route, and therefore do not run into problems after renaming the method
 in an IDE that can't find all its references.
 
+._Java-only: bean class with @Handler annotation_
 [source,java]
 ----
 public class Bar {
-    @Handler 
+    @Handler
     public String doSomething(String body) {
-        // process the in body and return whatever you want 
-        return "Bye World"; 
+        // process the in body and return whatever you want
+        return "Bye World";
     }
-} 
+}
 ----
 
 == Parameter binding using method option
@@ -224,6 +234,7 @@ next section about specifying types for overloaded methods.
 When invoking a xref:components:eips:bean-eip.adoc[Bean] you can instruct Camel to invoke a
 specific method by providing the method name:
 
+._Java-only: specifying method name on bean call_
 [source,java]
 ----
 .bean(OrderService.class, "doSomething")
@@ -234,18 +245,20 @@ Camel handles the parameters' binding.
 Now suppose the method has 2 parameters, and the
 second parameter is a boolean where we want to pass in a true value:
 
+._Java-only: method signature with boolean parameter_
 [source,java]
 ----
 public void doSomething(String payload, boolean highPriority) {
-    ... 
+    ...
 }
 ----
 
 This can be done as follows:
 
+._Java-only: bean binding with wildcard and fixed parameter_
 [source,java]
 ----
-.bean(OrderService.class, "doSomething(*, true)") 
+.bean(OrderService.class, "doSomething(*, true)")
 ----
 
 In the example above, we defined the first parameter using the wild card
@@ -254,9 +267,10 @@ Camel figure this out. The second parameter has a fixed value of `true`.
 Instead of the wildcard symbol, we can instruct Camel to use the message
 body as shown:
 
+._Java-only: bean binding with Simple expression parameter_
 [source,java]
 ----
-.bean(OrderService.class, "doSomething(${body}, true)") 
+.bean(OrderService.class, "doSomething(${body}, true)")
 ----
 
 The syntax of the parameters is using the xref:components:languages:simple-language.adoc[Simple]
@@ -266,6 +280,7 @@ refer to the message body.
 If you want to pass in a `null` value, then you can explicitly define this
 in the method option as shown below:
 
+._Java-only: bean binding with null parameter_
 [source,java]
 ----
 .to("bean:orderService?method=doSomething(null, true)")
@@ -277,17 +292,19 @@ a `null` value.
 Besides the message body, you can pass in the message headers as a
 `java.util.Map`:
 
+._Java-only: bean binding with headers map parameter_
 [source,java]
 ----
-.bean(OrderService.class, "doSomethingWithHeaders(${body}, ${headers})") 
+.bean(OrderService.class, "doSomethingWithHeaders(${body}, ${headers})")
 ----
 
 You can also pass in other fixed values besides booleans. For example,
 you can pass in a String and an integer:
 
+._Java-only: bean binding with String and integer parameters_
 [source,java]
 ----
-.bean(MyBean.class, "echo('World', 5)") 
+.bean(MyBean.class, "echo('World', 5)")
 ----
 
 In the example above, we invoke the echo method with two parameters. The
@@ -297,9 +314,10 @@ value of 5. Camel will automatically convert these values to the parameters' typ
 Having the power of the xref:components:languages:simple-language.adoc[Simple] language allows us to
 bind to message headers and other values such as:
 
+._Java-only: bean binding with header value parameter_
 [source,java]
 ----
-.bean(OrderService.class, "doSomething(${body}, ${header.high})") 
+.bean(OrderService.class, "doSomething(${body}, ${header.high})")
 ----
 
 You can also use the OGNL support of the xref:components:languages:simple-language.adoc[Simple]
@@ -307,17 +325,19 @@ expression language. Now suppose the message body is an object that has
 a method named `asXml`. To invoke the `asXml` method we can do as
 follows:
 
+._Java-only: bean binding with OGNL expression_
 [source,java]
 ----
-.bean(OrderService.class, "doSomething(${body.asXml}, ${header.high})") 
+.bean(OrderService.class, "doSomething(${body.asXml}, ${header.high})")
 ----
 
 Instead of using `.bean` as shown in the examples above, you may want to
 use `.to` instead as shown:
 
+._Java-only: bean binding using .to() with method parameter_
 [source,java]
 ----
-.to("bean:orderService?method=doSomething(${body.asXml}, ${header.high})") 
+.to("bean:orderService?method=doSomething(${body.asXml}, ${header.high})")
 ----
 
 === Using type qualifiers to select among overloaded methods
@@ -328,6 +348,7 @@ you intend to use.
 
 Given the following bean:
 
+._Java-only: bean binding with type qualifier_
 [source,java]
 ----
  from("direct:start")
@@ -339,16 +360,18 @@ Then the `MyBean` has 2 overloaded methods with the names `hello` and
 `times`. So if we want to use the method which has two parameters, we can
 do as follows in the Camel route:
 
+._Java-only: bean binding with multiple type qualifiers_
 [source,java]
 ----
 from("direct:start")
     .bean(MyBean.class, "hello(String.class, String.class)")
-    .to("mock:result"); 
+    .to("mock:result");
 ----
 
 We can also use a `*` as wildcard, so we can just say we want to execute
 the method with two parameters we do:
 
+._Java-only: bean binding with wildcard type qualifiers_
 [source,java]
 ----
  from("direct:start")
@@ -362,6 +385,7 @@ match using the FQN, then specify the FQN type and Camel will leverage
 that. So if you have a parameter of type `com.foo.MyOrder` and you want to match against
 the FQN, and *not* the simple name "MyOrder", then follow this example:
 
+._Java-only: bean binding with fully qualified type name_
 [source,java]
 ----
 .bean(OrderService.class, "doSomething(com.foo.MyOrder.class)")

--- a/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/bean-integration.adoc
@@ -53,6 +53,7 @@ the `@PropertyInject` annotation which can be set on fields and setter
 methods. For example, you can use that with `RouteBuilder` classes,
 such as shown below:
 
+._Java-only: injecting a property placeholder value with @PropertyInject_
 [source,java]
 ----
 public class MyRouteBuilder extends RouteBuilder {
@@ -76,6 +77,7 @@ with this key and inject its value, converted to a String type.
 You can also use multiple placeholders and text in the key, for example
 we can do:
 
+._Java-only: using multiple placeholders and text in @PropertyInject_
 [source,java]
 ----
 @PropertyInject("Hello {{name}} how are you?")
@@ -86,6 +88,7 @@ This will lookup the placeholder with they key `name`.
 
 You can also add a default value if the key does not exist, such as:
 
+._Java-only: using a default value with @PropertyInject_
 [source,java]
 ----
 @PropertyInject(value = "myTimeout", defaultValue = "5000")
@@ -98,6 +101,7 @@ You can also use `@PropertyInject` to inject an array of values. For example, yo
 in the configuration file, and need to inject this into an `String[]` or `List<String>` field.
 To do this, you need to tell Camel that the property value should be split using a separator, as follows:
 
+._Java-only: injecting an array of values using separator_
 [source,java]
 ----
 @PropertyInject(value = "myHostnames", separator = ",")
@@ -124,6 +128,7 @@ myServers = serverA=http://coolstore:4444,serverB=http://megastore:5555
 
 You can then inject this into a `Map` as follows:
 
+._Java-only: injecting key-value pairs into a Map_
 [source,java]
 ----
 @PropertyInject(value = "myServers", separator = ",")
@@ -132,6 +137,7 @@ private Map servers;
 
 You can use generic types in the Map such as the values should be `Integer` values:
 
+._Java-only: injecting a Map with typed values_
 [source,java]
 ----
 @PropertyInject(value = "ports", separator = ",")

--- a/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3-migration-guide.adoc
@@ -209,6 +209,7 @@ Endpoints with `consumer.` prefix such as `consumer.delay=5000` are no longer su
 
 Calling a processor as an endpoint from a route such as:
 
+._Java-only: calling a processor as an endpoint (no longer supported)_
 [source,java]
 ----
 from("jms:cheese")
@@ -217,6 +218,7 @@ from("jms:cheese")
 
 Is no longer supported. Instead either use the bean component to call the processor or use `process`:
 
+._Java-only: using the bean component to call a processor_
 [source,java]
 ----
 from("jms:cheese")
@@ -225,6 +227,7 @@ from("jms:cheese")
 
 Or
 
+._Java-only: using process to call a processor_
 [source,java]
 ----
 from("jms:cheese")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_1.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_1.adoc
@@ -520,6 +520,7 @@ This means that XML that were using the `http://camel.apache.org/schema/placehol
 namespace and that the java builders using the `.placeholder(key, value).` have to
 be modified.
 
+._Java-only: using property placeholders with multicast (old style)_
 [source,java]
 ----
     from("direct:start")
@@ -528,6 +529,8 @@ be modified.
         .to("mock:a")
 ----
 should be rewritten as:
+
+._Java-only: using property placeholders with multicast (new style)_
 [source,java]
 ----
     from("direct:start")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_16.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_16.adoc
@@ -30,6 +30,7 @@ and then link to this route from the REST service.
 
 For example
 
+._Java-only: Rest DSL with embedded route before migration_
 [source,java]
 ----
 rest("/users")
@@ -40,6 +41,7 @@ rest("/users")
 
 Should now be:
 
+._Java-only: Rest DSL with separate route after migration_
 [source,java]
 ----
 rest("/users")
@@ -185,6 +187,8 @@ Renamed `executorServiceRef` to `executorService`.
 Replaced by Choice EIP in precondition mode.
 
 Before it was:
+
+._Java-only: DoSwitch EIP before migration_
 [source,java]
 ----
 .doSwitch()
@@ -194,6 +198,8 @@ Before it was:
 ----
 
 Now it is:
+
+._Java-only: Choice EIP in precondition mode after migration_
 [source,java]
 ----
 .choice().precondition()

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_17.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_17.adoc
@@ -194,6 +194,7 @@ We aligned the MDC keys with OpenTelemetry, so they are changed from:
 
 This component was refactored to support the Resume API v2. As such, the options `filter` and `lastUpdate` where removed.
 
+._Java-only: using the Resume API with the atom component_
 [source,java]
 ----
 from("atom:file:src/test/data/feed.atom?splitEntries=true&delay=500")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_2.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_2.adoc
@@ -461,6 +461,7 @@ The context scope error handling has been modified a bit.  The processors in tho
 If there is a need to have a single set of processors involved (such as when using a loadbalancer or
 other stateful patterns), then an intermediary route needs to be used. The following excerpt:
 
+._Java-only: onException with embedded load balancer before migration_
 [source,java]
 ----
 onException(Exception.class).handled(true)
@@ -470,6 +471,7 @@ onException(Exception.class).handled(true)
 
 ... needs to be rewritten as:
 
+._Java-only: onException with intermediary route after migration_
 [source,java]
 ----
 onException(Exception.class).handled(true).to("direct:error");
@@ -498,6 +500,7 @@ To make Camel routing engine as fast as possible this feature has been removed.
 
 For example a timer with a 5 second period
 
+._Java-only: timer period with time pattern before migration_
 [source,java]
 ----
 from("timer:foo?period=5s")
@@ -505,6 +508,7 @@ from("timer:foo?period=5s")
 
 Should now be specified as numeric only:
 
+._Java-only: timer period with numeric value after migration_
 [source,java]
 ----
 from("timer:foo?period=5000")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_21.adoc
@@ -216,6 +216,7 @@ Therefore, all the HTTP endpoints are no longer prefixed with the servlet contex
 
 For example:
 
+._Java-only: platform-http endpoint without servlet context-path_
 [source,java]
 ----
 from("platform-http:myservice")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_4.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_4.adoc
@@ -48,6 +48,7 @@ camel-string-template, camel-chunk, camel-robotframework.
 
 The Java DSL `RouteBuilder` allows referring to a custom language as shown below:
 
+._Java-only: using custom language in a route_
 [source,java]
 ----
 from("direct:start")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_6.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_6.adoc
@@ -183,6 +183,7 @@ To configure the component to use a pre-configured cache, it is no longer requir
 
 For example, the following code:
 
+._Java-only: Caffeine cache endpoint before migration_
 [source,java]
 ----
 .to("caffeine-cache://cache?cache=#myCache&action=PUT&key=1")
@@ -190,6 +191,7 @@ For example, the following code:
 
 Should be replaced by:
 
+._Java-only: Caffeine cache endpoint after migration_
 [source,java]
 ----
 .to("caffeine-cache://myCache?action=PUT&key=1")

--- a/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_9.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-3x-upgrade-guide-3_9.adoc
@@ -54,6 +54,7 @@ The reason is the information is seldom in use, and by removing we were able to 
 
 Camel now validates that a route has only 1 onCompletion. Previously users could have code such as:
 
+._Java-only: multiple onCompletion per route (no longer allowed)_
 [source,java]
 ----
 from("direct:start")

--- a/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4-migration-guide.adoc
@@ -445,6 +445,7 @@ Deprecated `ProblemFactChange` has been replaced by `ProblemChange`.
 
 The new URI path is:
 
+._Java-only: new OptaPlanner URI syntax_
 [source,java]
 ----
 from("optaplanner:myProblemName")
@@ -460,6 +461,7 @@ When running `camel-optaplanner` on Spring Boot or Quarkus, it is preferable to 
 
 It is possible to migrate legacy Camel OptaPlanner Routes, by putting the XML config file, as show in the code below. Camel OptaPlanner will handle creating the SolverManager for those legacy Routes:
 
+._Java-only: legacy OptaPlanner route with XML config file_
 [source,java]
 ----
 from("optaplanner:myProblemName?configFile=PATH/TO/CONFIG.FILE.xml")
@@ -512,6 +514,7 @@ Therefore, all the HTTP endpoints are no longer prefixed with the servlet contex
 
 For example:
 
+._Java-only: platform-http endpoint without servlet context-path_
 [source,java]
 ----
 from("platform-http:myservice")

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc
@@ -47,6 +47,7 @@ we have refactored `endChoice` to work more consistent.
 
 For example the following code
 
+._Java-only: nested Choice EIP before migration_
 [source,java]
 ----
 from("direct:start")
@@ -65,6 +66,7 @@ from("direct:start")
 
 Should now be
 
+._Java-only: nested Choice EIP after migration_
 [source,java]
 ----
 from("direct:start")
@@ -124,6 +126,7 @@ other EIPs such as Multicast EIP already does this.
 The header `Exchange.BEAN_METHOD_NAME` with constant value `CamelBeanMethodName` has been deprecated, and support for using this header has been removed.
 Instead, you can specify the `method` option directly as shown, or using any other header of your choosing as follows.
 
+._Java-only: specifying bean method via header_
 [source,java]
 ----
     toD("bean:myBean?method=${header.myMethodName}");

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_12.adoc
@@ -67,6 +67,7 @@ we have refactored `endChoice` to work more consistent.
 
 For example the following code
 
+._Java-only: nested Choice EIP before migration_
 [source,java]
 ----
 from("direct:start")
@@ -85,6 +86,7 @@ from("direct:start")
 
 Should now be
 
+._Java-only: nested Choice EIP after migration_
 [source,java]
 ----
 from("direct:start")

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -241,6 +241,7 @@ untrusted producers) could override transport-security settings such as `mail.sm
 This behaviour is now disabled by default. Routes that legitimately rely on per-message
 `mail.smtp.*` headers must opt back in on the endpoint:
 
+._Java-only: opting in to JavaMail session properties from headers_
 [source,java]
 ----
 .to("smtp://mymailserver:1234?useJavaMailSessionPropertiesFromHeaders=true");
@@ -880,6 +881,7 @@ Routes that reference the constant symbolically (for example
 Routes that set or read the header by its literal string value (for example
 `setHeader("irc.sendTo", ...)`) must be updated to use the new value:
 
+._Java-only: updating IRC header literal string values_
 [source,java]
 ----
 // before
@@ -962,6 +964,7 @@ producer-direction routing headers: they are read back on the producer side by
 `DaprConfigurationOptionsProxy` and take precedence over the endpoint-configured
 `pubSubName` / `topic`. Setting them on a consumed exchange caused a route such as
 
+._Java-only: Dapr pubsub route affected by header change_
 [source,java]
 ----
 from("dapr-pubsub:configured-pubsub:configured-topic")
@@ -1162,6 +1165,7 @@ then reads it via `in.getHeader(...)` to dispatch to a specific peer). For
 defence in depth at the trust boundary, route authors should explicitly strip
 these headers from untrusted inbound traffic, for example:
 
+._Java-only: stripping websocket headers from untrusted inbound traffic_
 [source,java]
 ----
 from("jetty:http://0.0.0.0:8080/api")
@@ -1216,6 +1220,7 @@ Routes that set the header by its literal string value (for example
 In particular, the documented `cxfrs` `SimpleConsumer` dispatch idiom that routes
 on the operation name by its literal header name must be updated:
 
+._Java-only: updating CXF operation name header reference_
 [source,java]
 ----
 // before
@@ -1312,6 +1317,7 @@ Routes that set the header by its literal string value (for example
 `setHeader("dns.server", ...)` or `setHeader("term", ...)`) must be updated to
 use the new value:
 
+._Java-only: updating DNS header literal string values_
 [source,java]
 ----
 // before
@@ -1378,6 +1384,7 @@ changes. Routes that set or read the headers by their literal string values
 (for example `setHeader("kafka.OVERRIDE_TOPIC", ...)` or Simple expressions such
 as `${headers[kafka.TOPIC]}`) must be updated to use the new values:
 
+._Java-only: updating Kafka header literal string values_
 [source,java]
 ----
 // before

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_16.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_16.adoc
@@ -68,6 +68,7 @@ The `queryBuilder` option on `camel-infinispan` endpoint has been migrated to no
 
 This means old code such:
 
+._Java-only: old Infinispan query factory API_
 [source,java]
 ----
     private InfinispanQueryBuilder continuousQueryBuilder
@@ -168,14 +169,14 @@ DataSet API and more, with better performance and a unified programming model.
 
 Replace `flink:dataset` with `flink:datastream`:
 
-.Before
+._Java-only: Old flink DataSet endpoint_
 [source,java]
 -----------------------------------
 from("direct:start")
     .to("flink:dataset?dataSet=#myDataSet&dataSetCallback=#myCallback");
 -----------------------------------
 
-.After
+._Java-only: New flink DataStream endpoint_
 [source,java]
 -----------------------------------
 from("direct:start")

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_17.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_17.adoc
@@ -20,6 +20,7 @@ works across all DSLs (Java, XML and YAML).
 
 For Java DSL that means code should be changed
 
+._Java-only: Old transform with DataType_
 [source,java]
 ----
 from("direct:start")
@@ -29,6 +30,7 @@ from("direct:start")
 
 to:
 
+._Java-only: New transformDataType EIP_
 [source,java]
 ----
 from("direct:start")

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -284,6 +284,7 @@ messages from untrusted producers) could override transport-security settings su
 This behaviour is now disabled by default. Routes that legitimately rely on per-message
 `mail.smtp.*` / `mail.smtps.*` headers must opt back in on the endpoint:
 
+._Java-only: opting in to JavaMail session properties from headers_
 [source,java]
 ----
 .to("smtp://mymailserver:1234?useJavaMailSessionPropertiesFromHeaders=true");
@@ -982,6 +983,7 @@ Routes that reference the constant symbolically (for example
 Routes that set or read the header by its literal string value (for example
 `setHeader("irc.sendTo", ...)`) must be updated to use the new value:
 
+._Java-only: updating IRC header literal string values_
 [source,java]
 ----
 // before
@@ -1064,6 +1066,7 @@ producer-direction routing headers: they are read back on the producer side by
 `DaprConfigurationOptionsProxy` and take precedence over the endpoint-configured
 `pubSubName` / `topic`. Setting them on a consumed exchange caused a route such as
 
+._Java-only: Dapr pubsub route affected by header change_
 [source,java]
 ----
 from("dapr-pubsub:configured-pubsub:configured-topic")
@@ -1315,6 +1318,7 @@ The `CONVERT_TO_JSON` and `EXTRACT_STRUCTURED_DATA` operations now return a `Doc
 
 Code that previously received a `String` and manually deserialized it should be updated:
 
+._Java-only: updating DoclingDocument return type handling_
 [source,java]
 ----
 // Before (4.17)
@@ -1455,6 +1459,7 @@ then reads it via `in.getHeader(...)` to dispatch to a specific peer). For
 defence in depth at the trust boundary, route authors should explicitly strip
 these headers from untrusted inbound traffic, for example:
 
+._Java-only: stripping websocket headers from untrusted inbound traffic_
 [source,java]
 ----
 from("jetty:http://0.0.0.0:8080/api")
@@ -1509,6 +1514,7 @@ Routes that set the header by its literal string value (for example
 In particular, the documented `cxfrs` `SimpleConsumer` dispatch idiom that routes
 on the operation name by its literal header name must be updated:
 
+._Java-only: updating CXF operation name header reference_
 [source,java]
 ----
 // before
@@ -1583,6 +1589,7 @@ Routes that set the header by its literal string value (for example
 `setHeader("dns.server", ...)` or `setHeader("term", ...)`) must be updated to
 use the new value:
 
+._Java-only: updating DNS header literal string values_
 [source,java]
 ----
 // before
@@ -1649,6 +1656,7 @@ changes. Routes that set or read the headers by their literal string values
 (for example `setHeader("kafka.OVERRIDE_TOPIC", ...)` or Simple expressions such
 as `${headers[kafka.TOPIC]}`) must be updated to use the new values:
 
+._Java-only: updating Kafka header literal string values_
 [source,java]
 ----
 // before

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -826,6 +826,7 @@ Routes that set the header by its literal string value (for example
 In particular, the documented `cxfrs` `SimpleConsumer` dispatch idiom that routes
 on the operation name by its literal header name must be updated:
 
+._Java-only: updated CXF operation name header in recipientList_
 [source,java]
 ----
 // before
@@ -922,6 +923,7 @@ Routes that set the header by its literal string value (for example
 `setHeader("dns.server", ...)` or `setHeader("term", ...)`) must be updated to
 use the new value:
 
+._Java-only: updated DNS header names in route_
 [source,java]
 ----
 // before
@@ -1315,6 +1317,7 @@ producer-direction routing headers: they are read back on the producer side by
 `DaprConfigurationOptionsProxy` and take precedence over the endpoint-configured
 `pubSubName` / `topic`. Setting them on a consumed exchange caused a route such as
 
+._Java-only: Dapr pubsub route affected by header change_
 [source,java]
 ----
 from("dapr-pubsub:configured-pubsub:configured-topic")
@@ -1434,6 +1437,7 @@ then reads it via `in.getHeader(...)` to dispatch to a specific peer). For
 defence in depth at the trust boundary, route authors should explicitly strip
 these headers from untrusted inbound traffic, for example:
 
+._Java-only: stripping websocket headers at the trust boundary_
 [source,java]
 ----
 from("jetty:http://0.0.0.0:8080/api")
@@ -2070,6 +2074,7 @@ string values (for example `setHeader("kafka.OVERRIDE_TOPIC", ...)` or
 Simple expressions such as `${headers[kafka.TOPIC]}`) must be updated to
 use the new values:
 
+._Java-only: updated Kafka header names in route_
 [source,java]
 ----
 // before
@@ -2087,6 +2092,7 @@ A route that bridges an untrusted HTTP / REST consumer to a Kafka producer
 should also continue to apply the standard transport-boundary mitigation,
 which now also covers the kafka headers:
 
+._Java-only: stripping Camel headers at the transport boundary_
 [source,java]
 ----
 from("platform-http:/api/events")
@@ -2228,6 +2234,7 @@ declared parameters will have zero argument headers set from the LLM tool call.
 
 For example, a tool defined as:
 
+._Java-only: tool route without declared parameters_
 [source,java]
 ----
 from("langchain4j-tools:test1?tags=user&description=Does not really do anything")
@@ -2236,6 +2243,7 @@ from("langchain4j-tools:test1?tags=user&description=Does not really do anything"
 will no longer receive any LLM-provided arguments as headers. To restore argument flow, declare the
 expected parameters explicitly:
 
+._Java-only: tool route with declared parameters_
 [source,java]
 ----
 from("langchain4j-tools:test1?tags=user&description=Query user by number&parameter.number=integer")
@@ -2335,6 +2343,7 @@ Routes that reference the constant symbolically (for example
 Routes that set or read the header by its literal string value (for example
 `setHeader("irc.sendTo", ...)`) must be updated to use the new value:
 
+._Java-only: updated IRC header name in ProducerTemplate call_
 [source,java]
 ----
 // before

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_3.adoc
@@ -55,6 +55,7 @@ and remove any `timePeriodMillis` option.
 
 For example, update the following:
 
+._Java-only: Old throttle with maxRequestsPerPeriod_
 [source,java]
 ----
 long maxRequestsPerPeriod = 100L;
@@ -71,6 +72,7 @@ from("seda:c")
 
 to use `maxConcurrentRequests`:
 
+._Java-only: New throttle with maxConcurrentRequests_
 [source,java]
 ----
 long maxConcurrentRequests = 30L;

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_4.adoc
@@ -45,6 +45,7 @@ Some of the Java DSL for `tokenize`, `xmlTokenize`, `xpath`, `xquery` and `jsonp
 
 Here are a few examples of migration before vs after:
 
+._Java-only: Old xpath DSL with inline parameters_
 [source,java]
 ----
  from("direct:in")
@@ -60,6 +61,7 @@ Here are a few examples of migration before vs after:
 
 You can use the _fluent expression_ builder to configure all the options:
 
+._Java-only: New fluent expression builder for xpath_
 [source,java]
 ----
 // use fluent builder expression to create the languages
@@ -82,6 +84,7 @@ The `source` can also be variable, or exchange property.
 
 And another example with `tokenize`:
 
+._Java-only: Old tokenize DSL with inline parameters_
 [source,java]
 ----
 from("direct:start")
@@ -92,6 +95,7 @@ from("direct:start")
 
 You can use the _fluent expression_ builder to configure all the options:
 
+._Java-only: New fluent expression builder for tokenize_
 [source,java]
 ----
 // use fluent builder expression to create the languages

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_5.adoc
@@ -63,6 +63,7 @@ that otherwise is in use when using Rest DSL and many services. You can restore 
 
 However, the inlining requires that each REST endpoint inlined with `direct` endpoints must use unique direct names, ie.
 
+._Java-only: Rest DSL with shared direct endpoint names_
 [source,java]
 ----
 rest("/rest")
@@ -73,6 +74,7 @@ rest("/rest")
 
 Should be changed to:
 
+._Java-only: Rest DSL with unique direct endpoint names_
 [source,java]
 ----
 rest("/rest")
@@ -197,6 +199,7 @@ From this release onwards, Camel will convert each entry to a `Book` so the resu
 
 This is also how `camel-jq` works.
 
+._Java-only: Using jsonpath with resultType_
 [source,java]
 ----
 .transform().jsonpath(".book", Book.class)

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-devtools.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-devtools.adoc
@@ -150,6 +150,7 @@ $ camel cmd receive --endpoint='activemq:cheese'
 
 You can also auto-discover endpoints from a running integration. Given this route:
 
+._Java-only: route with FTP consumer and JMS producer_
 [source,java]
 ----
 from("ftp:myserver:1234/foo")

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-managing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-managing.adoc
@@ -301,6 +301,7 @@ The `camel get history` command shows a step-by-step summary of the last complet
 
 Example route that reads a file, splits by line, filters, calls HTTP, and logs:
 
+._Java-only: route with split, filter, and HTTP call_
 [source,java]
 ----
 import org.apache.camel.builder.RouteBuilder;

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-tips.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-tips.adoc
@@ -40,6 +40,7 @@ Limitations:
 From Camel 4.7, `--code` can also reference a `.java` file that contains bare route definitions
 (no `public class` wrapper):
 
+._Java-only: bare route definition for --code_
 [source,java]
 ----
 from("timer:java?period=1000")

--- a/docs/user-manual/modules/ROOT/pages/camel-report-maven-plugin.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-report-maven-plugin.adoc
@@ -287,6 +287,7 @@ public class FooApplicationTest {
 However if you are using `camel-test` and your unit tests are extending `CamelTestSupport` then you can
 turn on route coverage as shown:
 
+._Java-only: enabling route coverage in CamelTestSupport_
 [source,java]
 ----
 @Override
@@ -297,8 +298,12 @@ public boolean isDumpRouteCoverage() {
 
 IMPORTANT: Routes that can be route coveraged **MUST** have a unique id assigned, in other words you cannot use anonymous routes.
 
-You do this using `routeId` in Java DSL:
+You do this using `routeId`:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("jms:queue:cheese").routeId("cheesy")
@@ -306,8 +311,8 @@ from("jms:queue:cheese").routeId("cheesy")
   ...
 ----
 
-And in XML DSL you just assign the route id via the id attribute
-
+XML::
++
 [source,xml]
 ----
 <route id="cheesy">
@@ -316,6 +321,21 @@ And in XML DSL you just assign the route id via the id attribute
   ...
 </route>
 ----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: cheesy
+    from:
+      uri: jms:queue:cheese
+      steps:
+        - to:
+            uri: log:foo
+        ...
+----
+====
 
 === Generating route coverage report
 

--- a/docs/user-manual/modules/ROOT/pages/clustering.adoc
+++ b/docs/user-manual/modules/ROOT/pages/clustering.adoc
@@ -23,6 +23,7 @@ Represent a member of the cluster.
 A _Cluster Service_ is just like any other camel service so set it up you only need to register your implementations
 to the `CamelContext`:
 
+._Java-only: registering a cluster service on the CamelContext_
 [source,java]
 ----
 MyClusterServiceImpl service = new MyClusterServiceImpl();
@@ -195,6 +196,7 @@ The _Cluster SPI_ is leveraged by the following new implementations:
 +
 This is an implementation of a RoutePolicy that starts the routes it is associated to when the Cluster View it uses takes the leadership
 +
+._Java-only: using ClusteredRoutePolicy with a route_
 [source,java]
 ----
 context.addRoutes(new RouteBuilder {
@@ -213,6 +215,7 @@ context.addRoutes(new RouteBuilder {
 +
 To apply the same policy to all the routes a dedicated  _RoutePolicyFactory_ can be used:
 +
+._Java-only: using ClusteredRoutePolicyFactory_
 [source,java]
 ----
 // add the clustered route policy factory to context
@@ -232,6 +235,7 @@ context.addRoutes(new RouteBuilder {
 +
 This is an implementation of the _RouteController SPI_ that lets the camel context start then starts/stops the routes when the leadership is taken/lost. This is well integrated with spring-boot apps so assuming you have your routes set-up like:
 +
+._Java-only: Spring Boot route definition for ClusteredRouteController_
 [source,java]
 ----
 @Bean
@@ -275,6 +279,7 @@ master:namespace:delegateUri
 +
 A concrete example:
 +
+._Java-only: Spring Boot route using the master component_
 [source,java]
 ----
 @Bean

--- a/docs/user-manual/modules/ROOT/pages/configuring-route-startup-ordering-and-autostartup.adoc
+++ b/docs/user-manual/modules/ROOT/pages/configuring-route-startup-ordering-and-autostartup.adoc
@@ -151,6 +151,7 @@ camel.main.auto-startup = false
 To startup based on a boolean, String or
 xref:components::properties-component.adoc[Property], do one of the following:
 
+._Java-only: autoStartup with boolean, string, and property placeholder variants_
 [source,java]
 ----
 // using a boolean

--- a/docs/user-manual/modules/ROOT/pages/dataformat-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/dataformat-dsl.adoc
@@ -11,6 +11,7 @@ The DSL can be accessed directly from the `RouteBuilder` thanks to the method `d
 
 In the following example, a `CsvDataFormat` is created using the legacy approach where the data format is instantiated explicitly and configured using setters:
 
+._Java-only: creating a CSV data format using the legacy approach_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {
@@ -30,6 +31,7 @@ public class MyRoutes extends RouteBuilder {
 
 The previous code could be simplified using the utility methods available directly from the `DataFormatClause` corresponding to the type returned by the `marshal()` and `unmarshal()` methods:
 
+._Java-only: simplified marshalling using DataFormatClause utility method_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {
@@ -46,6 +48,7 @@ public class MyRoutes extends RouteBuilder {
 
 This approach is suitable for very basic configuration, but as there are only limited utility methods for each supported data format, for more complex configuration, we can quickly face situations where the utility method for our expected configuration doesn't exist. In this situation, you can either use the legacy approach or the data format DSL like in the next code snippet:
 
+._Java-only: configuring CSV marshalling using the Data Format DSL builder_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {

--- a/docs/user-manual/modules/ROOT/pages/debugger.adoc
+++ b/docs/user-manual/modules/ROOT/pages/debugger.adoc
@@ -14,6 +14,7 @@ method and return `true`.
 
 In this unit test
 
+._Java-only: extending CamelTestSupport for debugging_
 [source,java]
 ----
 public class DebugTest extends CamelTestSupport
@@ -21,6 +22,7 @@ public class DebugTest extends CamelTestSupport
 
 We want to debug the following route
 
+._Java-only: creating a route to debug in a unit test_
 [source,java]
 ----
 @Override
@@ -40,6 +42,7 @@ protected RouteBuilder createRouteBuilder() throws Exception {
 
 Which can easily done by overriding the `debugBefore` method as shown
 
+._Java-only: enabling the debugger and setting a breakpoint in debugBefore_
 [source,java]
 -----------------------------------------------
 @Override
@@ -82,6 +85,7 @@ A trick to debug a Camel route written with Java DSL is to modify the route to i
 
 For instance:
 
+._Java-only: inserting a processor breakpoint into a route for debugging_
 [source,java]
 ----
 public class MyRouteBuilder extends RouteBuilder {

--- a/docs/user-manual/modules/ROOT/pages/endpoint.adoc
+++ b/docs/user-manual/modules/ROOT/pages/endpoint.adoc
@@ -382,6 +382,7 @@ myFtpPassword=RAW(se+re?t&23)
 
 We could still have used the `RAW(value)` in the Camel route instead:
 
+._Java-only: using RAW() inline in the route URI_
 [source,java]
 ----
 .to("ftp:joe@myftpserver.com?password=RAW({{myFtpPassword}})&binary=true")
@@ -401,6 +402,7 @@ used endpoints (based on a LRUCache).
 
 This must be done on the `CamelContext` as a global option as shown in the following Java code:
 
+._Java-only: configuring the endpoint cache size via CamelContext API_
 [source,java]
 ----
 getCamelContext().getGlobalOptions().put(Exchange.MAXIMUM_ENDPOINT_CACHE_SIZE, "500");
@@ -431,19 +433,95 @@ In Camel you can configure this in a more readable syntax as explained:
 So for example the xref:components::timer-component.adoc[Timer] endpoint can be configured as
 follows:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("timer:foo?period=45m").to("log:foo");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="timer:foo?period=45m"/>
+    <to uri="log:foo"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: timer:foo?period=45m
+      steps:
+        - to:
+            uri: log:foo
+----
+====
+
 You can mix and match the units so you can do this as well:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("timer:foo?period=1h15m").to("log:foo");
 from("timer:bar?period=2h30s").to("log:bar");
 from("timer:bar?period=3h45m58s").to("log:bar");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="timer:foo?period=1h15m"/>
+    <to uri="log:foo"/>
+</route>
+
+<route>
+    <from uri="timer:bar?period=2h30s"/>
+    <to uri="log:bar"/>
+</route>
+
+<route>
+    <from uri="timer:bar?period=3h45m58s"/>
+    <to uri="log:bar"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: timer:foo?period=1h15m
+      steps:
+        - to:
+            uri: log:foo
+- route:
+    from:
+      uri: timer:bar?period=2h30s
+      steps:
+        - to:
+            uri: log:bar
+- route:
+    from:
+      uri: timer:bar?period=3h45m58s
+      steps:
+        - to:
+            uri: log:bar
+----
+====
 
 However, you can also use long syntax:
 
@@ -455,10 +533,37 @@ However, you can also use long syntax:
 |second _or_ seconds |second
 |=========================
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("timer:foo?period=45minutes").to("log:foo");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="timer:foo?period=45minutes"/>
+    <to uri="log:foo"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: timer:foo?period=45minutes
+      steps:
+        - to:
+            uri: log:foo
+----
+====
 
 
 == Java Endpoint API

--- a/docs/user-manual/modules/ROOT/pages/error-handler.adoc
+++ b/docs/user-manual/modules/ROOT/pages/error-handler.adoc
@@ -191,6 +191,7 @@ The error handler is scoped as either:
 
 The following example shows how you can register a global error handler for the `RouteBuilder`:
 
+._Java-only: RouteBuilder with global error handler_
 [source,java]
 ----
 RouteBuilder builder = new RouteBuilder() {
@@ -206,6 +207,7 @@ RouteBuilder builder = new RouteBuilder() {
 The following example shows how you can register a route specific error
 handler:
 
+._Java-only: RouteBuilder with route-specific error handler_
 [source,java]
 ----
 RouteBuilder builder = new RouteBuilder() {

--- a/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exception-clause.adoc
@@ -187,6 +187,7 @@ selected (recurring up the exception hierarchy).
 
 This is best illustrated with an exception:
 
+._Java-only: exception policy selection order_
 [source,java]
 ----
 onException(IOException.class)
@@ -218,6 +219,7 @@ select this as it's the *closest* match.
 If we add a third *`onException`* clause with the
 *`FileNotFoundException`*
 
+._Java-only: adding a more specific exception clause_
 [source,java]
 ----
 onException(IOException.class)
@@ -362,6 +364,7 @@ YAML::
 
 All redelivery attempts start at the point of the failure. So the route:
 
+._Java-only: redelivery starts at the point of failure_
 [source,java]
 ----
 onException(ConnectException.class)
@@ -446,6 +449,7 @@ And in YAML DSL you just add another exception in the array:
 We want to handle certain exceptions in a specific way, so we add
 a *`onException`* clause for the particular exception.
 
+._Java-only: using a processor as failure handler_
 [source,java]
 ----
 // here we register exception cause for MyFunctionException
@@ -468,6 +472,7 @@ attempted. In our processor we need to determine what to do. Camel
 regards the Exchange as *failure handled*. So our processor is the end
 of the route. So lets look the code for our processor.
 
+._Java-only: custom failure handler processor_
 [source,java]
 ----
 public static class MyFunctionFailureHandler implements Processor {
@@ -550,6 +555,7 @@ In this route below we want to do special handling of
 all *`OrderFailedException`* as we want to return a customized response
 to the caller. First we set up our routing as:
 
+._Java-only: handling OrderFailedException with custom response_
 [source,java]
 ----
     // we do special error handling for when OrderFailedException is
@@ -584,6 +590,7 @@ Then we have our service bean that is just a plain POJO demonstrating how you
 can use xref:bean-integration.adoc[Bean Integration] in Camel to avoid
 being tied to the Camel API:
 
+._Java-only: OrderService POJO using Bean Integration_
 [source,java]
 ----
     /**
@@ -618,6 +625,7 @@ being tied to the Camel API:
 
 And finally the exception that is being thrown is just a regular exception:
 
+._Java-only: custom exception class_
 [source,java]
 ----
     public static class OrderFailedException extends Exception {
@@ -646,6 +654,7 @@ caller receives an Exchange with the payload *`Order ERROR`* and a
 
 The same route as above in Spring XML DSL:
 
+._XML-only: handling OrderFailedException with custom response_
 [source,xml]
 ----
  <!-- setup our error handler as the deal letter channel -->
@@ -692,6 +701,7 @@ The same route as above in Spring XML DSL:
 
 And the same example in YAML DSL
 
+._YAML-only: handling OrderFailedException with custom response_
 [source,yaml]
 ----
 - beans:
@@ -730,6 +740,7 @@ And the same example in YAML DSL
 If you use `onException` to handle exceptions, and want to get the caused
 `Exception` from a `Processor` in Java code, such as shown below:
 
+._Java-only: exception is null in onException processor_
 [source,java]
 ----
 .onException(Exception.class)
@@ -750,6 +761,7 @@ the message is processed by the `onException` block.
 Instead, you can access the caused exception from exchange property on the
 exchange with the key `Exchange.EXCEPTION_CAUGHT`, as follows:
 
+._Java-only: accessing the caught exception from a property_
 [source,java]
 ----
 Exception cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
@@ -757,6 +769,7 @@ Exception cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.clas
 
 The correct code to use in the example is there:
 
+._Java-only: correct way to get exception in onException_
 [source,java]
 ----
 .onException(Exception.class).handled(true)
@@ -779,6 +792,7 @@ do as you do in normal Camel routing, use
 xref:components:eips:message-translator.adoc[transform] to set the response, as shown in
 the sample below:
 
+._Java-only: returning a fixed response with transform_
 [source,java]
 ----
 // we catch MyFunctionalException and want to mark it as handled
@@ -793,6 +807,7 @@ onException(MyFunctionalException.class)
 We modify the sample slightly to return the original caused exception
 message instead of the fixed text `Sorry`:
 
+._Java-only: returning the exception message_
 [source,java]
 ----
 // we catch MyFunctionalException and want to mark it as handled
@@ -807,6 +822,7 @@ onException(MyFunctionalException.class)
 And we can use the xref:components:languages:simple-language.adoc[Simple] language to set a readable error
 message with the caused exception message:
 
+._Java-only: using Simple language in error response_
 [source,java]
 ----
 // we catch MyFunctionalException and want to mark it as handled
@@ -1190,6 +1206,7 @@ You can define exception clauses either as:
 We start off with the sample that we change over time. First off
 we use only global exception clauses:
 
+._Java-only: global exception policies_
 [source,java]
 ----
 // default should errors go to mock:error
@@ -1222,6 +1239,7 @@ specific.
 *`.end()`* to indicate where it stops and when the regular route
 continues.
 
+._Java-only: route-specific exception policies with .end()_
 [source,java]
 ----
 // default should errors go to mock:error
@@ -1255,6 +1273,7 @@ from("direct:start")
 And now it gets complex as we combine global and route specific exception
 policies as we introduce a second route in the sample:
 
+._Java-only: combining global and route-specific exception policies_
 [source,java]
 ----
 // global error handler
@@ -1290,6 +1309,7 @@ exception policy.
 And finally we top this by throwing in a nested error handler as well,
 as we add the 3rd route shown below:
 
+._Java-only: nested error handler with route-specific exceptions_
 [source,java]
 ----
 from("direct:start3")
@@ -1475,6 +1495,7 @@ In YAML then you refer to the redelivery process using `onRedeliveryRef` which i
 And in our custom processor we set a special timeout header to the message.
 You can of course do anything what you like in your code.
 
+._Java-only: custom redelivery processor_
 [source,java]
 ----
 // This is our processor that is executed before every redelivery attempt
@@ -1568,6 +1589,7 @@ redeliver until the predicate returns false.
 
 Example:
 
+._Java-only: using retryWhile predicate for fine-grained retry_
 [source,java]
 ----
 // we want to use a predicate for retries so we can determine in
@@ -1579,6 +1601,7 @@ onException(MyFunctionalException.class).retryWhile(method("myRetryHandler")).ha
 
 Where the bean *`myRetryHandler`* is computing if we should retry or not:
 
+._Java-only: retry handler bean with Bean Binding_
 [source,java]
 ----
 public class MyRetryBean {
@@ -1600,6 +1623,7 @@ The default `org.apache.camel.processor.errorhandler.ExceptionPolicyStrategy` in
 However, if you need to use your own (use only for rare and advanced use-cases) this can be configured as the
 sample below illustrates:
 
+._Java-only: configuring a custom ExceptionPolicyStrategy_
 [source,java]
 ----
 // configure the error handler to use my policy instead of the default from Camel
@@ -1610,6 +1634,7 @@ Using our own strategy *`MyPolicy`* we can change the default behavior of
 Camel with our own code to resolve which exception type
 from above should be handling the given thrown exception.
 
+._Java-only: custom ExceptionPolicyStrategy implementation_
 [source,java]
 ----
 public static class MyPolicy implements ExceptionPolicyStrategy {

--- a/docs/user-manual/modules/ROOT/pages/java-dsl-model-writer.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl-model-writer.adoc
@@ -59,6 +59,7 @@ through the generated writer code.
 The entry point is `JavaDslModelWriter`. Each top-level construct has a dedicated `write` method
 that returns a `String` containing compilable Java DSL code:
 
+._Java-only: using JavaDslModelWriter to convert model definitions_
 [source,java]
 ----
 import org.apache.camel.java.out.JavaDslModelWriter;
@@ -94,6 +95,7 @@ String validatorDsl = writer.writeValidator(validatorDefinition);
 
 A typical conversion reads XML, parses it with `ModelParser`, then writes each definition:
 
+._Java-only: converting an XML route file to Java DSL_
 [source,java]
 ----
 import org.apache.camel.model.RoutesDefinition;
@@ -132,6 +134,7 @@ Given the XML:
 
 The writer produces:
 
+._Java-only: generated Java DSL output for a route with filter_
 [source,java]
 ----
 from("timer:tick?period=1000")
@@ -144,6 +147,7 @@ from("timer:tick?period=1000")
 
 === REST DSL
 
+._Java-only: generated Java DSL output for REST DSL_
 [source,java]
 ----
 rest("/api")
@@ -156,6 +160,7 @@ rest("/api")
 
 === Route Template
 
+._Java-only: generated Java DSL output for a route template_
 [source,java]
 ----
 routeTemplate("myTemplate")
@@ -167,6 +172,7 @@ routeTemplate("myTemplate")
 
 === Transformer
 
+._Java-only: generated Java DSL output for a transformer_
 [source,java]
 ----
 transformer()
@@ -177,6 +183,7 @@ transformer()
 
 === Validator
 
+._Java-only: generated Java DSL output for a validator_
 [source,java]
 ----
 validator()

--- a/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/java-dsl.adoc
@@ -12,6 +12,7 @@ In the code below we create a new class called `MyRouteBuilder` that extends the
 
 In the `configure` method the Java DSL is at our disposal.
 
+._Java-only: defining a route with content-based routing using Java DSL_
 [source,java]
 ----
 import org.apache.camel.builder.RouteBuilder;
@@ -44,6 +45,7 @@ In the `configure` method we can define Camel xref:routes.adoc[Routes].
 
 In the example above we have a single route, which pickup files (the `from`).
 
+._Java-only: the from endpoint that consumes files_
 [source,java]
 ----
 from("file:src/data?noop=true")
@@ -52,6 +54,7 @@ from("file:src/data?noop=true")
 Then we use the xref:components:eips:choice-eip.adoc[Content-Based Router] EIP
 (the `choice`) to route the message whether the person is from London or not.
 
+._Java-only: content-based router using choice and xpath_
 [source,java]
 ----
 .choice()
@@ -66,6 +69,7 @@ Then we use the xref:components:eips:choice-eip.adoc[Content-Based Router] EIP
 If you have very long endpoint xref:uris.adoc[uris], then you can declare those in Java text blocks, instead
 of breaking a String into multiple added elements:
 
+._Java-only: using text blocks for long endpoint URIs_
 [source,java]
 ----
     from("""
@@ -86,6 +90,7 @@ you may want to quickly define a few routes.
 
 For example, using lambda style you can define a Camel route that takes messages from Kafka and send to JMS in a single line of code:
 
+._Java-only: defining a route using lambda style_
 [source,java]
 ----
 rb -> rb.from("kafka:cheese").to("jms:queue:foo");
@@ -100,7 +105,7 @@ As mentioned in the Getting Started guide, you can use Camel's Java DSL in a way
 
 *Note*: comments afterward explain some of the constructs used in the example.
 
-.*Example of Camel's "Java DSL"*
+._Java-only: example of Camel's Java DSL_
 [source,java]
 ----
 RouteBuilder builder = new RouteBuilder() {

--- a/docs/user-manual/modules/ROOT/pages/lambda-route-builder.adoc
+++ b/docs/user-manual/modules/ROOT/pages/lambda-route-builder.adoc
@@ -3,6 +3,7 @@
 The `LambdaRouteBuilder` is a functional interface which is used for creating a routing rule using the xref:dsl.adoc[DSL],
 using Java lambda style.
 
+._Java-only: a route defined using lambda style_
 [source,java]
 ----
 rb -> rb.from("timer:foo").log("Hello Lambda");
@@ -21,6 +22,7 @@ In the example below the method `myRoute` is used to create a Camel route that c
 To make the route discoverable by Camel during startup, then the method must be annotated.
 The method should be annotated with `@BindToRegistry` in standalone mode with `camel-main`, `@Bean` in case of Spring Boot or `@Produce` in case of Quarkus.
 
+._Java-only: registering a LambdaRouteBuilder with @BindToRegistry_
 [source,java]
 ----
 public class MyConfiguration {
@@ -37,6 +39,7 @@ public class MyConfiguration {
 The xref:Endpoint-dsl.adoc[Endpoint DSL] can also be used as a lambda route builder with the
 `org.apache.camel.builder.endpoint.LambdaEndpointRouteBuilder` class from the `camel-endpointdsl` JAR.
 
+._Java-only: using LambdaEndpointRouteBuilder with type-safe endpoint DSL_
 [source,java]
 ----
 public class MyConfiguration {
@@ -51,6 +54,7 @@ public class MyConfiguration {
 The `LambdaEndpointRouteBuilder` has _type safe_ endpoint but requires to prefix with the instance name (`rb`)
 when choosing an endpoint name. Notice above how to select the kafka endpoint
 
+._Java-only: using type-safe endpoint builder with prefix_
 [source,java]
 ----
 rb.from(rb.kafka("cheese"))
@@ -58,6 +62,7 @@ rb.from(rb.kafka("cheese"))
 
 With the regular `LambdaRouteBuilder` it's just a `String` type, so the `rb` prefix is not needed anymore:
 
+._Java-only: using string-based endpoint URI without prefix_
 [source,java]
 ----
 rb.from("kafka:cheese")

--- a/docs/user-manual/modules/ROOT/pages/langchain4j-spring-boot-integration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/langchain4j-spring-boot-integration.adoc
@@ -113,17 +113,18 @@ langchain4j:
 
 The auto-configured beans are automatically available in your Camel routes:
 
+._Java-only: Spring Boot RouteBuilder using auto-configured LangChain4j beans_
 [source,java]
 ----
 @Component
 public class MyRoutes extends RouteBuilder {
-    
+
     @Override
     public void configure() {
         // Chat endpoint using auto-configured ChatLanguageModel
         from("direct:chat")
             .to("langchain4j-chat:openai?chatModel=#chatLanguageModel");
-        
+
         // Embeddings endpoint using auto-configured EmbeddingModel
         from("direct:embeddings")
             .to("langchain4j-embeddings:openai?embeddingModel=#embeddingModel");
@@ -163,7 +164,7 @@ langchain4j.open-ai.chat-model.model-name=gpt-4o
 langchain4j.open-ai.chat-model.temperature=0.7
 ----
 
-.ChatRoute.java
+._Java-only: Spring Boot ChatRoute with OpenAI_
 [source,java]
 ----
 import org.apache.camel.builder.RouteBuilder;
@@ -223,7 +224,7 @@ langchain4j:
       deployment-name: text-embedding-ada-002
 ----
 
-.RagRoute.java
+._Java-only: Spring Boot RagRoute with Azure OpenAI_
 [source,java]
 ----
 import org.apache.camel.builder.RouteBuilder;
@@ -351,7 +352,7 @@ langchain4j:
       model-name: llama2
 ----
 
-.MultiProviderRoute.java
+._Java-only: Spring Boot RouteBuilder with multiple LLM providers_
 [source,java]
 ----
 @Component
@@ -454,6 +455,7 @@ langchain4j.open-ai.chat-model.log-responses=false
 
 For long-running conversations, consider using streaming chat models:
 
+._Java-only: Spring Boot streaming chat RouteBuilder_
 [source,java]
 ----
 @Component

--- a/docs/user-manual/modules/ROOT/pages/language-dsl.adoc
+++ b/docs/user-manual/modules/ROOT/pages/language-dsl.adoc
@@ -11,6 +11,7 @@ The DSL can be accessed directly from the `RouteBuilder` with the `expression()`
 
 In the following example, a `TokenizerExpression` is created using the legacy approach where the expression is instantiated explicitly and configured using setters:
 
+._Java-only: creating a tokenizer expression using the legacy approach_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {
@@ -30,6 +31,7 @@ public class MyRoutes extends RouteBuilder {
 
 The previous code could be simplified using the utility methods available directly from the `ExpressionClause` corresponding to the type returned by several existing methods such as `split()`, `setBody()`, `setHeader(String)`, `aggregate()`, etc.:
 
+._Java-only: simplified tokenizer using ExpressionClause utility method_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {
@@ -46,6 +48,7 @@ public class MyRoutes extends RouteBuilder {
 
 This approach is suitable for very basic configuration, but as there are only limited utility methods for each supported language, for more complex configuration, we can quickly face situations where the utility method for our expected configuration doesn't exist. In this situation, you can either use the legacy approach or the language DSL like in the next code snippet:
 
+._Java-only: configuring a tokenizer using the Language DSL builder_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {
@@ -70,6 +73,7 @@ public class MyRoutes extends RouteBuilder {
 Sometimes creating an expression can be a bit verbose with a number of fluent builder methods.
 What you can do is to pre create the expression before the route as shown below:
 
+._Java-only: pre-creating an expression before the route_
 [source,java]
 ----
 public class MyRoutes extends RouteBuilder {

--- a/docs/user-manual/modules/ROOT/pages/message-size.adoc
+++ b/docs/user-manual/modules/ROOT/pages/message-size.adoc
@@ -125,6 +125,10 @@ The statistics are reset when the endpoint registry statistics are reset.
 For the IN direction, the computed sizes are available as exchange properties during routing.
 You can use them for logging, content-based routing, or custom processing:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("seda:start")
@@ -135,6 +139,48 @@ from("seda:start")
         .otherwise()
             .to("direct:normalMessage");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="seda:start"/>
+    <log message="Body size: ${exchangeProperty.CamelMessageBodySize} bytes"/>
+    <choice>
+        <when>
+            <simple>${exchangeProperty.CamelMessageBodySize} > 1048576</simple>
+            <to uri="direct:largeMessage"/>
+        </when>
+        <otherwise>
+            <to uri="direct:normalMessage"/>
+        </otherwise>
+    </choice>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:start
+      steps:
+        - log:
+            message: "Body size: ${exchangeProperty.CamelMessageBodySize} bytes"
+        - choice:
+            when:
+              - simple: "${exchangeProperty.CamelMessageBodySize} > 1048576"
+                steps:
+                  - to:
+                      uri: direct:largeMessage
+            otherwise:
+              steps:
+                - to:
+                    uri: direct:normalMessage
+----
+====
 
 [width="100%",cols="1m,3",options="header"]
 |===

--- a/docs/user-manual/modules/ROOT/pages/notify-builder.adoc
+++ b/docs/user-manual/modules/ROOT/pages/notify-builder.adoc
@@ -13,6 +13,7 @@ NOTE: The `NotifyBuilder` is only intended for testing purposes and you can only
 
 Suppose we have a very simple route:
 
+._Java-only: a simple route for NotifyBuilder demonstration_
 [source,java]
 ----
 from("jms:queue:quotes")
@@ -25,6 +26,7 @@ Now you want to test this route without using mocks or the likes.
 We want to test that it could process a message send to that queue.
 By using the `NotifyBuilder` we can build an expression which expresses when that condition occurred.
 
+._Java-only: basic NotifyBuilder waiting for one message to complete_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder().whenDone(1).create();
@@ -84,6 +86,7 @@ The names of these three ways are also incorporated in the names of the builder 
 
 === Examples
 
+._Java-only: matching when 5 messages are done from a specific endpoint_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -95,6 +98,7 @@ Here we want to match when the direct:foo endpoint have done 5 messages.
 
 You may also want to be notified when an message is done by the index, for example the very first message. To do that you can simply do:
 
+._Java-only: matching when the first message is done using index_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -112,6 +116,7 @@ That is why `whenDoneByIndex` was added to support this scenario.
 Here we want to match when the direct:foo endpoint have done 5 messages which contains the word 'test' in the body.
 The filter accepts a xref:predicate.adoc[Predicate].
 
+._Java-only: filtering messages with a predicate before matching_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -121,6 +126,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 Here we just say that at least one message should be done received from any JMS endpoint (notice the wildcard matching).
 
+._Java-only: matching messages from any JMS endpoint using wildcard_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -130,6 +136,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 Here, we just say that at least three message should be done received from any of myCoolRoutes (notice the wildcard matching).
 
+._Java-only: matching messages from routes using wildcard_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -139,6 +146,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 Here both 5 foo messages and 7 bar messages must be done. Notice the use of the and operator.
 
+._Java-only: combining conditions with the and operator_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -149,6 +157,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 Here we expect to receive two messages whose body is Hello World then Bye World.
 
+._Java-only: matching on expected message bodies_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -158,6 +167,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 Here we expect to receive a message which contains Camel in the body.
 
+._Java-only: matching any received message with a predicate_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -167,6 +177,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 === Using mock endpoint for fine-grained expectations
 
+._Java-only: combining Mock endpoint with NotifyBuilder_
 [source,java]
 ----
 // let's use a mock to set the expressions as it got many great assertions for that
@@ -187,6 +198,7 @@ However, we suggest using the mock for fine-grained expectations that you may al
 
 For example in the following we expect the message to be sent to mock:bar
 
+._Java-only: matching messages that were sent to a specific endpoint_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -196,6 +208,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 You can combine this with any of the other expectations, such as, to only match if 3+ messages are done, and were sent to the mock:bar endpoint:
 
+._Java-only: combining whenDone with wereSentTo_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -205,6 +218,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 You can add additional `wereSentTo`, such as the following two:
 
+._Java-only: chaining multiple wereSentTo conditions_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)
@@ -214,6 +228,7 @@ NotifyBuilder notify = new NotifyBuilder(context)
 
 As well as you can expect a number of messages to be done, and a message to fail, which has to be sent to another endpoint:
 
+._Java-only: combining done and failed conditions with different endpoints_
 [source,java]
 ----
 NotifyBuilder notify = new NotifyBuilder(context)

--- a/docs/user-manual/modules/ROOT/pages/pojo-consuming.adoc
+++ b/docs/user-manual/modules/ROOT/pages/pojo-consuming.adoc
@@ -12,6 +12,7 @@ inbound JMS message from ActiveMQ on the cheese
 queue; this will use the xref:type-converter.adoc[Type Converter] to
 convert the JMS payload to `String` as declared in the method signature.
 
+._Java-only: consuming messages using @Consume annotation_
 [source,java]
 ----
 public class Foo {
@@ -29,6 +30,7 @@ the method.
 
 This basically creates a route that looks kinda like this (based on the example above):
 
+._Java-only: equivalent route created by the @Consume annotation_
 [source,java]
 ----
 from("activemq:cheese").bean(Foo.class, "onCheese");
@@ -43,12 +45,13 @@ the property.
 
 For example:
 
+._Java-only: using a property to define the @Consume endpoint_
 [source,java]
 ----
 public class MyService {
 
   private String serviceEndpoint;
-  
+
   public void setServiceEndpoint(String uri) {
      this.serviceEndpoint = uri;
   }
@@ -116,6 +119,7 @@ The method must be a `getXXX` method.
 
 So in the example above, we could have defined the `@Consume` annotation as:
 
+._Java-only: using shortened property name with @Consume_
 [source,java]
 ----
   @Consume(property = "service")
@@ -127,6 +131,7 @@ the algorithm, and have Camel invoke the `getServiceEndpoint` method.
 
 We could also have omitted the property attribute, to make it implicit:
 
+._Java-only: using implicit property resolution with @Consume_
 [source,java]
 ----
   @Consume

--- a/docs/user-manual/modules/ROOT/pages/predicate.adoc
+++ b/docs/user-manual/modules/ROOT/pages/predicate.adoc
@@ -42,6 +42,10 @@ path they should be routed.
 A simple example is to route an xref:exchange.adoc[Exchange] based on a
 header value with the xref:components:eips:choice-eip.adoc[Content Based Router] EIP:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("jms:queue:order")
@@ -52,6 +56,53 @@ from("jms:queue:order")
       .to("bean:miscOrder")
    .end();
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="jms:queue:order"/>
+    <choice>
+        <when>
+            <simple>${header.type} == 'widget'</simple>
+            <to uri="bean:widgetOrder"/>
+        </when>
+        <when>
+            <simple>${header.type} == 'wombat'</simple>
+            <to uri="bean:wombatOrder"/>
+        </when>
+        <otherwise>
+            <to uri="bean:miscOrder"/>
+        </otherwise>
+    </choice>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: jms:queue:order
+      steps:
+        - choice:
+            when:
+              - simple: "${header.type} == 'widget'"
+                steps:
+                  - to:
+                      uri: bean:widgetOrder
+              - simple: "${header.type} == 'wombat'"
+                steps:
+                  - to:
+                      uri: bean:wombatOrder
+            otherwise:
+              steps:
+                - to:
+                    uri: bean:miscOrder
+----
+====
 
 In the route above the xref:predicate.adoc[Predicate] is the
 `header("type").isEqualTo("widget")` as it is constructed as an
@@ -72,6 +123,7 @@ Predicate isWidget = header("type").isEqualTo("widget");
 
 And then you can refer to it in the route as:
 
+._Java-only: using a predicate variable in a route_
 [source,java]
 ----
 from("jms:queue:order")
@@ -99,6 +151,10 @@ import static org.apache.camel.builder.PredicateBuilder.not;
 And then we can use it to enclose an existing predicate and negate it as
 the example shows:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("direct:start")
@@ -107,6 +163,45 @@ from("direct:start")
         .otherwise().to("mock:animals")
     .end();
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="direct:start"/>
+    <choice>
+        <when>
+            <simple>${header.username} not regex 'goofy|pluto'</simple>
+            <to uri="mock:people"/>
+        </when>
+        <otherwise>
+            <to uri="mock:animals"/>
+        </otherwise>
+    </choice>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - choice:
+            when:
+              - simple: "${header.username} not regex 'goofy|pluto'"
+                steps:
+                  - to:
+                      uri: mock:people
+            otherwise:
+              steps:
+                - to:
+                    uri: mock:animals
+----
+====
 
 == Compound Predicates
 
@@ -145,6 +240,7 @@ PredicateBuilder.and(XPathBuilder.xpath("/bookings/flights"), simple("${exchange
 
 The sample below demonstrates further use cases:
 
+._Java-only: compound predicates with PredicateBuilder_
 [source,java]
 ----
 // We define 3 predicates based on some user roles

--- a/docs/user-manual/modules/ROOT/pages/processor.adoc
+++ b/docs/user-manual/modules/ROOT/pages/processor.adoc
@@ -14,6 +14,7 @@ xref:components:eips:enterprise-integration-patterns.adoc[EIPs] implements.
 
 Once you have written a class which implements processor like this:
 
+._Java-only: implementing the Processor interface_
 [source,java]
 ----
 public class MyProcessor implements Processor {
@@ -117,6 +118,7 @@ NOTE: For more details about the `#class:` prefix (and others) then see xref:pro
 
 The process can be used in routes as an anonymous inner class such:
 
+._Java-only: using an anonymous inner class as a Processor_
 [source,java]
 ----
     from("activemq:myQueue").process(new Processor() {

--- a/docs/user-manual/modules/ROOT/pages/producertemplate.adoc
+++ b/docs/user-manual/modules/ROOT/pages/producertemplate.adoc
@@ -16,6 +16,7 @@ the `stop()` method to close down all the resources it has been using.
 The `sendBody()` method allows you to send any object to an endpoint
 easily as shown:
 
+._Java-only: sending messages using ProducerTemplate_
 [source,java]
 ----
 ProducerTemplate template = exchange.getContext().createProducerTemplate();
@@ -47,6 +48,7 @@ and all the methods starting with `requestXXX` are for InOut messaging.
 
 Let's see an example where we invoke an endpoint to get the response (InOut):
 
+._Java-only: using requestBody for request-reply messaging_
 [source,java]
 ----
 Object response = template.requestBody("<hello/>");
@@ -68,6 +70,7 @@ Here are some examples:
 
 This is the most common style with fluent builders to set headers, and message body as show:
 
+._Java-only: using FluentProducerTemplate with headers and body_
 [source,java]
 ----
 Integer result = FluentProducerTemplate.on(context)
@@ -82,6 +85,7 @@ Integer result = FluentProducerTemplate.on(context)
 
 Here we use xref:processor.adoc[Processor] to prepare the message to be sent.
 
+._Java-only: using FluentProducerTemplate with a Processor_
 [source,java]
 ----
 Integer result = FluentProducerTemplate.on(context)
@@ -95,6 +99,7 @@ Integer result = FluentProducerTemplate.on(context)
 This is rarely in use, but a `TemplateCustomizer` can be used for advanced use-cases
 to control various aspects of the `FluentProducerTemplate` such as configuring to use a custom thread pool:
 
+._Java-only: using FluentProducerTemplate with a template customizer_
 [source,java]
 ----
 Object result = FluentProducerTemplate.on(context)
@@ -124,6 +129,7 @@ an Exchange object.
 From the returned Exchange you can test if it has failed and get the caused
 exception. This is illustrated in the code sample:
 
+._Java-only: retrieving a thrown exception from the returned Exchange_
 [source,java]
 ----
 @Test
@@ -170,6 +176,7 @@ which will be created or dependency inject by `CamelContext`.
 
 This can be done on the `CamelContext` as a global option as shown in the following Java code:
 
+._Java-only: configuring cache size via CamelContext global options_
 [source,java]
 ----
 getCamelContext().getGlobalOptions().put(Exchange.MAXIMUM_CACHE_POOL_SIZE, "50");

--- a/docs/user-manual/modules/ROOT/pages/registry.adoc
+++ b/docs/user-manual/modules/ROOT/pages/registry.adoc
@@ -20,6 +20,7 @@ The lookup is used for looking up existing beans from the registry.
 
 The binding API is as follows:
 
+._Java-only: the Registry binding API_
 [source,java]
 ----
 public interface Registry extends BeanRepository {
@@ -51,6 +52,7 @@ IMPORTANT: The binding API will bind the bean to Camels internal registry, and n
 
 If you, for example, need to add a bean to the `Registry` then you can easily do this from Java as follows:
 
+._Java-only: binding a bean to the Registry_
 [source,java]
 ----
 Object myFoo = ...
@@ -59,6 +61,7 @@ camelContext.getRegistry().bind("foo", myFoo);
 
 Then you can access the bean by the id, such as from a Camel route:
 
+._Java-only: using a bean from the Registry in a route_
 [source,java]
 ----
 from("jms:cheese").bean("foo");
@@ -79,6 +82,7 @@ registered into Spring bean container; which means there is no need to bind the 
 When using Spring Boot, then you can also use annotations to declare beans
 such as with the `@Bean` annotation on the method that creates the bean:
 
+._Java-only: declaring a bean using Spring Boot @Bean annotation_
 [source,java]
 ----
 @Bean
@@ -95,6 +99,7 @@ the Spring Boot project documentation.
 Quarkus has similar functionality like Spring Boot to declare beans, which can be done
 with the `javax.inject.enterprise.Produces` and `javax.inject.Named` annotations:
 
+._Java-only: declaring a bean using Quarkus CDI annotations_
 [source,java]
 ----
 @Produces @Named("foo")
@@ -110,6 +115,7 @@ during startup of Camel where Camel is wiring up all components, endpoints, rout
 
 The lookup API is the following methods:
 
+._Java-only: the BeanRepository lookup API_
 [source,java]
 ----
 public interface BeanRepository {
@@ -156,6 +162,7 @@ public interface BeanRepository {
 
 You can lookup beans from Java code as shown:
 
+._Java-only: looking up beans from the Registry_
 [source,java]
 ----
 // lookup by id only

--- a/docs/user-manual/modules/ROOT/pages/route-configuration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-configuration.adoc
@@ -49,6 +49,7 @@ This configuration is a basic configuration that just catches and handles all ex
 
 To use this configuration in your routes, then you can assign it with `routeConfigurationId` as shown:
 
+._Java-only: RouteBuilder using routeConfigurationId_
 [source,java]
 ----
 public class MyJavaRouteBuilder extends RouteBuilder {
@@ -141,6 +142,7 @@ been explicitly assigned route configurations.
 
 Suppose you have one _nameless_ configuration and another named `_retryError_`:
 
+._Java-only: RouteConfigurationBuilder class definition_
 [source,java]
 ----
 public class MyJavaErrorHandler extends RouteConfigurationBuilder {
@@ -159,6 +161,10 @@ public class MyJavaErrorHandler extends RouteConfigurationBuilder {
 
 And the following two routes:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
    from("file:cheese").routeId("cheese")
@@ -168,6 +174,44 @@ And the following two routes:
         .routeConfigurationId("retryError")
         .to("jms:beer");
 ----
+
+XML::
++
+[source,xml]
+----
+<route id="cheese">
+    <from uri="file:cheese"/>
+    <to uri="kafka:cheese"/>
+</route>
+
+<route id="beer" routeConfigurationId="retryError">
+    <from uri="file:beer"/>
+    <to uri="jms:beer"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    id: cheese
+    from:
+      uri: file:cheese
+      steps:
+        - to:
+            uri: kafka:cheese
+
+- route:
+    id: beer
+    routeConfigurationId: retryError
+    from:
+      uri: file:beer
+      steps:
+        - to:
+            uri: jms:beer
+----
+====
 
 In the example above, the `_cheese_` route has no route configurations assigned, so the route
 will use the default configuration, which in case of an exception will log a warning.

--- a/docs/user-manual/modules/ROOT/pages/route-template.adoc
+++ b/docs/user-manual/modules/ROOT/pages/route-template.adoc
@@ -453,6 +453,7 @@ not use the _simple fluent builder_ when defining the simple expressions/predica
 
 For example, given the following route template in Java DSL:
 
+._Java-only: route template with Simple fluent builder (unsupported usage)_
 [source,java]
 ----
 public class MyRouteTemplates extends RouteBuilder {
@@ -480,6 +481,7 @@ This is **not supported** with route templates and would not work when creating 
 
 Instead, the simple expression should be a literal String value _only_ as follows:
 
+._Java-only: correct Simple expression syntax for route templates_
 [source,java]
 ----
 .when(simple("'{{color}}' == 'red'")
@@ -487,6 +489,7 @@ Instead, the simple expression should be a literal String value _only_ as follow
 
 So the correct solution would be as follows:
 
+._Java-only: correct route template with Simple String literal_
 [source,java]
 ----
 public class MyRouteTemplates extends RouteBuilder {
@@ -647,6 +650,7 @@ This allows using the same template to create multiple routes, where beans are l
 
 For example, given the following route template where we use `templateBean` to set up the local bean as shown:
 
+._Java-only: templateBean with lambda supplier_
 [source,java]
 ----
 routeTemplate("s3template")
@@ -686,6 +690,7 @@ creating routes from existing templates.
 
 Suppose the route template below is defined in XML:
 
+._XML-only: route template without bean binding_
 [source,xml]
 ----
   <routeTemplate id="s3template">
@@ -834,6 +839,7 @@ TIP: In *Camel 4.6* onwards, you can also use constructor arguments for beans
 
 So suppose we have a class as follows:
 
+._Java-only: bean class with getter/setter properties_
 [source,java]
 ----
 public class MyBar {
@@ -1193,6 +1199,7 @@ YAML::
 
 The method signature of `createS3Client` method **MUST** then have one parameter for the `RouteTemplateContext` as shown:
 
+._Java-only: bean factory method signature_
 [source,java]
 ----
 public static S3Client createS3Client(RouteTemplateContext rtc) {
@@ -1284,6 +1291,7 @@ NOTE: This is only available in Java DSL
 To support this you can use the `configure` in the route template DSL
 where you can specify the code to execute as show:
 
+._Java-only: custom configuration callback when creating route from template_
 [source,java]
 ----
 routeTemplate("myTemplate")
@@ -1303,8 +1311,12 @@ The route templates can be dumped as XML from the `ManagedCamelContextMBean` MBe
 
 When using `camel-main` you can specify the parameters for route templates in `application.properties` file.
 
-For example, given the route template below (from a `RouteBuilder` class):
+For example, given the route template below:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 routeTemplate("mytemplate")
@@ -1313,6 +1325,37 @@ routeTemplate("mytemplate")
     .from("direct:{{input}}")
         .to("mock:{{result}}");
 ----
+
+XML::
++
+[source,xml]
+----
+<routeTemplate id="mytemplate">
+    <templateParameter name="input"/>
+    <templateParameter name="result"/>
+    <route>
+        <from uri="direct:{{input}}"/>
+        <to uri="mock:{{result}}"/>
+    </route>
+</routeTemplate>
+----
+
+YAML::
++
+[source,yaml]
+----
+- routeTemplate:
+    id: mytemplate
+    parameters:
+      - name: input
+      - name: result
+    from:
+      uri: "direct:{{input}}"
+      steps:
+        - to:
+            uri: "mock:{{result}}"
+----
+====
 
 Then we can create two routes from this template by configuring the values in the `application.properties` file:
 

--- a/docs/user-manual/modules/ROOT/pages/routes.adoc
+++ b/docs/user-manual/modules/ROOT/pages/routes.adoc
@@ -177,6 +177,7 @@ You can create a route using the Java language by extending the xref:manual::rou
 
 Here's an example:
 
+._Java-only: anonymous RouteBuilder class_
 [source,java]
 ----
 RouteBuilder builder = new RouteBuilder() {
@@ -189,6 +190,7 @@ RouteBuilder builder = new RouteBuilder() {
 The code above is an anonymous class, and its more common to create your own class when using Java DSL for example we
 can create a class called `MyRoute` which then implements the route as follows:
 
+._Java-only: named RouteBuilder class_
 [source,java]
 ----
 import org.apache.camel.builder.RouteBuilder;

--- a/docs/user-manual/modules/ROOT/pages/security-model.adoc
+++ b/docs/user-manual/modules/ROOT/pages/security-model.adoc
@@ -887,12 +887,42 @@ vulnerabilities if skipped; all of them reduce the attack surface materially.
   receives messages from an untrusted producer, remove Camel-controlled
   headers before the message reaches any dispatching processor:
 +
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("jetty:http://0.0.0.0:8080/api")
     .removeHeaders("Camel*")
     .to("direct:trusted-pipeline");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="jetty:http://0.0.0.0:8080/api"/>
+    <removeHeaders pattern="Camel*"/>
+    <to uri="direct:trusted-pipeline"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: jetty:http://0.0.0.0:8080/api
+      steps:
+        - removeHeaders:
+            pattern: "Camel*"
+        - to:
+            uri: direct:trusted-pipeline
+----
+====
 * *Do not enable Java serialisation on consumers exposed to untrusted
   networks.* In particular, do not set `allowJavaSerializedObject=true`,
   `transferException=true`, or `mapJmsMessage=true` on a JMS consumer when the

--- a/docs/user-manual/modules/ROOT/pages/spring-xml-extensions.adoc
+++ b/docs/user-manual/modules/ROOT/pages/spring-xml-extensions.adoc
@@ -169,6 +169,7 @@ You can allow Camel to scan the container context, e.g. the Spring ApplicationCo
 
 This allows you to just annotate your routes using the Spring *`@Component`*  and have those routes included by Camel:
 
+._Java-only: Spring @Component annotated RouteBuilder_
 [source,java]
 ----
 @Component

--- a/docs/user-manual/modules/ROOT/pages/test-infra.adoc
+++ b/docs/user-manual/modules/ROOT/pages/test-infra.adoc
@@ -114,6 +114,7 @@ This registration is done in the `registerProperties` methods during the service
 
 Registering the properties in the concrete service implementation:
 
+._Java-only: registering service properties for test infrastructure_
 [source,java]
 ----
     public void registerProperties() {
@@ -171,6 +172,7 @@ Camel version when used outside the Camel Core project.
 
 On the test class, add a member variable for the service and annotate it with the `@RegisterExtension` to let JUnit manage its lifecycle.
 
+._Java-only: registering a test infrastructure service as a JUnit extension_
 [source,java]
 ----
 @RegisterExtension
@@ -179,6 +181,7 @@ static MyService service = MyServiceServiceFactory.createService();
 
 More complex test services can be created using something similar to:
 
+._Java-only: creating a complex test service with builder pattern_
 [source,java]
 ----
 @RegisterExtension
@@ -201,6 +204,7 @@ When using these properties in Spring XML files, you may use those properties.
 It's also possible to use these properties in the test code itself. For example, when setting up the test url for the
 Camel component:
 
+._Java-only: using test infrastructure properties in a Camel route_
 [source,java]
 ----
     protected RouteBuilder createRouteBuilder() throws Exception {
@@ -219,6 +223,7 @@ When combining the different modules of the test infra, you may need to ensure t
 
 For instance:
 
+._Java-only: controlling execution order of test extensions_
 [source,java]
 ----
     @Order(1)

--- a/docs/user-manual/modules/ROOT/pages/try-catch-finally.adoc
+++ b/docs/user-manual/modules/ROOT/pages/try-catch-finally.adoc
@@ -201,6 +201,7 @@ that is indented in a way where you think that a catch block is associated with 
 
 Given the following Java DSL:
 
+._Java-only: nested doTry scoping issue_
 [source,java]
 ----
 from("direct:test").routeId("myroute")
@@ -223,6 +224,7 @@ which then throws a second exception, that is not caught.
 
 So what you must do is to end the doCatch block correct (notice how we use `endDoTry()` two times) as shown below:
 
+._Java-only: correct nesting with endDoTry()_
 [source,java]
 ----
 from("direct:test")

--- a/docs/user-manual/modules/ROOT/pages/virtual-threads.adoc
+++ b/docs/user-manual/modules/ROOT/pages/virtual-threads.adoc
@@ -147,6 +147,7 @@ HTTP server components can be configured to use virtual threads for request hand
 
 Jetty 12+ supports virtual threads via `VirtualThreadPool`. Configure a custom thread pool:
 
+._Java-only: programmatic Jetty VirtualThreadPool configuration_
 [source,java]
 ----
 import org.eclipse.jetty.util.thread.VirtualThreadPool;
@@ -176,12 +177,43 @@ Or in Spring configuration:
 
 The camel-platform-http-vertx component uses Vert.x's event loop model. Virtual threads aren't directly applicable, but you can offload blocking work:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("platform-http:/api/orders")
     .threads()  // Offload to virtual thread pool
     .to("jpa:Order");  // Blocking JPA operation
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="platform-http:/api/orders"/>
+    <threads>
+        <to uri="jpa:Order"/>
+    </threads>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: platform-http:/api/orders
+      steps:
+        - threads:
+            steps:
+              - to:
+                  uri: jpa:Order
+----
+====
 
 ==== Undertow
 
@@ -207,6 +239,10 @@ Undertow can use virtual threads via XNIO worker configuration. Check Undertow d
 
 Virtual threads shine with blocking database operations:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // With virtual threads, these blocking calls don't waste platform threads
@@ -215,6 +251,38 @@ from("seda:process?virtualThreadPerTask=true&concurrentConsumers=500")
     .to("sql:SELECT * FROM inventory WHERE id = :#${body.itemId}")
     .to("mongodb:orders");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="seda:process?virtualThreadPerTask=true&amp;concurrentConsumers=500"/>
+    <to uri="jpa:Order"/>
+    <to uri="sql:SELECT * FROM inventory WHERE id = :#${body.itemId}"/>
+    <to uri="mongodb:orders"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:process
+      parameters:
+        virtualThreadPerTask: true
+        concurrentConsumers: 500
+      steps:
+        - to:
+            uri: jpa:Order
+        - to:
+            uri: "sql:SELECT * FROM inventory WHERE id = :#${body.itemId}"
+        - to:
+            uri: mongodb:orders
+----
+====
 
 == SEDA Deep Dive: Two Execution Models
 
@@ -233,12 +301,44 @@ The default SEDA consumer model uses a *fixed pool of long-running consumer thre
 
 ==== Configuration
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("seda:orders?concurrentConsumers=10")
     .process(this::processOrder)
     .to("direct:fulfillment");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="seda:orders?concurrentConsumers=10"/>
+    <process ref="processOrder"/>
+    <to uri="direct:fulfillment"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:orders
+      parameters:
+        concurrentConsumers: 10
+      steps:
+        - process:
+            ref: processOrder
+        - to:
+            uri: direct:fulfillment
+----
+====
 
 ==== Best For
 
@@ -261,12 +361,45 @@ The `virtualThreadPerTask` mode uses a fundamentally different approach: *spawn 
 
 ==== Configuration
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 from("seda:orders?virtualThreadPerTask=true&concurrentConsumers=100")
     .process(this::processOrder)  // I/O-bound operation
     .to("direct:fulfillment");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="seda:orders?virtualThreadPerTask=true&amp;concurrentConsumers=100"/>
+    <process ref="processOrder"/>
+    <to uri="direct:fulfillment"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:orders
+      parameters:
+        virtualThreadPerTask: true
+        concurrentConsumers: 100
+      steps:
+        - process:
+            ref: processOrder
+        - to:
+            uri: direct:fulfillment
+----
+====
 
 ==== Best For
 
@@ -376,11 +509,33 @@ When using virtual threads with high concurrency, proper backpressure is essenti
 
 The SEDA queue itself acts as a buffer with configurable size:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Queue holds up to 10,000 messages
 from("seda:orders?size=10000")
 ----
+
+XML::
++
+[source,xml]
+----
+<from uri="seda:orders?size=10000"/>
+----
+
+YAML::
++
+[source,yaml]
+----
+from:
+  uri: seda:orders
+  parameters:
+    size: 10000
+----
+====
 
 When the queue is full, producers can be configured to:
 
@@ -407,6 +562,10 @@ When the queue is full, producers can be configured to:
 
 Example with blocking and timeout:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Producer blocks up to 10 seconds when queue is full
@@ -414,10 +573,41 @@ from("direct:incoming")
     .to("seda:processing?size=5000&blockWhenFull=true&offerTimeout=10000");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="direct:incoming"/>
+    <to uri="seda:processing?size=5000&amp;blockWhenFull=true&amp;offerTimeout=10000"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:incoming
+      steps:
+        - to:
+            uri: seda:processing
+            parameters:
+              size: 5000
+              blockWhenFull: true
+              offerTimeout: 10000
+----
+====
+
 ==== Layer 2: Concurrency Limiting (Consumer Side)
 
 In `virtualThreadPerTask` mode, the `concurrentConsumers` parameter controls maximum concurrent processing tasks:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Max 200 concurrent virtual threads processing messages
@@ -425,12 +615,42 @@ from("seda:orders?virtualThreadPerTask=true&concurrentConsumers=200")
     .to("http://downstream-service/api");
 ----
 
+XML::
++
+[source,xml]
+----
+<route>
+    <from uri="seda:orders?virtualThreadPerTask=true&amp;concurrentConsumers=200"/>
+    <to uri="http://downstream-service/api"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: seda:orders
+      parameters:
+        virtualThreadPerTask: true
+        concurrentConsumers: 200
+      steps:
+        - to:
+            uri: http://downstream-service/api
+----
+====
+
 This uses a `Semaphore` internally to gate message dispatch, ensuring you don't overwhelm downstream services even with thousands of queued messages.
 
 ==== Layer 3: Combination Strategy
 
 For robust production systems, combine both:
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // Producer side: buffer up to 10,000, block if full (with timeout)
@@ -443,6 +663,58 @@ from("seda:order-queue?virtualThreadPerTask=true&concurrentConsumers=500")
     .to("http://payment-service/process")
     .to("jpa:Order");
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- Producer side: buffer up to 10,000, block if full (with timeout) -->
+<route>
+    <from uri="rest:post:/orders"/>
+    <to uri="seda:order-queue?size=10000&amp;blockWhenFull=true&amp;offerTimeout=30000"/>
+</route>
+
+<!-- Consumer side: process with virtual threads, max 500 concurrent -->
+<route>
+    <from uri="seda:order-queue?virtualThreadPerTask=true&amp;concurrentConsumers=500"/>
+    <to uri="http://inventory-service/check"/>
+    <to uri="http://payment-service/process"/>
+    <to uri="jpa:Order"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+# Producer side: buffer up to 10,000, block if full (with timeout)
+- route:
+    from:
+      uri: rest:post:/orders
+      steps:
+        - to:
+            uri: seda:order-queue
+            parameters:
+              size: 10000
+              blockWhenFull: true
+              offerTimeout: 30000
+
+# Consumer side: process with virtual threads, max 500 concurrent
+- route:
+    from:
+      uri: seda:order-queue
+      parameters:
+        virtualThreadPerTask: true
+        concurrentConsumers: 500
+      steps:
+        - to:
+            uri: http://inventory-service/check
+        - to:
+            uri: http://payment-service/process
+        - to:
+            uri: jpa:Order
+----
+====
 
 This configuration:
 
@@ -476,6 +748,7 @@ This configuration:
 
 === Example: High-Throughput Order Processing
 
+._Java-only: RouteBuilder class with REST and SEDA virtual thread processing_
 [source,java]
 ----
 public class OrderProcessingRoute extends RouteBuilder {
@@ -579,6 +852,7 @@ https://openjdk.org/jeps/487[JEP 487: Scoped Values] provides:
 
 ==== Basic Usage
 
+._Java-only: ContextValue API for scoped context propagation_
 [source,java]
 ----
 import org.apache.camel.util.concurrent.ContextValue;
@@ -602,6 +876,7 @@ public void processRequest() {
 
 ==== When to Use ThreadLocal vs ContextValue
 
+._Java-only: choosing between ContextValue factory methods_
 [source,java]
 ----
 // Use ContextValue.newInstance() for READ-ONLY context passing
@@ -615,6 +890,7 @@ private static final ContextValue<Counter> COUNTER = ContextValue.newThreadLocal
 
 Camel uses `ContextValue` internally for various purposes:
 
+._Java-only: ContextValue usage in Camel's internal processor creation_
 [source,java]
 ----
 // Example: Passing context during route creation
@@ -634,6 +910,7 @@ ProcessorDefinition<?> current = CREATE_PROCESSOR.orElse(null);
 
 If you have existing code using `ThreadLocal`, migration is straightforward:
 
+._Java-only: migrating from ThreadLocal to ContextValue_
 [source,java]
 ----
 // Before: ThreadLocal
@@ -697,6 +974,10 @@ camel.threads.virtual.enabled=true
 
 ==== SEDA Tuning
 
+[tabs]
+====
+Java::
++
 [source,java]
 ----
 // For I/O-bound: use virtualThreadPerTask with high concurrency limit
@@ -705,6 +986,36 @@ from("seda:io-bound?virtualThreadPerTask=true&concurrentConsumers=1000")
 // For CPU-bound: stick with traditional model, tune pool size
 from("seda:cpu-bound?concurrentConsumers=4")  // ~number of CPU cores
 ----
+
+XML::
++
+[source,xml]
+----
+<!-- For I/O-bound: use virtualThreadPerTask with high concurrency limit -->
+<from uri="seda:io-bound?virtualThreadPerTask=true&amp;concurrentConsumers=1000"/>
+
+<!-- For CPU-bound: stick with traditional model, tune pool size -->
+<from uri="seda:cpu-bound?concurrentConsumers=4"/>
+----
+
+YAML::
++
+[source,yaml]
+----
+# For I/O-bound: use virtualThreadPerTask with high concurrency limit
+from:
+  uri: seda:io-bound
+  parameters:
+    virtualThreadPerTask: true
+    concurrentConsumers: 1000
+
+# For CPU-bound: stick with traditional model, tune pool size
+from:
+  uri: seda:cpu-bound
+  parameters:
+    concurrentConsumers: 4
+----
+====
 
 ==== Avoid Pinning
 
@@ -715,6 +1026,7 @@ Virtual threads "pin" to carrier threads when:
 
 Prefer `ReentrantLock` over `synchronized`:
 
+._Java-only: using ReentrantLock instead of synchronized to avoid pinning_
 [source,java]
 ----
 // Avoid: can pin virtual thread
@@ -768,6 +1080,7 @@ java -Djdk.tracePinnedThreads=short \
 
 === Example 1: High-Concurrency REST API
 
+._Java-only: RouteBuilder class for high-concurrency REST API with virtual threads_
 [source,java]
 ----
 public class RestApiRoute extends RouteBuilder {
@@ -792,6 +1105,7 @@ public class RestApiRoute extends RouteBuilder {
 
 === Example 2: Parallel Enrichment with Virtual Threads
 
+._Java-only: RouteBuilder class with programmatic executor service for parallel enrichment_
 [source,java]
 ----
 public class ParallelEnrichmentRoute extends RouteBuilder {
@@ -819,6 +1133,7 @@ public class ParallelEnrichmentRoute extends RouteBuilder {
 
 === Example 3: Context Propagation Within a Route
 
+._Java-only: RouteBuilder class demonstrating context propagation with exchange properties_
 [source,java]
 ----
 public class TenantAwareRoute extends RouteBuilder {

--- a/dsl/camel-java-joor-dsl/src/main/docs/java-joor-dsl.adoc
+++ b/dsl/camel-java-joor-dsl/src/main/docs/java-joor-dsl.adoc
@@ -21,6 +21,8 @@ which then are loaded via class loader and behaves as regular Java compiled rout
 
 The following `MyRoute.java` source file:
 
+._Java-only: Java DSL source file for runtime compilation_
+
 .MyRoute.java
 [source,java]
 ----

--- a/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
+++ b/dsl/camel-xml-io-dsl/src/main/docs/java-xml-io-dsl.adoc
@@ -25,6 +25,8 @@ You can use this in all of Camel's runtime such as Spring Boot, Quarkus, Camel M
 
 The following `my-route.xml` source file:
 
+._XML-only:_
+
 .my-route.xml
 [source,xml]
 ----


### PR DESCRIPTION
## Summary

Wave 2 of making Apache Camel component documentation multi-DSL friendly (CAMEL-23789).

- **50 files changed** across component docs, test docs, and language docs
- Adds Java/XML/YAML `[tabs]` blocks to route examples that can be expressed in all DSLs
- Adds `._Java-only: description_` markers to code blocks that are inherently Java-specific (test frameworks, programmatic APIs, language expressions, mock assertions)

### Highlights

**Multi-DSL tabs added** (~85 new tab blocks):
- `camel-pqc` (14 tab blocks) — post-quantum cryptography route examples
- `camel-mina-sftp` (22 tab blocks) — SFTP route examples
- `camel-spring-ai-chat` (12 tab blocks) — Spring AI chat route examples
- `camel-openai` (15 tab blocks) — OpenAI route examples
- `camel-mongodb` (5 tab blocks) — MongoDB route examples
- `camel-metrics` (2 tab blocks) — Metrics route examples
- Hazelcast variants: map, pncounter, atomicvalue, multimap, replicatedmap, ringbuffer, seda
- Google components: firestore, plus Java-only markers for vision, storage, functions, speech-to-text, text-to-speech
- Various small files: reactive-streams, spring-rabbitmq, spring-ws, csv-dataformat, and more

**Java-only markers added** (~170 blocks):
- Test frameworks: test-main-junit5/6, test-spring-junit5/6, test-junit5
- Language docs: java-language (17 blocks), joor-language (15 blocks), xpath-language (3 blocks)
- Mock component: 22 blocks (MockEndpoint assertion API)
- CXF component: 13 blocks (CXF programmatic APIs)
- Dynamic router: 13 blocks (JMX operations)
- Micrometer/Metrics: programmatic CamelContext configuration
- PQC: 50 blocks (key management, vault integration, advanced APIs)

**Bug fixes included:**
- Fixed incorrect XML header names in hazelcast-map docs (`hazelcast.operation.type` → `CamelHazelcastOperationType`)
- Fixed `[source,java]` tag on XML content in barcode-dataformat
- Normalized existing tab labels (`Java DSL::` → `Java::`, `Spring XML::` → `XML::`)
- Added YAML tabs to existing 2-tab blocks (Java+XML → Java+XML+YAML)

## Test plan

- [ ] CI passes (doc generation, AsciiDoc validation)
- [ ] Verify no unterminated listing blocks in generated docs
- [ ] Spot-check tabs render correctly on camel.apache.org

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)