### PR TITLE
CAMEL-23807: make the route-diagram web component render in the dev console (follow-up)

### DIFF
--- a/components/camel-diagram/src/main/java/org/apache/camel/diagram/DiagramDevConsole.java
+++ b/components/camel-diagram/src/main/java/org/apache/camel/diagram/DiagramDevConsole.java
@@ -17,6 +17,9 @@
 package org.apache.camel.diagram;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.StringJoiner;
 
@@ -205,19 +208,31 @@ public class DiagramDevConsole extends AbstractDevConsole {
         return root;
     }
 
+    private static final String WEB_COMPONENT_JS = loadWebComponentJs();
+
     private static String buildRouteWebComponentHtml(String filter, boolean refresh) {
         String f = filter == null ? "*" : filter;
         String refreshAttr = refresh ? " refresh=\"5000\"" : "";
-        // script path + route-structure src assume the dev console and static resources share an origin
+        // inline the web component script: static resource serving is not available when only the developer
+        // console is enabled (camel run --console). route-structure is a sibling console on the same origin.
         return "<html>\n"
                + "  <head>\n"
-               + "    <script type=\"module\" src=\"/camel/diagram/camel-route-diagram.js\"></script>\n"
+               + "    <script type=\"module\">\n" + WEB_COMPONENT_JS + "\n    </script>\n"
                + "  </head>\n"
                + "  <body>\n"
                + String.format("    <camel-route-diagram src=\"route-structure\" filter=\"%s\"%s></camel-route-diagram>%n",
                        escapeAttr(f), refreshAttr)
                + "  </body>\n"
                + "</html>\n";
+    }
+
+    private static String loadWebComponentJs() {
+        try (InputStream is = DiagramDevConsole.class.getResourceAsStream(
+                "/META-INF/resources/camel/diagram/camel-route-diagram.js")) {
+            return is != null ? new String(is.readAllBytes(), StandardCharsets.UTF_8) : "";
+        } catch (IOException e) {
+            return "";
+        }
     }
 
     private static String escapeAttr(String s) {

--- a/components/camel-diagram/src/main/resources/META-INF/resources/camel/diagram/camel-route-diagram.js
+++ b/components/camel-diagram/src/main/resources/META-INF/resources/camel/diagram/camel-route-diagram.js
@@ -382,7 +382,11 @@ class CamelRouteDiagram extends HTMLElement {
                 this.#render();
                 return;
             }
-            const data = await res.json();
+            let data = await res.json();
+            // the dev console nests each console's payload under its id, e.g. {"route-structure": {"routes": [...]}}
+            if (data && !Array.isArray(data.routes) && data['route-structure']) {
+                data = data['route-structure'];
+            }
             if (!Array.isArray(data?.routes)) {
                 this.#error = 'Unexpected response: missing routes array';
                 this.#render();

--- a/components/camel-diagram/src/test/java/org/apache/camel/diagram/DiagramDevConsoleTest.java
+++ b/components/camel-diagram/src/test/java/org/apache/camel/diagram/DiagramDevConsoleTest.java
@@ -72,7 +72,8 @@ class DiagramDevConsoleTest extends CamelTestSupport {
         assertThat(text).contains("<html>");
         assertThat(text).contains("<camel-route-diagram");
         assertThat(text).contains("src=\"route-structure\"");
-        assertThat(text).contains("camel-route-diagram.js");
+        assertThat(text).contains("customElements.define");
+        assertThat(text).doesNotContain("src=\"/camel/diagram/");
         assertThat(text).doesNotContain("data:image/png;base64,");
     }
 


### PR DESCRIPTION
# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

Follow-up after the merge (https://github.com/apache/camel/pull/24156): the diagram wasn't actually rendering when running with `--console`.

The page pulled the web component from `/camel/diagram/camel-route-diagram.js`, but that path isn't served when only the developer console is up, so it 404'd and nothing showed. It's now embedded straight into the console's HTML response, so there's no separate file to fetch.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

