### PR TITLE
CAMEL-23711: Add automated tests and harden camel-test-infra-jaeger

### DIFF
--- a/test-infra/camel-test-infra-jaeger/pom.xml
+++ b/test-infra/camel-test-infra-jaeger/pom.xml
@@ -30,6 +30,11 @@
     <artifactId>camel-test-infra-jaeger</artifactId>
     <name>Camel :: Test Infra :: Jaeger</name>
 
+    <properties>
+        <!-- ITs require Docker; skip by default, opt in with -Djaeger-it-test -->
+        <skipITs>true</skipITs>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -58,6 +63,43 @@
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jaeger-it-test</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>jaeger-it-test</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/common/JaegerProperties.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/common/JaegerProperties.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.test.infra.jaeger.common;
 
+/**
+ * @since 4.21
+ */
 public final class JaegerProperties {
     public static final String JAEGER_CONTAINER = "jaeger.container";
     public static final String HOST = "jaeger.host";

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerContainer.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerContainer.java
@@ -22,6 +22,9 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * @since 4.21
+ */
 public class JaegerContainer extends GenericContainer<JaegerContainer> {
     public static final String CONTAINER_NAME = "jaeger";
 
@@ -52,8 +55,12 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
         return this;
     }
 
+    /**
+     * Creates a configured but unstarted Jaeger container with a custom image and network alias.
+     *
+     * @return an unstarted container; the caller is responsible for starting and closing it
+     */
     @SuppressWarnings("resource")
-    // NOTE: the object must be closed by the client.
     public static JaegerContainer initContainer(String imageName, String networkAlias) {
         return new JaegerContainer(imageName) // NOSONAR
                 .withNetworkAliases(networkAlias)

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerInfraService.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerInfraService.java
@@ -20,6 +20,8 @@ import org.apache.camel.test.infra.common.services.InfrastructureService;
 
 /**
  * Test infra service for Jaeger distributed tracing
+ *
+ * @since 4.21
  */
 public interface JaegerInfraService extends InfrastructureService {
 
@@ -31,6 +33,7 @@ public interface JaegerInfraService extends InfrastructureService {
 
     int queryUiPort();
 
+    // OTLP gRPC exporters expect an http(s):// URL per the OTel spec, not a grpc:// scheme.
     default String collectorGrpcEndpoint() {
         return String.format("http://%s:%d", host(), collectorGrpcPort());
     }

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerLocalContainerInfraService.java
@@ -23,6 +23,9 @@ import org.apache.camel.test.infra.jaeger.common.JaegerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @since 4.21
+ */
 @InfraService(service = JaegerInfraService.class,
               description = "Jaeger is a distributed tracing backend with OTLP collector and UI",
               serviceAlias = { "jaeger" })

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerRemoteInfraService.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerRemoteInfraService.java
@@ -18,6 +18,9 @@ package org.apache.camel.test.infra.jaeger.services;
 
 import org.apache.camel.test.infra.jaeger.common.JaegerProperties;
 
+/**
+ * @since 4.21
+ */
 public class JaegerRemoteInfraService implements JaegerInfraService {
 
     @Override
@@ -37,7 +40,13 @@ public class JaegerRemoteInfraService implements JaegerInfraService {
 
     @Override
     public String host() {
-        return System.getProperty(JaegerProperties.HOST);
+        String host = System.getProperty(JaegerProperties.HOST);
+        if (host == null) {
+            throw new IllegalStateException(
+                    "Remote Jaeger selected but system property '" + JaegerProperties.HOST
+                                            + "' is not set. Set it (and optionally the port properties) to point at the remote Jaeger instance.");
+        }
+        return host;
     }
 
     @Override

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerService.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerService.java
@@ -20,7 +20,10 @@ import org.apache.camel.test.infra.common.services.ContainerTestService;
 import org.apache.camel.test.infra.common.services.TestService;
 
 /**
- * Test infra service for Jaeger
+ * JUnit 5 extension-facing service for Jaeger; combines the infra endpoint contract with the TestService lifecycle
+ * (BeforeAllCallback / AfterAllCallback) so it can be used directly with {@code @RegisterExtension}.
+ *
+ * @since 4.21
  */
 public interface JaegerService extends TestService, JaegerInfraService, ContainerTestService {
 }

--- a/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerServiceFactory.java
+++ b/test-infra/camel-test-infra-jaeger/src/main/java/org/apache/camel/test/infra/jaeger/services/JaegerServiceFactory.java
@@ -18,6 +18,9 @@ package org.apache.camel.test.infra.jaeger.services;
 
 import org.apache.camel.test.infra.common.services.SimpleTestServiceBuilder;
 
+/**
+ * @since 4.21
+ */
 public final class JaegerServiceFactory {
     private JaegerServiceFactory() {
     }

--- a/test-infra/camel-test-infra-jaeger/src/test/java/org/apache/camel/test/infra/jaeger/JaegerRemoteInfraServiceTest.java
+++ b/test-infra/camel-test-infra-jaeger/src/test/java/org/apache/camel/test/infra/jaeger/JaegerRemoteInfraServiceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.infra.jaeger;
+
+import org.apache.camel.test.infra.jaeger.common.JaegerProperties;
+import org.apache.camel.test.infra.jaeger.services.JaegerRemoteInfraService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @since 4.21
+ */
+class JaegerRemoteInfraServiceTest {
+
+    private JaegerRemoteInfraService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new JaegerRemoteInfraService();
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(JaegerProperties.HOST);
+        System.clearProperty(JaegerProperties.COLLECTOR_GRPC_PORT);
+        System.clearProperty(JaegerProperties.COLLECTOR_HTTP_PORT);
+        System.clearProperty(JaegerProperties.QUERY_UI_PORT);
+        service.shutdown();
+    }
+
+    @Test
+    void hostReturnsValueFromSystemProperty() {
+        System.setProperty(JaegerProperties.HOST, "my-jaeger-host");
+        assertEquals("my-jaeger-host", service.host());
+    }
+
+    @Test
+    void hostThrowsWhenPropertyNotSet() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.host());
+        assertTrue(ex.getMessage().contains(JaegerProperties.HOST));
+    }
+
+    @Test
+    void collectorGrpcPortReturnsDefaultWhenNotSet() {
+        assertEquals(JaegerProperties.DEFAULT_COLLECTOR_GRPC_PORT, service.collectorGrpcPort());
+    }
+
+    @Test
+    void collectorGrpcPortReturnsValueFromSystemProperty() {
+        System.setProperty(JaegerProperties.COLLECTOR_GRPC_PORT, "9317");
+        assertEquals(9317, service.collectorGrpcPort());
+    }
+
+    @Test
+    void collectorHttpPortReturnsDefaultWhenNotSet() {
+        assertEquals(JaegerProperties.DEFAULT_COLLECTOR_HTTP_PORT, service.collectorHttpPort());
+    }
+
+    @Test
+    void collectorHttpPortReturnsValueFromSystemProperty() {
+        System.setProperty(JaegerProperties.COLLECTOR_HTTP_PORT, "9318");
+        assertEquals(9318, service.collectorHttpPort());
+    }
+
+    @Test
+    void queryUiPortReturnsDefaultWhenNotSet() {
+        assertEquals(JaegerProperties.DEFAULT_QUERY_UI_PORT, service.queryUiPort());
+    }
+
+    @Test
+    void queryUiPortReturnsValueFromSystemProperty() {
+        System.setProperty(JaegerProperties.QUERY_UI_PORT, "18686");
+        assertEquals(18686, service.queryUiPort());
+    }
+
+    @Test
+    void collectorGrpcEndpointFormatsCorrectly() {
+        System.setProperty(JaegerProperties.HOST, "my-jaeger-host");
+        System.setProperty(JaegerProperties.COLLECTOR_GRPC_PORT, "9317");
+        assertEquals("http://my-jaeger-host:9317", service.collectorGrpcEndpoint());
+        // Verify the OTel-required http:// scheme is used, not grpc://
+        assertFalse(service.collectorGrpcEndpoint().startsWith("grpc://"),
+                "OTLP gRPC endpoint must use http:// scheme, not grpc://");
+    }
+
+    @Test
+    void collectorHttpEndpointFormatsCorrectly() {
+        System.setProperty(JaegerProperties.HOST, "my-jaeger-host");
+        System.setProperty(JaegerProperties.COLLECTOR_HTTP_PORT, "9318");
+        assertEquals("http://my-jaeger-host:9318", service.collectorHttpEndpoint());
+    }
+
+    @Test
+    void queryUiUrlFormatsCorrectly() {
+        System.setProperty(JaegerProperties.HOST, "my-jaeger-host");
+        System.setProperty(JaegerProperties.QUERY_UI_PORT, "18686");
+        assertEquals("http://my-jaeger-host:18686", service.queryUiUrl());
+    }
+}

--- a/test-infra/camel-test-infra-jaeger/src/test/java/org/apache/camel/test/infra/jaeger/JaegerServiceIT.java
+++ b/test-infra/camel-test-infra-jaeger/src/test/java/org/apache/camel/test/infra/jaeger/JaegerServiceIT.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.infra.jaeger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.apache.camel.test.infra.jaeger.services.JaegerService;
+import org.apache.camel.test.infra.jaeger.services.JaegerServiceFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @since 4.21
+ */
+class JaegerServiceIT {
+
+    @RegisterExtension
+    static JaegerService service = JaegerServiceFactory.createService();
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    @Test
+    void shouldReceiveTraceViaOtlpHttp() throws Exception {
+        final String serviceName = "camel-jaeger-it-http";
+        final String operationName = "http-test-operation";
+
+        try (OtlpHttpSpanExporter exporter = OtlpHttpSpanExporter.builder()
+                .setEndpoint(service.collectorHttpEndpoint() + "/v1/traces")
+                .build()) {
+            sendAndFlushTrace(exporter, serviceName, operationName);
+        }
+
+        assertTraceReceived(serviceName, operationName);
+    }
+
+    @Test
+    void shouldReceiveTraceViaOtlpGrpc() throws Exception {
+        final String serviceName = "camel-jaeger-it-grpc";
+        final String operationName = "grpc-test-operation";
+
+        try (OtlpGrpcSpanExporter exporter = OtlpGrpcSpanExporter.builder()
+                .setEndpoint(service.collectorGrpcEndpoint())
+                .build()) {
+            sendAndFlushTrace(exporter, serviceName, operationName);
+        }
+
+        assertTraceReceived(serviceName, operationName);
+    }
+
+    private static void sendAndFlushTrace(SpanExporter exporter, String serviceName, String operationName)
+            throws Exception {
+        Resource resource = Resource.getDefault().merge(
+                Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), serviceName)));
+
+        try (SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .setResource(resource)
+                .build();
+             OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+                     .setTracerProvider(tracerProvider)
+                     .build()) {
+            Tracer tracer = sdk.getTracer(serviceName);
+            Span span = tracer.spanBuilder(operationName)
+                    .setAttribute("test.key", "test-value")
+                    .startSpan();
+            span.end();
+
+            CompletableResultCode flushResult = tracerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+            assertTrue(flushResult.isSuccess(), "Span flush timed out or failed after 10 seconds");
+        }
+    }
+
+    private static void assertTraceReceived(String serviceName, String operationName) {
+        String queryUrl = service.queryUiUrl() + "/api/traces?service=" + serviceName + "&limit=10";
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    HttpResponse<String> response = HTTP_CLIENT.send(
+                            HttpRequest.newBuilder(URI.create(queryUrl)).GET().build(),
+                            HttpResponse.BodyHandlers.ofString());
+                    assertEquals(200, response.statusCode());
+                    String body = response.body();
+                    assertTrue(body.contains(operationName),
+                            "Expected '" + operationName + "' in Jaeger response but got: " + body);
+                    assertTrue(body.contains("test-value"),
+                            "Expected span attribute 'test-value' in Jaeger response but got: " + body);
+                });
+    }
+}

--- a/test-infra/camel-test-infra-jaeger/src/test/java/org/apache/camel/test/infra/jaeger/JaegerTestApp.java
+++ b/test-infra/camel-test-infra-jaeger/src/test/java/org/apache/camel/test/infra/jaeger/JaegerTestApp.java
@@ -35,9 +35,12 @@ import org.apache.camel.test.infra.jaeger.services.JaegerLocalContainerInfraServ
 /**
  * Manual test application that starts a Jaeger container, sends sample OTEL traces, and waits for the user to press
  * Enter before shutting down.
- *
+ * <p/>
  * Run with: mvn test-compile exec:java -Dexec.mainClass=org.apache.camel.test.infra.jaeger.JaegerTestApp
- * -Dexec.classpathScope=test -pl test-infra/camel-test-infra-jaeger
+ * -Dexec.classpathScope=test -pl test-infra/camel-test-infra-jaeger -am (-am is required so the reactor builds the
+ * camel-test-infra-common snapshot before exec resolves the classpath)
+ *
+ * @since 4.21
  */
 public final class JaegerTestApp {
 


### PR DESCRIPTION
# Description

Adds automated test coverage for `camel-test-infra-jaeger` and hardens the module
so it is production-ready for use by component integration tests.

Changes:

- **`JaegerRemoteInfraServiceTest`** (unit): covers `host()` fail-fast behaviour,
  default/override port resolution, and URL formatting for all three endpoints
  (OTLP gRPC, OTLP HTTP, Query UI). No Docker required.

- **`JaegerServiceIT`** (integration): spins up the Jaeger Testcontainers service
  via `JaegerServiceFactory`, sends real OTLP spans over both the HTTP and gRPC
  collectors, then queries the Jaeger API to confirm the traces landed. Uses
  Awaitility instead of `Thread.sleep` for the polling assertion. Gated behind
  `mvn verify -Djaeger-it-test` so it does not run in the default CI build.

- **`JaegerRemoteInfraService.host()`**: changed from returning `null` silently
  to throwing `IllegalStateException` with an actionable message when the required
  system property is not set.

- **Javadoc `@since 4.21`** added to all public types and new public methods in
  the module, per project convention.

- Minor Javadoc improvement on `JaegerContainer.initContainer()` and
  `JaegerInfraService.collectorGrpcEndpoint()` (clarifying the OTel-required
  `http://` scheme).

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

JIRA: https://issues.apache.org/jira/browse/CAMEL-23711

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

_Claude Code on behalf of Adriano Machado_