### PR TITLE
CAMEL-23798: Replace AtomicBoolean/AtomicInteger with boolean[]/int[] lambda capture holders

### DIFF
--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionParser.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleExpressionParser.java
@@ -19,7 +19,6 @@ package org.apache.camel.language.simple;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Expression;
@@ -242,8 +241,8 @@ public class SimpleExpressionParser extends BaseSimpleParser {
     protected void parseAndCreateAstModel() {
         // we loop the tokens and create a sequence of ast nodes
 
-        // counter to keep track of number of functions in the tokens
-        AtomicInteger functions = new AtomicInteger();
+        // single-element array used as a mutable counter (no concurrency; AtomicInteger is not needed here)
+        int[] functions = { 0 };
 
         LiteralNode imageToken = null;
         for (SimpleToken token : tokens) {
@@ -288,15 +287,15 @@ public class SimpleExpressionParser extends BaseSimpleParser {
         }
     }
 
-    private SimpleNode createNode(SimpleToken token, AtomicInteger functions) {
+    private SimpleNode createNode(SimpleToken token, int[] functions) {
         // expression only support functions, unary operators, operators, and other operators
         if (token.getType().isFunctionStart()) {
             // starting a new function
-            functions.incrementAndGet();
+            functions[0]++;
             return new SimpleFunctionStart(token, cacheExpression, skipFileFunctions);
-        } else if (functions.get() > 0 && token.getType().isFunctionEnd()) {
+        } else if (functions[0] > 0 && token.getType().isFunctionEnd()) {
             // there must be a start function already, to let this be an end function
-            functions.decrementAndGet();
+            functions[0]--;
             return new SimpleFunctionEnd(token);
         } else if (token.getType().isUnary()) {
             // there must be an end function as previous, to let this be a unary function

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimplePredicateParser.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimplePredicateParser.java
@@ -23,7 +23,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Expression;
@@ -239,9 +238,9 @@ public class SimplePredicateParser extends BaseSimpleParser {
         SimpleNode lastSingle = null;
         SimpleNode lastDouble = null;
         SimpleNode lastFunction = null;
-        AtomicBoolean startSingle = new AtomicBoolean();
-        AtomicBoolean startDouble = new AtomicBoolean();
-        AtomicBoolean startFunction = new AtomicBoolean();
+        boolean[] startSingle = { false };
+        boolean[] startDouble = { false };
+        boolean[] startFunction = { false };
 
         LiteralNode imageToken = null;
         for (SimpleToken token : tokens) {
@@ -287,15 +286,15 @@ public class SimplePredicateParser extends BaseSimpleParser {
         }
 
         // validate the single, double quote pairs and functions is in balance
-        if (startSingle.get()) {
+        if (startSingle[0]) {
             int index = evalIndex(lastSingle);
             throw new SimpleParserException("single quote has no ending quote", index);
         }
-        if (startDouble.get()) {
+        if (startDouble[0]) {
             int index = evalIndex(lastDouble);
             throw new SimpleParserException("double quote has no ending quote", index);
         }
-        if (startFunction.get()) {
+        if (startFunction[0]) {
             // we have a start function, but no ending function
             int index = evalIndex(lastFunction);
             throw new SimpleParserException("function has no ending token", index);
@@ -334,25 +333,25 @@ public class SimplePredicateParser extends BaseSimpleParser {
      * Creates a node from the given token
      *
      * @param  token         the token
-     * @param  startSingle   state of single quoted blocks
-     * @param  startDouble   state of double quoted blocks
-     * @param  startFunction state of function blocks
+     * @param  startSingle   state of single quoted blocks (single-element boolean array used as a mutable holder)
+     * @param  startDouble   state of double quoted blocks (single-element boolean array used as a mutable holder)
+     * @param  startFunction state of function blocks (single-element boolean array used as a mutable holder)
      * @return               the created node, or <tt>null</tt> to let a default node be created instead.
      */
     private SimpleNode createNode(
-            SimpleToken token, AtomicBoolean startSingle, AtomicBoolean startDouble,
-            AtomicBoolean startFunction) {
+            SimpleToken token, boolean[] startSingle, boolean[] startDouble,
+            boolean[] startFunction) {
         if (token.getType().isFunctionStart()) {
-            startFunction.set(true);
+            startFunction[0] = true;
             return new SimpleFunctionStart(token, cacheExpression, skipFileFunctions);
         } else if (token.getType().isFunctionEnd()) {
-            startFunction.set(false);
+            startFunction[0] = false;
             return new SimpleFunctionEnd(token);
         }
 
         // if we are inside a function, then we do not support any other kind of tokens
         // as we want all the tokens to be literal instead
-        if (startFunction.get()) {
+        if (startFunction[0]) {
             return null;
         }
 
@@ -365,7 +364,7 @@ public class SimplePredicateParser extends BaseSimpleParser {
 
         // if we are inside a quote, then we do not support any further kind of tokens
         // as we want to only support embedded functions and all other kinds to be literal tokens
-        if (startSingle.get() || startDouble.get()) {
+        if (startSingle[0] || startDouble[0]) {
             return null;
         }
 
@@ -393,29 +392,29 @@ public class SimplePredicateParser extends BaseSimpleParser {
         return null;
     }
 
-    private static SimpleNode createDoubleQuoted(SimpleToken token, AtomicBoolean startDouble) {
+    private static SimpleNode createDoubleQuoted(SimpleToken token, boolean[] startDouble) {
         SimpleNode answer;
-        boolean start = startDouble.get();
+        boolean start = startDouble[0];
         if (!start) {
             answer = new DoubleQuoteStart(token);
         } else {
             answer = new DoubleQuoteEnd(token);
         }
         // flip state on start/end flag
-        startDouble.set(!start);
+        startDouble[0] = !start;
         return answer;
     }
 
-    private static SimpleNode createSingleQuoted(SimpleToken token, AtomicBoolean startSingle) {
+    private static SimpleNode createSingleQuoted(SimpleToken token, boolean[] startSingle) {
         SimpleNode answer;
-        boolean start = startSingle.get();
+        boolean start = startSingle[0];
         if (!start) {
             answer = new SingleQuoteStart(token);
         } else {
             answer = new SingleQuoteEnd(token);
         }
         // flip state on start/end flag
-        startSingle.set(!start);
+        startSingle[0] = !start;
         return answer;
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleParserMutableStateTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleParserMutableStateTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.simple;
+
+import org.apache.camel.ExchangeTestSupport;
+import org.apache.camel.Expression;
+import org.apache.camel.Predicate;
+import org.apache.camel.language.simple.types.SimpleIllegalSyntaxException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the mutable state holders (boolean[] / int[]) used in place of AtomicBoolean / AtomicInteger in
+ * the predicate and expression parsers. Exercises balanced-quote and function tracking logic.
+ */
+public class SimpleParserMutableStateTest extends ExchangeTestSupport {
+
+    // --- predicate parser (boolean[] startSingle / startDouble / startFunction) ---
+
+    @Test
+    public void testPredicateSingleQuoteBalance() {
+        exchange.getIn().setBody("hello");
+
+        SimplePredicateParser parser = new SimplePredicateParser(context, "${body} == 'hello'", true, null);
+        Predicate predicate = parser.parsePredicate();
+        predicate.init(context);
+
+        assertTrue(predicate.matches(exchange));
+    }
+
+    @Test
+    public void testPredicateDoubleQuoteBalance() {
+        exchange.getIn().setBody("world");
+
+        SimplePredicateParser parser = new SimplePredicateParser(context, "${body} == \"world\"", true, null);
+        Predicate predicate = parser.parsePredicate();
+        predicate.init(context);
+
+        assertTrue(predicate.matches(exchange));
+    }
+
+    @Test
+    public void testPredicateUnclosedSingleQuoteThrows() {
+        SimplePredicateParser parser = new SimplePredicateParser(context, "${body} == 'unclosed", true, null);
+        assertThrows(SimpleIllegalSyntaxException.class, parser::parsePredicate);
+    }
+
+    @Test
+    public void testPredicateUnclosedFunctionThrows() {
+        SimplePredicateParser parser = new SimplePredicateParser(context, "${body", true, null);
+        assertThrows(SimpleIllegalSyntaxException.class, parser::parsePredicate);
+    }
+
+    @Test
+    public void testPredicateMultipleFunctionBalance() {
+        exchange.getIn().setBody("hello");
+        exchange.getIn().setHeader("key", "body");
+
+        SimplePredicateParser parser
+                = new SimplePredicateParser(context, "${body} == 'hello' && ${header.key} != null", true, null);
+        Predicate predicate = parser.parsePredicate();
+        predicate.init(context);
+
+        assertTrue(predicate.matches(exchange));
+    }
+
+    // --- expression parser (int[] functions counter) ---
+
+    @Test
+    public void testExpressionFunctionCounter() {
+        exchange.getIn().setBody("world");
+
+        SimpleExpressionParser parser = new SimpleExpressionParser(context, "Hello ${body}!", true, null);
+        Expression expression = parser.parseExpression();
+        expression.init(context);
+
+        assertEquals("Hello world!", expression.evaluate(exchange, String.class));
+    }
+
+    @Test
+    public void testExpressionMultipleFunctions() {
+        exchange.getIn().setBody("Camel");
+        exchange.getIn().setHeader("version", "4.x");
+
+        SimpleExpressionParser parser
+                = new SimpleExpressionParser(context, "${body} ${header.version}", true, null);
+        Expression expression = parser.parseExpression();
+        expression.init(context);
+
+        assertEquals("Camel 4.x", expression.evaluate(exchange, String.class));
+    }
+
+    @Test
+    public void testExpressionUnclosedFunctionThrows() {
+        SimpleExpressionParser parser = new SimpleExpressionParser(context, "Hello ${body", true, null);
+        assertThrows(SimpleIllegalSyntaxException.class, parser::parseExpression);
+    }
+}


### PR DESCRIPTION
# Description

`SimpleExpressionParser` and `SimplePredicateParser` used `AtomicBoolean` and `AtomicInteger` solely as mutable holders to capture state inside lambda expressions. Since both parsers are single-threaded, using `Atomic*` types is semantically misleading (it implies concurrent access) and carries unnecessary overhead.

This commit replaces them with single-element `boolean[]` and `int[]` arrays, which are the standard Java idiom for capturing mutable state in a lambda without implying thread safety.

A new `SimpleParserMutableStateTest` covers the state-tracking paths in both parsers: balanced/unbalanced single quotes, balanced/unbalanced function blocks, and compound predicate expressions.

Discovered during the work on CAMEL-22894 (simple language parser hardening).

_Claude Code on behalf of Adriano Machado_

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.