### PR TITLE
CAMEL-23789: Replace Java constant references with string header names in component docs

### DIFF
--- a/components/camel-caffeine/src/main/docs/caffeine-cache-component.adoc
+++ b/components/camel-caffeine/src/main/docs/caffeine-cache-component.adoc
@@ -48,8 +48,8 @@ include::partial$component-endpoint-headers.adoc[]
 
 Each time you'll use an operation on the cache, you'll have two different headers to check for status:
 
-* `CaffeineConstants.ACTION_HAS_RESULT`
-* `CaffeineConstants.ACTION_SUCCEEDED`
+* `CamelCaffeineActionHasResult`
+* `CamelCaffeineActionSucceeded`
 
 == Examples
 

--- a/components/camel-camunda/src/main/docs/camunda-component.adoc
+++ b/components/camel-camunda/src/main/docs/camunda-component.adoc
@@ -297,7 +297,7 @@ Java::
 ----
 from("direct:deploy")
     .process(exchange -> {
-        exchange.getIn().setHeader(CamundaConstants.RESOURCE_NAME, "process.bpmn");
+        exchange.getIn().setHeader("CamelCamundaResourceName", "process.bpmn");
         exchange.getIn().setBody(content.getBytes());
     })
     .to("camunda://deployResource");
@@ -460,8 +460,8 @@ Java::
 ----
 from("camunda://worker?jobType=myJobType&timeout=20")
     .process(exchange -> {
-        exchange.getIn().setHeader(CamundaConstants.ERROR_CODE, "INVALID_DATA");
-        exchange.getIn().setHeader(CamundaConstants.ERROR_MESSAGE, "Data validation failed");
+        exchange.getIn().setHeader("CamelCamundaErrorCode", "INVALID_DATA");
+        exchange.getIn().setHeader("CamelCamundaErrorMessage", "Data validation failed");
     })
     .to("camunda://throwError");
 ----

--- a/components/camel-consul/src/main/docs/consul-component.adoc
+++ b/components/camel-consul/src/main/docs/consul-component.adoc
@@ -68,7 +68,7 @@ As an example, we will show how to use the `ConsulAgentProducer` to register a s
 
 Registering and unregistering are examples for possible actions against the Consul agent api.
 
-The desired action can be defined by setting the header `ConsulConstants.CONSUL_ACTION` to a value from the `ConsulXXXActions` interface of the respective Consul api. E.g.  `ConsulAgentActions` contains the actions for the agent api.
+The desired action can be defined by setting the header `CamelConsulAction` to a value from the respective Consul api.
 
 If you set `CONSUL_ACTION` to `ConsulAgentActions.REGISTER`, the agent action `REGISTER` will be executed.
 
@@ -88,7 +88,7 @@ from("direct:registerFooService")
         .address("localhost")
         .port(80)
         .build())
-    .setHeader(ConsulConstants.CONSUL_ACTION, constant(ConsulAgentActions.REGISTER))
+    .setHeader("CamelConsulAction", constant("REGISTER"))
     .to("consul:agent");
 ----
 

--- a/components/camel-crypto/src/main/docs/crypto-component.adoc
+++ b/components/camel-crypto/src/main/docs/crypto-component.adoc
@@ -69,10 +69,8 @@ crypto:sign:name[?options]
 crypto:verify:name[?options]
 ----
 
-* `crypto:sign` creates the signature and stores it in the Header keyed
-by the constant
-`org.apache.camel.component.crypto.DigitalSignatureConstants.SIGNATURE`,
-i.e., `"CamelDigitalSignature"`.
+* `crypto:sign` creates the signature and stores it in the header
+`CamelDigitalSignature`.
 * `crypto:verify` will read in the contents of this header and do the
 verification calculation.
 
@@ -290,13 +288,13 @@ then be dynamically enriched with the key of its target recipient prior
 to signing. To facilitate this, the signature mechanisms allow for keys
 to be supplied dynamically via the message headers below
 
-* `DigitalSignatureConstants.SIGNATURE_PRIVATE_KEY`, `"CamelSignaturePrivateKey"`
-* `DigitalSignatureConstants.SIGNATURE_PUBLIC_KEY_OR_CERT`, `"CamelSignaturePublicKeyOrCert"`
+* `CamelSignaturePrivateKey`
+* `CamelSignaturePublicKeyOrCert`
 
 Even better would be to dynamically supply a keystore alias. Again, the
 alias can be supplied in a message header
 
-* `DigitalSignatureConstants.KEYSTORE_ALIAS`, `"CamelSignatureKeyStoreAlias"`
+* `CamelSignatureKeyStoreAlias`
 
 The header would be set as follows:
 
@@ -402,12 +400,12 @@ kpGen.initialize(MLDSAParameterSpec.ml_dsa_65);
 KeyPair kp = kpGen.generateKeyPair();
 
 from("direct:sign")
-    .setHeader(DigitalSignatureConstants.SIGNATURE_PRIVATE_KEY, constant(kp.getPrivate()))
+    .setHeader("CamelSignaturePrivateKey", constant(kp.getPrivate()))
     .to("crypto:sign:pqc?algorithm=ML-DSA&provider=BC")
     .to("direct:verify");
 
 from("direct:verify")
-    .setHeader(DigitalSignatureConstants.SIGNATURE_PUBLIC_KEY_OR_CERT, constant(kp.getPublic()))
+    .setHeader("CamelSignaturePublicKeyOrCert", constant(kp.getPublic()))
     .to("crypto:verify:pqc?algorithm=ML-DSA&provider=BC")
     .to("mock:result");
 ----

--- a/components/camel-cyberark-vault/src/main/docs/cyberark-vault-component.adoc
+++ b/components/camel-cyberark-vault/src/main/docs/cyberark-vault-component.adoc
@@ -301,7 +301,7 @@ Java::
 [source,java]
 ----
 from("direct:start")
-    .setHeader(CyberArkVaultConstants.SECRET_ID, simple("${header.secretName}"))
+    .setHeader("CamelCyberArkVaultSecretId", simple("${header.secretName}"))
     .to("cyberark-vault:secret?operation=getSecret&url=https://conjur.example.com&account=myaccount&username=admin&password=secretpass")
     .log("Retrieved secret: ${body}");
 ----
@@ -353,7 +353,7 @@ Java::
 [source,java]
 ----
 from("direct:start")
-    .setHeader(CyberArkVaultConstants.SECRET_VERSION, constant("3"))
+    .setHeader("CamelCyberArkVaultSecretVersion", constant("3"))
     .to("cyberark-vault:secret?secretId=db/password&url=https://conjur.example.com&account=myaccount&username=admin&apiKey=3ahx8dy3...")
     .log("Retrieved secret version 3: ${body}");
 ----
@@ -461,8 +461,8 @@ Java::
 [source,java]
 ----
 from("direct:start")
-    .setHeader(CyberArkVaultConstants.SECRET_VALUE, constant("myNewPassword"))
-    .setHeader(CyberArkVaultConstants.SECRET_ID, constant("db/password"))
+    .setHeader("CamelCyberArkVaultSecretValue", constant("myNewPassword"))
+    .setHeader("CamelCyberArkVaultSecretId", constant("db/password"))
     .to("cyberark-vault:secret?operation=createSecret&url=https://conjur.example.com&account=myaccount&username=admin&apiKey=3ahx8dy3...")
     .log("Secret created/updated");
 ----
@@ -521,7 +521,7 @@ Java::
 ----
 from("direct:start")
     .setBody(simple("${header.newSecretValue}"))
-    .setHeader(CyberArkVaultConstants.SECRET_ID, simple("${header.secretPath}"))
+    .setHeader("CamelCyberArkVaultSecretId", simple("${header.secretPath}"))
     .to("cyberark-vault:secret?operation=createSecret&url=https://conjur.example.com&account=myaccount&username=admin&apiKey=3ahx8dy3...")
     .log("Secret ${header.secretPath} created/updated");
 ----

--- a/components/camel-digitalocean/src/main/docs/digitalocean-component.adoc
+++ b/components/camel-digitalocean/src/main/docs/digitalocean-component.adoc
@@ -377,13 +377,13 @@ ou can find the per-method limits in the https://developers.digitalocean.com/doc
 
 == Examples
 
-._Java-only: requires Java enum DigitalOceanOperations.get_
+._Java-only: get account info_
 
 .Get your account info
 [source,java]
 ----
 from("direct:getAccountInfo")
-    .setHeader("CamelDigitalOceanOperation", constant(DigitalOceanOperations.get))
+    .setHeader("CamelDigitalOceanOperation", constant("get"))
     .to("digitalocean:account?oAuthToken=XXXXXX")
 ----
 

--- a/components/camel-elasticsearch/src/main/docs/elasticsearch-component.adoc
+++ b/components/camel-elasticsearch/src/main/docs/elasticsearch-component.adoc
@@ -94,7 +94,7 @@ You can set the indexId by setting the message header with
 the key "indexId". Be aware of the fact that unlike the component _camel-elasticsearch-rest_, by default, the expected content of
 an update request must be the same as what the https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html[Update API expects], consequently
 if you want to update one part of an existing document, you need to embed the content to update into a "doc" object. To change the default behavior, it is possible
-to configure it globally at the component level thanks to the option _enableDocumentOnlyMode_ or by request by setting the header _ElasticsearchConstants.PARAM_DOCUMENT_MODE_ to true.
+to configure it globally at the component level thanks to the option _enableDocumentOnlyMode_ or by request by setting the header `CamelElasticsearchEnableDocumentOnlyMode` to true.
 |Ping |None  |Pings the Elasticsearch cluster and returns true if the ping succeeded, false otherwise
 
 |===

--- a/components/camel-geocoder/src/main/docs/geocoder-component.adoc
+++ b/components/camel-geocoder/src/main/docs/geocoder-component.adoc
@@ -114,7 +114,7 @@ Copenhagen, Denmark we can send a message with a headers as shown:
 ._Java-only: overriding the address via a message header_
 [source,java]
 ----
-template.sendBodyAndHeader("direct:start", "Hello", GeoCoderConstants.ADDRESS, "Copenhagen, Denmark");
+template.sendBodyAndHeader("direct:start", "Hello", "CamelGeoCoderAddress", "Copenhagen, Denmark");
 ----
 
 To get the address for a latitude and longitude we can do:

--- a/components/camel-git/src/main/docs/git-component.adoc
+++ b/components/camel-git/src/main/docs/git-component.adoc
@@ -57,9 +57,9 @@ then pushes it to remote repository.
 [source,java]
 ----
 from("direct:start")
-    .setHeader(GitConstants.GIT_FILE_NAME, constant("test.java"))
+    .setHeader("CamelGitFilename", constant("test.java"))
     .to("git:///tmp/testRepo?operation=add")
-    .setHeader(GitConstants.GIT_COMMIT_MESSAGE, constant("first commit"))
+    .setHeader("CamelGitCommitMessage", constant("first commit"))
     .to("git:///tmp/testRepo?operation=commit")
     .to("git:///tmp/testRepo?operation=push&remotePath=https://foo.com/test/test.git&username=xxx&password=xxx")
     .to("git:///tmp/testRepo?operation=createTag&tagName=myTag")

--- a/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-atomicvalue-component.adoc
@@ -56,8 +56,8 @@ Java::
 [source,java]
 ----
 from("direct:set")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.SET_VALUE))
-    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("setValue"))
+    .to("hazelcast-atomicvalue:foo");
 ----
 
 XML::
@@ -101,8 +101,8 @@ Java::
 [source,java]
 ----
 from("direct:get")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("get"))
+    .to("hazelcast-atomicvalue:foo");
 ----
 
 XML::
@@ -146,8 +146,8 @@ Java::
 [source,java]
 ----
 from("direct:increment")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
-    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("increment"))
+    .to("hazelcast-atomicvalue:foo");
 ----
 
 XML::
@@ -191,8 +191,8 @@ Java::
 [source,java]
 ----
 from("direct:decrement")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
-    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("decrement"))
+    .to("hazelcast-atomicvalue:foo");
 ----
 
 XML::
@@ -236,8 +236,8 @@ Java::
 [source,java]
 ----
 from("direct:destroy")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
-    .toF("hazelcast-%sfoo", HazelcastConstants.ATOMICNUMBER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("destroy"))
+    .to("hazelcast-atomicvalue:foo");
 ----
 
 XML::

--- a/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-map-component.adoc
@@ -53,7 +53,7 @@ You can call the samples with:
 ._Java-only: calling producer operations using ProducerTemplate_
 [source,java]
 ----
-template.sendBodyAndHeader("direct:[put|get|update|delete|query|evict]", "my-foo", HazelcastConstants.OBJECT_ID, "4711");
+template.sendBodyAndHeader("direct:[put|get|update|delete|query|evict]", "my-foo", "CamelHazelcastObjectId", "4711");
 ----
 
 === Example for *put*:
@@ -65,8 +65,8 @@ Java::
 [source,java]
 ----
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
-.toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
+.setHeader("CamelHazelcastOperationType", constant("put"))
+.to("hazelcast-map:foo");
 ----
 
 XML::
@@ -107,10 +107,10 @@ Java::
 [source,java]
 ----
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
-.setHeader(HazelcastConstants.TTL_VALUE, constant(Long.valueOf(1)))
-.setHeader(HazelcastConstants.TTL_UNIT, constant(TimeUnit.MINUTES))
-.toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
+.setHeader("CamelHazelcastOperationType", constant("put"))
+.setHeader("CamelHazelcastObjectTtlValue", constant(Long.valueOf(1)))
+.setHeader("CamelHazelcastObjectTtlUnit", constant(TimeUnit.MINUTES))
+.to("hazelcast-map:foo");
 ----
 
 XML::
@@ -163,8 +163,8 @@ Java::
 [source,java]
 ----
 from("direct:get")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-.toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX)
+.setHeader("CamelHazelcastOperationType", constant("get"))
+.to("hazelcast-map:foo")
 .to("seda:out");
 ----
 
@@ -209,8 +209,8 @@ Java::
 [source,java]
 ----
 from("direct:update")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.UPDATE))
-.toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
+.setHeader("CamelHazelcastOperationType", constant("update"))
+.to("hazelcast-map:foo");
 ----
 
 XML::
@@ -251,8 +251,8 @@ Java::
 [source,java]
 ----
 from("direct:delete")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
-.toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX);
+.setHeader("CamelHazelcastOperationType", constant("delete"))
+.to("hazelcast-map:foo");
 ----
 
 XML::
@@ -293,8 +293,8 @@ Java::
 [source,java]
 ----
 from("direct:query")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.QUERY))
-.toF("hazelcast-%sfoo", HazelcastConstants.MAP_PREFIX)
+.setHeader("CamelHazelcastOperationType", constant("query"))
+.to("hazelcast-map:foo")
 .to("seda:out");
 ----
 
@@ -337,7 +337,7 @@ distributed map.
 [source,java]
 ----
 String q1 = "bar > 1000";
-template.sendBodyAndHeader("direct:query", null, HazelcastConstants.QUERY, q1);
+template.sendBodyAndHeader("direct:query", null, "CamelHazelcastQuery", q1);
 ----
 
 

--- a/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-multimap-component.adoc
@@ -51,8 +51,8 @@ Java::
 [source,java]
 ----
 from("direct:put")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
-    .to(String.format("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX));
+    .setHeader("CamelHazelcastOperationType", constant("put"))
+    .to("hazelcast-multimap:bar");
 ----
 
 XML::
@@ -94,8 +94,8 @@ Java::
 [source,java]
 ----
 from("direct:removevalue")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
-    .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("removeValue"))
+    .to("hazelcast-multimap:bar");
 ----
 
 XML::
@@ -142,8 +142,8 @@ Java::
 [source,java]
 ----
 from("direct:get")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-    .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX)
+    .setHeader("CamelHazelcastOperationType", constant("get"))
+    .to("hazelcast-multimap:bar")
     .to("seda:out");
 ----
 
@@ -189,8 +189,8 @@ Java::
 [source,java]
 ----
 from("direct:delete")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
-    .toF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("delete"))
+    .to("hazelcast-multimap:bar");
 ----
 
 XML::
@@ -228,7 +228,7 @@ You can call them in your test class with:
 ._Java-only: uses ProducerTemplate API and Java constants_
 [source,java]
 ----
-template.sendBodyAndHeader("direct:[put|get|removevalue|delete]", "my-foo", HazelcastConstants.OBJECT_ID, "4711");
+template.sendBodyAndHeader("direct:[put|get|removevalue|delete]", "my-foo", "CamelHazelcastObjectId", "4711");
 ----
 
 == multimap cache consumer - from("hazelcast-multimap:foo")

--- a/components/camel-hazelcast/src/main/docs/hazelcast-pncounter-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-pncounter-component.adoc
@@ -49,8 +49,8 @@ Java::
 [source,java]
 ----
 from("direct:increment")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.INCREMENT))
-    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("increment"))
+    .to("hazelcast-pncounter:foo");
 ----
 
 XML::
@@ -93,8 +93,8 @@ Java::
 [source,java]
 ----
 from("direct:decrement")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DECREMENT))
-    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("decrement"))
+    .to("hazelcast-pncounter:foo");
 ----
 
 XML::
@@ -137,8 +137,8 @@ Java::
 [source,java]
 ----
 from("direct:get")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("get"))
+    .to("hazelcast-pncounter:foo");
 ----
 
 XML::
@@ -182,8 +182,8 @@ Java::
 [source,java]
 ----
 from("direct:getAndAdd")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET_AND_ADD))
-    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("getAndAdd"))
+    .to("hazelcast-pncounter:foo");
 ----
 
 XML::
@@ -229,8 +229,8 @@ Java::
 [source,java]
 ----
 from("direct:destroy")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DESTROY))
-    .toF("hazelcast-%sfoo", HazelcastConstants.PNCOUNTER_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("destroy"))
+    .to("hazelcast-pncounter:foo");
 ----
 
 XML::

--- a/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-queue-component.adoc
@@ -52,7 +52,7 @@ Java::
 [source,java]
 ----
 from("direct:add")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD))
+    .setHeader("CamelHazelcastOperationType", constant("add"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -94,7 +94,7 @@ Java::
 [source,java]
 ----
 from("direct:put")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
+    .setHeader("CamelHazelcastOperationType", constant("put"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -136,7 +136,7 @@ Java::
 [source,java]
 ----
 from("direct:poll")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.POLL))
+    .setHeader("CamelHazelcastOperationType", constant("poll"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -178,7 +178,7 @@ Java::
 [source,java]
 ----
 from("direct:peek")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PEEK))
+    .setHeader("CamelHazelcastOperationType", constant("peek"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -220,7 +220,7 @@ Java::
 [source,java]
 ----
 from("direct:offer")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.OFFER))
+    .setHeader("CamelHazelcastOperationType", constant("offer"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -262,7 +262,7 @@ Java::
 [source,java]
 ----
 from("direct:removevalue")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_VALUE))
+    .setHeader("CamelHazelcastOperationType", constant("removeValue"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -304,7 +304,7 @@ Java::
 [source,java]
 ----
 from("direct:remaining-capacity")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMAINING_CAPACITY))
+    .setHeader("CamelHazelcastOperationType", constant("remainingCapacity"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -346,7 +346,7 @@ Java::
 [source,java]
 ----
 from("direct:removeAll")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_ALL))
+    .setHeader("CamelHazelcastOperationType", constant("removeAll"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -388,7 +388,7 @@ Java::
 [source,java]
 ----
 from("direct:removeIf")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.REMOVE_IF))
+    .setHeader("CamelHazelcastOperationType", constant("removeIf"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -430,7 +430,7 @@ Java::
 [source,java]
 ----
 from("direct:drainTo")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DRAIN_TO))
+    .setHeader("CamelHazelcastOperationType", constant("drainTo"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -472,7 +472,7 @@ Java::
 [source,java]
 ----
 from("direct:take")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.TAKE))
+    .setHeader("CamelHazelcastOperationType", constant("take"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -514,7 +514,7 @@ Java::
 [source,java]
 ----
 from("direct:retainAll")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.RETAIN_ALL))
+    .setHeader("CamelHazelcastOperationType", constant("retainAll"))
     .to("hazelcast-queue:bar");
 ----
 
@@ -611,10 +611,10 @@ Java::
 from("hazelcast-queue:mm")
     .log("object...")
     .choice()
-        .when(header(HazelcastConstants.LISTENER_ACTION).isEqualTo(HazelcastConstants.ADDED))
+        .when(header("CamelHazelcastListenerAction").isEqualTo("added"))
             .log("...added")
             .to("mock:added")
-        .when(header(HazelcastConstants.LISTENER_ACTION).isEqualTo(HazelcastConstants.REMOVED))
+        .when(header("CamelHazelcastListenerAction").isEqualTo("removed"))
             .log("...removed")
             .to("mock:removed")
         .otherwise()

--- a/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-replicatedmap-component.adoc
@@ -46,8 +46,8 @@ Java::
 [source,java]
 ----
 from("direct:put")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.PUT))
-    .to(String.format("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX));
+    .setHeader("CamelHazelcastOperationType", constant("put"))
+    .to("hazelcast-replicatedmap:bar");
 ----
 
 XML::
@@ -89,8 +89,8 @@ Java::
 [source,java]
 ----
 from("direct:get")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.GET))
-    .toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX)
+    .setHeader("CamelHazelcastOperationType", constant("get"))
+    .to("hazelcast-replicatedmap:bar")
     .to("seda:out");
 ----
 
@@ -136,8 +136,8 @@ Java::
 [source,java]
 ----
 from("direct:delete")
-    .setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.DELETE))
-    .toF("hazelcast-%sbar", HazelcastConstants.REPLICATEDMAP_PREFIX);
+    .setHeader("CamelHazelcastOperationType", constant("delete"))
+    .to("hazelcast-replicatedmap:bar");
 ----
 
 XML::
@@ -175,7 +175,7 @@ You can call them in your test class with:
 ._Java-only: uses ProducerTemplate API and Java constants_
 [source,java]
 ----
-template.sendBodyAndHeader("direct:[put|get|delete|clear]", "my-foo", HazelcastConstants.OBJECT_ID, "4711");
+template.sendBodyAndHeader("direct:[put|get|delete|clear]", "my-foo", "CamelHazelcastObjectId", "4711");
 ----
 
 == replicatedmap cache consumer
@@ -188,16 +188,16 @@ Here is a sample:
 ._Java-only: uses Java constants, string formatting, and choice/when/otherwise_
 [source,java]
 ----
-fromF("hazelcast-%sbar", HazelcastConstants.MULTIMAP_PREFIX)
+from("hazelcast-multimap:bar")
 .log("object...")
 .choice()
-    .when(header(HazelcastConstants.LISTENER_ACTION).isEqualTo(HazelcastConstants.ADDED))
+    .when(header("CamelHazelcastListenerAction").isEqualTo("added"))
         .log("...added")
                 .to("mock:added")
-        //.when(header(HazelcastConstants.LISTENER_ACTION).isEqualTo(HazelcastConstants.ENVICTED))
+        //.when(header("CamelHazelcastListenerAction").isEqualTo("envicted"))
         //        .log("...envicted")
         //        .to("mock:envicted")
-        .when(header(HazelcastConstants.LISTENER_ACTION).isEqualTo(HazelcastConstants.REMOVED))
+        .when(header("CamelHazelcastListenerAction").isEqualTo("removed"))
                 .log("...removed")
                 .to("mock:removed")
         .otherwise()

--- a/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
+++ b/components/camel-hazelcast/src/main/docs/hazelcast-ringbuffer-component.adoc
@@ -45,8 +45,8 @@ Java::
 [source,java]
 ----
 from("direct:put")
-.setHeader(HazelcastConstants.OPERATION, constant(HazelcastOperation.ADD))
-.to(String.format("hazelcast-%sbar", HazelcastConstants.RINGBUFFER_PREFIX));
+.setHeader("CamelHazelcastOperationType", constant("add"))
+.to("hazelcast-ringbuffer:bar");
 ----
 
 XML::

--- a/components/camel-hl7/src/main/docs/hl7terser-language.adoc
+++ b/components/camel-hl7/src/main/docs/hl7terser-language.adoc
@@ -154,7 +154,7 @@ import ca.uhn.hl7v2.AcknowledgmentCode;
 import ca.uhn.hl7v2.ErrorCode;
 
 // In process block
-exchange.setProperty(MllpConstants.MLLP_ACKNOWLEDGEMENT,
+exchange.setProperty("CamelMllpAcknowledgement",
   ack(AcknowledgmentCode.AR, "Server didn't accept this message", ErrorCode.UNKNOWN_KEY_IDENTIFIER).evaluate(exchange, Object.class)
 ----
 

--- a/components/camel-ignite/src/main/docs/ignite-cache-component.adoc
+++ b/components/camel-ignite/src/main/docs/ignite-cache-component.adoc
@@ -18,9 +18,9 @@
 The Ignite Cache endpoint is one of camel-ignite endpoints that allow you to interact with an https://apacheignite.readme.io/docs/data-grid[Ignite Cache].
 This offers both a Producer (to invoke cache operations on an Ignite cache) and a Consumer (to consume changes from a continuous query).
 
-The cache value is always the body of the message, whereas the cache key is always stored in the `IgniteConstants.IGNITE_CACHE_KEY` message header.
+The cache value is always the body of the message, whereas the cache key is always stored in the `CamelIgniteCacheKey` message header.
 
-Even if you configure a fixed operation in the endpoint URI, you can vary it per-exchange by setting the `IgniteConstants.IGNITE_CACHE_OPERATION` message header.
+Even if you configure a fixed operation in the endpoint URI, you can vary it per-exchange by setting the `CamelIgniteCacheOperation` message header.
 
 // component options: START
 include::partial$component-configure-options.adoc[]

--- a/components/camel-influxdb/src/main/docs/influxdb-component.adoc
+++ b/components/camel-influxdb/src/main/docs/influxdb-component.adoc
@@ -18,7 +18,7 @@ This component allows you to interact with https://influxdata.com/time-series-pl
 a time series database.
 
 The native body type for this component is `Point` (the native influxdb class).
-However, it can also accept `Map<String, Object>` as message body, and it will get converted to `Point.class`, please note that the map must contain an element with `InfluxDbConstants.MEASUREMENT_NAME` as key.
+However, it can also accept `Map<String, Object>` as message body, and it will get converted to `Point.class`, please note that the map must contain an element with `camelInfluxDB.MeasurementName` as key.
 
 Additionally, you may register your own Converters to your data type to `Point`, or use the
 (un)marshalling tools provided by Camel.

--- a/components/camel-influxdb2/src/main/docs/influxdb2-component.adoc
+++ b/components/camel-influxdb2/src/main/docs/influxdb2-component.adoc
@@ -17,7 +17,7 @@
 This component allows you to interact with https://influxdata.com/time-series-platform/influxdb/[InfluxDB] 2.x,
 a time series database.
 The native body type for this component is `Point` (the native InfluxDB class).
-However, it can also accept `Map<String, Object>` as message body, and it will get converted to `Point.class`, please note that the map must contain an element with `InfluxDbConstants.MEASUREMENT_NAME` as key.
+However, it can also accept `Map<String, Object>` as message body, and it will get converted to `Point.class`, please note that the map must contain an element with `camelInfluxDB.MeasurementName` as key.
 
 Additionally, you may register your own Converters to your data type to `Point`, or use the (un)marshalling tools provided by Camel.
 

--- a/components/camel-jaxb/src/main/docs/jaxb-dataformat.adoc
+++ b/components/camel-jaxb/src/main/docs/jaxb-dataformat.adoc
@@ -98,24 +98,23 @@ need to unmarshall only part of the tree.
 
 In that case, you can use partial unmarshalling. To enable this
 behavior, you need set property `partClass` on the `JaxbDataFormat`. Camel will pass this class
-to the JAXB unmarshaller. If `JaxbConstants.JAXB_PART_CLASS` is set as
+to the JAXB unmarshaller. If `CamelJaxbPartClass` is set as
 one of the exchange headers, its value is used to override the `partClass` property
 on the `JaxbDataFormat`.
 
 For marshalling you have to add the `partNamespace` attribute with the `QName` of
 the destination namespace.
 
-If `JaxbConstants.JAXB_PART_NAMESPACE` is set as
+If `CamelJaxbPartNamespace` is set as
 one of the exchange headers, its value is used to override the `partNamespace` property
 on the `JaxbDataFormat`.
 
-While setting `partNamespace` through `JaxbConstants.JAXB_PART_NAMESPACE`, please
+While setting `partNamespace` through the `CamelJaxbPartNamespace` header, please
 note that you need to specify its value in the format `\{namespaceUri\}localPart`, as per the example below.
 
-._Java-only: Java constant reference_
 [source,java]
 ----
-.setHeader(JaxbConstants.JAXB_PART_NAMESPACE, constant("{http://www.camel.apache.org/jaxb/example/address/1}address"));
+.setHeader("CamelJaxbPartNamespace", constant("{http://www.camel.apache.org/jaxb/example/address/1}address"));
 ----
 
 === Fragment

--- a/components/camel-jcr/src/main/docs/jcr-component.adoc
+++ b/components/camel-jcr/src/main/docs/jcr-component.adoc
@@ -64,7 +64,7 @@ Java::
 +
 [source,java]
 ----
-from("direct:a").setHeader(JcrConstants.JCR_NODE_NAME, constant("node"))
+from("direct:a").setHeader("CamelJcrNodeName", constant("node"))
     .setHeader("my.contents.property", body())
     .to("jcr://user:pass@repository/home/test");
 ----
@@ -75,7 +75,7 @@ XML::
 ----
 <route>
     <from uri="direct:a"/>
-    <setHeader name="JcrConstants.JCR_NODE_NAME">
+    <setHeader name="CamelJcrNodeName">
         <constant>node</constant>
     </setHeader>
     <setHeader name="my.contents.property">
@@ -94,7 +94,7 @@ YAML::
       uri: direct:a
       steps:
         - setHeader:
-            name: JcrConstants.JCR_NODE_NAME
+            name: CamelJcrNodeName
             expression:
               constant:
                 expression: node

--- a/components/camel-jms/src/main/docs/jms-component.adoc
+++ b/components/camel-jms/src/main/docs/jms-component.adoc
@@ -1275,7 +1275,7 @@ reacts.
 If you want to use a per message timeout value, you can set the header
 `CamelJmsRequestTimeout` with a timeout value as a long type.
 
-TIP: In Java code, you can use the constant `JmsConstants.JMS_REQUEST_TIMEOUT` for the header name.
+TIP: The header name is `CamelJmsRequestTimeout`.
 
 For example, we can use a bean to compute the timeout value per
 individual message, such as calling the `"whatIsTheTimeout"` method on

--- a/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
+++ b/components/camel-jsonpath/src/main/docs/jsonpath-language.adoc
@@ -333,8 +333,7 @@ detected automatically, if the document is encoded in unicode (UTF-8,
 UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE) as specified in RFC-4627.
 If the encoding is a non-unicode encoding, you can either make sure that
 you enter the document in String format to JSONPath, or you
-can specify the encoding in the header `CamelJsonPathJsonEncoding` which
-is defined as a constant in: `JsonpathConstants.HEADER_JSON_ENCODING`.
+can specify the encoding in the header `CamelJsonPathJsonEncoding`.
 
 === Split JSON data into sub rows as JSON
 

--- a/components/camel-jt400/src/main/docs/jt400-component.adoc
+++ b/components/camel-jt400/src/main/docs/jt400-component.adoc
@@ -318,7 +318,7 @@ YAML::
 ----
 from("jt400://username:password@localhost/qsys.lib/qusrsys.lib/myq.msgq?sendingReply=true")
 .choice()
-    .when(header(Jt400Constants.MESSAGE_TYPE).isEqualTo(AS400Message.INQUIRY))
+    .when(header("CamelJt400MessageType").isEqualTo(AS400Message.INQUIRY))
         .process((exchange) -> {
             String reply = // insert reply logic here
             exchange.getIn().setBody(reply);

--- a/components/camel-kafka/src/main/docs/kafka-component.adoc
+++ b/components/camel-kafka/src/main/docs/kafka-component.adoc
@@ -49,7 +49,7 @@ For more information about Producer/Consumer configuration:
 http://kafka.apache.org/documentation.html#newconsumerconfigs[http://kafka.apache.org/documentation.html#newconsumerconfigs]
 http://kafka.apache.org/documentation.html#producerconfigs[http://kafka.apache.org/documentation.html#producerconfigs]
 
-If you want to send a message to a dynamic topic then use `KafkaConstants.OVERRIDE_TOPIC` as it is used as a one-time header that is not sent along the message, and actually is removed in the producer.
+If you want to send a message to a dynamic topic then use the `CamelKafkaOverrideTopic` header as it is used as a one-time header that is not sent along the message, and actually is removed in the producer.
 
 == Usage
 
@@ -299,7 +299,7 @@ public void process(Exchange exchange) {
 }
 ----
 
-TIP: The header name `CamelKafkaManualCommit` is also available as the constant `KafkaConstants.MANUAL_COMMIT`.
+TIP: The header name is `CamelKafkaManualCommit`.
 
 The `KafkaManualCommit` will force a synchronous commit which will block until the commit is acknowledged on Kafka, or if it fails an exception is thrown.
 You can use an asynchronous commit as well by configuring the `KafkaManualCommitFactory` with the `DefaultKafkaManualAsyncCommitFactory` implementation.
@@ -1498,7 +1498,7 @@ YAML::
 ----
 ====
 
-TIP: In Java, you can use the constant `KafkaConstants.KEY` instead of the string `"CamelKafkaKey"`.
+TIP: The header name is `CamelKafkaKey`.
 
 === SSL configuration
 

--- a/components/camel-keycloak/src/main/docs/keycloak-component.adoc
+++ b/components/camel-keycloak/src/main/docs/keycloak-component.adoc
@@ -173,15 +173,15 @@ Java::
 ----
 // Create a new realm
 template.sendBodyAndHeader("keycloak:admin?operation=createRealm", null,
-    KeycloakConstants.REALM_NAME, "my-new-realm");
+    "CamelKeycloakRealmName", "my-new-realm");
 
 // Get realm information
 template.sendBodyAndHeader("keycloak:admin?operation=getRealm", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 
 // Delete a realm
 template.sendBodyAndHeader("keycloak:admin?operation=deleteRealm", null,
-    KeycloakConstants.REALM_NAME, "my-old-realm");
+    "CamelKeycloakRealmName", "my-old-realm");
 ----
 ====
 
@@ -195,18 +195,18 @@ Java::
 ----
 // Create a new user
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.REALM_NAME, "my-realm");
-headers.put(KeycloakConstants.USERNAME, "john.doe");
-headers.put(KeycloakConstants.USER_EMAIL, "john.doe@example.com");
-headers.put(KeycloakConstants.USER_FIRST_NAME, "John");
-headers.put(KeycloakConstants.USER_LAST_NAME, "Doe");
+headers.put("CamelKeycloakRealmName", "my-realm");
+headers.put("CamelKeycloakUsername", "john.doe");
+headers.put("CamelKeycloakUserEmail", "john.doe@example.com");
+headers.put("CamelKeycloakUserFirstName", "John");
+headers.put("CamelKeycloakUserLastName", "Doe");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createUser", null, headers);
 
 // Set user password
 Map<String, Object> passwordHeaders = new HashMap<>();
-passwordHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-passwordHeaders.put(KeycloakConstants.USERNAME, "john.doe");
+passwordHeaders.put("CamelKeycloakRealmName", "my-realm");
+passwordHeaders.put("CamelKeycloakUsername", "john.doe");
 passwordHeaders.put("CamelKeycloakUserPassword", "secure-password");
 passwordHeaders.put("CamelKeycloakUserPasswordTemporary", false);
 
@@ -214,12 +214,12 @@ template.sendBodyAndHeaders("keycloak:admin?operation=setUserPassword", null, pa
 
 // List all users in realm
 template.sendBodyAndHeader("keycloak:admin?operation=listUsers", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 
 // Delete a user
 Map<String, Object> deleteHeaders = new HashMap<>();
-deleteHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-deleteHeaders.put(KeycloakConstants.USERNAME, "john.doe");
+deleteHeaders.put("CamelKeycloakRealmName", "my-realm");
+deleteHeaders.put("CamelKeycloakUsername", "john.doe");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteUser", null, deleteHeaders);
 ----
@@ -235,31 +235,31 @@ Java::
 ----
 // Create a new role
 Map<String, Object> roleHeaders = new HashMap<>();
-roleHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-roleHeaders.put(KeycloakConstants.ROLE_NAME, "manager");
-roleHeaders.put(KeycloakConstants.ROLE_DESCRIPTION, "Manager role with elevated privileges");
+roleHeaders.put("CamelKeycloakRealmName", "my-realm");
+roleHeaders.put("CamelKeycloakRoleName", "manager");
+roleHeaders.put("CamelKeycloakRoleDescription", "Manager role with elevated privileges");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createRole", null, roleHeaders);
 
 // Get role information
 Map<String, Object> getRoleHeaders = new HashMap<>();
-getRoleHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-getRoleHeaders.put(KeycloakConstants.ROLE_NAME, "manager");
+getRoleHeaders.put("CamelKeycloakRealmName", "my-realm");
+getRoleHeaders.put("CamelKeycloakRoleName", "manager");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=getRole", null, getRoleHeaders);
 
 // Assign role to user
 Map<String, Object> assignHeaders = new HashMap<>();
-assignHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-assignHeaders.put(KeycloakConstants.USERNAME, "john.doe");
-assignHeaders.put(KeycloakConstants.ROLE_NAME, "manager");
+assignHeaders.put("CamelKeycloakRealmName", "my-realm");
+assignHeaders.put("CamelKeycloakUsername", "john.doe");
+assignHeaders.put("CamelKeycloakRoleName", "manager");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=assignRoleToUser", null, assignHeaders);
 
 // Delete a role
 Map<String, Object> deleteRoleHeaders = new HashMap<>();
-deleteRoleHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-deleteRoleHeaders.put(KeycloakConstants.ROLE_NAME, "old-role");
+deleteRoleHeaders.put("CamelKeycloakRealmName", "my-realm");
+deleteRoleHeaders.put("CamelKeycloakRoleName", "old-role");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteRole", null, deleteRoleHeaders);
 ----
@@ -370,7 +370,7 @@ Java::
 ----
 // Create a new client
 Map<String, Object> clientHeaders = new HashMap<>();
-clientHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
+clientHeaders.put("CamelKeycloakRealmName", "my-realm");
 clientHeaders.put("CamelKeycloakClientId", "my-service-client");
 clientHeaders.put("CamelKeycloakClientSecretRequired", true);
 clientHeaders.put("CamelKeycloakClientDirectAccessGrantsEnabled", true);
@@ -379,14 +379,14 @@ template.sendBodyAndHeaders("keycloak:admin?operation=createClient", null, clien
 
 // Get client information
 Map<String, Object> getClientHeaders = new HashMap<>();
-getClientHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
+getClientHeaders.put("CamelKeycloakRealmName", "my-realm");
 getClientHeaders.put("CamelKeycloakClientId", "my-service-client");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=getClient", null, getClientHeaders);
 
 // Get client secret
 Map<String, Object> secretHeaders = new HashMap<>();
-secretHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
+secretHeaders.put("CamelKeycloakRealmName", "my-realm");
 secretHeaders.put("CamelKeycloakClientId", "my-service-client");
 
 String clientSecret = template.requestBodyAndHeaders("keycloak:admin?operation=getClientSecret",
@@ -394,7 +394,7 @@ String clientSecret = template.requestBodyAndHeaders("keycloak:admin?operation=g
 
 // Delete a client
 Map<String, Object> deleteClientHeaders = new HashMap<>();
-deleteClientHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
+deleteClientHeaders.put("CamelKeycloakRealmName", "my-realm");
 deleteClientHeaders.put("CamelKeycloakClientId", "old-client");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteClient", null, deleteClientHeaders);
@@ -502,34 +502,34 @@ Java::
 ----
 // Create a new group
 Map<String, Object> groupHeaders = new HashMap<>();
-groupHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-groupHeaders.put(KeycloakConstants.GROUP_NAME, "developers");
+groupHeaders.put("CamelKeycloakRealmName", "my-realm");
+groupHeaders.put("CamelKeycloakGroupName", "developers");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createGroup", null, groupHeaders);
 
 // List all groups
 template.sendBodyAndHeader("keycloak:admin?operation=listGroups", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 
 // Add user to group
 Map<String, Object> addToGroupHeaders = new HashMap<>();
-addToGroupHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-addToGroupHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-addToGroupHeaders.put(KeycloakConstants.GROUP_ID, "group-id-456");
+addToGroupHeaders.put("CamelKeycloakRealmName", "my-realm");
+addToGroupHeaders.put("CamelKeycloakUserId", "user-id-123");
+addToGroupHeaders.put("CamelKeycloakGroupId", "group-id-456");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=addUserToGroup", null, addToGroupHeaders);
 
 // List user's groups
 Map<String, Object> userGroupsHeaders = new HashMap<>();
-userGroupsHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-userGroupsHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+userGroupsHeaders.put("CamelKeycloakRealmName", "my-realm");
+userGroupsHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=listUserGroups", null, userGroupsHeaders);
 
 // Delete a group
 Map<String, Object> deleteGroupHeaders = new HashMap<>();
-deleteGroupHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-deleteGroupHeaders.put(KeycloakConstants.GROUP_ID, "group-id-456");
+deleteGroupHeaders.put("CamelKeycloakRealmName", "my-realm");
+deleteGroupHeaders.put("CamelKeycloakGroupId", "group-id-456");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteGroup", null, deleteGroupHeaders);
 ----
@@ -630,19 +630,19 @@ Java::
 ----
 // Reset user password
 Map<String, Object> passwordHeaders = new HashMap<>();
-passwordHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-passwordHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-passwordHeaders.put(KeycloakConstants.USER_PASSWORD, "newSecurePassword123!");
-passwordHeaders.put(KeycloakConstants.PASSWORD_TEMPORARY, false); // User won't need to change password
+passwordHeaders.put("CamelKeycloakRealmName", "my-realm");
+passwordHeaders.put("CamelKeycloakUserId", "user-id-123");
+passwordHeaders.put("CamelKeycloakUserPassword", "newSecurePassword123!");
+passwordHeaders.put("CamelKeycloakPasswordTemporary", false); // User won't need to change password
 
 template.sendBodyAndHeaders("keycloak:admin?operation=resetUserPassword", null, passwordHeaders);
 
 // Reset with temporary password (user must change on first login)
 Map<String, Object> tempPasswordHeaders = new HashMap<>();
-tempPasswordHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-tempPasswordHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-tempPasswordHeaders.put(KeycloakConstants.USER_PASSWORD, "tempPassword123");
-tempPasswordHeaders.put(KeycloakConstants.PASSWORD_TEMPORARY, true);
+tempPasswordHeaders.put("CamelKeycloakRealmName", "my-realm");
+tempPasswordHeaders.put("CamelKeycloakUserId", "user-id-123");
+tempPasswordHeaders.put("CamelKeycloakUserPassword", "tempPassword123");
+tempPasswordHeaders.put("CamelKeycloakPasswordTemporary", true);
 
 template.sendBodyAndHeaders("keycloak:admin?operation=resetUserPassword", null, tempPasswordHeaders);
 ----
@@ -721,24 +721,24 @@ Java::
 ----
 // Search users by query
 Map<String, Object> searchHeaders = new HashMap<>();
-searchHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-searchHeaders.put(KeycloakConstants.SEARCH_QUERY, "john");
+searchHeaders.put("CamelKeycloakRealmName", "my-realm");
+searchHeaders.put("CamelKeycloakSearchQuery", "john");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=searchUsers", null, searchHeaders);
 
 // Search with pagination
 Map<String, Object> paginatedSearchHeaders = new HashMap<>();
-paginatedSearchHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-paginatedSearchHeaders.put(KeycloakConstants.SEARCH_QUERY, "doe");
-paginatedSearchHeaders.put(KeycloakConstants.FIRST_RESULT, 0);
-paginatedSearchHeaders.put(KeycloakConstants.MAX_RESULTS, 10);
+paginatedSearchHeaders.put("CamelKeycloakRealmName", "my-realm");
+paginatedSearchHeaders.put("CamelKeycloakSearchQuery", "doe");
+paginatedSearchHeaders.put("CamelKeycloakFirstResult", 0);
+paginatedSearchHeaders.put("CamelKeycloakMaxResults", 10);
 
 template.sendBodyAndHeaders("keycloak:admin?operation=searchUsers", null, paginatedSearchHeaders);
 
 // Get user roles
 Map<String, Object> rolesHeaders = new HashMap<>();
-rolesHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-rolesHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+rolesHeaders.put("CamelKeycloakRealmName", "my-realm");
+rolesHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 List<RoleRepresentation> roles = template.requestBodyAndHeaders(
     "keycloak:admin?operation=getUserRoles", null, rolesHeaders, List.class);
@@ -830,35 +830,35 @@ Java::
 ----
 // Create client role
 Map<String, Object> clientRoleHeaders = new HashMap<>();
-clientRoleHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-clientRoleHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
-clientRoleHeaders.put(KeycloakConstants.ROLE_NAME, "service-admin");
-clientRoleHeaders.put(KeycloakConstants.ROLE_DESCRIPTION, "Service administrator role");
+clientRoleHeaders.put("CamelKeycloakRealmName", "my-realm");
+clientRoleHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
+clientRoleHeaders.put("CamelKeycloakRoleName", "service-admin");
+clientRoleHeaders.put("CamelKeycloakRoleDescription", "Service administrator role");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createClientRole", null, clientRoleHeaders);
 
 // List client roles
 Map<String, Object> listClientRolesHeaders = new HashMap<>();
-listClientRolesHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-listClientRolesHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
+listClientRolesHeaders.put("CamelKeycloakRealmName", "my-realm");
+listClientRolesHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=listClientRoles", null, listClientRolesHeaders);
 
 // Assign client role to user
 Map<String, Object> assignClientRoleHeaders = new HashMap<>();
-assignClientRoleHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-assignClientRoleHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-assignClientRoleHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
-assignClientRoleHeaders.put(KeycloakConstants.ROLE_NAME, "service-admin");
+assignClientRoleHeaders.put("CamelKeycloakRealmName", "my-realm");
+assignClientRoleHeaders.put("CamelKeycloakUserId", "user-id-123");
+assignClientRoleHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
+assignClientRoleHeaders.put("CamelKeycloakRoleName", "service-admin");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=assignClientRoleToUser", null, assignClientRoleHeaders);
 
 // Remove client role from user
 Map<String, Object> removeClientRoleHeaders = new HashMap<>();
-removeClientRoleHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-removeClientRoleHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-removeClientRoleHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
-removeClientRoleHeaders.put(KeycloakConstants.ROLE_NAME, "service-admin");
+removeClientRoleHeaders.put("CamelKeycloakRealmName", "my-realm");
+removeClientRoleHeaders.put("CamelKeycloakUserId", "user-id-123");
+removeClientRoleHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
+removeClientRoleHeaders.put("CamelKeycloakRoleName", "service-admin");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=removeClientRoleFromUser", null, removeClientRoleHeaders);
 ----
@@ -959,22 +959,22 @@ Java::
 ----
 // List user sessions
 Map<String, Object> sessionsHeaders = new HashMap<>();
-sessionsHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-sessionsHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+sessionsHeaders.put("CamelKeycloakRealmName", "my-realm");
+sessionsHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 List<UserSessionRepresentation> sessions = template.requestBodyAndHeaders(
     "keycloak:admin?operation=listUserSessions", null, sessionsHeaders, List.class);
 
 // Logout user (invalidate all sessions)
 Map<String, Object> logoutHeaders = new HashMap<>();
-logoutHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-logoutHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+logoutHeaders.put("CamelKeycloakRealmName", "my-realm");
+logoutHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=logoutUser", null, logoutHeaders);
 
 // Logout all users in realm
 template.sendBodyAndHeader("keycloak:admin?operation=logoutAllUsers", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 ----
 
 YAML::
@@ -1048,22 +1048,22 @@ Java::
 ----
 // Revoke an access token
 Map<String, Object> revokeHeaders = new HashMap<>();
-revokeHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-revokeHeaders.put(KeycloakConstants.TOKEN, accessToken);
+revokeHeaders.put("CamelKeycloakRealmName", "my-realm");
+revokeHeaders.put("CamelKeycloakToken", accessToken);
 
 template.sendBodyAndHeaders("keycloak:admin?operation=revokeAccessToken", null, revokeHeaders);
 
 // Introspect a token
 Map<String, Object> introspectHeaders = new HashMap<>();
-introspectHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-introspectHeaders.put(KeycloakConstants.TOKEN, tokenToVerify);
+introspectHeaders.put("CamelKeycloakRealmName", "my-realm");
+introspectHeaders.put("CamelKeycloakToken", tokenToVerify);
 
 Map<String, Object> claims = template.requestBodyAndHeaders("keycloak:admin?operation=introspectToken",
     null, introspectHeaders, Map.class);
 
 // Push not-before policy (invalidates all tokens issued before now)
 template.sendBodyAndHeader("keycloak:admin?operation=pushNotBefore", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 ----
 
 YAML::
@@ -1129,26 +1129,26 @@ Java::
 ----
 // Create client scope
 Map<String, Object> scopeHeaders = new HashMap<>();
-scopeHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-scopeHeaders.put(KeycloakConstants.CLIENT_SCOPE_NAME, "custom-scope");
+scopeHeaders.put("CamelKeycloakRealmName", "my-realm");
+scopeHeaders.put("CamelKeycloakClientScopeName", "custom-scope");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createClientScope", null, scopeHeaders);
 
 // List client scopes
 template.sendBodyAndHeader("keycloak:admin?operation=listClientScopes", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 
 // Get client scope
 Map<String, Object> getScopeHeaders = new HashMap<>();
-getScopeHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-getScopeHeaders.put(KeycloakConstants.CLIENT_SCOPE_ID, "scope-id-123");
+getScopeHeaders.put("CamelKeycloakRealmName", "my-realm");
+getScopeHeaders.put("CamelKeycloakClientScopeId", "scope-id-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=getClientScope", null, getScopeHeaders);
 
 // Delete client scope
 Map<String, Object> deleteScopeHeaders = new HashMap<>();
-deleteScopeHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-deleteScopeHeaders.put(KeycloakConstants.CLIENT_SCOPE_ID, "scope-id-123");
+deleteScopeHeaders.put("CamelKeycloakRealmName", "my-realm");
+deleteScopeHeaders.put("CamelKeycloakClientScopeId", "scope-id-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteClientScope", null, deleteScopeHeaders);
 ----
@@ -1224,7 +1224,7 @@ Identity providers allow you to configure external authentication systems like L
 ----
 // Create OIDC identity provider
 Map<String, Object> idpHeaders = new HashMap<>();
-idpHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
+idpHeaders.put("CamelKeycloakRealmName", "my-realm");
 
 IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
 idp.setAlias("google-idp");
@@ -1243,12 +1243,12 @@ template.sendBodyAndHeaders("keycloak:admin?operation=createIdentityProvider&poj
 
 // List all identity providers
 template.sendBodyAndHeader("keycloak:admin?operation=listIdentityProviders", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 
 // Get specific identity provider
 Map<String, Object> getIdpHeaders = new HashMap<>();
-getIdpHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-getIdpHeaders.put(KeycloakConstants.IDP_ALIAS, "google-idp");
+getIdpHeaders.put("CamelKeycloakRealmName", "my-realm");
+getIdpHeaders.put("CamelKeycloakIdpAlias", "google-idp");
 
 IdentityProviderRepresentation provider = template.requestBodyAndHeaders(
     "keycloak:admin?operation=getIdentityProvider", null, getIdpHeaders,
@@ -1268,11 +1268,11 @@ Organizations (introduced in Keycloak 26) allow you to model multi-tenant scenar
 ----
 // Create a new organization
 Map<String, Object> orgHeaders = new HashMap<>();
-orgHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-orgHeaders.put(KeycloakConstants.ORGANIZATION_NAME, "acme-corp");
-orgHeaders.put(KeycloakConstants.ORGANIZATION_ALIAS, "acme");
-orgHeaders.put(KeycloakConstants.ORGANIZATION_DESCRIPTION, "Acme Corporation");
-orgHeaders.put(KeycloakConstants.ORGANIZATION_DOMAIN, "acme.com");
+orgHeaders.put("CamelKeycloakRealmName", "my-realm");
+orgHeaders.put("CamelKeycloakOrganizationName", "acme-corp");
+orgHeaders.put("CamelKeycloakOrganizationAlias", "acme");
+orgHeaders.put("CamelKeycloakOrganizationDescription", "Acme Corporation");
+orgHeaders.put("CamelKeycloakOrganizationDomain", "acme.com");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createOrganization", null, orgHeaders);
 
@@ -1286,23 +1286,23 @@ domain.setName("acme.com");
 org.addDomain(domain);
 
 template.sendBodyAndHeader("keycloak:admin?operation=createOrganization&pojoRequest=true",
-    org, KeycloakConstants.REALM_NAME, "my-realm");
+    org, "CamelKeycloakRealmName", "my-realm");
 
 // List all organizations in a realm
 template.sendBodyAndHeader("keycloak:admin?operation=listOrganizations", null,
-    KeycloakConstants.REALM_NAME, "my-realm");
+    "CamelKeycloakRealmName", "my-realm");
 
 // Search organizations by name/alias/domain
 Map<String, Object> searchHeaders = new HashMap<>();
-searchHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-searchHeaders.put(KeycloakConstants.ORGANIZATION_SEARCH, "acme");
+searchHeaders.put("CamelKeycloakRealmName", "my-realm");
+searchHeaders.put("CamelKeycloakOrganizationSearch", "acme");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=searchOrganizations", null, searchHeaders);
 
 // Get a specific organization by ID
 Map<String, Object> getOrgHeaders = new HashMap<>();
-getOrgHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-getOrgHeaders.put(KeycloakConstants.ORGANIZATION_ID, "<organization-id>");
+getOrgHeaders.put("CamelKeycloakRealmName", "my-realm");
+getOrgHeaders.put("CamelKeycloakOrganizationId", "<organization-id>");
 
 OrganizationRepresentation organization = template.requestBodyAndHeaders(
     "keycloak:admin?operation=getOrganization", null, getOrgHeaders,
@@ -1310,9 +1310,9 @@ OrganizationRepresentation organization = template.requestBodyAndHeaders(
 
 // Add an existing user as a member of an organization
 Map<String, Object> addMemberHeaders = new HashMap<>();
-addMemberHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-addMemberHeaders.put(KeycloakConstants.ORGANIZATION_ID, "<organization-id>");
-addMemberHeaders.put(KeycloakConstants.USER_ID, "<user-id>");
+addMemberHeaders.put("CamelKeycloakRealmName", "my-realm");
+addMemberHeaders.put("CamelKeycloakOrganizationId", "<organization-id>");
+addMemberHeaders.put("CamelKeycloakUserId", "<user-id>");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=addOrganizationMember", null, addMemberHeaders);
 
@@ -1324,9 +1324,9 @@ template.sendBodyAndHeaders("keycloak:admin?operation=removeOrganizationMember",
 
 // Link an identity provider to an organization
 Map<String, Object> linkIdpHeaders = new HashMap<>();
-linkIdpHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-linkIdpHeaders.put(KeycloakConstants.ORGANIZATION_ID, "<organization-id>");
-linkIdpHeaders.put(KeycloakConstants.IDP_ALIAS, "acme-saml");
+linkIdpHeaders.put("CamelKeycloakRealmName", "my-realm");
+linkIdpHeaders.put("CamelKeycloakOrganizationId", "<organization-id>");
+linkIdpHeaders.put("CamelKeycloakIdpAlias", "acme-saml");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=linkOrganizationIdentityProvider",
     null, linkIdpHeaders);
@@ -1355,26 +1355,26 @@ Java::
 ----
 // Set user attribute
 Map<String, Object> attrHeaders = new HashMap<>();
-attrHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-attrHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-attrHeaders.put(KeycloakConstants.ATTRIBUTE_NAME, "department");
-attrHeaders.put(KeycloakConstants.ATTRIBUTE_VALUE, "Engineering");
+attrHeaders.put("CamelKeycloakRealmName", "my-realm");
+attrHeaders.put("CamelKeycloakUserId", "user-id-123");
+attrHeaders.put("CamelKeycloakAttributeName", "department");
+attrHeaders.put("CamelKeycloakAttributeValue", "Engineering");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=setUserAttribute", null, attrHeaders);
 
 // Get all user attributes
 Map<String, Object> getUserAttrHeaders = new HashMap<>();
-getUserAttrHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-getUserAttrHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+getUserAttrHeaders.put("CamelKeycloakRealmName", "my-realm");
+getUserAttrHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 Map<String, List<String>> attributes = template.requestBodyAndHeaders(
     "keycloak:admin?operation=getUserAttributes", null, getUserAttrHeaders, Map.class);
 
 // Delete user attribute
 Map<String, Object> delAttrHeaders = new HashMap<>();
-delAttrHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-delAttrHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-delAttrHeaders.put(KeycloakConstants.ATTRIBUTE_NAME, "department");
+delAttrHeaders.put("CamelKeycloakRealmName", "my-realm");
+delAttrHeaders.put("CamelKeycloakUserId", "user-id-123");
+delAttrHeaders.put("CamelKeycloakAttributeName", "department");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteUserAttribute", null, delAttrHeaders);
 ----
@@ -1472,49 +1472,49 @@ Java::
 ----
 // Get user credentials
 Map<String, Object> credHeaders = new HashMap<>();
-credHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-credHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+credHeaders.put("CamelKeycloakRealmName", "my-realm");
+credHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 List<CredentialRepresentation> credentials = template.requestBodyAndHeaders(
     "keycloak:admin?operation=getUserCredentials", null, credHeaders, List.class);
 
 // Delete specific credential
 Map<String, Object> delCredHeaders = new HashMap<>();
-delCredHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-delCredHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-delCredHeaders.put(KeycloakConstants.CREDENTIAL_ID, "credential-id-456");
+delCredHeaders.put("CamelKeycloakRealmName", "my-realm");
+delCredHeaders.put("CamelKeycloakUserId", "user-id-123");
+delCredHeaders.put("CamelKeycloakCredentialId", "credential-id-456");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=deleteUserCredential", null, delCredHeaders);
 
 // Send verification email
 Map<String, Object> verifyHeaders = new HashMap<>();
-verifyHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-verifyHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+verifyHeaders.put("CamelKeycloakRealmName", "my-realm");
+verifyHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=sendVerifyEmail", null, verifyHeaders);
 
 // Send password reset email
 Map<String, Object> resetHeaders = new HashMap<>();
-resetHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-resetHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
+resetHeaders.put("CamelKeycloakRealmName", "my-realm");
+resetHeaders.put("CamelKeycloakUserId", "user-id-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=sendPasswordResetEmail", null, resetHeaders);
 
 // Add required action
 Map<String, Object> actionHeaders = new HashMap<>();
-actionHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-actionHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-actionHeaders.put(KeycloakConstants.REQUIRED_ACTION, "VERIFY_EMAIL");
+actionHeaders.put("CamelKeycloakRealmName", "my-realm");
+actionHeaders.put("CamelKeycloakUserId", "user-id-123");
+actionHeaders.put("CamelKeycloakRequiredAction", "VERIFY_EMAIL");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=addRequiredAction", null, actionHeaders);
 
 // Execute multiple actions via email
 Map<String, Object> execHeaders = new HashMap<>();
-execHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-execHeaders.put(KeycloakConstants.USER_ID, "user-id-123");
-execHeaders.put(KeycloakConstants.ACTIONS, Arrays.asList("UPDATE_PASSWORD", "VERIFY_EMAIL"));
-execHeaders.put(KeycloakConstants.REDIRECT_URI, "https://myapp.com/auth/callback");
-execHeaders.put(KeycloakConstants.LIFESPAN, 3600); // 1 hour
+execHeaders.put("CamelKeycloakRealmName", "my-realm");
+execHeaders.put("CamelKeycloakUserId", "user-id-123");
+execHeaders.put("CamelKeycloakActions", Arrays.asList("UPDATE_PASSWORD", "VERIFY_EMAIL"));
+execHeaders.put("CamelKeycloakRedirectUri", "https://myapp.com/auth/callback");
+execHeaders.put("CamelKeycloakLifespan", 3600); // 1 hour
 
 template.sendBodyAndHeaders("keycloak:admin?operation=executeActionsEmail", null, execHeaders);
 ----
@@ -1651,8 +1651,8 @@ Java::
 ----
 // Get client secret
 Map<String, Object> getSecretHeaders = new HashMap<>();
-getSecretHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-getSecretHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
+getSecretHeaders.put("CamelKeycloakRealmName", "my-realm");
+getSecretHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
 
 CredentialRepresentation secret = template.requestBodyAndHeaders(
     "keycloak:admin?operation=getClientSecret", null, getSecretHeaders,
@@ -1662,8 +1662,8 @@ System.out.println("Client secret: " + secret.getValue());
 
 // Regenerate client secret (rotates the secret)
 Map<String, Object> regenHeaders = new HashMap<>();
-regenHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-regenHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
+regenHeaders.put("CamelKeycloakRealmName", "my-realm");
+regenHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
 
 CredentialRepresentation newSecret = template.requestBodyAndHeaders(
     "keycloak:admin?operation=regenerateClientSecret", null, regenHeaders,
@@ -1738,8 +1738,8 @@ resource.setUris(Collections.singleton("/documents/*"));
 resource.addScope("read", "write", "delete");
 
 Map<String, Object> resourceHeaders = new HashMap<>();
-resourceHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-resourceHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
+resourceHeaders.put("CamelKeycloakRealmName", "my-realm");
+resourceHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
 
 Response response = template.requestBodyAndHeaders(
     "keycloak:admin?operation=createResource&pojoRequest=true",
@@ -1759,8 +1759,8 @@ policyConfig.put("roles", "[{\"id\":\"admin-role-id\",\"required\":true}]");
 policy.setConfig(policyConfig);
 
 Map<String, Object> policyHeaders = new HashMap<>();
-policyHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-policyHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
+policyHeaders.put("CamelKeycloakRealmName", "my-realm");
+policyHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createResourcePolicy&pojoRequest=true",
     policy, policyHeaders);
@@ -1772,8 +1772,8 @@ permission.addResource("documents");
 permission.addPolicy("admin-policy");
 
 Map<String, Object> permHeaders = new HashMap<>();
-permHeaders.put(KeycloakConstants.REALM_NAME, "my-realm");
-permHeaders.put(KeycloakConstants.CLIENT_UUID, "client-uuid-123");
+permHeaders.put("CamelKeycloakRealmName", "my-realm");
+permHeaders.put("CamelKeycloakClientUuid", "client-uuid-123");
 
 template.sendBodyAndHeaders("keycloak:admin?operation=createResourcePermission&pojoRequest=true",
     permission, permHeaders);
@@ -1847,8 +1847,8 @@ Java::
 ----
 // Evaluate all permissions for a user
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.ACCESS_TOKEN, userAccessToken);
-headers.put(KeycloakConstants.PERMISSIONS_ONLY, true);
+headers.put("CamelKeycloakAccessToken", userAccessToken);
+headers.put("CamelKeycloakPermissionsOnly", true);
 
 Map<String, Object> result = template.requestBodyAndHeaders(
     "keycloak:authz?serverUrl=http://localhost:8080&realm=myrealm"
@@ -1863,10 +1863,10 @@ System.out.println("Granted permissions: " + permissions.size());
 
 // Check specific resource permissions
 Map<String, Object> resourceHeaders = new HashMap<>();
-resourceHeaders.put(KeycloakConstants.ACCESS_TOKEN, userAccessToken);
-resourceHeaders.put(KeycloakConstants.PERMISSION_RESOURCE_NAMES, "document1,document2");
-resourceHeaders.put(KeycloakConstants.PERMISSION_SCOPES, "read,write");
-resourceHeaders.put(KeycloakConstants.PERMISSIONS_ONLY, true);
+resourceHeaders.put("CamelKeycloakAccessToken", userAccessToken);
+resourceHeaders.put("CamelKeycloakPermissionResourceNames", "document1,document2");
+resourceHeaders.put("CamelKeycloakPermissionScopes", "read,write");
+resourceHeaders.put("CamelKeycloakPermissionsOnly", true);
 
 Map<String, Object> resourceResult = template.requestBodyAndHeaders(
     "keycloak:authz?serverUrl=http://localhost:8080&realm=myrealm"
@@ -1875,7 +1875,7 @@ Map<String, Object> resourceResult = template.requestBodyAndHeaders(
 
 // Get RPT token with permissions (default mode)
 Map<String, Object> rptHeaders = new HashMap<>();
-rptHeaders.put(KeycloakConstants.PERMISSION_RESOURCE_NAMES, "protected-resource");
+rptHeaders.put("CamelKeycloakPermissionResourceNames", "protected-resource");
 
 Map<String, Object> rptResult = template.requestBodyAndHeaders(
     "keycloak:authz?serverUrl=http://localhost:8080&realm=myrealm"
@@ -2003,10 +2003,10 @@ YAML::
 // Check if user can access a specific document
 public boolean canAccessDocument(String accessToken, String documentId) {
     Map<String, Object> headers = new HashMap<>();
-    headers.put(KeycloakConstants.ACCESS_TOKEN, accessToken);
-    headers.put(KeycloakConstants.PERMISSION_RESOURCE_NAMES, documentId);
-    headers.put(KeycloakConstants.PERMISSION_SCOPES, "view");
-    headers.put(KeycloakConstants.PERMISSIONS_ONLY, true);
+    headers.put("CamelKeycloakAccessToken", accessToken);
+    headers.put("CamelKeycloakPermissionResourceNames", documentId);
+    headers.put("CamelKeycloakPermissionScopes", "view");
+    headers.put("CamelKeycloakPermissionsOnly", true);
 
     Map<String, Object> result = template.requestBodyAndHeaders(
         "keycloak:authz?operation=evaluatePermission", null, headers, Map.class);
@@ -2034,9 +2034,9 @@ public Map<String, Boolean> checkMultipleResources(String accessToken, List<Stri
 ----
 // Evaluate permissions on behalf of another user (token exchange)
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.SUBJECT_TOKEN, userToken);  // The user's token
-headers.put(KeycloakConstants.PERMISSION_RESOURCE_NAMES, "admin-resource");
-headers.put(KeycloakConstants.PERMISSIONS_ONLY, true);
+headers.put("CamelKeycloakSubjectToken", userToken);  // The user's token
+headers.put("CamelKeycloakPermissionResourceNames", "admin-resource");
+headers.put("CamelKeycloakPermissionsOnly", true);
 
 // Service evaluates if the user (from subject token) can access the resource
 Map<String, Object> result = template.requestBodyAndHeaders(
@@ -2123,8 +2123,8 @@ for (int i = 1; i <= 100; i++) {
 }
 
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.REALM_NAME, "my-realm");
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, true); // Continue even if some users fail
+headers.put("CamelKeycloakRealmName", "my-realm");
+headers.put("CamelKeycloakContinueOnError", true); // Continue even if some users fail
 
 Map<String, Object> result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkCreateUsers", users, headers, Map.class);
@@ -2179,17 +2179,17 @@ Java::
 List<String> userIds = List.of("user-id-1", "user-id-2", "user-id-3");
 
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.REALM_NAME, "my-realm");
-headers.put(KeycloakConstants.USER_IDS, userIds);
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, true);
+headers.put("CamelKeycloakRealmName", "my-realm");
+headers.put("CamelKeycloakUserId"S, userIds);
+headers.put("CamelKeycloakContinueOnError", true);
 
 Map<String, Object> result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkDeleteUsers", null, headers, Map.class);
 
 // Or delete by usernames
 List<String> usernames = List.of("user1", "user2", "user3");
-headers.put(KeycloakConstants.USERNAMES, usernames);
-headers.remove(KeycloakConstants.USER_IDS);
+headers.put("CamelKeycloakUsername"S, usernames);
+headers.remove("CamelKeycloakUserId"S);
 
 result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkDeleteUsers", null, headers, Map.class);
@@ -2240,10 +2240,10 @@ Java::
 List<String> roleNames = List.of("admin", "manager", "developer");
 
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.REALM_NAME, "my-realm");
-headers.put(KeycloakConstants.USER_ID, "user-id-123");
-headers.put(KeycloakConstants.ROLE_NAMES, roleNames);
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, true);
+headers.put("CamelKeycloakRealmName", "my-realm");
+headers.put("CamelKeycloakUserId", "user-id-123");
+headers.put("CamelKeycloakRoleName"S, roleNames);
+headers.put("CamelKeycloakContinueOnError", true);
 
 Map<String, Object> result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkAssignRolesToUser", null, headers, Map.class);
@@ -2305,10 +2305,10 @@ Java::
 List<String> userIds = List.of("user-id-1", "user-id-2", "user-id-3");
 
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.REALM_NAME, "my-realm");
-headers.put(KeycloakConstants.ROLE_NAME, "developer");
-headers.put(KeycloakConstants.USER_IDS, userIds);
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, true);
+headers.put("CamelKeycloakRealmName", "my-realm");
+headers.put("CamelKeycloakRoleName", "developer");
+headers.put("CamelKeycloakUserId"S, userIds);
+headers.put("CamelKeycloakContinueOnError", true);
 
 Map<String, Object> result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkAssignRoleToUsers", null, headers, Map.class);
@@ -2317,8 +2317,8 @@ System.out.println("Assigned role to " + result.get("success") + " users");
 
 // Or use usernames instead of IDs
 List<String> usernames = List.of("user1", "user2", "user3");
-headers.put(KeycloakConstants.USERNAMES, usernames);
-headers.remove(KeycloakConstants.USER_IDS);
+headers.put("CamelKeycloakUsername"S, usernames);
+headers.remove("CamelKeycloakUserId"S);
 
 result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkAssignRoleToUsers", null, headers, Map.class);
@@ -2372,7 +2372,7 @@ List<UserRepresentation> users = new ArrayList<>();
 // Fetch users and update them
 List<UserRepresentation> existingUsers = template.requestBodyAndHeader(
     "keycloak:admin?operation=listUsers", null,
-    KeycloakConstants.REALM_NAME, "my-realm", List.class);
+    "CamelKeycloakRealmName", "my-realm", List.class);
 
 for (UserRepresentation user : existingUsers) {
     // Update user properties
@@ -2382,9 +2382,9 @@ for (UserRepresentation user : existingUsers) {
 }
 
 Map<String, Object> headers = new HashMap<>();
-headers.put(KeycloakConstants.REALM_NAME, "my-realm");
-headers.put(KeycloakConstants.USERS, users);
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, true);
+headers.put("CamelKeycloakRealmName", "my-realm");
+headers.put("CamelKeycloakUsers", users);
+headers.put("CamelKeycloakContinueOnError", true);
 
 Map<String, Object> result = template.requestBodyAndHeaders(
     "keycloak:admin?operation=bulkUpdateUsers", null, headers, Map.class);
@@ -2458,10 +2458,10 @@ Java::
 [source,java]
 ----
 // Continue processing even if some operations fail
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, true);
+headers.put("CamelKeycloakContinueOnError", true);
 
 // Stop on first error (default behavior)
-headers.put(KeycloakConstants.CONTINUE_ON_ERROR, false);
+headers.put("CamelKeycloakContinueOnError", false);
 ----
 
 YAML::
@@ -2518,8 +2518,8 @@ public class BulkUserProvisioningRoute extends RouteBuilder {
             })
 
             // Bulk create users
-            .setHeader(KeycloakConstants.REALM_NAME, constant("my-realm"))
-            .setHeader(KeycloakConstants.CONTINUE_ON_ERROR, constant(true))
+            .setHeader("CamelKeycloakRealmName", constant("my-realm"))
+            .setHeader("CamelKeycloakContinueOnError", constant(true))
             .to("keycloak:admin?operation=bulkCreateUsers")
 
             // Log results
@@ -2542,10 +2542,10 @@ public class BulkUserProvisioningRoute extends RouteBuilder {
             .routeId("bulk-assign-roles")
             .log("Bulk assigning roles to users")
             .unmarshal().json()
-            .setHeader(KeycloakConstants.REALM_NAME, simple("${body[realm]}"))
-            .setHeader(KeycloakConstants.USER_ID, simple("${body[userId]}"))
+            .setHeader("CamelKeycloakRealmName", simple("${body[realm]}"))
+            .setHeader("CamelKeycloakUserId", simple("${body[userId]}"))
             .setBody(simple("${body[roles]}"))
-            .setHeader(KeycloakConstants.CONTINUE_ON_ERROR, constant(true))
+            .setHeader("CamelKeycloakContinueOnError", constant(true))
             .to("keycloak:admin?operation=bulkAssignRolesToUser")
             .marshal().json()
             .setHeader("Content-Type", constant("application/json"));
@@ -2554,7 +2554,7 @@ public class BulkUserProvisioningRoute extends RouteBuilder {
         from("timer:cleanup?period=86400000") // Daily
             .routeId("cleanup-inactive-users")
             .log("Starting inactive user cleanup")
-            .setHeader(KeycloakConstants.REALM_NAME, constant("my-realm"))
+            .setHeader("CamelKeycloakRealmName", constant("my-realm"))
             .to("keycloak:admin?operation=listUsers")
             .process(exchange -> {
                 List<UserRepresentation> allUsers = exchange.getIn().getBody(List.class);
@@ -2571,7 +2571,7 @@ public class BulkUserProvisioningRoute extends RouteBuilder {
                 exchange.getIn().setBody(inactiveUserIds);
             })
             .filter(simple("${body.size} > 0"))
-            .setHeader(KeycloakConstants.CONTINUE_ON_ERROR, constant(true))
+            .setHeader("CamelKeycloakContinueOnError", constant(true))
             .to("keycloak:admin?operation=bulkDeleteUsers")
             .log("Deleted ${body[success]} inactive users");
     }
@@ -2726,18 +2726,18 @@ public class KeycloakManagementRoutes extends RouteBuilder {
             .log("Setting up user environment...")
 
             // Step 1: Create realm
-            .setHeader(KeycloakConstants.REALM_NAME, constant("my-company"))
+            .setHeader("CamelKeycloakRealmName", constant("my-company"))
             .to("keycloak:admin?operation=createRealm")
             .log("Created realm: my-company")
 
             // Step 2: Create roles
-            .setHeader(KeycloakConstants.ROLE_NAME, constant("admin"))
-            .setHeader(KeycloakConstants.ROLE_DESCRIPTION, constant("Administrator role"))
+            .setHeader("CamelKeycloakRoleName", constant("admin"))
+            .setHeader("CamelKeycloakRoleDescription", constant("Administrator role"))
             .to("keycloak:admin?operation=createRole")
             .log("Created admin role")
 
-            .setHeader(KeycloakConstants.ROLE_NAME, constant("user"))
-            .setHeader(KeycloakConstants.ROLE_DESCRIPTION, constant("Standard user role"))
+            .setHeader("CamelKeycloakRoleName", constant("user"))
+            .setHeader("CamelKeycloakRoleDescription", constant("Standard user role"))
             .to("keycloak:admin?operation=createRole")
             .log("Created user role")
 
@@ -2749,10 +2749,10 @@ public class KeycloakManagementRoutes extends RouteBuilder {
             .log("Created client: my-app")
 
             // Step 4: Create users
-            .setHeader(KeycloakConstants.USERNAME, constant("admin.user"))
-            .setHeader(KeycloakConstants.USER_EMAIL, constant("admin@company.com"))
-            .setHeader(KeycloakConstants.USER_FIRST_NAME, constant("Admin"))
-            .setHeader(KeycloakConstants.USER_LAST_NAME, constant("User"))
+            .setHeader("CamelKeycloakUsername", constant("admin.user"))
+            .setHeader("CamelKeycloakUserEmail", constant("admin@company.com"))
+            .setHeader("CamelKeycloakUserFirstName", constant("Admin"))
+            .setHeader("CamelKeycloakUserLastName", constant("User"))
             .to("keycloak:admin?operation=createUser")
             .log("Created admin user")
 
@@ -2763,7 +2763,7 @@ public class KeycloakManagementRoutes extends RouteBuilder {
             .log("Set admin user password")
 
             // Step 6: Assign role
-            .setHeader(KeycloakConstants.ROLE_NAME, constant("admin"))
+            .setHeader("CamelKeycloakRoleName", constant("admin"))
             .to("keycloak:admin?operation=assignRoleToUser")
             .log("Assigned admin role to user")
 
@@ -2773,11 +2773,11 @@ public class KeycloakManagementRoutes extends RouteBuilder {
         from("rest:post:/users")
             .routeId("create-user-api")
             .log("Creating user: ${body}")
-            .setHeader(KeycloakConstants.REALM_NAME, constant("my-company"))
-            .setHeader(KeycloakConstants.USERNAME, jsonpath("$.username"))
-            .setHeader(KeycloakConstants.USER_EMAIL, jsonpath("$.email"))
-            .setHeader(KeycloakConstants.USER_FIRST_NAME, jsonpath("$.firstName"))
-            .setHeader(KeycloakConstants.USER_LAST_NAME, jsonpath("$.lastName"))
+            .setHeader("CamelKeycloakRealmName", constant("my-company"))
+            .setHeader("CamelKeycloakUsername", jsonpath("$.username"))
+            .setHeader("CamelKeycloakUserEmail", jsonpath("$.email"))
+            .setHeader("CamelKeycloakUserFirstName", jsonpath("$.firstName"))
+            .setHeader("CamelKeycloakUserLastName", jsonpath("$.lastName"))
             .to("keycloak:admin?operation=createUser")
             .setHeader("Content-Type", constant("application/json"))
             .transform().constant("{\"status\": \"success\", \"message\": \"User created\"}");
@@ -2785,15 +2785,15 @@ public class KeycloakManagementRoutes extends RouteBuilder {
         from("rest:get:/users")
             .routeId("list-users-api")
             .log("Listing users")
-            .setHeader(KeycloakConstants.REALM_NAME, constant("my-company"))
+            .setHeader("CamelKeycloakRealmName", constant("my-company"))
             .to("keycloak:admin?operation=listUsers")
             .setHeader("Content-Type", constant("application/json"));
 
         from("rest:delete:/users/{username}")
             .routeId("delete-user-api")
             .log("Deleting user: ${header.username}")
-            .setHeader(KeycloakConstants.REALM_NAME, constant("my-company"))
-            .setHeader(KeycloakConstants.USERNAME, header("username"))
+            .setHeader("CamelKeycloakRealmName", constant("my-company"))
+            .setHeader("CamelKeycloakUsername", header("username"))
             .to("keycloak:admin?operation=deleteUser")
             .setHeader("Content-Type", constant("application/json"))
             .transform().constant("{\"status\": \"success\", \"message\": \"User deleted\"}");
@@ -4688,7 +4688,7 @@ When using token introspection, you can implement a complete token revocation wo
 ----
 // 1. Revoke token in Keycloak (via admin API)
 template.sendBodyAndHeader("keycloak:admin?operation=revokeSession", null,
-    KeycloakConstants.SESSION_ID, sessionId);
+    "CamelKeycloakSessionId", sessionId);
 
 // 2. Subsequent requests with the revoked token will be rejected
 // The introspection endpoint will return "active": false
@@ -4804,7 +4804,7 @@ The security policy expects access tokens to be provided in one of the following
 ----
 // Using header
 template.sendBodyAndHeader("direct:protected", "message",
-    KeycloakSecurityConstants.ACCESS_TOKEN_HEADER, accessToken);
+    "CamelKeycloakAccessToken", accessToken);
 
 // Using Authorization header
 template.sendBodyAndHeader("direct:protected", "message",
@@ -5154,7 +5154,7 @@ String accessToken = "eyJhbGciOiJSUzI1NiIsInR5cC..."; // From Keycloak
 // Option 1: Using custom header
 template.sendBodyAndHeader("direct:protected-endpoint",
     requestBody,
-    KeycloakSecurityConstants.ACCESS_TOKEN_HEADER,
+    "CamelKeycloakAccessToken",
     accessToken);
 
 // Option 2: Using Authorization header (standard)
@@ -5166,7 +5166,7 @@ template.sendBodyAndHeader("direct:protected-endpoint",
 // Option 3: Using exchange property
 Exchange exchange = ExchangeBuilder.anExchange(camelContext)
     .withBody(requestBody)
-    .withProperty(KeycloakSecurityConstants.ACCESS_TOKEN_PROPERTY, accessToken)
+    .withProperty("CamelKeycloakAccessToken", accessToken)
     .build();
 template.send("direct:protected-endpoint", exchange);
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-config-maps-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-config-maps-component.adoc
@@ -93,7 +93,7 @@ Java::
 [source,java]
 ----
 from("direct:listByLabels")
-    .setHeader(KubernetesConstants.KUBERNETES_CONFIGMAPS_LABELS, constant("key1=value1,key2=value2"))
+    .setHeader("CamelKubernetesConfigMapsLabels", constant("key1=value1,key2=value2"))
     .to("kubernetes-config-maps:///?kubernetesClient=#kubernetesClient&operation=listConfigMapsByLabels")
     .to("mock:result");
 ----
@@ -150,7 +150,7 @@ fromF("kubernetes-config-maps://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             ConfigMap cm = exchange.getIn().getBody(ConfigMap.class);
-            log.info("Got event with configmap name: " + cm.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with configmap name: " + cm.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-deployments-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-deployments-component.adoc
@@ -54,7 +54,7 @@ This operation returns a List of Deployment from your cluster
 
 - `listDeploymentsByLabels`:  this operation lists the deployments by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -63,7 +63,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_DEPLOYMENTS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesDeploymentsLabels", labels);
             }
         });
     toF("kubernetes-deployments:///?kubernetesClient=#kubernetesClient&operation=listDeploymentsByLabels").
@@ -74,7 +74,7 @@ This operation returns a List of Deployments from your cluster, using a label se
 
 === Kubernetes Deployments Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-deployments://%s?oauthToken=%s", host, authToken)
@@ -85,7 +85,7 @@ fromF("kubernetes-deployments://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             Deployment dp = exchange.getIn().getBody(Deployment.class);
-            log.info("Got event with deployment name: " + dp.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with deployment name: " + dp.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-events-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-events-component.adoc
@@ -98,7 +98,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENTS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesEventsLabels", labels);
             }
         });
     to("kubernetes-events:///?kubernetesClient=#kubernetesClient&operation=listEventsByLabels").
@@ -118,8 +118,8 @@ from("direct:get").process(new Processor() {
 
             @Override
             public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NAMESPACE_NAME, "test");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_NAME, "event1");
+                exchange.getIn().setHeader("CamelKubernetesNamespaceName", "test");
+                exchange.getIn().setHeader("CamelKubernetesEventName", "event1");
             }
         });
     to("kubernetes-events:///?kubernetesClient=#kubernetesClient&operation=getEvent").
@@ -141,16 +141,16 @@ from("direct:get").process(new Processor() {
 
             @Override
             public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NAMESPACE_NAME, "default");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_NAME, "test1");
+                exchange.getIn().setHeader("CamelKubernetesNamespaceName", "default");
+                exchange.getIn().setHeader("CamelKubernetesEventName", "test1");
                 Map<String, String> labels = new HashMap<>();
                 labels.put("this", "rocks");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENTS_LABELS, labels);
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION_PRODUCER, "Some Action");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_TYPE, "Normal");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_REASON, "Some Reason");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_REPORTING_CONTROLLER, "Some-Reporting-Controller");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_REPORTING_INSTANCE, "Some-Reporting-Instance");
+                exchange.getIn().setHeader("CamelKubernetesEventsLabels", labels);
+                exchange.getIn().setHeader("CamelKubernetesEventAction", "Some Action");
+                exchange.getIn().setHeader("CamelKubernetesEventType", "Normal");
+                exchange.getIn().setHeader("CamelKubernetesEventReason", "Some Reason");
+                exchange.getIn().setHeader("CamelKubernetesEventReportingController", "Some-Reporting-Controller");
+                exchange.getIn().setHeader("CamelKubernetesEventReportingInstance", "Some-Reporting-Instance");
             }
         });
     to("kubernetes-events:///?kubernetesClient=#kubernetesClient&operation=createEvent").
@@ -181,8 +181,8 @@ from("direct:get").process(new Processor() {
 
             @Override
             public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NAMESPACE_NAME, "default");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_EVENT_NAME, "test1");
+                exchange.getIn().setHeader("CamelKubernetesNamespaceName", "default");
+                exchange.getIn().setHeader("CamelKubernetesEventName", "test1");
             }
         });
     to("kubernetes-events:///?kubernetesClient=#kubernetesClient&operation=deleteEvent").
@@ -206,7 +206,7 @@ fromF("kubernetes-events://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             Event e = exchange.getIn().getBody(Event.class);
-            log.info("Got event with event name: " + e.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with event name: " + e.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-hpa-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-hpa-component.adoc
@@ -53,7 +53,7 @@ This operation returns a list of HPAs from your cluster
 
 - `listDeploymentsByLabels`: this operation lists the HPAs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -62,7 +62,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_HPA_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesHPALabels", labels);
             }
         });
     toF("kubernetes-hpa:///?kubernetesClient=#kubernetesClient&operation=listHPAByLabels").
@@ -73,7 +73,7 @@ This operation returns a List of HPAs from your cluster using a label selector (
 
 === Kubernetes HPA Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-hpa://%s?oauthToken=%s", host, authToken)
@@ -84,7 +84,7 @@ fromF("kubernetes-hpa://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             HorizontalPodAutoscaler hpa = exchange.getIn().getBody(HorizontalPodAutoscaler.class);
-            log.info("Got event with hpa name: " + hpa.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with hpa name: " + hpa.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-job-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-job-component.adoc
@@ -54,7 +54,7 @@ This operation returns a list of jobs from your cluster
 
 - `listJobByLabels`: this operation lists the jobs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -63,7 +63,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_JOB_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesJobLabels", labels);
             }
         });
     toF("kubernetes-job:///?kubernetesClient=#kubernetesClient&operation=listJobByLabels").
@@ -76,7 +76,7 @@ This operation returns a list of jobs from your cluster, using a label selector 
 
 We have a wonderful example of this operation thanks to https://github.com/Emmerson-Miranda[Emmerson Miranda] from this https://github.com/Emmerson-Miranda/camel/blob/master/camel3-cdi/cdi-k8s-pocs/src/main/java/edu/emmerson/camel/k8s/jobs/camel_k8s_jobs/KubernetesCreateJob.java[Java test]
 
-._Java-only: full RouteBuilder class with KubernetesConstants, lambda Processors, and programmatic JobSpec construction_
+._Java-only: full RouteBuilder class with lambda Processors and programmatic JobSpec construction_
 [source,java]
 ----
 import java.util.ArrayList;
@@ -90,8 +90,6 @@ import javax.inject.Inject;
 import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.kubernetes.KubernetesConstants;
-import org.apache.camel.component.kubernetes.KubernetesOperations;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -114,18 +112,18 @@ public class KubernetesCreateJob extends RouteBuilder {
         from(inputEndpoint)
         	.routeId("kubernetes-jobcreate-client")
         	.process(exchange -> {
-        		exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_JOB_NAME, "camel-job"); //DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NAMESPACE_NAME, "default");
+        		exchange.getIn().setHeader("CamelKubernetesJobName", "camel-job"); //DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+                exchange.getIn().setHeader("CamelKubernetesNamespaceName", "default");
                 
                 Map<String, String> joblabels = new HashMap<String, String>();
                 joblabels.put("jobLabelKey1", "value1");
                 joblabels.put("jobLabelKey2", "value2");
                 joblabels.put("app", "jobFromCamelApp");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_JOB_LABELS, joblabels);
+                exchange.getIn().setHeader("CamelKubernetesJobLabels", joblabels);
 
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_JOB_SPEC, generateJobSpec());
+                exchange.getIn().setHeader("CamelKubernetesJobSpec", generateJobSpec());
         	})
-        	.toF("kubernetes-job:///{{kubernetes-master-url}}?oauthToken={{kubernetes-oauth-token:}}&operation=" + KubernetesOperations.CREATE_JOB_OPERATION)
+        	.toF("kubernetes-job:///{{kubernetes-master-url}}?oauthToken={{kubernetes-oauth-token:}}&operation=" + "createJob")
         	.log("Job created:")
         	.process(exchange -> {
         		System.out.println(exchange.getIn().getBody());

--- a/components/camel-kubernetes/src/main/docs/kubernetes-namespaces-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-namespaces-component.adoc
@@ -54,7 +54,7 @@ This operation returns a list of namespaces from your cluster
 
 - `listNamespacesByLabels`: this operation lists the namespaces by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -63,7 +63,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NAMESPACES_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesNamespaceLabels", labels);
             }
         });
     toF("kubernetes-namespaces:///?kubernetesClient=#kubernetesClient&operation=listNamespacesByLabels").
@@ -74,7 +74,7 @@ This operation returns a list of namespaces from your cluster, using a label sel
 
 === Kubernetes Namespaces Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-namespaces://%s?oauthToken=%s", host, authToken)
@@ -85,7 +85,7 @@ fromF("kubernetes-namespaces://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             Namespace ns = exchange.getIn().getBody(Namespace.class);
-            log.info("Got event with namespace name: " + ns.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with namespace name: " + ns.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-nodes-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-nodes-component.adoc
@@ -55,7 +55,7 @@ This operation returns a List of Nodes from your cluster
 
 - `listNodesByLabels`: this operation lists the nodes by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -64,7 +64,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_NODES_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesNodeLabels", labels);
             }
         });
     toF("kubernetes-deployments:///?kubernetesClient=#kubernetesClient&operation=listNodesByLabels").
@@ -75,7 +75,7 @@ This operation returns a list of nodes from your cluster, using a label selector
 
 === Kubernetes Nodes Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-nodes://%s?oauthToken=%s", host, authToken)
@@ -86,7 +86,7 @@ fromF("kubernetes-nodes://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             Node node = exchange.getIn().getBody(Node.class);
-            log.info("Got event with node name: " + node.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with node name: " + node.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-claims-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-claims-component.adoc
@@ -64,7 +64,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_PERSISTENT_VOLUMES_CLAIMS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesPersistentVolumesClaimsLabels", labels);
             }
         });
     toF("kubernetes-persistent-volumes-claims:///?kubernetesClient=#kubernetesClient&operation=listPersistentVolumesClaimsByLabels").

--- a/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-component.adoc
@@ -61,7 +61,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_PERSISTENT_VOLUMES_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesPersistentVolumesLabels", labels);
             }
         });
     toF("kubernetes-persistent-volumes:///?kubernetesClient=#kubernetesClient&operation=listPersistentVolumesByLabels").

--- a/components/camel-kubernetes/src/main/docs/kubernetes-pods-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-pods-component.adoc
@@ -55,7 +55,7 @@ This operation returns a list of pods from your cluster
 
 - `listPodsByLabels`: this operation lists the pods by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -64,7 +64,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_PODS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesPodLabels", labels);
             }
         });
     toF("kubernetes-pods:///?kubernetesClient=#kubernetesClient&operation=listPodsByLabels").
@@ -75,7 +75,7 @@ This operation returns a list of pods from your cluster using a label selector (
 
 === Kubernetes Pods Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-pods://%s?oauthToken=%s", host, authToken)
@@ -85,7 +85,7 @@ fromF("kubernetes-pods://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             Pod pod = exchange.getIn().getBody(Pod.class);
-            log.info("Got event with pod name: " + pod.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with pod name: " + pod.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-replication-controllers-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-replication-controllers-component.adoc
@@ -57,7 +57,7 @@ This operation returns a list of RCs from your cluster
 
 - `listReplicationControllersByLabels`: this operation lists the RCs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -66,7 +66,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_REPLICATION_CONTROLLERS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesReplicationControllersLabels", labels);
             }
         });
     toF("kubernetes-replication-controllers:///?kubernetesClient=#kubernetesClient&operation=listReplicationControllersByLabels").
@@ -77,7 +77,7 @@ This operation returns a list of RCs from your cluster using a label selector (w
 
 === Kubernetes Replication Controllers Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-replication-controllers://%s?oauthToken=%s", host, authToken)
@@ -88,7 +88,7 @@ fromF("kubernetes-replication-controllers://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             ReplicationController rc = exchange.getIn().getBody(ReplicationController.class);
-            log.info("Got event with replication controller name: " + rc.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with replication controller name: " + rc.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-resources-quota-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-resources-quota-component.adoc
@@ -64,7 +64,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_RESOURCES_QUOTA_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesResourcesQuotaLabels", labels);
             }
         });
     toF("kubernetes-resources-quota:///?kubernetesClient=#kubernetesClient&operation=listResourcesQuotaByLabels").

--- a/components/camel-kubernetes/src/main/docs/kubernetes-secrets-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-secrets-component.adoc
@@ -94,7 +94,7 @@ Java::
 [source,java]
 ----
 from("direct:listByLabels")
-    .setHeader(KubernetesConstants.KUBERNETES_SECRETS_LABELS, constant("key1=value1,key2=value2"))
+    .setHeader("CamelKubernetesSecretsLabels", constant("key1=value1,key2=value2"))
     .to("kubernetes-secrets:///?kubernetesClient=#kubernetesClient&operation=listSecretsByLabels")
     .to("mock:result");
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-service-accounts-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-service-accounts-component.adoc
@@ -64,7 +64,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_SERVICE_ACCOUNTS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesServiceAccountsLabels", labels);
             }
         });
     toF("kubernetes-service-accounts:///?kubernetesClient=#kubernetesClient&operation=listServiceAccountsByLabels").

--- a/components/camel-kubernetes/src/main/docs/kubernetes-services-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-services-component.adoc
@@ -54,7 +54,7 @@ This operation returns a List of services from your cluster
 
 - `listServicesByLabels`: this operation lists the deployments by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -63,7 +63,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_SERVICE_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesServiceLabels", labels);
             }
         });
     toF("kubernetes-services:///?kubernetesClient=#kubernetesClient&operation=listServicesByLabels").
@@ -74,7 +74,7 @@ This operation returns a list of services from your cluster using a label select
 
 === Kubernetes Services Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("kubernetes-services://%s?oauthToken=%s", host, authToken)
@@ -85,7 +85,7 @@ fromF("kubernetes-services://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             Service sv = exchange.getIn().getBody(Service.class);
-            log.info("Got event with service name: " + sv.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with service name: " + sv.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-summary.adoc
@@ -46,7 +46,7 @@ from("direct:createPod")
     .toF("kubernetes-pods://%s?oauthToken=%s&operation=createPod", host, authToken);
 ----
 
-By using the `KubernetesConstants.KUBERNETES_POD_SPEC` header, you can specify your PodSpec and pass it to this operation.
+By using the `CamelKubernetesPodSpec` header, you can specify your PodSpec and pass it to this operation.
 
 === Delete a pod
 
@@ -57,7 +57,7 @@ from("direct:createPod")
     .toF("kubernetes-pods://%s?oauthToken=%s&operation=deletePod", host, authToken);
 ----
 
-By using the `KubernetesConstants.KUBERNETES_POD_NAME` header, you can specify your Pod name and pass it to this operation.
+By using the `CamelKubernetesPodName` header, you can specify your Pod name and pass it to this operation.
 
 == Using Kubernetes ConfigMaps and Secrets
 

--- a/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
@@ -61,7 +61,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_BUILD_CONFIGS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesBuildConfigsLabels", labels);
             }
         });
     toF("openshift-build-configs:///?kubernetesClient=#kubernetesClient&operation=listBuildConfigsByLabels").

--- a/components/camel-kubernetes/src/main/docs/openshift-builds-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-builds-component.adoc
@@ -61,7 +61,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_BUILDS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesBuildsLabels", labels);
             }
         });
     toF("openshift-builds:///?kubernetesClient=#kubernetesClient&operation=listBuildsByLabels").

--- a/components/camel-kubernetes/src/main/docs/openshift-deploymentconfigs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-deploymentconfigs-component.adoc
@@ -54,7 +54,7 @@ This operation returns a list of deployment configs from your cluster
 
 - `listDeploymentConfigsByLabels`: this operation lists the deployment configs by labels on an Openshift cluster
 
-._Java-only: uses inline Processor with KubernetesConstants and HashMap_
+._Java-only: uses inline Processor with HashMap_
 [source,java]
 ----
 from("direct:listByLabels").process(new Processor() {
@@ -63,7 +63,7 @@ from("direct:listByLabels").process(new Processor() {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("key1", "value1");
                 labels.put("key2", "value2");
-                exchange.getIn().setHeader(KubernetesConstants.KUBERNETES_DEPLOYMENTS_LABELS, labels);
+                exchange.getIn().setHeader("CamelKubernetesDeploymentsLabels", labels);
             }
         });
     toF("openshift-deploymentconfigs:///?kubernetesClient=#kubernetesClient&operation=listDeploymentConfigsByLabels").
@@ -74,7 +74,7 @@ This operation returns a list of deployment configs from your cluster using a la
 
 === Openshift Deployment Configs Consumer Example
 
-._Java-only: uses fromF(), inline Processor class, KubernetesConstants, and string concatenation_
+._Java-only: uses fromF(), inline Processor class, and string concatenation_
 [source,java]
 ----
 fromF("openshift-deploymentconfigs://%s?oauthToken=%s", host, authToken)
@@ -85,7 +85,7 @@ fromF("openshift-deploymentconfigs://%s?oauthToken=%s", host, authToken)
         public void process(Exchange exchange) throws Exception {
             Message in = exchange.getIn();
             DeploymentConfig dp = exchange.getIn().getBody(DeploymentConfig.class);
-            log.info("Got event with deployment config name: " + dp.getMetadata().getName() + " and action " + in.getHeader(KubernetesConstants.KUBERNETES_EVENT_ACTION));
+            log.info("Got event with deployment config name: " + dp.getMetadata().getName() + " and action " + in.getHeader("CamelKubernetesEventAction"));
         }
     }
 ----

--- a/components/camel-lucene/src/main/docs/lucene-component.adoc
+++ b/components/camel-lucene/src/main/docs/lucene-component.adoc
@@ -116,7 +116,7 @@ registry.bind("whitespaceAnalyzer", new WhitespaceAnalyzer());
 RouteBuilder builder = new RouteBuilder() {
     public void configure() {
        from("direct:start").
-          setHeader(LuceneConstants.HEADER_QUERY, constant("Seinfeld")).
+          setHeader("CamelLuceneQuery", constant("Seinfeld")).
           to("lucene:searchIndex:query?
              analyzer=#whitespaceAnalyzer&indexDir=#whitespace&maxHits=20").
           to("direct:next");
@@ -149,7 +149,7 @@ RouteBuilder builder = new RouteBuilder() {
     public void configure() {
         try {
             from("direct:start").
-                setHeader(LuceneConstants.HEADER_QUERY, constant("Rodney Dangerfield")).
+                setHeader("CamelLuceneQuery", constant("Rodney Dangerfield")).
                 process(new LuceneQueryProcessor("target/stdindexDir", analyzer, null, 20)).
                 to("direct:next");
         } catch (Exception e) {

--- a/components/camel-metrics/src/main/docs/metrics-component.adoc
+++ b/components/camel-metrics/src/main/docs/metrics-component.adoc
@@ -539,7 +539,7 @@ Java::
 ----
 // adds value 992 to simple.histogram
 from("direct:in")
-    .setHeader(MetricsConstants.HEADER_HISTOGRAM_VALUE, constant(992L))
+    .setHeader("CamelMetricsHistogramValue", constant(992L))
     .to("metrics:histogram:simple.histogram?value=700")
     .to("direct:out");
 ----
@@ -692,7 +692,7 @@ Java::
 ----
 // updates meter simple.meter with value 345
 from("direct:in")
-    .setHeader(MetricsConstants.HEADER_METER_MARK, constant(345L))
+    .setHeader("CamelMetricsMeterMark", constant(345L))
     .to("metrics:meter:simple.meter?mark=123")
     .to("direct:out");
 ----

--- a/components/camel-micrometer/src/main/docs/micrometer-component.adoc
+++ b/components/camel-micrometer/src/main/docs/micrometer-component.adoc
@@ -919,7 +919,7 @@ Java::
 +
 [source,java]
 ----
-    @Bean(name = MicrometerConstants.METRICS_REGISTRY_NAME)
+    @Bean(name = "metricsRegistry")
     public MeterRegistry getMeterRegistry() {
         CompositeMeterRegistry meterRegistry = new CompositeMeterRegistry();
         meterRegistry.add(...);
@@ -936,7 +936,7 @@ CDI::
 [source,java]
 ----
     @Produces
-    @Named(MicrometerConstants.METRICS_REGISTRY_NAME))
+    @Named("metricsRegistry"))
     public MeterRegistry getMeterRegistry() {
         CompositeMeterRegistry meterRegistry = new CompositeMeterRegistry();
         meterRegistry.add(...);

--- a/components/camel-mina/src/main/docs/mina-component.adoc
+++ b/components/camel-mina/src/main/docs/mina-component.adoc
@@ -87,9 +87,9 @@ your codec. See xref:dataformats:hl7-dataformat.adoc[HL7] that has a custom code
 === Get the IoSession for message
 
 You can get the IoSession from the message header with this key
-`MinaConstants.MINA_IOSESSION`, and also get the local host address
-with the key `MinaConstants.MINA_LOCAL_ADDRESS` and remote host address
-with the key `MinaConstants.MINA_REMOTE_ADDRESS`.
+`CamelMinaIoSession`, and also get the local host address
+with the key `CamelMinaLocalAddress` and remote host address
+with the key `CamelMinaRemoteAddress`.
 
 === Configuring Mina filters
 
@@ -227,7 +227,7 @@ written the `bye` message back to the client:
             public void process(Exchange exchange) throws Exception {
                 String body = exchange.getIn().getBody(String.class);
                 exchange.getOut().setBody("Bye " + body);
-                exchange.getOut().setHeader(MinaConstants.MINA_CLOSE_SESSION_WHEN_COMPLETE, true);
+                exchange.getOut().setHeader("CamelMinaCloseSessionWhenComplete", true);
             }
         });
 ----

--- a/components/camel-minio/src/main/docs/minio-component.adoc
+++ b/components/camel-minio/src/main/docs/minio-component.adoc
@@ -625,7 +625,7 @@ YAML::
 ----
 ====
 
-`createDownLink` and `createUploadLink` have a default expiry of 3600s which can be overridden by setting the header `MinioConstants.PRESIGNED_URL_EXPIRATION_TIME` (value in seconds)
+`createDownLink` and `createUploadLink` have a default expiry of 3600s which can be overridden by setting the header `CamelMinioPresignedURLExpirationTime` (value in seconds)
 
 === Bucket Auto-creation
 

--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -319,7 +319,7 @@ from("netty:tcp://0.0.0.0:8080").process(new Processor() {
         exchange.getOut().setBody("Bye " + body);
         // some condition that determines if we should close
         if (close) {
-            exchange.getOut().setHeader(NettyConstants.NETTY_CLOSE_CHANNEL_WHEN_COMPLETE, true);
+            exchange.getOut().setHeader("CamelNettyCloseChannelWhenComplete", true);
         }
     }
 });
@@ -719,7 +719,7 @@ header on the Camel Message as shown below:
 ._Java-only: Java SSL session API_
 [source,java]
 ----
-SSLSession session = exchange.getIn().getHeader(NettyConstants.NETTY_SSL_SESSION, SSLSession.class);
+SSLSession session = exchange.getIn().getHeader("CamelNettySSLSession", SSLSession.class);
 // get the first certificate which is client certificate
 javax.security.cert.X509Certificate cert = session.getPeerCertificateChain()[0];
 Principal principal = cert.getSubjectDN();

--- a/components/camel-opentelemetry-metrics/src/main/docs/opentelemetry-metrics-component.adoc
+++ b/components/camel-opentelemetry-metrics/src/main/docs/opentelemetry-metrics-component.adoc
@@ -84,8 +84,8 @@ For example
 [source,java]
 ----
 from("direct:in")
-    .setHeader(OpenTelemetryConstants.HEADER_METRIC_NAME, constant("new.name"))
-    .setHeader(OpenTelemetryConstants.HEADER_METRIC_ATTRIBUTES, constant(Attributes.of(AttributeKey.stringKey("dynamic-key"), "dynamic-value")))
+    .setHeader("CamelMetricsName", constant("new.name"))
+    .setHeader("CamelMetricsAttributes", constant(Attributes.of(AttributeKey.stringKey("dynamic-key"), "dynamic-value")))
     .to("opentelemetry-metrics:counter:name.not.used?attributes.key=value")
     .to("direct:out");
 ----
@@ -615,7 +615,7 @@ A specific Message header can be used to override action value specified in the 
 ----
 // sets timer action using header
 from("direct:in")
-    .setHeader(OpenTelemetryConstants.HEADER_TIMER_ACTION, OpenTelemetryTimerAction.start)
+    .setHeader("CamelMetricsTimerAction", constant("start"))
     .to("opentelemetry-metrics:timer:simple.timer")
     .to("direct:out");
 ----

--- a/components/camel-paho-mqtt5/src/main/docs/paho-mqtt5-component.adoc
+++ b/components/camel-paho-mqtt5/src/main/docs/paho-mqtt5-component.adoc
@@ -201,7 +201,7 @@ Java::
 [source,java]
 ----
 from("direct:test")
-    .setHeader(PahoMqtt5Constants.CAMEL_PAHO_OVERRIDE_TOPIC, simple("${header.customerId}"))
+    .setHeader("CamelPahoOverrideTopic", simple("${header.customerId}"))
     .to("paho-mqtt5:some/target/queue");
 ----
 

--- a/components/camel-paho/src/main/docs/paho-component.adoc
+++ b/components/camel-paho/src/main/docs/paho-component.adoc
@@ -201,7 +201,7 @@ Java::
 [source,java]
 ----
 from("direct:test")
-    .setHeader(PahoConstants.CAMEL_PAHO_OVERRIDE_TOPIC, simple("${header.customerId}"))
+    .setHeader("CamelPahoOverrideTopic", simple("${header.customerId}"))
     .to("paho:some/target/queue");
 ----
 

--- a/components/camel-platform-http/src/main/docs/platform-http-component.adoc
+++ b/components/camel-platform-http/src/main/docs/platform-http-component.adoc
@@ -185,7 +185,7 @@ import org.apache.camel.spi.OAuthTokenValidationResult;
 from("platform-http:/secure?oauthProfile=myprofile")
     .process(exchange -> {
         OAuthTokenValidationResult result = exchange.getProperty(
-                PlatformHttpConstants.OAUTH_TOKEN_VALIDATION_RESULT,
+                "CamelOAuthTokenValidationResult",
                 OAuthTokenValidationResult.class);
         exchange.getMessage().setHeader("X-Principal", result.getName());
     });

--- a/components/camel-robotframework/src/main/docs/robotframework-component.adoc
+++ b/components/camel-robotframework/src/main/docs/robotframework-component.adoc
@@ -96,11 +96,11 @@ and pass them to generate a custom report if such need happens
 It's possible to specify what template the component
 should use dynamically via a header, so for example:
 
-._Java-only: Java constants for header names_
+._Java-only: dynamic template via header_
 [source,java]
 ----
 from("direct:in")
-    .setHeader(RobotFrameworkCamelConstants.CAMEL_ROBOT_RESOURCE_URI).constant("path/to/my/template.robot")
+    .setHeader("CamelRobotResourceUri").constant("path/to/my/template.robot")
     .to("robotframework:dummy?allowTemplateFromHeader=true");
 ----
 
@@ -109,12 +109,12 @@ with the similar approach how you would be able to pass values using
 Camel Simple Language. Components support passing values in three
 different ways. Exchange body, headers, and properties.
 
-._Java-only: Java constants for header names_
+._Java-only: dynamic template via header_
 [source,java]
 ----
 from("direct:in")
     .setBody(constant("Hello Robot"))
-    .setHeader(RobotFrameworkCamelConstants.CAMEL_ROBOT_RESOURCE_URI).constant("path/to/my/template.robot")
+    .setHeader("CamelRobotResourceUri").constant("path/to/my/template.robot")
     .to("robotframework:dummy?allowTemplateFromHeader=true");
 ----
 
@@ -128,12 +128,12 @@ And the `template.robot` file:
     Should Be True    ${myvar} == ${body}
 ----
 
-._Java-only: Java constants for header names_
+._Java-only: dynamic template via header_
 [source,java]
 ----
 from("direct:in")
     .setHeader("testHeader", constant("testHeaderValue"))
-    .setHeader(RobotFrameworkCamelConstants.CAMEL_ROBOT_RESOURCE_URI).constant("path/to/my/template.robot")
+    .setHeader("CamelRobotResourceUri").constant("path/to/my/template.robot")
     .to("robotframework:dummy?allowTemplateFromHeader=true");
 ----
 
@@ -147,12 +147,12 @@ And the `template.robot` file:
     Should Be True    ${myvar} == ${headers.testHeader}
 ----
 
-._Java-only: Java constants for header names_
+._Java-only: dynamic template via header_
 [source,java]
 ----
 from("direct:in")
     .setProperty"testProperty", constant("testPropertyValue"))
-    .setHeader(RobotFrameworkCamelConstants.CAMEL_ROBOT_RESOURCE_URI).constant("path/to/my/template.robot")
+    .setHeader("CamelRobotResourceUri").constant("path/to/my/template.robot")
     .to("robotframework:dummy?allowTemplateFromHeader=true");
 ----
 

--- a/components/camel-rocketmq/src/main/docs/rocketmq-component.adoc
+++ b/components/camel-rocketmq/src/main/docs/rocketmq-component.adoc
@@ -124,17 +124,17 @@ YAML::
 ----
 ====
 
-Setting specific headers can change routing behaviour. For example, if header `RocketMQConstants.OVERRIDE_TOPIC_NAME` was set,
+Setting specific headers can change routing behaviour. For example, if header `CamelRockerMQOverrideTopicName` was set,
 the message will be sent to `ACTUAL_TARGET` instead of `ORIGIN_TARGET`.
 
-._Java-only: uses inline Processor lambda and RocketMQConstants Java constants_
+._Java-only: uses inline Processor lambda_
 [source,java]
 ----
 from("rocketmq:FROM?consumerGroup=consumer")
         .process(exchange -> {
-            exchange.getMessage().setHeader(RocketMQConstants.OVERRIDE_TOPIC_NAME, "ACTUAL_TARGET");
-            exchange.getMessage().setHeader(RocketMQConstants.OVERRIDE_TAG, "OVERRIDE_TAG");
-            exchange.getMessage().setHeader(RocketMQConstants.OVERRIDE_MESSAGE_KEY, "OVERRIDE_MESSAGE_KEY");
+            exchange.getMessage().setHeader("CamelRockerMQOverrideTopicName", "ACTUAL_TARGET");
+            exchange.getMessage().setHeader("CamelRockerMQOverrideTag", "OVERRIDE_TAG");
+            exchange.getMessage().setHeader("CamelRockerMQOverrideMessageKey", "OVERRIDE_MESSAGE_KEY");
         }
 )
 .to("rocketmq:ORIGIN_TARGET?producerGroup=producer")

--- a/components/camel-sap-netweaver/src/main/docs/sap-netweaver-component.adoc
+++ b/components/camel-sap-netweaver/src/main/docs/sap-netweaver-component.adoc
@@ -83,11 +83,11 @@ Service] format.
 
 We have the following Camel route
 
-._Java-only: route using Java constants and toF() string formatting_
+._Java-only: route using toF() string formatting_
 [source,java]
 ----
 from("direct:start")
-    .setHeader(NetWeaverConstants.COMMAND, constant(command))
+    .setHeader("CamelNetWeaverCommand", constant(command))
     .toF("sap-netweaver:%s?username=%s&password=%s", url, username, password)
     .to("log:response")
     .to("velocity:flight-info.vm")

--- a/components/camel-shiro/src/main/docs/shiro.adoc
+++ b/components/camel-shiro/src/main/docs/shiro.adoc
@@ -287,7 +287,7 @@ ProducerTemplate in Camel along with a SecurityToken
 === Using ShiroSecurityToken
 
 You can send a message to a Camel route with a header of key
-`ShiroSecurityConstants.SHIRO_SECURITY_TOKEN` of the type
+`CamelShiroSecurityToken` of the type
 `org.apache.camel.component.shiro.security.ShiroSecurityToken` that
 contains the username and password. For example:
 
@@ -296,7 +296,7 @@ contains the username and password. For example:
 ----
         ShiroSecurityToken shiroSecurityToken = new ShiroSecurityToken("ringo", "starr");
 
-        template.sendBodyAndHeader("direct:secureEndpoint", "Beatle Mania", ShiroSecurityConstants.SHIRO_SECURITY_TOKEN, shiroSecurityToken);
+        template.sendBodyAndHeader("direct:secureEndpoint", "Beatle Mania", "CamelShiroSecurityToken", shiroSecurityToken);
 ----
 
 You can also provide the username and password in two different headers
@@ -306,15 +306,15 @@ as shown below:
 [source,java]
 ----
         Map<String, Object> headers = new HashMap<String, Object>();
-        headers.put(ShiroSecurityConstants.SHIRO_SECURITY_USERNAME, "ringo");
-        headers.put(ShiroSecurityConstants.SHIRO_SECURITY_PASSWORD, "starr");
+        headers.put("CamelShiroSecurityUsername", "ringo");
+        headers.put("CamelShiroSecurityPassword", "starr");
         template.sendBodyAndHeaders("direct:secureEndpoint", "Beatle Mania", headers);
 ----
 
 When you use the username and password headers, then the
 ShiroSecurityPolicy in the Camel route will automatically transform those
 into a single header with key
-ShiroSecurityConstants.SHIRO_SECURITY_TOKEN with the token. Then token
+`CamelShiroSecurityToken` with the token. Then token
 is either a `ShiroSecurityToken` instance, or a base64 representation as
 a String (the latter is when you have set base64=true).
 

--- a/components/camel-solr/src/main/docs/solr-component.adoc
+++ b/components/camel-solr/src/main/docs/solr-component.adoc
@@ -85,16 +85,16 @@ Java::
 [source,java]
 ----
 from("direct:insert")
-    .setHeader(SolrConstants.PARAM_OPERATION, constant(SolrOperation.INSERT))
-    .setHeader(SolrConstants.FIELD + "id", body())
+    .setHeader("CamelSolrOperation", constant("INSERT"))
+    .setHeader("CamelSolrField.id", body())
     .to("solr://localhost:8983/solr");
 
 from("direct:delete")
-    .setHeader(SolrConstants.PARAM_OPERATION, constant(SolrOperation.DELETE))
+    .setHeader("CamelSolrOperation", constant("DELETE"))
     .to("solr://localhost:8983/solr");
 
 from("direct:search")
-    .setHeader(SolrConstants.PARAM_OPERATION, constant(SolrOperation.SEARCH))
+    .setHeader("CamelSolrOperation", constant("SEARCH"))
     .to("solr://localhost:8983/solr");
 ----
 

--- a/components/camel-splunk-hec/src/main/docs/splunk-hec-component.adoc
+++ b/components/camel-splunk-hec/src/main/docs/splunk-hec-component.adoc
@@ -100,11 +100,11 @@ If you are ingesting a large enough dataset with a big enough lag, then the time
 the event hits the server and when that event actually happened could be skewed. If
 you want to override the index time, you can do so.
 
-._Java-only: uses SplunkHECConstants.INDEX_TIME Java constant_
+._Java-only: overrides index time from Kafka header_
 [source,java]
 ----
 from("kafka:logs")
-        .setHeader(SplunkHECConstants.INDEX_TIME, simple("${headers[kafka.HEADERS].lastKey('TIME')}"))
+        .setHeader("CamelSplunkHECIndexTime", simple("${headers[kafka.HEADERS].lastKey('TIME')}"))
         .to("splunk-hec://localhost:8080?token=token");
 ----
 

--- a/components/camel-ssh/src/main/docs/ssh-component.adoc
+++ b/components/camel-ssh/src/main/docs/ssh-component.adoc
@@ -118,8 +118,8 @@ certificate-based authentication.
 3.  If neither `certResource` nor `keyPairProvider` are set, it will use
 the `username` and `password` options for authentication. Even though the `username` 
 and `password` are provided in the endpoint configuration and headers set with 
-`SshConstants.USERNAME_HEADER` (`CamelSshUsername`) and 
-`SshConstants.PASSWORD_HEADER` (`CamelSshPassword`), the endpoint 
+`CamelSshUsername` and
+`CamelSshPassword`, the endpoint 
 configuration is surpassed and credentials set in the headers are used.
 
 The following route fragment shows an SSH polling consumer using a

--- a/components/camel-stitch/src/main/docs/stitch-component.adoc
+++ b/components/camel-stitch/src/main/docs/stitch-component.adoc
@@ -135,9 +135,9 @@ from("direct:sendStitch")
 ----
 from("direct:sendStitch")
      .process(exchange -> {
-         exchange.getMessage().setHeader(StitchConstants.SCHEMA, StitchSchema.builder().addKeyword("field_1", "string").build());
-         exchange.getMessage().setHeader(StitchConstants.KEY_NAMES, "field_1");
-         exchange.getMessage().setHeader(StitchConstants.TABLE_NAME, "table_1");
+         exchange.getMessage().setHeader("CamelStitchSchema", StitchSchema.builder().addKeyword("field_1", "string").build());
+         exchange.getMessage().setHeader("CamelStitchKeyNames", "field_1");
+         exchange.getMessage().setHeader("CamelStitchTableName", "table_1");
 
          final StitchMessage stitchMessage = StitchMessage.builder()
                .withData("field_1", "stitchMessage2-1")
@@ -179,9 +179,9 @@ from("direct:sendStitch")
 ----
 from("direct:sendStitch")
      .process(exchange -> {
-         exchange.getMessage().setHeader(StitchConstants.SCHEMA, StitchSchema.builder().addKeyword("field_1", "string").build());
-         exchange.getMessage().setHeader(StitchConstants.KEY_NAMES, "field_1");
-         exchange.getMessage().setHeader(StitchConstants.TABLE_NAME, "table_1");
+         exchange.getMessage().setHeader("CamelStitchSchema", StitchSchema.builder().addKeyword("field_1", "string").build());
+         exchange.getMessage().setHeader("CamelStitchKeyNames", "field_1");
+         exchange.getMessage().setHeader("CamelStitchTableName", "table_1");
 
         final StitchMessage stitchMessage1 = StitchMessage.builder()
                 .withData("field_1", "stitchMessage1")


### PR DESCRIPTION
## Summary

- Replace `XxxConstants.FIELD` Java constant references with their actual string header names (e.g. `"CamelKafkaPartitionKey"`) across 64 component documentation files
- Makes documentation multi-DSL friendly so XML and YAML DSL users don't need to know Java imports to understand header names
- Also replaces Java enum references (e.g. `HazelcastOperation.PUT` → `"put"`, `SolrOperation.INSERT` → `"INSERT"`) and URI prefix constants (e.g. `HazelcastConstants.MAP_PREFIX` → inline `hazelcast-map:`)
- Improves AI training data quality by using universal string names instead of Java-specific constant references

Components affected: caffeine, camunda, consul, crypto, cyberark-vault, digitalocean, elasticsearch, geocoder, git, hazelcast (7 sub-components), hl7, ignite, influxdb, influxdb2, jaxb, jcr, jms, jsonpath, jt400, kafka, keycloak, kubernetes (18 sub-components), lucene, metrics, micrometer, mina, minio, netty, opentelemetry-metrics, paho, paho-mqtt5, platform-http, robotframework, rocketmq, sap-netweaver, shiro, solr, splunk-hec, ssh, stitch.

## Test plan

- [ ] Verify no remaining `Constants.` references in component docs (except valid class name references like `MimeConstants.java`)
- [ ] Verify string header names match the values in the corresponding `*Constants.java` files
- [ ] Documentation-only change, no code changes

_Claude Code on behalf of Claus Ibsen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)