### PR TITLE
CAMEL-23767: camel-platform-http-main - warn when authentication is enabled but no mechanism is configured

### DIFF
--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/DefaultMainHttpServerFactory.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/DefaultMainHttpServerFactory.java
@@ -28,9 +28,13 @@ import org.apache.camel.main.MainHttpServerFactory;
 import org.apache.camel.spi.annotations.JdkService;
 import org.apache.camel.support.TempDirHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @JdkService(MainConstants.PLATFORM_HTTP_SERVER)
 public class DefaultMainHttpServerFactory implements CamelContextAware, MainHttpServerFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultMainHttpServerFactory.class);
 
     private static final String DEFAULT_UPLOAD_DIR = "${java.io.tmpdir}/camel/camel-tmp-#uuid#/";
 
@@ -118,6 +122,11 @@ public class DefaultMainHttpServerFactory implements CamelContextAware, MainHttp
             ObjectHelper.notNull(configuration.getJwtKeystorePassword(), "jwtKeyStorePassword");
             JWTAuthenticationConfigurer auth = new JWTAuthenticationConfigurer();
             auth.configureAuthentication(server.getConfiguration().getAuthenticationConfig(), configuration);
+        } else {
+            LOG.warn("Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is"
+                     + " configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore"
+                     + " (jwtKeystoreType) is set. The HTTP server will start WITHOUT authentication. Configure an"
+                     + " authentication mechanism, or set authenticationEnabled=false to disable authentication.");
         }
     }
 
@@ -131,6 +140,12 @@ public class DefaultMainHttpServerFactory implements CamelContextAware, MainHttp
             ObjectHelper.notNull(configuration.getJwtKeystorePassword(), "jwtKeyStorePassword");
             JWTAuthenticationConfigurer auth = new JWTAuthenticationConfigurer();
             auth.configureAuthentication(server.getConfiguration().getAuthenticationConfig(), configuration);
+        } else {
+            LOG.warn("Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is"
+                     + " configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore"
+                     + " (jwtKeystoreType) is set. The HTTP management server will start WITHOUT authentication."
+                     + " Configure an authentication mechanism, or set authenticationEnabled=false to disable"
+                     + " authentication.");
         }
     }
 

--- a/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/authentication/AuthenticationConfigurationMainHttpServerTest.java
+++ b/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/authentication/AuthenticationConfigurationMainHttpServerTest.java
@@ -16,13 +16,30 @@
  */
 package org.apache.camel.component.platform.http.main.authentication;
 
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.main.Main;
-import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.platform.http.main.DefaultMainHttpServerFactory;
+import org.apache.camel.main.Main;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AuthenticationConfigurationMainHttpServerTest {
+
+    @RegisterExtension
+    static AvailablePortFinder.Port port = AvailablePortFinder.find();
 
     @Test
     public void testIncompleteAuthenticationConfiguration() {
@@ -34,6 +51,37 @@ public class AuthenticationConfigurationMainHttpServerTest {
         assertThrows(RuntimeException.class, main::start);
 
         main.stop();
+    }
+
+    @Test
+    public void testAuthenticationEnabledWithoutMechanism() {
+        List<String> warnings = new CopyOnWriteArrayList<>();
+        AbstractAppender appender = new AbstractAppender("CaptureWarn", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                if (event.getLevel() == Level.WARN) {
+                    warnings.add(event.getMessage().getFormattedMessage());
+                }
+            }
+        };
+        appender.start();
+        Logger logger = (Logger) LogManager.getLogger(DefaultMainHttpServerFactory.class);
+        logger.addAppender(appender);
+
+        Main main = MainHttpServerAuthenticationTestSupport.createMain(
+                "auth-no-mechanism.properties", port, new PlatformHttpRouteBuilder());
+        try {
+            // Unlike an incomplete JWT configuration, a missing mechanism must not fail startup: the server
+            // still starts (unprotected) so the change stays backward compatible.
+            assertDoesNotThrow(main::start);
+            // ...but a clear warning must be logged so the misconfiguration is surfaced rather than silent.
+            assertTrue(warnings.stream().anyMatch(m -> m.contains("no authentication mechanism is configured")),
+                    "Expected a warning about the missing authentication mechanism, but got: " + warnings);
+        } finally {
+            logger.removeAppender(appender);
+            appender.stop();
+            MainHttpServerAuthenticationTestSupport.stopMain(main);
+        }
     }
 
     private static class PlatformHttpRouteBuilder extends RouteBuilder {

--- a/components/camel-platform-http-main/src/test/resources/auth-no-mechanism.properties
+++ b/components/camel-platform-http-main/src/test/resources/auth-no-mechanism.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+camel.server.enabled=true
+
+# Authentication is enabled but NO mechanism (neither basicPropertiesFile nor jwtKeystoreType) is configured.
+camel.server.authenticationEnabled=true
+camel.server.authenticationPath=/*

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -2154,6 +2154,13 @@ for the embedded HTTP server:
 Both default to unset. When both are unset, JWT validation behaviour is unchanged (signature plus the
 default `exp` / `nbf` checks).
 
+Additionally, when `authenticationEnabled=true` but neither a basic-auth properties file
+(`basicPropertiesFile`) nor a JWT keystore (`jwtKeystoreType`) is configured, the embedded HTTP server now
+logs a clear warning at startup that it is starting without authentication. Previously this
+misconfiguration started an unprotected server silently. The server still starts and the behaviour is
+otherwise unchanged; configure an authentication mechanism or set `authenticationEnabled=false` to remove
+the warning.
+
 === camel-test
 
 `org.apache.camel.test.AvailablePortFinder.Port` now also implements


### PR DESCRIPTION
Fixes [CAMEL-23767](https://issues.apache.org/jira/browse/CAMEL-23767).

## Problem

`DefaultMainHttpServerFactory.configureAuthentication` wires basic or JWT authentication only when a basic-auth properties file (`basicPropertiesFile`) or a JWT keystore (`jwtKeystoreType`) is configured:

```java
if (configuration.getBasicPropertiesFile() != null) {        // basic
} else if (configuration.getJwtKeystoreType() != null) {     // JWT
}
// else: nothing
```

When `authenticationEnabled=true` but neither is configured, the embedded HTTP server (and the management server) started **without any authentication and without any warning** — silently exposing an unprotected server while the operator believes it is protected.

## Change

Both `configureAuthentication` overloads now log a clear **warning** at startup when authentication is enabled but no mechanism is configured:

> Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore (jwtKeystoreType) is set. The HTTP server will start WITHOUT authentication. Configure an authentication mechanism, or set authenticationEnabled=false to disable authentication.

The server still starts (behaviour otherwise unchanged), so the change is **non-breaking**. Warning rather than failing fast keeps it safe for the patch-release backports (per the Jira `fixVersions`); note the JWT branch already fails fast for a *partial* keystore configuration, so warning for a *missing* mechanism is consistent.

## Tests

- `AuthenticationConfigurationMainHttpServerTest#testAuthenticationEnabledWithoutMechanism` — captures the log and asserts the server starts **and** the warning is emitted (new `auth-no-mechanism.properties`).
- All existing module tests pass (17).
- Full reactor build (`mvn clean install -DskipTests`, 1854 modules) green, no drift. No generated-file impact (internal factory, no `@UriParam`).

## Documentation

- `camel-4x-upgrade-guide-4_21.adoc` — note appended to the existing `camel-platform-http-main` section.

## Compatibility / backport

Non-breaking; suitable for backport to `camel-4.18.x` and `camel-4.14.x`. The matching 4_18/4_14 upgrade-guide entries will be added on `main` with the backports.

---
_Claude Code on behalf of Andrea Cosentino_