### PR TITLE
chore: Fix fragment anchor in pqc-dataformat xref to pqc-hybrid

### DIFF
--- a/components/camel-pqc/src/main/docs/pqc-dataformat.adoc
+++ b/components/camel-pqc/src/main/docs/pqc-dataformat.adoc
@@ -39,7 +39,7 @@ This approach provides **defense-in-depth**: even if the symmetric algorithm is 
 
 == Wire Format
 
-Since Camel 4.19, the PQC DataFormat uses wire format v2 which includes magic bytes, version, and algorithm identifiers (see xref:others:pqc-hybrid.adoc#wire-format-v2-and-algorithm-identification[Wire Format v2 and Algorithm Identification]). The v1 format `[4 bytes: encapsulation length][N bytes: encapsulation][M bytes: encrypted data]` is still accepted on input for backward compatibility.
+Since Camel 4.19, the PQC DataFormat uses wire format v2 which includes magic bytes, version, and algorithm identifiers (see xref:others:pqc-hybrid.adoc#_wire_format_v2_and_algorithm_identification[Wire Format v2 and Algorithm Identification]). The v1 format `[4 bytes: encapsulation length][N bytes: encapsulation][M bytes: encrypted data]` is still accepted on input for backward compatibility.
 
 The v2 encrypted message format is:
 


### PR DESCRIPTION
## Summary

Fix broken fragment link in `pqc-dataformat.adoc`. Antora generates section anchors from `== Section Title` using underscores with a leading underscore (`_section_title`), not hyphens (`section-title`).

Changed `#wire-format-v2-and-algorithm-identification` to `#_wire_format_v2_and_algorithm_identification`.

Follow-up to #24146.