### PR TITLE
camel-salesforce: Fix NPE in maven plugin codegen due to missing worker pool

### DIFF
--- a/components/camel-salesforce/camel-salesforce-codegen/src/main/java/org/apache/camel/component/salesforce/codegen/AbstractSalesforceExecution.java
+++ b/components/camel-salesforce/camel-salesforce-codegen/src/main/java/org/apache/camel/component/salesforce/codegen/AbstractSalesforceExecution.java
@@ -22,6 +22,7 @@ import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.salesforce.SalesforceHttpClient;
@@ -245,7 +246,9 @@ public abstract class AbstractSalesforceExecution {
 
             SecurityUtils.adaptToIBMCipherNames(sslContextFactory);
 
-            httpClient = new SalesforceHttpClient(sslContextFactory);
+            ExecutorService workerPool = camelContext.getExecutorServiceManager()
+                    .newSingleThreadExecutor(this, "SalesforceHttpClient");
+            httpClient = new SalesforceHttpClient(camelContext, workerPool, sslContextFactory);
         } catch (GeneralSecurityException | IOException e) {
             throw new RuntimeException("Error creating default SSL context: " + e.getMessage(), e);
         }


### PR DESCRIPTION
Backport of https://github.com/apache/camel/pull/24140 to `camel-4.18.x`.

## Summary

`AbstractSalesforceExecution.createHttpClient()` in the `camel-salesforce-codegen` module uses the test-only `SalesforceHttpClient(SslContextFactory.Client)` constructor, which sets `workerPool` to `null`. When `AbstractClientBase.onComplete()` calls `httpClient.getWorkerPool().execute(...)`, this causes a `NullPointerException`.

The NPE is swallowed by Jetty's response handling, so the callback never fires and the plugin times out with:
```
Error getting global Objects: Timeout waiting for getGlobalObjects!
```

### Fix

Use the production 3-arg constructor that accepts `CamelContext` and `ExecutorService`, matching what `SalesforceComponent.createHttpClient()` already does.