### PR TITLE
CAMEL-23789: Clean up component docs - remove boilerplate, use lambdas and string headers

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent/src/main/docs/langchain4j-agent-component.adoc
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/docs/langchain4j-agent-component.adoc
@@ -126,24 +126,17 @@ The langchain4j-agent component accepts a pre-built `Agent` or `ChatModel` bean 
 ._Java-only: programmatic `ChatModel` bean registration with `OAuthHelper`_
 [source,java]
 ----
-import org.apache.camel.support.OAuthHelper;
+String token = OAuthHelper.resolveOAuthToken(getContext(), "azure");
 
-public class MyRouteBuilder extends RouteBuilder {
-    @Override
-    public void configure() throws Exception {
-        String token = OAuthHelper.resolveOAuthToken(getContext(), "azure");
+ChatModel chatModel = OpenAiChatModel.builder()
+        .apiKey(token)
+        .modelName("gpt-4")
+        .build();
 
-        ChatModel chatModel = OpenAiChatModel.builder()
-                .apiKey(token)
-                .modelName("gpt-4")
-                .build();
+getContext().getRegistry().bind("myChatModel", chatModel);
 
-        getContext().getRegistry().bind("myChatModel", chatModel);
-
-        from("direct:agent")
-            .to("langchain4j-agent:myAgent");
-    }
-}
+from("direct:agent")
+    .to("langchain4j-agent:myAgent");
 ----
 
 NOTE: In Quarkus or Spring Boot, configure the ChatModel via the framework's own properties and dependency injection instead of programmatic bean registration.
@@ -1785,46 +1778,31 @@ WordCountGuardrail custom = WordCountGuardrail.builder()
 ._Java-only: `RouteBuilder` class with `AgentConfiguration`, guardrails, memory, and `doTry`/`doCatch`_
 [source,java]
 ----
-import org.apache.camel.component.langchain4j.agent.api.*;
-import org.apache.camel.component.langchain4j.agent.api.guardrails.*;
-import dev.langchain4j.model.openai.OpenAiChatModel;
-import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+ChatModel chatModel = OpenAiChatModel.builder()
+    .apiKey("{{openai.api.key}}")
+    .modelName("gpt-4o")
+    .build();
 
-public class SecureAgentRoute extends RouteBuilder {
+ChatMemoryProvider memoryProvider = memoryId ->
+    MessageWindowChatMemory.withMaxMessages(20);
 
-    @Override
-    public void configure() throws Exception {
-        // Create chat model
-        ChatModel chatModel = OpenAiChatModel.builder()
-            .apiKey("{{openai.api.key}}")
-            .modelName("gpt-4o")
-            .build();
+AgentConfiguration configuration = new AgentConfiguration()
+    .withChatModel(chatModel)
+    .withChatMemoryProvider(memoryProvider)
+    .withInputGuardrailClasses(Guardrails.defaultInputGuardrails())
+    .withOutputGuardrailClasses(Guardrails.defaultOutputGuardrails());
 
-        // Create memory provider
-        ChatMemoryProvider memoryProvider = memoryId ->
-            MessageWindowChatMemory.withMaxMessages(20);
+Agent secureAgent = new AgentWithMemory(configuration);
+getContext().getRegistry().bind("secureAgent", secureAgent);
 
-        // Create secure agent configuration
-        AgentConfiguration configuration = new AgentConfiguration()
-            .withChatModel(chatModel)
-            .withChatMemoryProvider(memoryProvider)
-            .withInputGuardrailClasses(Guardrails.defaultInputGuardrails())
-            .withOutputGuardrailClasses(Guardrails.defaultOutputGuardrails());
-
-        Agent secureAgent = new AgentWithMemory(configuration);
-        getContext().getRegistry().bind("secureAgent", secureAgent);
-
-        // Secure chat route with error handling
-        from("direct:chat")
-            .setHeader("CamelLangChain4jAgentMemoryId", simple("${header.userId}"))
-            .doTry()
-                .to("langchain4j-agent:chat?agent=#secureAgent")
-            .doCatch(dev.langchain4j.service.guardrail.GuardrailException.class)
-                .log("Guardrail blocked request: ${exception.message}")
-                .setBody(constant("Your message was blocked due to security policies."))
-            .end();
-    }
-}
+from("direct:chat")
+    .setHeader("CamelLangChain4jAgentMemoryId", simple("${header.userId}"))
+    .doTry()
+        .to("langchain4j-agent:chat?agent=#secureAgent")
+    .doCatch(dev.langchain4j.service.guardrail.GuardrailException.class)
+        .log("Guardrail blocked request: ${exception.message}")
+        .setBody(constant("Your message was blocked due to security policies."))
+    .end();
 ----
 
 ==== Spring Boot Configuration Example

--- a/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddb-component.adoc
+++ b/components/camel-aws/camel-aws2-ddb/src/main/docs/aws2-ddb-component.adoc
@@ -78,25 +78,15 @@ URI:
 ._Java-only: programmatic `DynamoDbClient` configuration and registry binding_
 [source,java]
 ----
-public class MyRouteBuilder extends RouteBuilder {
+DynamoDbClient client = DynamoDbClient.builder()
+    .region(Region.AP_SOUTHEAST_2)
+    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+    .build();
 
-    private String accessKey = "myaccessKey";
-    private String secretKey = "secretKey";
+getCamelContext().getRegistry().bind("client", client);
 
-    @Override
-    public void configure() throws Exception {
-
-        DynamoDbClient client = DynamoDbClient.builder()
-        .region(Region.AP_SOUTHEAST_2)
-        .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
-        .build();
-
-        getCamelContext().getRegistry().bind("client", client);
-
-    	from("direct:start")
-        .to("aws2-ddb://domainName?amazonDDBClient=#client");
-    }
-}
+from("direct:start")
+    .to("aws2-ddb://domainName?amazonDDBClient=#client");
 ----
 
 The `#client` refers to a `DynamoDbClient` in the
@@ -195,7 +185,7 @@ from("direct:get")
       exchange.getIn().setHeader("CamelAwsDdbAttributeNames", constant(List.of("table-key", "message")));
       exchange.getIn().setHeader("CamelAwsDdbKey", keyMap);
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client&consistentRead=true", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client&consistentRead=true");
 ----
 
 - DeleteItem: this operation will delete an entry from DynamoDB
@@ -211,7 +201,7 @@ from("direct:delete")
       exchange.getIn().setHeader("CamelAwsDdbOperation", "DeleteItem");
       exchange.getIn().setHeader("CamelAwsDdbKey", keyMap);
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client&consistentRead=true", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client&consistentRead=true");
 ----
 
 
@@ -229,7 +219,7 @@ from("direct:partiql")
           List.of(AttributeValue.builder().s("myKeyValue").build()));
       exchange.getIn().setHeader("CamelAwsDdbConsistentRead", true);
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client");
 ----
 
 - BatchExecuteStatement (PartiQL batch): this operation runs multiple PartiQL statements in a batch
@@ -248,7 +238,7 @@ from("direct:batchPartiql")
               .statement("INSERT INTO \"MyTable\" VALUE {'key': 'k2', 'data': 'v2'}")
               .build()));
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client");
 ----
 
 - TransactWriteItems: this operation performs a transactional write across one or more tables
@@ -268,7 +258,7 @@ from("direct:transactWrite")
               .put(Put.builder().tableName("MyTable").item(item).build())
               .build()));
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client");
 ----
 
 - TransactGetItems: this operation performs a transactional read across one or more tables
@@ -287,7 +277,7 @@ from("direct:transactGet")
               .get(Get.builder().tableName("MyTable").key(key).build())
               .build()));
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client");
 ----
 
 - BatchWriteItems: this operation puts or deletes multiple items in one or more tables in a single batch
@@ -310,7 +300,7 @@ from("direct:batchWrite")
       exchange.getIn().setHeader("CamelAwsDdbOperation", "BatchWriteItems");
       exchange.getIn().setHeader("CamelAwsDdbBatchWriteItems", requestItems);
   })
-  .toF("aws2-ddb://%s?amazonDDBClient=#client", tableName);
+  .to("aws2-ddb://" + tableName + "?amazonDDBClient=#client");
 ----
 
 

--- a/components/camel-aws/camel-aws2-ec2/src/main/docs/aws2-ec2-component.adoc
+++ b/components/camel-aws/camel-aws2-ec2/src/main/docs/aws2-ec2-component.adoc
@@ -96,10 +96,10 @@ Java::
 [source,java]
 ----
 from("direct:createAndRun")
-     .setHeader(EC2Constants.IMAGE_ID, constant("ami-fd65ba94"))
-     .setHeader(EC2Constants.INSTANCE_TYPE, constant(InstanceType.T2_MICRO))
-     .setHeader(EC2Constants.INSTANCE_MIN_COUNT, constant("1"))
-     .setHeader(EC2Constants.INSTANCE_MAX_COUNT, constant("1"))
+     .setHeader("CamelAwsEC2ImageId", constant("ami-fd65ba94"))
+     .setHeader("CamelAwsEC2InstanceType", constant(InstanceType.T2_MICRO))
+     .setHeader("CamelAwsEC2InstanceMinCount", constant("1"))
+     .setHeader("CamelAwsEC2InstanceMaxCount", constant("1"))
      .to("aws2-ec2://TestDomain?accessKey=xxxx&secretKey=xxxx&operation=createAndRunInstances");
 ----
 
@@ -156,52 +156,37 @@ YAML::
 
 - startInstances: this operation will start a list of EC2 instances
 
-._Java-only: using a Processor to set the instance IDs collection_
+._Java-only: sets a collection header for instance IDs_
 [source,java]
 ----
 from("direct:start")
-     .process(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                Collection<String> l = new ArrayList<>();
-                l.add("myinstance");
-                exchange.getIn().setHeader(AWS2EC2Constants.INSTANCES_IDS, l);
-            }
-        })
+     .process(exchange -> {
+         exchange.getIn().setHeader("CamelAwsEC2InstancesIds", List.of("myinstance"));
+     })
      .to("aws2-ec2://TestDomain?accessKey=xxxx&secretKey=xxxx&operation=startInstances");
 ----
 
 - stopInstances: this operation will stop a list of EC2 instances
 
-._Java-only: using a Processor to set the instance IDs collection_
+._Java-only: sets a collection header for instance IDs_
 [source,java]
 ----
 from("direct:stop")
-     .process(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                Collection<String> l = new ArrayList<>();
-                l.add("myinstance");
-                exchange.getIn().setHeader(AWS2EC2Constants.INSTANCES_IDS, l);
-            }
-        })
+     .process(exchange -> {
+         exchange.getIn().setHeader("CamelAwsEC2InstancesIds", List.of("myinstance"));
+     })
      .to("aws2-ec2://TestDomain?accessKey=xxxx&secretKey=xxxx&operation=stopInstances");
 ----
 
 - terminateInstances: this operation will terminate a list of EC2 instances
 
-._Java-only: using a Processor to set the instance IDs collection_
+._Java-only: sets a collection header for instance IDs_
 [source,java]
 ----
-from("direct:stop")
-     .process(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                Collection<String> l = new ArrayList<>();
-                l.add("myinstance");
-                exchange.getIn().setHeader(AWS2EC2Constants.INSTANCES_IDS, l);
-            }
-        })
+from("direct:terminate")
+     .process(exchange -> {
+         exchange.getIn().setHeader("CamelAwsEC2InstancesIds", List.of("myinstance"));
+     })
      .to("aws2-ec2://TestDomain?accessKey=xxxx&secretKey=xxxx&operation=terminateInstances");
 ----
 

--- a/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-firehose-component.adoc
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-firehose-component.adoc
@@ -150,25 +150,16 @@ Camel-AWS s3 component provides the following operation on the producer side:
 
 You can send an iterable of Kinesis Record (as the following example shows), or you can send directly a PutRecordBatchRequest POJO instance in the body.
 
-._Java-only: uses ProducerTemplate, inline Processor, and AWS SDK builders_
+._Java-only: uses AWS SDK `Record` builders_
 [source,java]
 ----
-    @Test
-    public void testFirehoseBatchRouting() throws Exception {
-        Exchange exchange = template.send("direct:start", ExchangePattern.InOnly, new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                List<Record> recs = new ArrayList<Record>();
-                Record rec = Record.builder().data(SdkBytes.fromString("Test1", Charset.defaultCharset())).build();
-                Record rec1 = Record.builder().data(SdkBytes.fromString("Test2", Charset.defaultCharset())).build();
-                recs.add(rec);
-                recs.add(rec1);
-                exchange.getIn().setBody(recs);
-            }
-        });
-        assertNotNull(exchange.getIn().getBody());
-    }
-
-from("direct:start").to("aws2-kinesis-firehose://cc?amazonKinesisFirehoseClient=#FirehoseClient&operation=sendBatchRecord");
+from("direct:start")
+    .process(exchange -> {
+        exchange.getIn().setBody(List.of(
+            Record.builder().data(SdkBytes.fromString("Test1", Charset.defaultCharset())).build(),
+            Record.builder().data(SdkBytes.fromString("Test2", Charset.defaultCharset())).build()));
+    })
+    .to("aws2-kinesis-firehose://cc?amazonKinesisFirehoseClient=#FirehoseClient&operation=sendBatchRecord");
 ----
 
 In the deliveryStream you'll find "Test1Test2".

--- a/components/camel-aws/camel-aws2-lambda/src/main/docs/aws2-lambda-component.adoc
+++ b/components/camel-aws/camel-aws2-lambda/src/main/docs/aws2-lambda-component.adoc
@@ -159,24 +159,20 @@ and by sending
 
 [source,java]
 ----
-        template.send("direct:createFunction", ExchangePattern.InOut, new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(Lambda2Constants.RUNTIME, "nodejs6.10");
-                exchange.getIn().setHeader(Lambda2Constants.HANDLER, "GetHelloWithName.handler");
-                exchange.getIn().setHeader(Lambda2Constants.DESCRIPTION, "Hello with node.js on Lambda");
-                exchange.getIn().setHeader(Lambda2Constants.ROLE,
-                        "arn:aws:iam::643534317684:role/lambda-execution-role");
+template.send("direct:createFunction", ExchangePattern.InOut, exchange -> {
+    exchange.getIn().setHeader("CamelAwsLambdaRuntime", "nodejs6.10");
+    exchange.getIn().setHeader("CamelAwsLambdaHandler", "GetHelloWithName.handler");
+    exchange.getIn().setHeader("CamelAwsLambdaDescription", "Hello with node.js on Lambda");
+    exchange.getIn().setHeader("CamelAwsLambdaRole",
+            "arn:aws:iam::643534317684:role/lambda-execution-role");
 
-                ClassLoader classLoader = getClass().getClassLoader();
-                File file = new File(
-                        classLoader
-                                .getResource("org/apache/camel/component/aws2/lambda/function/node/GetHelloWithName.zip")
-                                .getFile());
-                FileInputStream inputStream = new FileInputStream(file);
-                exchange.getIn().setBody(inputStream);
-            }
-        });
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(
+            classLoader
+                    .getResource("org/apache/camel/component/aws2/lambda/function/node/GetHelloWithName.zip")
+                    .getFile());
+    exchange.getIn().setBody(new FileInputStream(file));
+});
 ----
 
 === Function URL Operations
@@ -816,13 +812,13 @@ You can also configure CORS settings for function URLs:
 from("direct:createFunctionUrlWithCors")
     .process(exchange -> {
         exchange.getIn().setHeader("CamelAwsLambdaFunctionUrlAuthType", "NONE");
-        exchange.getIn().setHeader(Lambda2Constants.FUNCTION_URL_CORS_ALLOW_ORIGINS,
-            Arrays.asList("https://example.com"));
-        exchange.getIn().setHeader(Lambda2Constants.FUNCTION_URL_CORS_ALLOW_METHODS,
-            Arrays.asList("GET", "POST"));
-        exchange.getIn().setHeader(Lambda2Constants.FUNCTION_URL_CORS_ALLOW_HEADERS,
-            Arrays.asList("Content-Type", "Authorization"));
-        exchange.getIn().setHeader(Lambda2Constants.FUNCTION_URL_CORS_MAX_AGE, 3600);
+        exchange.getIn().setHeader("CamelAwsLambdaFunctionUrlCorsAllowOrigins",
+            List.of("https://example.com"));
+        exchange.getIn().setHeader("CamelAwsLambdaFunctionUrlCorsAllowMethods",
+            List.of("GET", "POST"));
+        exchange.getIn().setHeader("CamelAwsLambdaFunctionUrlCorsAllowHeaders",
+            List.of("Content-Type", "Authorization"));
+        exchange.getIn().setHeader("CamelAwsLambdaFunctionUrlCorsMaxAge", 3600);
     })
     .to("aws2-lambda://myFunction?operation=createFunctionUrlConfig")
     .to("mock:result");

--- a/components/camel-aws/camel-aws2-mq/src/main/docs/aws2-mq-component.adoc
+++ b/components/camel-aws/camel-aws2-mq/src/main/docs/aws2-mq-component.adoc
@@ -123,29 +123,21 @@ YAML::
 
 - createBroker: this operation will create an MQ Broker in AWS
 
-._Java-only: uses inline Processor, Java constants, and AWS SDK builders_
+._Java-only: uses AWS SDK enum types and `User` builder_
 [source,java]
 ----
 from("direct:createBroker")
-    .process(new Processor() {
-       @Override
-       public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(MQ2Constants.BROKER_NAME, "test");
-                exchange.getIn().setHeader(MQ2Constants.BROKER_DEPLOYMENT_MODE, DeploymentMode.SINGLE_INSTANCE);
-                exchange.getIn().setHeader(MQ2Constants.BROKER_INSTANCE_TYPE, "mq.t2.micro");
-                exchange.getIn().setHeader(MQ2Constants.BROKER_ENGINE, EngineType.ACTIVEMQ.name());
-                exchange.getIn().setHeader(MQ2Constants.BROKER_ENGINE_VERSION, "5.15.6");
-                exchange.getIn().setHeader(MQ2Constants.BROKER_PUBLICLY_ACCESSIBLE, false);
-                List<User> users = new ArrayList<>();
-                User.Builder user = User.builder();
-                user.username("camel");
-                user.password("camelpwd");
-                users.add(user.build());
-                exchange.getIn().setHeader(MQ2Constants.BROKER_USERS, users);
-
-       }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelAwsMQBrokerName", "test");
+        exchange.getIn().setHeader("CamelAwsMQBrokerDeploymentMode", DeploymentMode.SINGLE_INSTANCE);
+        exchange.getIn().setHeader("CamelAwsMQBrokerInstanceType", "mq.t2.micro");
+        exchange.getIn().setHeader("CamelAwsMQBrokerEngine", EngineType.ACTIVEMQ.name());
+        exchange.getIn().setHeader("CamelAwsMQBrokerEngineVersion", "5.15.6");
+        exchange.getIn().setHeader("CamelAwsMQBrokerPubliclyAccessible", false);
+        exchange.getIn().setHeader("CamelAwsMQBrokerUsers",
+            List.of(User.builder().username("camel").password("camelpwd").build()));
     })
-    .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=createBroker")
+    .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=createBroker");
 ----
 
 - deleteBroker: this operation will delete an MQ Broker in AWS
@@ -157,7 +149,7 @@ Java::
 [source,java]
 ----
 from("direct:deleteBroker")
-    .setHeader(MQ2Constants.BROKER_ID, constant("123"))
+    .setHeader("CamelAwsMQBrokerID", constant("123"))
     .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=deleteBroker");
 ----
 
@@ -202,7 +194,7 @@ Java::
 [source,java]
 ----
 from("direct:rebootBroker")
-    .setHeader(MQ2Constants.BROKER_ID, constant("123"))
+    .setHeader("CamelAwsMQBrokerID", constant("123"))
     .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=rebootBroker");
 ----
 

--- a/components/camel-aws/camel-aws2-msk/src/main/docs/aws2-msk-component.adoc
+++ b/components/camel-aws/camel-aws2-msk/src/main/docs/aws2-msk-component.adoc
@@ -115,21 +115,18 @@ YAML::
 
 - createCluster: this operation will create an MSK Cluster in AWS
 
-._Java-only: creating an MSK Cluster with a Processor and MSK2Constants_
+._Java-only: uses AWS SDK `BrokerNodeGroupInfo` builder_
 [source,java]
 ----
 from("direct:createCluster")
-    .process(new Processor() {
-       @Override
-       public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(MSK2Constants.CLUSTER_NAME, "test-kafka");
-                exchange.getIn().setHeader(MSK2Constants.CLUSTER_KAFKA_VERSION, "2.1.1");
-                exchange.getIn().setHeader(MSK2Constants.BROKER_NODES_NUMBER, 2);
-                BrokerNodeGroupInfo groupInfo = BrokerNodeGroupInfo.builder().build();
-                exchange.getIn().setHeader(MSK2Constants.BROKER_NODES_GROUP_INFO, groupInfo);
-       }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelAwsMSKClusterName", "test-kafka");
+        exchange.getIn().setHeader("CamelAwsMSKClusterKafkaVersion", "2.1.1");
+        exchange.getIn().setHeader("CamelAwsMSKBrokerNodesNumber", 2);
+        exchange.getIn().setHeader("CamelAwsMSKBrokerNodesGroupInfo",
+            BrokerNodeGroupInfo.builder().build());
     })
-    .to("aws2-msk://test?mskClient=#amazonMskClient&operation=createCluster")
+    .to("aws2-msk://test?mskClient=#amazonMskClient&operation=createCluster");
 ----
 
 - deleteCluster: this operation will delete an MSK Cluster in AWS
@@ -141,7 +138,7 @@ Java::
 [source,java]
 ----
 from("direct:deleteCluster")
-    .setHeader(MSK2Constants.CLUSTER_ARN, constant("test-kafka"))
+    .setHeader("CamelAwsMSKClusterArn", constant("test-kafka"))
     .to("aws2-msk://test?mskClient=#amazonMskClient&operation=deleteCluster");
 ----
 
@@ -177,21 +174,18 @@ YAML::
 ----
 ====
 
-._Java-only: deleting an MSK Cluster with a Processor and MSK2Constants_
+._Java-only: uses AWS SDK `BrokerNodeGroupInfo` builder_
 [source,java]
 ----
-from("direct:createCluster")
-    .process(new Processor() {
-       @Override
-       public void process(Exchange exchange) throws Exception {
-                exchange.getIn().setHeader(MSK2Constants.CLUSTER_NAME, "test-kafka");
-                exchange.getIn().setHeader(MSK2Constants.CLUSTER_KAFKA_VERSION, "2.1.1");
-                exchange.getIn().setHeader(MSK2Constants.BROKER_NODES_NUMBER, 2);
-                BrokerNodeGroupInfo groupInfo = BrokerNodeGroupInfo.builder().build();
-                exchange.getIn().setHeader(MSK2Constants.BROKER_NODES_GROUP_INFO, groupInfo);
-       }
+from("direct:deleteCluster")
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelAwsMSKClusterName", "test-kafka");
+        exchange.getIn().setHeader("CamelAwsMSKClusterKafkaVersion", "2.1.1");
+        exchange.getIn().setHeader("CamelAwsMSKBrokerNodesNumber", 2);
+        exchange.getIn().setHeader("CamelAwsMSKBrokerNodesGroupInfo",
+            BrokerNodeGroupInfo.builder().build());
     })
-    .to("aws2-msk://test?mskClient=#amazonMskClient&operation=deleteCluster")
+    .to("aws2-msk://test?mskClient=#amazonMskClient&operation=deleteCluster");
 ----
 
 === Using a POJO as body

--- a/components/camel-bindy/src/main/docs/bindy-dataformat.adoc
+++ b/components/camel-bindy/src/main/docs/bindy-dataformat.adoc
@@ -1937,12 +1937,10 @@ the following:
 from("file://inbox")
     .unmarshal(bindy)
     .split(body())
-        .process(new Processor() {
-            public void process(Exchange exchange) throws Exception {
-                Message in = exchange.getIn();
-                Map<String, Object> modelMap = (Map<String, Object>) in.getBody();
-                in.setBody(modelMap.get(Order.class.getCanonicalName()));
-            }
+        .process(exchange -> {
+            Message in = exchange.getIn();
+            Map<String, Object> modelMap = (Map<String, Object>) in.getBody();
+            in.setBody(modelMap.get(Order.class.getCanonicalName()));
         })
         .to("direct:handleSingleOrder")
     .end();

--- a/components/camel-crypto/src/main/docs/crypto-dataformat.adoc
+++ b/components/camel-crypto/src/main/docs/crypto-dataformat.adoc
@@ -254,11 +254,9 @@ from("direct:key-in-header-encrypt")
     .removeHeader(CryptoDataFormat.KEY)
     .to("mock:encrypted");
 
-from("direct:key-in-header-decrypt").unmarshal(cryptoFormat).process(new Processor() {
-    public void process(Exchange exchange) throws Exception {
-        exchange.getIn().getHeaders().remove(CryptoDataFormat.KEY);
-        exchange.getMessage().copyFrom(exchange.getIn());
-    }
+from("direct:key-in-header-decrypt").unmarshal(cryptoFormat).process(exchange -> {
+    exchange.getIn().getHeaders().remove(CryptoDataFormat.KEY);
+    exchange.getMessage().copyFrom(exchange.getIn());
 }).to("mock:unencrypted");
 ----
 

--- a/components/camel-cxf/camel-cxf-rest/src/main/docs/cxfrs-component.adoc
+++ b/components/camel-cxf/camel-cxf-rest/src/main/docs/cxfrs-component.adoc
@@ -394,22 +394,14 @@ Here is an example:
 ._Java-only: Java test API (ProducerTemplate with inline Processor)_
 [source,java]
 ----
-Exchange exchange = template.send("direct://proxy", new Processor() {
-    public void process(Exchange exchange) throws Exception {
-        exchange.setPattern(ExchangePattern.InOut);
-        Message inMessage = exchange.getIn();
-        // set the operation name
-        inMessage.setHeader(CxfConstants.OPERATION_NAME, "getCustomer");
-        // using the proxy client API
-        inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, Boolean.FALSE);
-        // set a customer header
-        inMessage.setHeader("key", "value");
-        // set up the accepted content type
-        inMessage.setHeader(CxfConstants.ACCEPT_CONTENT_TYPE, "application/json");
-        // set the parameters, if you just have one parameter,
-        // camel will put this object into an Object[] itself
-        inMessage.setBody("123");
-    }
+Exchange exchange = template.send("direct://proxy", ex -> {
+    ex.setPattern(ExchangePattern.InOut);
+    Message inMessage = ex.getIn();
+    inMessage.setHeader("CamelCxfOperationName", "getCustomer");
+    inMessage.setHeader("CamelCxfRsUsingHttpAPI", Boolean.FALSE);
+    inMessage.setHeader("key", "value");
+    inMessage.setHeader("Accept", "application/json");
+    inMessage.setBody("123");
 });
 
 // get the response message
@@ -431,31 +423,23 @@ and
 the https://www.javadoc.io/doc/org.apache.camel/camel-api/current/org/apache/camel/Exchange.html#HTTP_METHOD[HTTP_METHOD] and
 let the producer use the http centric client API by using the URI option
 *httpClientAPI* or by setting the message header
-https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_USING_HTTP_API[CxfConstants.CAMEL_CXF_RS_USING_HTTP_API].
+`CamelCxfRsUsingHttpAPI`.
 You can turn the response object to the type class specified with the
 message
-header https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_RESPONSE_CLASS[CxfConstants.CAMEL_CXF_RS_RESPONSE_CLASS].
+header `CamelCxfRsResponseClass`.
 
 ._Java-only: Java test API (ProducerTemplate with inline Processor)_
 [source,java]
 ----
-Exchange exchange = template.send("direct://http", new Processor() {
-    public void process(Exchange exchange) throws Exception {
-        exchange.setPattern(ExchangePattern.InOut)
-        Message inMessage = exchange.getIn();
-        // using the http central client API
-        inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, Boolean.TRUE);
-        // set the Http method
-        inMessage.setHeader(Exchange.HTTP_METHOD, "GET");
-        // set the relative path
-        inMessage.setHeader(Exchange.HTTP_PATH, "/customerservice/customers/123");
-        // Specify the response class, cxfrs will use InputStream as the response object type
-        inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_RESPONSE_CLASS, Customer.class);
-        // set a customer header
-        inMessage.setHeader("key", "value");
-        // since we use the Get method, so we don't need to set the message body
-        inMessage.setBody(null);
-    }
+Exchange exchange = template.send("direct://http", ex -> {
+    ex.setPattern(ExchangePattern.InOut);
+    Message inMessage = ex.getIn();
+    inMessage.setHeader("CamelCxfRsUsingHttpAPI", Boolean.TRUE);
+    inMessage.setHeader(Exchange.HTTP_METHOD, "GET");
+    inMessage.setHeader(Exchange.HTTP_PATH, "/customerservice/customers/123");
+    inMessage.setHeader("CamelCxfRsResponseClass", Customer.class);
+    inMessage.setHeader("key", "value");
+    inMessage.setBody(null);
 });
 ----
 We also support to specify the query parameters from
@@ -467,7 +451,7 @@ cxfrs URI for the CXFRS http centric client.
 Exchange exchange = template.send("cxfrs://http://localhost:9003/testQuery?httpClientAPI=true&q1=12&q2=13"
 ----
 To support the Dynamical routing, you can override the URI's query
-parameters by using the https://www.javadoc.io/doc/org.apache.camel/camel-cxf-transport/current/org/apache/camel/component/cxf/common/message/CxfConstants.html#CAMEL_CXF_RS_QUERY_MAP[CxfConstants.CAMEL_CXF_RS_QUERY_MAP]
+parameters by using the `CamelCxfRsQueryMap`
 header to set the parameter map for it.
 
 ._Java-only: Java collection API_
@@ -476,7 +460,7 @@ header to set the parameter map for it.
 Map<String, String> queryMap = new LinkedHashMap<>();
 queryMap.put("q1", "new");
 queryMap.put("q2", "world");
-inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_QUERY_MAP, queryMap);
+inMessage.setHeader("CamelCxfRsQueryMap", queryMap);
 ----
 
 

--- a/components/camel-cxf/camel-cxf-soap/src/main/docs/cxf-component.adoc
+++ b/components/camel-cxf/camel-cxf-soap/src/main/docs/cxf-component.adoc
@@ -603,7 +603,7 @@ and setDefaultBus properties from spring configuration file.
 The Camel CXF endpoint consumer POJO data format is based on the
 http://cxf.apache.org/docs/invokers.html[CXF invoker], so the
 message header has a property with the name of
-`CxfConstants.OPERATION_NAME` and the message body is a list of the SEI
+`CamelCxfOperationName` and the message body is a list of the SEI
 operation parameters.
 
 Having simple java web service interface:
@@ -631,7 +631,7 @@ We can then create the simplest CXF service (note we didn't specify the `POJO` m
 ----
 from("cxf:textServiceResponseFromRoute?serviceClass=org.apache.camel.component.cxf.soap.server.TextService&address=/text-route")
     .process(exchange -> {
-        String operation = (String) exchange.getIn().getHeader(CxfConstants.OPERATION_NAME);
+        String operation = (String) exchange.getIn().getHeader("CamelCxfOperationName");
         String inputArg = ((MessageContentsList) exchange.getIn().getBody()).get(0).toString();
         String result = null;
         if (operation.equals("upperCase")) {
@@ -669,7 +669,7 @@ final List<String> params = new ArrayList<>();
 // Prepare the request message for the camel-cxf procedure
 params.add(TEST_MESSAGE);
 senderExchange.getIn().setBody(params);
-senderExchange.getIn().setHeader(CxfConstants.OPERATION_NAME, ECHO_OPERATION);
+senderExchange.getIn().setHeader("CamelCxfOperationName", ECHO_OPERATION);
 
 Exchange exchange = template.send("direct:EndpointA", senderExchange);
 
@@ -698,42 +698,30 @@ See https://github.com/apache/camel/blob/main/components/camel-cxf/camel-cxf-soa
 ._Java-only: consuming and processing CXF PAYLOAD with `CxfPayload` API_
 [source,java]
 ----
-protected RouteBuilder createRouteBuilder() {
-    return new RouteBuilder() {
-        public void configure() {
-            from(simpleEndpointURI + "&dataFormat=PAYLOAD").to("log:info").process(new Processor() {
-                @SuppressWarnings("unchecked")
-                public void process(final Exchange exchange) throws Exception {
-                    CxfPayload<SoapHeader> requestPayload = exchange.getIn().getBody(CxfPayload.class);
-                    List<Source> inElements = requestPayload.getBodySources();
-                    List<Source> outElements = new ArrayList<>();
-                    // You can use a customer toStringConverter to turn a CxfPayLoad message into String as you want
-                    String request = exchange.getIn().getBody(String.class);
-                    XmlConverter converter = new XmlConverter();
-                    String documentString = ECHO_RESPONSE;
+from(simpleEndpointURI + "&dataFormat=PAYLOAD").to("log:info").process(exchange -> {
+    CxfPayload<SoapHeader> requestPayload = exchange.getIn().getBody(CxfPayload.class);
+    List<Source> inElements = requestPayload.getBodySources();
+    List<Source> outElements = new ArrayList<>();
+    String request = exchange.getIn().getBody(String.class);
+    XmlConverter converter = new XmlConverter();
+    String documentString = ECHO_RESPONSE;
 
-                    Element in = new XmlConverter().toDOMElement(inElements.get(0));
-                    // Check the element namespace
-                    if (!in.getNamespaceURI().equals(ELEMENT_NAMESPACE)) {
-                        throw new IllegalArgumentException("Wrong element namespace");
-                    }
-                    if (in.getLocalName().equals("echoBoolean")) {
-                        documentString = ECHO_BOOLEAN_RESPONSE;
-                        checkRequest("ECHO_BOOLEAN_REQUEST", request);
-                    } else {
-                        documentString = ECHO_RESPONSE;
-                        checkRequest("ECHO_REQUEST", request);
-                    }
-                    Document outDocument = converter.toDOMDocument(documentString, exchange);
-                    outElements.add(new DOMSource(outDocument.getDocumentElement()));
-                    // set the payload header with null
-                    CxfPayload<SoapHeader> responsePayload = new CxfPayload<>(null, outElements, null);
-                    exchange.getMessage().setBody(responsePayload);
-                }
-            });
-        }
-    };
-}
+    Element in = new XmlConverter().toDOMElement(inElements.get(0));
+    if (!in.getNamespaceURI().equals(ELEMENT_NAMESPACE)) {
+        throw new IllegalArgumentException("Wrong element namespace");
+    }
+    if (in.getLocalName().equals("echoBoolean")) {
+        documentString = ECHO_BOOLEAN_RESPONSE;
+        checkRequest("ECHO_BOOLEAN_REQUEST", request);
+    } else {
+        documentString = ECHO_RESPONSE;
+        checkRequest("ECHO_REQUEST", request);
+    }
+    Document outDocument = converter.toDOMDocument(documentString, exchange);
+    outElements.add(new DOMSource(outDocument.getDocumentElement()));
+    CxfPayload<SoapHeader> responsePayload = new CxfPayload<>(null, outElements, null);
+    exchange.getMessage().setBody(responsePayload);
+});
 ----
 
 === How to get and set SOAP headers in POJO mode
@@ -846,33 +834,27 @@ For example, see https://github.com/apache/camel/blob/main/components/camel-cxf/
 ._Java-only: accessing SOAP headers from `CxfPayload` in PAYLOAD mode_
 [source,java]
 ----
-from(getRouterEndpointURI()).process(new Processor() {
-    @SuppressWarnings("unchecked")
-    public void process(Exchange exchange) throws Exception {
-        CxfPayload<SoapHeader> payload = exchange.getIn().getBody(CxfPayload.class);
-        List<Source> elements = payload.getBodySources();
-        assertNotNull(elements, "We should get the elements here");
-        assertEquals(1, elements.size(), "Get the wrong elements size");
+from(getRouterEndpointURI()).process(exchange -> {
+    CxfPayload<SoapHeader> payload = exchange.getIn().getBody(CxfPayload.class);
+    List<Source> elements = payload.getBodySources();
+    assertNotNull(elements, "We should get the elements here");
+    assertEquals(1, elements.size(), "Get the wrong elements size");
 
-        Element el = new XmlConverter().toDOMElement(elements.get(0));
-        elements.set(0, new DOMSource(el));
-        assertEquals("http://camel.apache.org/pizza/types",
-                el.getNamespaceURI(), "Get the wrong namespace URI");
+    Element el = new XmlConverter().toDOMElement(elements.get(0));
+    elements.set(0, new DOMSource(el));
+    assertEquals("http://camel.apache.org/pizza/types",
+            el.getNamespaceURI(), "Get the wrong namespace URI");
 
-        List<SoapHeader> headers = payload.getHeaders();
-        assertNotNull(headers, "We should get the headers here");
-        assertEquals(1, headers.size(), "Get the wrong headers size");
-        assertEquals("http://camel.apache.org/pizza/types",
-                ((Element) (headers.get(0).getObject())).getNamespaceURI(), "Get the wrong namespace URI");
-        // alternatively, you can also get the SOAP header via the camel header:
-        headers = exchange.getIn().getHeader(Header.HEADER_LIST, List.class);
-        assertNotNull(headers, "We should get the headers here");
-        assertEquals(1, headers.size(), "Get the wrong headers size");
-        assertEquals("http://camel.apache.org/pizza/types",
-                ((Element) (headers.get(0).getObject())).getNamespaceURI(), "Get the wrong namespace URI");
-
-    }
-
+    List<SoapHeader> headers = payload.getHeaders();
+    assertNotNull(headers, "We should get the headers here");
+    assertEquals(1, headers.size(), "Get the wrong headers size");
+    assertEquals("http://camel.apache.org/pizza/types",
+            ((Element) (headers.get(0).getObject())).getNamespaceURI(), "Get the wrong namespace URI");
+    headers = exchange.getIn().getHeader(Header.HEADER_LIST, List.class);
+    assertNotNull(headers, "We should get the headers here");
+    assertEquals(1, headers.size(), "Get the wrong headers size");
+    assertEquals("http://camel.apache.org/pizza/types",
+            ((Element) (headers.get(0).getObject())).getNamespaceURI(), "Get the wrong namespace URI");
 })
 .to(getServiceEndpointURI());
 ----
@@ -949,17 +931,14 @@ response context with the following code:
 ._Java-only: setting request context and reading response context via `ProducerTemplate`_
 [source,java]
 ----
-CxfExchange exchange = (CxfExchange)template.send(getJaxwsEndpointUri(), new Processor() {
-     public void process(final Exchange exchange) {
-         final List<String> params = new ArrayList<String>();
-         params.add(TEST_MESSAGE);
-         // Set the request context to the inMessage
-         Map<String, Object> requestContext = new HashMap<String, Object>();
-         requestContext.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, JAXWS_SERVER_ADDRESS);
-         exchange.getIn().setBody(params);
-         exchange.getIn().setHeader(Client.REQUEST_CONTEXT , requestContext);
-         exchange.getIn().setHeader(CxfConstants.OPERATION_NAME, GREET_ME_OPERATION);
-     }
+CxfExchange exchange = (CxfExchange)template.send(getJaxwsEndpointUri(), ex -> {
+    final List<String> params = new ArrayList<String>();
+    params.add(TEST_MESSAGE);
+    Map<String, Object> requestContext = new HashMap<String, Object>();
+    requestContext.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, JAXWS_SERVER_ADDRESS);
+    ex.getIn().setBody(params);
+    ex.getIn().setHeader(Client.REQUEST_CONTEXT, requestContext);
+    ex.getIn().setHeader("CamelCxfOperationName", GREET_ME_OPERATION);
 });
 org.apache.camel.Message out = exchange.getMessage();
 // The output is an object array, the first element of the array is the return value
@@ -997,85 +976,22 @@ SwA is the default (same as setting the CXF endpoint property `mtomEnabled` to `
 
 To enable MTOM, set the CXF endpoint property `mtomEnabled` to `true`.
 
-[tabs]
-====
-Java (Quarkus)::
-+
-[source,java]
-----
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.cxf.common.DataFormat;
-import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Named;
-
-@ApplicationScoped
-public class CxfSoapMtomRoutes extends RouteBuilder {
-
-    @Override
-    public void configure() {
-        from("cxf:bean:mtomPayloadModeEndpoint")
-                .process( exchange -> { ... });
-    }
-
-    @Produces
-    @SessionScoped
-    @Named
-    CxfEndpoint mtomPayloadModeEndpoint() {
-        final CxfEndpoint result = new CxfEndpoint();
-        result.setServiceClass(MyMtomService.class);
-        result.setDataFormat(DataFormat.PAYLOAD);
-        result.setMtomEnabled(true);
-        result.setAddress("/mtom/hello");
-        return result;
-    }
-}
-----
-
-XML (Spring)::
-+
-[source,xml]
-----
-<cxf:cxfEndpoint id="mtomPayloadModeEndpoint" address="http://localhost:${CXFTestSupport.port1}/CxfMtomRouterPayloadModeTest/mtom"
-        wsdlURL="mtom.wsdl"
-        serviceName="ns:MyMtomService"
-        endpointName="ns:MyMtomPort"
-        xmlns:ns="http://apache.org/camel/cxf/mtom_feature">
-
-    <cxf:properties>
-        <!--  enable mtom by setting this property to true -->
-        <entry key="mtom-enabled" value="true"/>
-        <!--  set the Camel CXF endpoint data format to PAYLOAD mode -->
-        <entry key="dataFormat" value="PAYLOAD"/>
-    </cxf:properties>
-</cxf:cxfEndpoint>
-----
-====
-
 You can produce a Camel message with attachment to send to a CXF endpoint in Payload mode.
 
 ._Java-only: sending and receiving MTOM attachments via `ProducerTemplate`_
 [source,java]
 ----
-Exchange exchange = context.createProducerTemplate().send("direct:testEndpoint", new Processor() {
-
-    public void process(Exchange exchange) throws Exception {
-        exchange.setPattern(ExchangePattern.InOut);
-        List<Source> elements = new ArrayList<Source>();
-        elements.add(new DOMSource(DOMUtils.readXml(new StringReader(MtomTestHelper.REQ_MESSAGE)).getDocumentElement()));
-        CxfPayload<SoapHeader> body = new CxfPayload<SoapHeader>(new ArrayList<SoapHeader>(),
-            elements, null);
-        exchange.getIn().setBody(body);
-        exchange.getIn(AttachmentMessage.class).addAttachment(MtomTestHelper.REQ_PHOTO_CID,
-            new DataHandler(new ByteArrayDataSource(MtomTestHelper.REQ_PHOTO_DATA, "application/octet-stream")));
-
-        exchange.getIn(AttachmentMessage.class).addAttachment(MtomTestHelper.REQ_IMAGE_CID,
-            new DataHandler(new ByteArrayDataSource(MtomTestHelper.requestJpeg, "image/jpeg")));
-
-    }
-
+Exchange exchange = context.createProducerTemplate().send("direct:testEndpoint", ex -> {
+    ex.setPattern(ExchangePattern.InOut);
+    List<Source> elements = new ArrayList<Source>();
+    elements.add(new DOMSource(DOMUtils.readXml(new StringReader(MtomTestHelper.REQ_MESSAGE)).getDocumentElement()));
+    CxfPayload<SoapHeader> body = new CxfPayload<SoapHeader>(new ArrayList<SoapHeader>(),
+        elements, null);
+    ex.getIn().setBody(body);
+    ex.getIn(AttachmentMessage.class).addAttachment(MtomTestHelper.REQ_PHOTO_CID,
+        new DataHandler(new ByteArrayDataSource(MtomTestHelper.REQ_PHOTO_DATA, "application/octet-stream")));
+    ex.getIn(AttachmentMessage.class).addAttachment(MtomTestHelper.REQ_IMAGE_CID,
+        new DataHandler(new ByteArrayDataSource(MtomTestHelper.requestJpeg, "image/jpeg")));
 });
 
 // process response
@@ -1180,7 +1096,7 @@ Here is the code snippet:
 [source,java]
 ----
 org.apache.cxf.message.Message cxfMessage = exchange.getIn().getHeader(
-        CxfConstants.CAMEL_CXF_MESSAGE, org.apache.cxf.message.Message.class);
+        "CamelCxfMessage", org.apache.cxf.message.Message.class);
 ServletRequest request = (ServletRequest) cxfMessage.get("HTTP.REQUEST");
 String remoteAddress = request.getRemoteAddr();
 ----

--- a/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
+++ b/components/camel-dhis2/camel-dhis2-component/src/main/docs/dhis2-component.adoc
@@ -59,19 +59,10 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.builder.RouteBuilder;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:getResource")
-            .to("dhis2:get/resource?path=organisationUnits/O6uvpzGd5pu&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .unmarshal()
-            .json(org.hisp.dhis.api.model.v40_2_2.OrganisationUnit.class);
-    }
-}
+from("direct:getResource")
+    .to("dhis2:get/resource?path=organisationUnits/O6uvpzGd5pu&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .unmarshal()
+    .json(org.hisp.dhis.api.model.v40_2_2.OrganisationUnit.class);
 ----
 
 YAML::
@@ -103,19 +94,10 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.builder.RouteBuilder;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:getCollection")
-            .to("dhis2:get/collection?path=organisationUnits&arrayName=organisationUnits&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .split().body()
-            .convertBodyTo(org.hisp.dhis.api.model.v40_2_2.OrganisationUnit.class).log("${body}");
-    }
-}
+from("direct:getCollection")
+    .to("dhis2:get/collection?path=organisationUnits&arrayName=organisationUnits&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .split().body()
+    .convertBodyTo(org.hisp.dhis.api.model.v40_2_2.OrganisationUnit.class).log("${body}");
 ----
 
 YAML::
@@ -154,19 +136,10 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.builder.RouteBuilder;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:getCollection")
-            .to("dhis2:get/collection?path=organisationUnits&arrayName=organisationUnits&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .split().body()
-            .convertBodyTo(org.hisp.dhis.api.model.v40_2_2.OrganisationUnit.class).log("${body}");
-    }
-}
+from("direct:getCollection")
+    .to("dhis2:get/collection?path=organisationUnits&arrayName=organisationUnits&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .split().body()
+    .convertBodyTo(org.hisp.dhis.api.model.v40_2_2.OrganisationUnit.class).log("${body}");
 ----
 
 YAML::
@@ -206,20 +179,11 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.builder.RouteBuilder;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:getCollection")
-            .to("dhis2://get/collection?path=users&filter=phoneNumber:!null:&arrayName=users&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .split().body()
-            .convertBodyTo(org.hisp.dhis.api.model.v40_2_2.User.class)
-            .log("${body}");
-    }
-}
+from("direct:getCollection")
+    .to("dhis2://get/collection?path=users&filter=phoneNumber:!null:&arrayName=users&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .split().body()
+    .convertBodyTo(org.hisp.dhis.api.model.v40_2_2.User.class)
+    .log("${body}");
 ----
 
 YAML::
@@ -259,38 +223,19 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
-import org.hisp.dhis.api.model.v40_2_2.DataValueSet;
-import org.hisp.dhis.api.model.v40_2_2.DataValue;
-import org.hisp.dhis.integration.sdk.support.period.PeriodBuilder;
-
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.List;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:postResource")
-            .setBody(exchange -> new DataValueSet().withCompleteDate(
-                    ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE))
-                                                                   .withOrgUnit("O6uvpzGd5pu")
-                                                                   .withDataSet("lyLU2wR22tC").withPeriod(PeriodBuilder.monthOf(new Date(), -1))
-                                                                   .withDataValues(
-                                                                       List.of(new DataValue().withDataElement("aIJZ2d2QgVV").withValue("20"))))
-            .to("dhis2://post/resource?path=dataValueSets&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .unmarshal().json()
-            .choice()
-            .when().groovy("body.status != 'OK'")
-                .log(LoggingLevel.ERROR, "Import error from DHIS2 while saving data value set => ${body}")
-            .end();
-    }
-}
+from("direct:postResource")
+    .setBody(exchange -> new DataValueSet().withCompleteDate(
+            ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE))
+        .withOrgUnit("O6uvpzGd5pu")
+        .withDataSet("lyLU2wR22tC").withPeriod(PeriodBuilder.monthOf(new Date(), -1))
+        .withDataValues(
+            List.of(new DataValue().withDataElement("aIJZ2d2QgVV").withValue("20"))))
+    .to("dhis2://post/resource?path=dataValueSets&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .unmarshal().json()
+    .choice()
+    .when().groovy("body.status != 'OK'")
+        .log(LoggingLevel.ERROR, "Import error from DHIS2 while saving data value set => ${body}")
+    .end();
 ----
 
 YAML::
@@ -336,27 +281,14 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
-import org.hisp.dhis.api.model.v40_2_2.OrganisationUnit;
-
-import java.util.Date;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:putResource")
-            .setBody(exchange -> new OrganisationUnit().withName("Acme").withShortName("Acme").withOpeningDate(new Date()))
-            .to("dhis2://put/resource?path=organisationUnits/jUb8gELQApl&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .unmarshal().json()
-            .choice()
-            .when().groovy("body.status != 'OK'")
-                .log(LoggingLevel.ERROR, "Import error from DHIS2 while updating org unit => ${body}")
-            .end();
-    }
-}
+from("direct:putResource")
+    .setBody(exchange -> new OrganisationUnit().withName("Acme").withShortName("Acme").withOpeningDate(new Date()))
+    .to("dhis2://put/resource?path=organisationUnits/jUb8gELQApl&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .unmarshal().json()
+    .choice()
+    .when().groovy("body.status != 'OK'")
+        .log(LoggingLevel.ERROR, "Import error from DHIS2 while updating org unit => ${body}")
+    .end();
 ----
 
 YAML::
@@ -400,24 +332,13 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:deleteResource")
-            .to("dhis2://delete/resource?path=organisationUnits/jUb8gELQApl&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
-            .unmarshal().json()
-            .choice()
-            .when().groovy("body.status != 'OK'")
-                .log(LoggingLevel.ERROR, "Import error from DHIS2 while deleting org unit => ${body}")
-            .end();
-    }
-}
-
+from("direct:deleteResource")
+    .to("dhis2://delete/resource?path=organisationUnits/jUb8gELQApl&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api")
+    .unmarshal().json()
+    .choice()
+    .when().groovy("body.status != 'OK'")
+        .log(LoggingLevel.ERROR, "Import error from DHIS2 while deleting org unit => ${body}")
+    .end();
 ----
 YAML::
 +
@@ -454,17 +375,8 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.builder.RouteBuilder;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:resourceTablesAnalytics")
-            .to("dhis2://resourceTables/analytics?skipAggregate=false&skipEvents=true&lastYears=1&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api");
-    }
-}
+from("direct:resourceTablesAnalytics")
+    .to("dhis2://resourceTables/analytics?skipAggregate=false&skipEvents=true&lastYears=1&username=admin&password=district&baseApiUrl=https://play.im.dhis2.org/stable-2-40-5/api");
 ----
 
 YAML::
@@ -495,22 +407,11 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
+Dhis2Client dhis2Client = Dhis2ClientBuilder.newClient("https://play.im.dhis2.org/stable-2-40-5/api", "admin", "district").build();
+getCamelContext().getRegistry().bind("dhis2Client", dhis2Client);
 
-import org.apache.camel.builder.RouteBuilder;
-import org.hisp.dhis.integration.sdk.Dhis2ClientBuilder;
-import org.hisp.dhis.integration.sdk.api.Dhis2Client;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        Dhis2Client dhis2Client = Dhis2ClientBuilder.newClient("https://play.im.dhis2.org/stable-2-40-5/api", "admin", "district").build();
-        getCamelContext().getRegistry().bind("dhis2Client", dhis2Client);
-
-        from("direct:resourceTablesAnalytics")
-            .to("dhis2://resourceTables/analytics?skipAggregate=true&skipEvents=true&lastYears=1&client=#dhis2Client");
-    }
-}
+from("direct:resourceTablesAnalytics")
+    .to("dhis2://resourceTables/analytics?skipAggregate=true&skipEvents=true&lastYears=1&client=#dhis2Client");
 ----
 
 YAML::
@@ -546,20 +447,9 @@ Java::
 +
 [source,java]
 ----
-package org.camel.dhis2.example;
-
-import org.apache.camel.builder.RouteBuilder;
-
-import java.util.Map;
-
-public class MyRouteBuilder extends RouteBuilder {
-
-    public void configure() {
-        from("direct:clearCache")
-            .setHeader("CamelDhis2.queryParams", constant(Map.of("cacheClear", "true")))
-            .to("dhis2://post/resource?path=maintenance&client=#dhis2Client");
-    }
-}
+from("direct:clearCache")
+    .setHeader("CamelDhis2.queryParams", constant(Map.of("cacheClear", "true")))
+    .to("dhis2://post/resource?path=maintenance&client=#dhis2Client");
 ----
 
 YAML::

--- a/components/camel-file/src/main/docs/file-component.adoc
+++ b/components/camel-file/src/main/docs/file-component.adoc
@@ -1777,11 +1777,9 @@ outputdir/sub/bar.txt
 
 [source,java]
 ----
-from("file://inputdir/").process(new Processor() {
-  public void process(Exchange exchange) throws Exception {
+from("file://inputdir/").process(exchange -> {
     Object body = exchange.getIn().getBody();
     // do some business logic with the input body
-  }
 });
 ----
 

--- a/components/camel-keycloak/src/main/docs/keycloak-component.adoc
+++ b/components/camel-keycloak/src/main/docs/keycloak-component.adoc
@@ -2488,11 +2488,8 @@ Java::
 +
 [source,java]
 ----
-public class BulkUserProvisioningRoute extends RouteBuilder {
-    @Override
-    public void configure() throws Exception {
-        // Provision users from CSV file
-        from("file:data/incoming?noop=true")
+// Provision users from CSV file
+from("file:data/incoming?noop=true")
             .routeId("bulk-user-provisioning")
             .log("Processing user provisioning file: ${header.CamelFileName}")
 
@@ -2574,7 +2571,6 @@ public class BulkUserProvisioningRoute extends RouteBuilder {
             .setHeader("CamelKeycloakContinueOnError", constant(true))
             .to("keycloak:admin?operation=bulkDeleteUsers")
             .log("Deleted ${body[success]} inactive users");
-    }
 
     private boolean isInactive(UserRepresentation user) {
         // Custom logic to determine if user is inactive
@@ -2706,13 +2702,8 @@ Java::
 +
 [source,java]
 ----
-public class KeycloakManagementRoutes extends RouteBuilder {
-
-    @Override
-    public void configure() throws Exception {
-
-        // Configure Keycloak component
-        KeycloakComponent keycloak = getContext().getComponent("keycloak", KeycloakComponent.class);
+// Configure Keycloak component
+KeycloakComponent keycloak = getContext().getComponent("keycloak", KeycloakComponent.class);
         KeycloakConfiguration config = new KeycloakConfiguration();
         config.setServerUrl("http://localhost:8080");
         config.setRealm("master");
@@ -2797,8 +2788,6 @@ public class KeycloakManagementRoutes extends RouteBuilder {
             .to("keycloak:admin?operation=deleteUser")
             .setHeader("Content-Type", constant("application/json"))
             .transform().constant("{\"status\": \"success\", \"message\": \"User deleted\"}");
-    }
-}
 ----
 
 YAML::
@@ -3737,22 +3726,17 @@ Java::
 +
 [source,java]
 ----
-public class KeycloakEventMonitoringRoutes extends RouteBuilder {
+// Configure Keycloak component
+KeycloakComponent keycloak = getContext().getComponent("keycloak", KeycloakComponent.class);
+KeycloakConfiguration config = new KeycloakConfiguration();
+config.setServerUrl("http://localhost:8080");
+config.setRealm("master");
+config.setUsername("admin");
+config.setPassword("admin");
+keycloak.setConfiguration(config);
 
-    @Override
-    public void configure() throws Exception {
-
-        // Configure Keycloak component
-        KeycloakComponent keycloak = getContext().getComponent("keycloak", KeycloakComponent.class);
-        KeycloakConfiguration config = new KeycloakConfiguration();
-        config.setServerUrl("http://localhost:8080");
-        config.setRealm("master");
-        config.setUsername("admin");
-        config.setPassword("admin");
-        keycloak.setConfiguration(config);
-
-        // Consume admin events and send to audit system
-        from("keycloak:adminEvents"
+// Consume admin events and send to audit system
+from("keycloak:adminEvents"
              + "?realm=production-realm"
              + "&eventType=admin-events"
              + "&operationTypes=CREATE,UPDATE,DELETE"
@@ -3795,12 +3779,10 @@ public class KeycloakEventMonitoringRoutes extends RouteBuilder {
             .to("bean:analyticsService?method=processUserActivity")
             .to("log:analytics");
 
-        // Process security alerts
-        from("direct:security-check")
-            .to("bean:securityService?method=checkFailedLogin")
-            .to("log:security");
-    }
-}
+// Process security alerts
+from("direct:security-check")
+    .to("bean:securityService?method=checkFailedLogin")
+    .to("log:security");
 ----
 
 YAML::
@@ -4297,12 +4279,8 @@ Java::
 +
 [source,java]
 ----
-public class HybridSecurityRoutes extends RouteBuilder {
-    @Override
-    public void configure() throws Exception {
-
-        // Introspection for admin operations
-        KeycloakSecurityPolicy adminIntrospection = new KeycloakSecurityPolicy(
+// Introspection for admin operations
+KeycloakSecurityPolicy adminIntrospection = new KeycloakSecurityPolicy(
             "{{keycloak.server-url}}", "{{keycloak.realm}}",
             "{{keycloak.client-id}}", "{{keycloak.client-secret}}");
         adminIntrospection.setRequiredRoles("admin");
@@ -4331,11 +4309,9 @@ public class HybridSecurityRoutes extends RouteBuilder {
             .policy(readPolicy)
             .to("bean:userService?method=listUsers");
 
-        from("rest:get:/profile")
-            .policy(readPolicy)
-            .to("bean:userService?method=getProfile");
-    }
-}
+from("rest:get:/profile")
+    .policy(readPolicy)
+    .to("bean:userService?method=getProfile");
 ----
 
 YAML::
@@ -5301,13 +5277,8 @@ Java::
 +
 [source,java]
 ----
-public class KeycloakSecurityRoutes extends RouteBuilder {
-
-    @Override
-    public void configure() throws Exception {
-
-        // Admin policy - requires admin role
-        KeycloakSecurityPolicy adminPolicy = new KeycloakSecurityPolicy(
+// Admin policy - requires admin role
+KeycloakSecurityPolicy adminPolicy = new KeycloakSecurityPolicy(
             "{{keycloak.server-url}}", "{{keycloak.realm}}",
             "{{keycloak.client-id}}", "{{keycloak.client-secret}}");
         adminPolicy.setRequiredRoles("admin");
@@ -5330,11 +5301,9 @@ public class KeycloakSecurityRoutes extends RouteBuilder {
             .policy(adminPolicy)
             .to("bean:userService?method=getAllUsers");
 
-        from("rest:get:/profile")
-            .policy(userPolicy)
-            .to("bean:userService?method=getCurrentUser");
-    }
-}
+from("rest:get:/profile")
+    .policy(userPolicy)
+    .to("bean:userService?method=getCurrentUser");
 ----
 
 YAML::

--- a/components/camel-kubernetes/src/main/docs/kubernetes-deployments-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-deployments-component.adoc
@@ -86,18 +86,13 @@ This operation returns a List of Deployment from your cluster
 
 - `listDeploymentsByLabels`:  this operation lists the deployments by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesDeploymentsLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesDeploymentsLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-deployments:///?kubernetesClient=#kubernetesClient&operation=listDeploymentsByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-hpa-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-hpa-component.adoc
@@ -85,18 +85,13 @@ This operation returns a list of HPAs from your cluster
 
 - `listDeploymentsByLabels`: this operation lists the HPAs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesHPALabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesHPALabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-hpa:///?kubernetesClient=#kubernetesClient&operation=listHPAByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-job-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-job-component.adoc
@@ -42,134 +42,101 @@ include::partial$component-endpoint-headers.adoc[]
 
 - `listJob`: this operation lists the jobs on a kubernetes cluster
 
-._Java-only: uses toF() for endpoint URI formatting_
+[tabs]
+====
+Java::
++
 [source,java]
 ----
-from("direct:list").
-    toF("kubernetes-job:///?kubernetesClient=#kubernetesClient&operation=listJob").
-    to("mock:result");
+from("direct:list")
+    .to("kubernetes-job:///?kubernetesClient=#kubernetesClient&operation=listJob")
+    .to("mock:result");
 ----
+
+XML::
++
+[source,xml]
+----
+<route>
+  <from uri="direct:list"/>
+  <to uri="kubernetes-job:///?kubernetesClient=#kubernetesClient&amp;operation=listJob"/>
+  <to uri="mock:result"/>
+</route>
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:list
+    steps:
+      - to:
+          uri: kubernetes-job:///
+          parameters:
+            kubernetesClient: "#kubernetesClient"
+            operation: listJob
+      - to:
+          uri: mock:result
+----
+====
 
 This operation returns a list of jobs from your cluster
 
 - `listJobByLabels`: this operation lists the jobs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
-from("direct:listByLabels").process(new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                Map<String, String> labels = new HashMap<>();
-                labels.put("key1", "value1");
-                labels.put("key2", "value2");
-                exchange.getIn().setHeader("CamelKubernetesJobLabels", labels);
-            }
-        });
-    toF("kubernetes-job:///?kubernetesClient=#kubernetesClient&operation=listJobByLabels").
-    to("mock:result");
+from("direct:listByLabels")
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesJobLabels",
+            Map.of("key1", "value1", "key2", "value2"));
+    })
+    .to("kubernetes-job:///?kubernetesClient=#kubernetesClient&operation=listJobByLabels")
+    .to("mock:result");
 ----
 
 This operation returns a list of jobs from your cluster, using a label selector (with key1 and key2, with value value1 and value2)
 
 - `createJob`: This operation creates a job on a Kubernetes Cluster
 
-We have a wonderful example of this operation thanks to https://github.com/Emmerson-Miranda[Emmerson Miranda] from this https://github.com/Emmerson-Miranda/camel/blob/master/camel3-cdi/cdi-k8s-pocs/src/main/java/edu/emmerson/camel/k8s/jobs/camel_k8s_jobs/KubernetesCreateJob.java[Java test]
-
-._Java-only: full RouteBuilder class with lambda Processors and programmatic JobSpec construction_
+._Java-only: programmatic JobSpec construction with Fabric8 Kubernetes client_
 [source,java]
 ----
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+from("timer:foo?delay=1000&repeatCount=1")
+    .routeId("kubernetes-jobcreate-client")
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesJobName", "camel-job");
+        exchange.getIn().setHeader("CamelKubernetesNamespaceName", "default");
+        exchange.getIn().setHeader("CamelKubernetesJobLabels",
+            Map.of("jobLabelKey1", "value1", "jobLabelKey2", "value2", "app", "jobFromCamelApp"));
 
-import javax.inject.Inject;
+        Container container = new Container();
+        container.setName("pi");
+        container.setImage("perl");
+        container.setCommand(List.of("echo", "Job created from Apache Camel"));
 
-import org.apache.camel.Endpoint;
-import org.apache.camel.EndpointInject;
-import org.apache.camel.builder.RouteBuilder;
+        PodSpec ps = new PodSpec();
+        ps.setRestartPolicy("Never");
+        ps.setContainers(List.of(container));
 
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.PodTemplateSpec;
-import io.fabric8.kubernetes.api.model.batch.JobSpec;
+        ObjectMeta metadata = new ObjectMeta();
+        metadata.setAnnotations(Map.of("jobMetadataAnnotation1", "random value"));
+        metadata.setLabels(Map.of("podLabelKey1", "value1", "podLabelKey2", "value2", "app", "podFromCamelApp"));
 
-public class KubernetesCreateJob extends RouteBuilder {
+        PodTemplateSpec pts = new PodTemplateSpec();
+        pts.setSpec(ps);
+        pts.setMetadata(metadata);
 
-    @EndpointInject("timer:foo?delay=1000&repeatCount=1")
-    private Endpoint inputEndpoint;
-
-    @EndpointInject("log:output")
-    private Endpoint resultEndpoint;
-
-    @Override
-    public void configure() {
-        // you can configure the route rule with Java DSL here
-
-        from(inputEndpoint)
-        	.routeId("kubernetes-jobcreate-client")
-        	.process(exchange -> {
-        		exchange.getIn().setHeader("CamelKubernetesJobName", "camel-job"); //DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
-                exchange.getIn().setHeader("CamelKubernetesNamespaceName", "default");
-                
-                Map<String, String> joblabels = new HashMap<String, String>();
-                joblabels.put("jobLabelKey1", "value1");
-                joblabels.put("jobLabelKey2", "value2");
-                joblabels.put("app", "jobFromCamelApp");
-                exchange.getIn().setHeader("CamelKubernetesJobLabels", joblabels);
-
-                exchange.getIn().setHeader("CamelKubernetesJobSpec", generateJobSpec());
-        	})
-        	.to("kubernetes-job:///{{kubernetes-master-url}}?oauthToken={{kubernetes-oauth-token:}}&operation=createJob")
-        	.log("Job created:")
-        	.process(exchange -> {
-        		System.out.println(exchange.getIn().getBody());
-        	})
-            .to(resultEndpoint);
-    }
-
-	private JobSpec generateJobSpec() {
-		JobSpec js = new JobSpec();
-		
-		PodTemplateSpec pts = new PodTemplateSpec();
-		
-		PodSpec ps = new PodSpec();
-		ps.setRestartPolicy("Never");
-		ps.setContainers(generateContainers());
-		pts.setSpec(ps);
-		
-		ObjectMeta metadata = new ObjectMeta();
-		Map<String, String> annotations = new HashMap<String, String>();
-		annotations.put("jobMetadataAnnotation1", "random value");
-		metadata.setAnnotations(annotations);
-		
-		Map<String, String> podlabels = new HashMap<String, String>();
-		podlabels.put("podLabelKey1", "value1");
-		podlabels.put("podLabelKey2", "value2");
-		podlabels.put("app", "podFromCamelApp");
-		metadata.setLabels(podlabels);
-		
-		pts.setMetadata(metadata);
-		js.setTemplate(pts);
-		return js;
-	}
-
-	private List<Container> generateContainers() {
-		Container container = new Container();
-		container.setName("pi");
-		container.setImage("perl");
-		List<String> command = new ArrayList<String>();
-		command.add("echo");
-		command.add("Job created from Apache Camel code at " + (new Date()));
-		container.setCommand(command);
-		List<Container> containers = new ArrayList<Container>();
-		containers.add(container);
-		return containers;
-	}
-}
+        JobSpec js = new JobSpec();
+        js.setTemplate(pts);
+        exchange.getIn().setHeader("CamelKubernetesJobSpec", js);
+    })
+    .to("kubernetes-job:///{{kubernetes-master-url}}?oauthToken={{kubernetes-oauth-token:}}&operation=createJob")
+    .log("Job created:")
+    .to("log:output");
 ----
 
 

--- a/components/camel-kubernetes/src/main/docs/kubernetes-namespaces-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-namespaces-component.adoc
@@ -86,18 +86,13 @@ This operation returns a list of namespaces from your cluster
 
 - `listNamespacesByLabels`: this operation lists the namespaces by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesNamespaceLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesNamespaceLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-namespaces:///?kubernetesClient=#kubernetesClient&operation=listNamespacesByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-nodes-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-nodes-component.adoc
@@ -87,18 +87,13 @@ This operation returns a List of Nodes from your cluster
 
 - `listNodesByLabels`: this operation lists the nodes by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesNodeLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesNodeLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-nodes:///?kubernetesClient=#kubernetesClient&operation=listNodesByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-claims-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-claims-component.adoc
@@ -87,18 +87,13 @@ This operation returns a list of PVC from your cluster
 
 - `listPersistentVolumesClaimsByLabels`: this operation lists the PVCs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesPersistentVolumesClaimsLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesPersistentVolumesClaimsLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-persistent-volumes-claims:///?kubernetesClient=#kubernetesClient&operation=listPersistentVolumesClaimsByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-persistent-volumes-component.adoc
@@ -84,18 +84,13 @@ This operation returns a list of PVs from your cluster
 
 - `listPersistentVolumesByLabels`: this operation lists the PVs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesPersistentVolumesLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesPersistentVolumesLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-persistent-volumes:///?kubernetesClient=#kubernetesClient&operation=listPersistentVolumesByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-pods-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-pods-component.adoc
@@ -87,18 +87,13 @@ This operation returns a list of pods from your cluster
 
 - `listPodsByLabels`: this operation lists the pods by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesPodLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesPodLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-pods:///?kubernetesClient=#kubernetesClient&operation=listPodsByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-replication-controllers-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-replication-controllers-component.adoc
@@ -89,18 +89,13 @@ This operation returns a list of RCs from your cluster
 
 - `listReplicationControllersByLabels`: this operation lists the RCs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesReplicationControllersLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesReplicationControllersLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-replication-controllers:///?kubernetesClient=#kubernetesClient&operation=listReplicationControllersByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-resources-quota-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-resources-quota-component.adoc
@@ -87,18 +87,13 @@ This operation returns a list of resource quotas from your cluster
 
 - `listResourcesQuotaByLabels`: this operation lists the resource quotas by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesResourcesQuotaLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesResourcesQuotaLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-resources-quota:///?kubernetesClient=#kubernetesClient&operation=listResourcesQuotaByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-service-accounts-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-service-accounts-component.adoc
@@ -87,18 +87,13 @@ This operation returns a list of services from your cluster
 
 - `listServiceAccountsByLabels`: this operation lists the SAs by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesServiceAccountsLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesServiceAccountsLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-service-accounts:///?kubernetesClient=#kubernetesClient&operation=listServiceAccountsByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/kubernetes-services-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/kubernetes-services-component.adoc
@@ -86,18 +86,13 @@ This operation returns a List of services from your cluster
 
 - `listServicesByLabels`: this operation lists the deployments by labels on a kubernetes cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesServiceLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesServiceLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("kubernetes-services:///?kubernetesClient=#kubernetesClient&operation=listServicesByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-build-configs-component.adoc
@@ -84,18 +84,13 @@ This operation returns a list of builds from your Openshift cluster
 
 - `listBuildsByLabels`: this operation lists the build configs by labels on an Openshift cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesBuildConfigsLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesBuildConfigsLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("openshift-build-configs:///?kubernetesClient=#kubernetesClient&operation=listBuildConfigsByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/openshift-builds-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-builds-component.adoc
@@ -84,18 +84,13 @@ This operation returns a List of Builds from your Openshift cluster
 
 - `listBuildsByLabels`: this operation lists the builds by labels on an Openshift cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesBuildsLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesBuildsLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("openshift-builds:///?kubernetesClient=#kubernetesClient&operation=listBuildsByLabels")
     .to("mock:result");

--- a/components/camel-kubernetes/src/main/docs/openshift-deploymentconfigs-component.adoc
+++ b/components/camel-kubernetes/src/main/docs/openshift-deploymentconfigs-component.adoc
@@ -86,18 +86,13 @@ This operation returns a list of deployment configs from your cluster
 
 - `listDeploymentConfigsByLabels`: this operation lists the deployment configs by labels on an Openshift cluster
 
-._Java-only: uses inline Processor with HashMap_
+._Java-only: sets a Map header for label selection_
 [source,java]
 ----
 from("direct:listByLabels")
-    .process(new Processor() {
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            Map<String, String> labels = new HashMap<>();
-            labels.put("key1", "value1");
-            labels.put("key2", "value2");
-            exchange.getIn().setHeader("CamelKubernetesDeploymentsLabels", labels);
-        }
+    .process(exchange -> {
+        exchange.getIn().setHeader("CamelKubernetesDeploymentsLabels",
+            Map.of("key1", "value1", "key2", "value2"));
     })
     .to("openshift-deploymentconfigs:///?kubernetesClient=#kubernetesClient&operation=listDeploymentConfigsByLabels")
     .to("mock:result");

--- a/components/camel-metrics/src/main/docs/metrics-component.adoc
+++ b/components/camel-metrics/src/main/docs/metrics-component.adoc
@@ -59,62 +59,6 @@ This default registry can be replaced with a custom one by providing
 a `MetricRegistry` bean. If multiple `MetricRegistry` beans exist in the
 application, the one with name `metricRegistry` is used.
 
-For example:
-
-[tabs]
-====
-
-Java (Spring)::
-+
-[source,java]
-----
-@Configuration
-public static class MyConfig extends SingleRouteCamelConfiguration {
-
-    @Bean
-    @Override
-    public RouteBuilder route() {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                // define Camel routes here
-            }
-        };
-    }
-
-    @Bean(name = MetricsComponent.METRIC_REGISTRY_NAME)
-    public MetricRegistry getMetricRegistry() {
-        MetricRegistry registry = ...;
-        return registry;
-    }
-}
-----
-
-Java (CDI)::
-+
-[source,java]
-----
-class MyBean extends RouteBuilder {
-
-    @Override
-    public void configure() {
-      from("...")
-          // Register the 'my-meter' meter in the MetricRegistry below
-          .to("metrics:meter:my-meter");
-    }
-
-    @Produces
-    // If multiple MetricRegistry beans
-    // @Named(MetricsComponent.METRIC_REGISTRY_NAME)
-    MetricRegistry registry() {
-        MetricRegistry registry = new MetricRegistry();
-        // ...
-        return registry;
-    }
-}
-----
-
-====
 
 == Usage
 

--- a/components/camel-micrometer-observability/src/main/docs/micrometer-observability.adoc
+++ b/components/camel-micrometer-observability/src/main/docs/micrometer-observability.adoc
@@ -187,12 +187,9 @@ public void process(Exchange exchange) throws Exception {
                         .setProperty("CamelBaggage_myValue", constant("1234"))
                         .routeId("start")
                         .log("A message")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) throws Exception {
-                                // Baggage is available via the Micrometer Observability API
-                                String val = tracer.getBaggage("myValue").get();
-                            }
+                        .process(exchange -> {
+                            // Baggage is available via the Micrometer Observability API
+                            String val = tracer.getBaggage("myValue").get();
                         })
                         .to("log:info");
 ----

--- a/components/camel-opentelemetry2/src/main/docs/opentelemetry2.adoc
+++ b/components/camel-opentelemetry2/src/main/docs/opentelemetry2.adoc
@@ -375,12 +375,9 @@ For this reason, whenever you need to provide custom telemetry information, it i
                         .setProperty("CamelBaggage_myValue", constant("1234"))
                         .routeId("start")
                         .log("A message")
-                        .process(new Processor() {
-                            @Override
-                            public void process(Exchange exchange) throws Exception {
-                                // Baggage is available via the OpenTelemetry API
-                                String val = Baggage.current().getEntryValue("myValue");
-                            }
+                        .process(exchange -> {
+                            // Baggage is available via the OpenTelemetry API
+                            String val = Baggage.current().getEntryValue("myValue");
                         })
                         .to("log:info");
 ----

--- a/components/camel-stax/src/main/docs/stax-component.adoc
+++ b/components/camel-stax/src/main/docs/stax-component.adoc
@@ -73,12 +73,9 @@ Here is an example:
 from("file:target/in")
   .to("stax:org.superbiz.handler.CountingHandler") 
   // CountingHandler implements org.xml.sax.ContentHandler or extends org.xml.sax.helpers.DefaultHandler
-  .process(new Processor() {
-    @Override
-    public void process(Exchange exchange) throws Exception {
-        CountingHandler handler = exchange.getIn().getBody(CountingHandler.class);
-        // do some great work with the handler
-    }
+  .process(exchange -> {
+      CountingHandler handler = exchange.getIn().getBody(CountingHandler.class);
+      // do some great work with the handler
   });
 ----
 


### PR DESCRIPTION
## Summary

- Remove `RouteBuilder` class wrappers from Java code examples across 33 component docs, keeping just the route DSL
- Convert `new Processor() { @Override public void process(Exchange exchange) {...} }` anonymous classes to lambdas
- Replace Java constant references (`CxfConstants.OPERATION_NAME`, etc.) with string header names (`"CamelCxfOperationName"`, etc.)
- Remove obsolete CDI-based examples (CXF MTOM stub with `@Produces`, Metrics `MetricRegistry` bean examples using removed camel-cdi)

Components cleaned up: Kubernetes (13), DHIS2, Keycloak, LangChain4j Agent, CXF, CXFRS, AWS (DDB, EC2, Kinesis Firehose, Lambda, MQ, MSK), StAX, File, Crypto, Bindy, Metrics, Micrometer Observability, OpenTelemetry2.

## Test plan

- [ ] Verify docs render correctly (no broken asciidoc syntax)
- [ ] No functional code changes — documentation only

_Claude Code on behalf of Claus Ibsen_