### PR TITLE
CAMEL-23797: Collapse identical evalBinary/evalOther/evalTernary into one helper

### DIFF
--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleTokenizer.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleTokenizer.java
@@ -294,30 +294,23 @@ public class SimpleTokenizer {
     }
 
     private static boolean evalBinary(SimpleTokenType token, String text, String expression, int index) {
-        int len = token.getValue().length();
-        // The binary operator must be used in the format of "exp1 op exp2"
-        if (index < 2 || len >= text.length() - 1) {
-            return false;
-        }
-        String previousOne = expression.substring(index - 1, index);
-        String afterOne = text.substring(len, len + 1);
-        return " ".equals(previousOne) && " ".equals(afterOne) && text.substring(0, len).equals(token.getValue());
+        return evalSurroundedBySpace(token, text, expression, index);
     }
 
     private static boolean evalOther(SimpleTokenType token, String text, String expression, int index) {
-        int len = token.getValue().length();
-        // The other operator must be used in the format of "exp1 op exp2"
-        if (index < 2 || len >= text.length() - 1) {
-            return false;
-        }
-        String previousOne = expression.substring(index - 1, index);
-        String afterOne = text.substring(len, len + 1);
-        return " ".equals(previousOne) && " ".equals(afterOne) && text.substring(0, len).equals(token.getValue());
+        return evalSurroundedBySpace(token, text, expression, index);
     }
 
     private static boolean evalTernary(SimpleTokenType token, String text, String expression, int index) {
+        return evalSurroundedBySpace(token, text, expression, index);
+    }
+
+    /**
+     * Checks that the token appears surrounded by spaces: "exp1 op exp2". Used by all infix operators (binary, other,
+     * ternary).
+     */
+    private static boolean evalSurroundedBySpace(SimpleTokenType token, String text, String expression, int index) {
         int len = token.getValue().length();
-        // The ternary operator must be used in the format of "exp1 ? exp2 : exp3"
         if (index < 2 || len >= text.length() - 1) {
             return false;
         }

--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTokenizerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTokenizerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.simple;
+
+import org.apache.camel.language.simple.types.SimpleToken;
+import org.apache.camel.language.simple.types.TokenType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests that binary, other, and ternary infix operators are each recognized when surrounded by spaces, using the shared
+ * evalSurroundedBySpace logic.
+ */
+public class SimpleTokenizerTest {
+
+    private final SimpleTokenizer tokenizer = new SimpleTokenizer();
+
+    @Test
+    public void testBinaryOperatorIsRecognized() {
+        // "a == b": at index 2, " ==" starts and should be recognized as binary
+        String expression = "a == b";
+        // index 2 is at '=' after the space
+        SimpleToken token = tokenizer.nextToken(expression, 2, false);
+        assertEquals(TokenType.binaryOperator, token.getType().getType());
+        assertEquals("==", token.getType().getValue());
+    }
+
+    @Test
+    public void testBinaryOperatorNotRecognizedAtStartOfExpression() {
+        // "== b": binary op at index 0 should NOT match (no space before it)
+        String expression = "== b";
+        SimpleToken token = tokenizer.nextToken(expression, 0, false);
+        assertFalse(token.getType().isBinary(), "Binary op at index 0 must not match without preceding space");
+    }
+
+    @Test
+    public void testOtherOperatorIsRecognized() {
+        // "a ?: b": at index 2, "?:" should be recognized as other operator
+        String expression = "a ?: b";
+        SimpleToken token = tokenizer.nextToken(expression, 2, false);
+        assertEquals(TokenType.otherOperator, token.getType().getType());
+        assertEquals("?:", token.getType().getValue());
+    }
+
+    @Test
+    public void testTernaryOperatorQuestionMarkIsRecognized() {
+        // "a ? b : c": at index 2, "?" should be recognized as ternary operator
+        String expression = "a ? b : c";
+        SimpleToken token = tokenizer.nextToken(expression, 2, false);
+        assertEquals(TokenType.ternaryOperator, token.getType().getType());
+        assertEquals("?", token.getType().getValue());
+    }
+
+    @Test
+    public void testTernaryOperatorColonIsRecognized() {
+        // "b : c": at index 2, ":" should be recognized as ternary operator
+        String expression = "b : c";
+        SimpleToken token = tokenizer.nextToken(expression, 2, false);
+        assertEquals(TokenType.ternaryOperator, token.getType().getType());
+        assertEquals(":", token.getType().getValue());
+    }
+
+    @Test
+    public void testTernaryOperatorNotRecognizedWithoutTrailingSpace() {
+        // "a ?b": "?" at index 2 without trailing space must not match as ternary
+        String expression = "a ?b";
+        SimpleToken token = tokenizer.nextToken(expression, 2, false);
+        assertFalse(token.getType().isTernary(), "Ternary op without trailing space must not match");
+    }
+
+    @Test
+    public void testContainsBinaryOperatorIsRecognized() {
+        // "a contains b": at index 2, "contains" is a binary operator
+        String expression = "a contains b";
+        SimpleToken token = tokenizer.nextToken(expression, 2, false);
+        assertEquals(TokenType.binaryOperator, token.getType().getType());
+        assertEquals("contains", token.getType().getValue());
+    }
+}


### PR DESCRIPTION
# Description

`SimpleTokenizer` contained three private static methods (`evalBinary`, `evalOther`, `evalTernary`) with byte-for-byte identical bodies. This commit extracts the shared logic into a single `evalSurroundedBySpace` helper and makes each method delegate to it.

The change is a pure behavior-preserving refactor: all three methods enforced the same invariant (the operator must appear surrounded by spaces: `"exp1 op exp2"`), so collapsing them removes duplication and makes future changes to the space-check logic a single-site edit.

A new `SimpleTokenizerTest` covers all three operator classes (binary, other, ternary) plus boundary cases (operator at index 0, operator without trailing space).

Discovered during the work on CAMEL-22894 (simple language parser hardening).

_Claude Code on behalf of Adriano Machado_

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.