### PR TITLE
CAMEL-21438: Fix flaky file-based tests (Thread.sleep, missing Awaitility guards, discarded matchesWaitTime return)

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeHiddenFilesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumeHiddenFilesTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -42,7 +43,7 @@ public class FileConsumeHiddenFilesTest extends ContextTestSupport {
 
         assertMockEndpointsSatisfied();
 
-        Awaitility.await().untilAsserted(() -> {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             // file should be deleted
             assertFalse(Files.exists(testFile("report.txt")), "File should been deleted");
             assertFalse(Files.exists(testFile(".report.hidden")), "File should been deleted");

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFOptimizedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFOptimizedTest.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,12 +55,14 @@ public class FileProducerCharsetUTFOptimizedTest extends ContextTestSupport {
 
     @Test
     public void testFileProducerCharsetUTFOptimized() throws Exception {
-        oneExchangeDone.matchesWaitTime();
+        assertTrue(oneExchangeDone.matchesWaitTime());
 
-        assertTrue(Files.exists(testFile("output.txt")), "File should exist");
-
-        byte[] data = Files.readAllBytes(testFile("output.txt"));
-        assertArrayEquals(utf, data);
+        // The file may have been created but not yet fully flushed to disk
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(Files.exists(testFile("output.txt")), "File should exist");
+            byte[] data = Files.readAllBytes(testFile("output.txt"));
+            assertArrayEquals(utf, data);
+        });
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConfiguredTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoISOConfiguredTest.java
@@ -19,9 +19,11 @@ package org.apache.camel.component.file;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,10 +45,12 @@ class FileProducerCharsetUTFtoISOConfiguredTest extends ContextTestSupport {
 
         assertTrue(oneExchangeDone.matchesWaitTime());
 
-        assertFileExists(testFile(OUTPUT_FILE));
-        byte[] data = Files.readAllBytes(testFile(OUTPUT_FILE));
-
-        assertEquals(DATA, new String(data, StandardCharsets.ISO_8859_1));
+        // The file may have been created but not yet fully flushed to disk
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFileExists(testFile(OUTPUT_FILE));
+            byte[] data = Files.readAllBytes(testFile(OUTPUT_FILE));
+            assertEquals(DATA, new String(data, StandardCharsets.ISO_8859_1));
+        });
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerCharsetUTFtoUTFTest.java
@@ -19,9 +19,11 @@ package org.apache.camel.component.file;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -43,11 +45,14 @@ class FileProducerCharsetUTFtoUTFTest extends ContextTestSupport {
 
         assertTrue(oneExchangeDone.matchesWaitTime());
 
-        assertFileExists(testFile(OUTPUT_FILE));
-        byte[] target = Files.readAllBytes(testFile(OUTPUT_FILE));
-
-        assertArrayEquals(source, target, "The byte arrays should be equals but they are not.\n Source:\n" + new String(source)
-                                          + "\nTarget:\n" + new String(target));
+        // The file may have been created but not yet fully flushed to disk
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFileExists(testFile(OUTPUT_FILE));
+            byte[] target = Files.readAllBytes(testFile(OUTPUT_FILE));
+            assertArrayEquals(source, target,
+                    "The byte arrays should be equals but they are not.\n Source:\n" + new String(source)
+                                              + "\nTarget:\n" + new String(target));
+        });
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistFailTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistFailTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileProducerFileExistFailTest extends ContextTestSupport {
     private static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
@@ -52,7 +53,7 @@ public class FileProducerFileExistFailTest extends ContextTestSupport {
                         "File already exist: " + testFile(TEST_FILE_NAME).toString() + ". Cannot write new file."),
                 cause.getMessage());
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistFailTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerFileExistFailTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
@@ -51,6 +52,7 @@ public class FileProducerFileExistFailTest extends ContextTestSupport {
                         "File already exist: " + testFile(TEST_FILE_NAME).toString() + ". Cannot write new file."),
                 cause.getMessage());
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -55,6 +56,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 
@@ -75,6 +77,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 
@@ -95,6 +98,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 
@@ -115,6 +119,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 
@@ -135,6 +140,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 
@@ -161,6 +167,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 
@@ -192,6 +199,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
+        mock.await(10, TimeUnit.SECONDS);
         assertMockEndpointsSatisfied();
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileConverterTest.java
@@ -31,6 +31,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.converter.stream.InputStreamCache;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class GenericFileConverterTest extends ContextTestSupport {
 
     public static final String TEST_FILE_NAME = "hello." + UUID.randomUUID() + ".txt";
@@ -56,7 +58,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 
@@ -77,7 +79,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 
@@ -98,7 +100,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 
@@ -119,7 +121,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 
@@ -140,7 +142,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 
@@ -167,7 +169,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 
@@ -199,7 +201,7 @@ public class GenericFileConverterTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, TEST_FILE_NAME);
 
-        mock.await(10, TimeUnit.SECONDS);
+        assertTrue(mock.await(10, TimeUnit.SECONDS), "Timed out waiting for mock endpoint");
         assertMockEndpointsSatisfied();
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollEnrichFileCustomAggregationStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollEnrichFileCustomAggregationStrategyTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class PollEnrichFileCustomAggregationStrategyTest extends ContextTestSupport {
 
     @Test
@@ -41,7 +43,7 @@ public class PollEnrichFileCustomAggregationStrategyTest extends ContextTestSupp
 
         context.getRouteController().startAllRoutes();
 
-        getMockEndpoint("mock:start").await(10, TimeUnit.SECONDS);
+        assertTrue(getMockEndpoint("mock:start").await(10, TimeUnit.SECONDS), "Timed out waiting for mock:start");
         log.info("mock:start satisfied, writing enrichdata file");
         template.sendBodyAndHeader(fileUri("enrichdata"), "Big file",
                 Exchange.FILE_NAME, "AAA.dat");

--- a/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollEnrichFileCustomAggregationStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollEnrichFileCustomAggregationStrategyTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.processor.enricher;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.AggregationStrategy;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -39,8 +41,8 @@ public class PollEnrichFileCustomAggregationStrategyTest extends ContextTestSupp
 
         context.getRouteController().startAllRoutes();
 
-        log.info("Sleeping for 0.5 sec before writing enrichdata file");
-        Thread.sleep(500);
+        getMockEndpoint("mock:start").await(10, TimeUnit.SECONDS);
+        log.info("mock:start satisfied, writing enrichdata file");
         template.sendBodyAndHeader(fileUri("enrichdata"), "Big file",
                 Exchange.FILE_NAME, "AAA.dat");
         log.info("... write done");

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
@@ -194,12 +194,7 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:a' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onComplete(Exchange ex) {
-                                    s.release();
-                                }
-
-                                @Override
-                                public void onFailure(Exchange ex) {
+                                public void onDone(Exchange ex) {
                                     s.release();
                                 }
                             });
@@ -213,12 +208,11 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:expressionConstant' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                            exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
-                                @Override
                                 public void onDone(Exchange ex) {
                                     s.release();
                                 }
                             });
+                        })
                         .to("log:result", "mock:result");
 
                 from("direct:expressionHeader").throttle(header("throttleValue")).concurrentRequestsMode()
@@ -227,12 +221,7 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:expressionHeader' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onComplete(Exchange ex) {
-                                    s.release();
-                                }
-
-                                @Override
-                                public void onFailure(Exchange ex) {
+                                public void onDone(Exchange ex) {
                                     s.release();
                                 }
                             });

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
@@ -194,7 +194,12 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:a' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onDone(Exchange ex) {
+                                public void onComplete(Exchange ex) {
+                                    s.release();
+                                }
+
+                                @Override
+                                public void onFailure(Exchange ex) {
                                     s.release();
                                 }
                             });
@@ -208,11 +213,17 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:expressionConstant' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onDone(Exchange ex) {
+                                public void onComplete(Exchange ex) {
+                                    s.release();
+                                }
+
+                                @Override
+                                public void onFailure(Exchange ex) {
                                     s.release();
                                 }
                             });
                         })
+                        .delay(100)
                         .to("log:result", "mock:result");
 
                 from("direct:expressionHeader").throttle(header("throttleValue")).concurrentRequestsMode()
@@ -221,7 +232,12 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:expressionHeader' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onDone(Exchange ex) {
+                                public void onComplete(Exchange ex) {
+                                    s.release();
+                                }
+
+                                @Override
+                                public void onFailure(Exchange ex) {
                                     s.release();
                                 }
                             });

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/concurrent/ConcurrentRequestsThrottlerTest.java
@@ -213,17 +213,12 @@ public class ConcurrentRequestsThrottlerTest extends ContextTestSupport {
                             assertTrue(s.tryAcquire(), "'direct:expressionConstant' too many requests");
                             exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onComplete(Exchange ex) {
-                                    s.release();
-                                }
-
+                            exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
                                 @Override
-                                public void onFailure(Exchange ex) {
+                                public void onDone(Exchange ex) {
                                     s.release();
                                 }
                             });
-                        })
-                        .delay(100)
                         .to("log:result", "mock:result");
 
                 from("direct:expressionHeader").throttle(header("throttleValue")).concurrentRequestsMode()


### PR DESCRIPTION
# Description

Fix a set of flaky tests in the file component area. Each fix addresses a specific non-determinism pattern:

**1. `PollEnrichFileCustomAggregationStrategyTest`**
Replace `Thread.sleep(500)` with `getMockEndpoint("mock:start").await(10, TimeUnit.SECONDS)`. The sleep was guessing that the route had consumed the first file and reached the `pollEnrich` step; the `await` waits for the observable proof of that (the `mock:start` latch reaching zero) before writing the enrichdata file.

**2. `FileConsumeHiddenFilesTest`**
Add explicit `atMost(10, TimeUnit.SECONDS)` to a bare `Awaitility.await()` call. Without it the test relies on Awaitility's opaque library default, violating the project guideline that every `await()` must have an explicit timeout.

**3. `FileProducerFileExistFailTest`**
Add `mock.await(10, TimeUnit.SECONDS)` before `assertMockEndpointsSatisfied()`. The `doAssertIsSatisfied` only calls `waitForCompleteLatch()` if `expectedCount != getReceivedCounter()` at the moment it is entered; on a fast machine the count is already met and the latch wait is skipped entirely, leaving `runTests()` (which evaluates `expectedFileExists`) with no stable-state guarantee.

**4. `GenericFileConverterTest`**
Same root cause as #3. The test uses `isUseRouteBuilder()=false` so each of the 7 test methods manually starts the context; `assertMockEndpointsSatisfied()` is the only timing gate but has no explicit latch wait before `runTests()`. Add `mock.await(10, TimeUnit.SECONDS)` before `assertMockEndpointsSatisfied()` in every method.

**5. `FileProducerCharsetUTFtoUTFTest`, `FileProducerCharsetUTFOptimizedTest`, `FileProducerCharsetUTFtoISOConfiguredTest`**
After `oneExchangeDone.matchesWaitTime()` confirms the exchange completed, `Files.readAllBytes` on the output file can still return 0 bytes because Camel's file producer writes via a temp file + atomic rename, and the OS may not have flushed the page to the reader yet. `FileProducerCharsetUTFtoISOTest` already carries an explicit comment about this and uses an Awaitility guard; apply the same pattern to the three missing tests.
Additionally, `FileProducerCharsetUTFOptimizedTest` was silently discarding the boolean return value of `matchesWaitTime()`, masking any timeout before the file assertions ran.

**6. Review feedback (oscerd, davsclaus)**
- All `MockEndpoint.await(10, TimeUnit.SECONDS)` calls in `FileProducerFileExistFailTest`, `GenericFileConverterTest`, and `PollEnrichFileCustomAggregationStrategyTest` now assert the returned boolean with `assertTrue(...)` so a timeout causes an explicit, descriptive failure instead of silently falling through to `assertMockEndpointsSatisfied()`.
- `ConcurrentRequestsThrottlerTest.java` was reverted to match `main` exactly (commit `0c03b30d0f3` had already fixed it). Prior commits in this branch introduced an out-of-scope `onDone` refactor and accidentally dropped `.delay(100)` from `direct:expressionConstant`; both are now restored.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

_Claude Code on behalf of Adriano Machado_