### PR TITLE
Fix Jenkins matrix filters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,11 +63,15 @@ pipeline {
                 options {
                     throttle(['camel'])
                 }
-                when { anyOf {
-                    expression { params.PLATFORM_FILTER == 'all' }
-                    expression { params.PLATFORM_FILTER == env.PLATFORM }
-                    expression { params.JDK_FILTER == 'all' }
-                    expression { params.JDK_FILTER == env.JDK_NAME }
+                when { allOf {
+                    anyOf {
+                        expression { params.PLATFORM_FILTER == 'all' }
+                        expression { params.PLATFORM_FILTER == env.PLATFORM }
+                    }
+                    anyOf {
+                        expression { params.JDK_FILTER == 'all' }
+                        expression { params.JDK_FILTER == env.JDK_NAME }
+                    }
                 } }
                 axes {
                     axis {

--- a/Jenkinsfile.jdk26
+++ b/Jenkinsfile.jdk26
@@ -68,11 +68,15 @@ pipeline {
                 options {
                     throttle(['camel'])
                 }
-                when { anyOf {
-                    expression { params.PLATFORM_FILTER == 'all' }
-                    expression { params.PLATFORM_FILTER == env.PLATFORM }
-                    expression { params.JDK_FILTER == 'all' }
-                    expression { params.JDK_FILTER == env.JDK_NAME }
+                when { allOf {
+                    anyOf {
+                        expression { params.PLATFORM_FILTER == 'all' }
+                        expression { params.PLATFORM_FILTER == env.PLATFORM }
+                    }
+                    anyOf {
+                        expression { params.JDK_FILTER == 'all' }
+                        expression { params.JDK_FILTER == env.JDK_NAME }
+                    }
                 } }
                 axes {
                     axis {


### PR DESCRIPTION
## Summary

- Require the platform filter and JDK filter to both match before a matrix cell runs.
- Apply the same filter logic to the JDK 26 Jenkinsfile.

## Root cause

The matrix `when` block used one broad `anyOf`, so selecting a platform could also run every JDK on that platform, and selecting a JDK could also run that JDK across every platform. The filters are independent dimensions, so each dimension needs its own wildcard-or-match check.

## Validation

- `git diff --check -- Jenkinsfile Jenkinsfile.jdk26`
- Ran a small truth-table sanity check: selecting one platform and one JDK now allows exactly one cell instead of five.