### PR TITLE
CAMEL-23786: block unsafe polymorphic base types by default in camel-jackson data format (backport to 4.14.x)

### DIFF
--- a/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/JacksonDataFormat.java
+++ b/components/camel-jackson/src/main/java/org/apache/camel/component/jackson/JacksonDataFormat.java
@@ -17,7 +17,9 @@
 package org.apache.camel.component.jackson;
 
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.slf4j.Logger;
@@ -85,7 +87,11 @@ public class JacksonDataFormat extends AbstractJacksonDataFormat {
 
     @Override
     protected ObjectMapper createNewObjectMapper() {
-        ObjectMapper om = new ObjectMapper();
+        // Enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default as defense-in-depth against gadget-chain
+        // deserialization when polymorphic typing is enabled, consistent with transform/Json.java.
+        ObjectMapper om = JsonMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build();
         int len = getMaxStringLength();
         if (len > 0) {
             LOG.debug("Creating ObjectMapper with maxStringLength: {}", len);

--- a/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/JacksonDataFormatPolymorphicHardeningTest.java
+++ b/components/camel-jackson/src/test/java/org/apache/camel/component/jackson/JacksonDataFormatPolymorphicHardeningTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the ObjectMapper created by {@link JacksonDataFormat} enables
+ * {@link MapperFeature#BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES} by default — the Jackson mechanism that refuses unsafe
+ * polymorphic base types (e.g. Object/Serializable) when polymorphic/default typing is enabled, as defense-in-depth
+ * against gadget-chain deserialization.
+ */
+public class JacksonDataFormatPolymorphicHardeningTest {
+
+    @Test
+    void blockUnsafePolymorphicBaseTypesEnabledByDefault() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+            JacksonDataFormat df = new JacksonDataFormat();
+            // force createNewObjectMapper() rather than a registry-provided mapper
+            df.setUseDefaultObjectMapper(false);
+            df.setCamelContext(context);
+            df.start();
+            ObjectMapper om = df.getObjectMapper();
+            assertNotNull(om);
+            assertTrue(om.isEnabled(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES),
+                    "camel-jackson data format must enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default");
+        }
+    }
+}


### PR DESCRIPTION
Backport of CAMEL-23786 to the `camel-4.14.x` maintenance branch (main PR: apache/camel#24134).

Enables `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES` by default on the camel-jackson data format's `ObjectMapper` (`JacksonDataFormat.createNewObjectMapper()`), consistent with the component's `transform/Json.java` which already enables it on this branch. Defense-in-depth against gadget-chain deserialization when polymorphic / default typing is enabled.

## Changes
- `createNewObjectMapper()` builds the mapper via `JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build()` (clean cherry-pick of the main commit).
- New `JacksonDataFormatPolymorphicHardeningTest` asserts the feature is enabled by default.

## Notes
- **Potential breaking change** for routes that enable polymorphic / default typing on an unsafe base type; opt out via a custom `ObjectMapper`.
- All camel-jackson module tests pass (101) on this branch; ordinary marshalling / unmarshalling is unaffected.
- The 4.14.8 upgrade-guide entry is added on `main` (`camel-4x-upgrade-guide-4_14.adoc`), per the project's docs-on-main convention.

Jira: https://issues.apache.org/jira/browse/CAMEL-23786

_Claude Code on behalf of Andrea Cosentino_
