### PR TITLE
chore: Fix broken fragment links from doc-split

### DIFF
--- a/components/camel-ibm/camel-ibm-watsonx-ai/src/main/docs/ibm-watsonx-ai-examples.adoc
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/src/main/docs/ibm-watsonx-ai-examples.adoc
@@ -944,7 +944,7 @@ from("azure-storage-blob://mycontainer?prefix=documents/")
 
 Text classification operations allow you to classify documents using IBM watsonx.ai's document processing capabilities. These operations require Cloud Object Storage (COS) configuration.
 
-IMPORTANT: The COS connection in your watsonx.ai project must be configured with HMAC credentials (access_key_id and secret_access_key), not just IAM Service Credentials. See <<cos-connection-setup>> for details.
+IMPORTANT: The COS connection in your watsonx.ai project must be configured with HMAC credentials (access_key_id and secret_access_key), not just IAM Service Credentials. See xref:ROOT:ibm-watsonx-ai-component.adoc#cos-connection-setup[COS Connection Setup] for details.
 
 ==== Classify Documents from Cloud Object Storage
 

--- a/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-rest-api.adoc
+++ b/components/camel-salesforce/camel-salesforce-component/src/main/docs/salesforce-rest-api.adoc
@@ -25,7 +25,7 @@ The following operations are supported:
 results) using the result link returned from the 'query' API.
 * <<queryAll,queryAll>> - Runs a SOQL query. Unlike the query operation, queryAll returns records that are deleted because of a merge or delete. queryAll also returns information about archived task and event records.
 * <<sosl_search,search>> - Runs a Salesforce SOSL query.
-* <<apexCall,apexCall>> - Executes a user defined APEX REST API call.
+* xref:ROOT:salesforce-component.adoc#apexCall[apexCall] - Executes a user defined APEX REST API call.
 * <<approval,approval>> - Submits a record or records (batch) for approval process.
 * <<approvals,approvals>> - Fetches a list of all approval processes.
 * <<composite,composite>> - Executes up to 25 REST API requests in a single call. You can use the output of one


### PR DESCRIPTION
## Summary

- Fix broken `<<anchor>>` fragment links that referenced sections staying in parent pages after the CAMEL-23806 doc split
- `ibm-watsonx-ai-examples.adoc`: `<<cos-connection-setup>>` → xref to main component page
- `salesforce-rest-api.adoc`: `<<apexCall>>` → xref to main component page

## Test plan

- [ ] Antora link checker passes (no more broken fragments)
- [ ] Build checks pass

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>