### PR TITLE
camel-salesforce: Fix NPE in maven plugin codegen due to missing worker pool

### DIFF
--- a/components/camel-salesforce/camel-salesforce-codegen/src/main/java/org/apache/camel/component/salesforce/codegen/AbstractSalesforceExecution.java
+++ b/components/camel-salesforce/camel-salesforce-codegen/src/main/java/org/apache/camel/component/salesforce/codegen/AbstractSalesforceExecution.java
@@ -22,6 +22,7 @@ import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
@@ -245,7 +246,9 @@ public abstract class AbstractSalesforceExecution {
 
             SecurityUtils.adaptToIBMCipherNames(sslContextFactory);
 
-            httpClient = new SalesforceHttpClient(sslContextFactory);
+            ExecutorService workerPool = camelContext.getExecutorServiceManager()
+                    .newSingleThreadExecutor(this, "SalesforceHttpClient");
+            httpClient = new SalesforceHttpClient(camelContext, workerPool, sslContextFactory);
         } catch (GeneralSecurityException | IOException e) {
             throw new RuntimeException("Error creating default SSL context: " + e.getMessage(), e);
         }


### PR DESCRIPTION
## Summary

`AbstractSalesforceExecution.createHttpClient()` in the `camel-salesforce-codegen` module uses the test-only `SalesforceHttpClient(SslContextFactory.Client)` constructor, which sets `workerPool` to `null`. When `AbstractClientBase.onComplete()` calls `httpClient.getWorkerPool().execute(...)`, this causes a `NullPointerException`.

The NPE is swallowed by Jetty's response handling, so the callback never fires and the plugin times out with:
```
Error getting global Objects: Timeout waiting for getGlobalObjects!
```

The stack trace visible in the build log is:
```
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ExecutorService.execute(java.lang.Runnable)"
because the return value of "org.apache.camel.component.salesforce.SalesforceHttpClient.getWorkerPool()" is null
    at org.apache.camel.component.salesforce.internal.client.AbstractClientBase$1.onComplete(AbstractClientBase.java:266)
```

### Fix

Use the production 3-arg constructor that accepts `CamelContext` and `ExecutorService`, matching what `SalesforceComponent.createHttpClient()` already does. The worker pool is automatically cleaned up by `SalesforceHttpClient.doStop()` when `ServiceHelper.stopAndShutdownServices()` is called during disconnect.

### How was this tested

Built the `amqp-salesforce` example from `camel-spring-boot-examples` with `-Dgenerate.dto=true` (which triggers the `camel-salesforce-maven-plugin:generate` goal). Before the fix: `BUILD FAILURE` with the NPE/timeout. After the fix: `BUILD SUCCESS` — Salesforce login, DTO generation, compilation, and packaging all pass.