### PR TITLE
CAMEL-23783: document the camel-schematron XXE hardening in the 4.18.3 and 4.14.8 upgrade guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -983,6 +983,19 @@ the removed headers were redundant with the endpoint configuration. Routes that 
 on reading `CamelDaprPubSubName` / `CamelDaprTopic` from a consumed exchange should read
 the configured destination from the endpoint URI instead.
 
+=== camel-schematron - potential breaking change
+
+The Schematron rules-compilation `TransformerFactory` now runs with secure processing enabled
+(`FEATURE_SECURE_PROCESSING`) and with external DTD and external stylesheet access disabled
+(`accessExternalDTD` and `accessExternalStylesheet` set to empty), as defense-in-depth against XXE and
+external-resource resolution while compiling Schematron rules. This matches the hardening already applied
+to the component's `SAXParserFactory`. The bundled ISO Schematron skeleton stylesheets continue to be
+resolved from the classpath via the component's `URIResolver` and are therefore unaffected.
+
+If your Schematron rules legitimately reference an external DTD, external entity, or external stylesheet,
+those references will no longer be resolved and rule compilation will fail; inline the referenced content
+instead.
+
 == Upgrading from 4.14.2 to 4.14.3
 
 === camel-tika

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -1085,6 +1085,19 @@ the removed headers were redundant with the endpoint configuration. Routes that 
 on reading `CamelDaprPubSubName` / `CamelDaprTopic` from a consumed exchange should read
 the configured destination from the endpoint URI instead.
 
+=== camel-schematron - potential breaking change
+
+The Schematron rules-compilation `TransformerFactory` now runs with secure processing enabled
+(`FEATURE_SECURE_PROCESSING`) and with external DTD and external stylesheet access disabled
+(`accessExternalDTD` and `accessExternalStylesheet` set to empty), as defense-in-depth against XXE and
+external-resource resolution while compiling Schematron rules. This matches the hardening already applied
+to the component's `SAXParserFactory`. The bundled ISO Schematron skeleton stylesheets continue to be
+resolved from the classpath via the component's `URIResolver` and are therefore unaffected.
+
+If your Schematron rules legitimately reference an external DTD, external entity, or external stylesheet,
+those references will no longer be resolved and rule compilation will fail; inline the referenced content
+instead.
+
 == Upgrading from 4.18.0 to 4.18.1
 
 === camel-bom


### PR DESCRIPTION
Doc-sync: adds the camel-schematron XXE-hardening migration note (CAMEL-23783) to `main`'s canonical version-specific upgrade guides for the backported releases **4.18.3** and **4.14.8**.

CAMEL-23783 (apache/camel#24105) merged to main (4.21.0) and was backported to 4.18.x (#24106) and 4.14.x (#24107), but only the `4_21` guide carried the note. Per the docs-on-main convention, the 4.18.3 and 4.14.8 entries belong in `main`'s version-specific guides.

## Changes
- `camel-4x-upgrade-guide-4_18.adoc`: add `=== camel-schematron - potential breaking change` under the 4.18.1→4.18.3 section.
- `camel-4x-upgrade-guide-4_14.adoc`: same note under the 4.14.3→4.14.8 section.

Docs-only; no code change.

Jira: https://issues.apache.org/jira/browse/CAMEL-23783

_Claude Code on behalf of Andrea Cosentino_
