### PR TITLE
CAMEL-23805: HTTP endpoint summary not logged when supervised route controller is enabled

### DIFF
--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerUtil.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerUtil.java
@@ -95,6 +95,7 @@ public class MainHttpServerUtil {
                     @Override
                     public boolean isEnabled(CamelEvent event) {
                         return event instanceof CamelEvent.CamelContextStartedEvent
+                                || event instanceof CamelEvent.CamelContextRoutesStartedEvent
                                 || event instanceof CamelEvent.RouteReloadedEvent;
                     }
 

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultSupervisingRouteController.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultSupervisingRouteController.java
@@ -564,6 +564,9 @@ public class DefaultSupervisingRouteController extends DefaultRouteController im
             // log after first round of attempts (some routes may be scheduled for restart)
             logRouteStartupSummary();
         }
+
+        // signal that routes have been started so other services can react
+        EventHelper.notifyCamelContextRoutesStarted(getCamelContext());
     }
 
     private void logRouteStartupSummary() {


### PR DESCRIPTION
## Summary

When using `camel.routeController.enabled=true` (supervised route controller), the HTTP endpoint summary log is missing on startup. The endpoints work correctly, but the startup log listing them never appears.

**Root cause:** `MainHttpServerUtil` registers an EventNotifier that logs the HTTP summary on `CamelContextStartedEvent`. With the supervised route controller, routes start AFTER that event fires (in `onCamelContextFullyStarted()`), so `platformHttpComponent.getHttpEndpoints()` is empty when the summary runs.

**Fix:**
- Fire `CamelContextRoutesStartedEvent` from `DefaultSupervisingRouteController` after routes finish starting
- Have `MainHttpServerUtil` also listen for `CamelContextRoutesStartedEvent` to re-trigger the summary

No double-logging risk — `logSummary()` has a guard that only logs when endpoints have changed.

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude <noreply@anthropic.com>