### PR TITLE
CAMEL-23594: Fix kamelet properties being URL-encoded in YAML DSL

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -451,6 +451,16 @@ defense-in-depth only. The primary mitigation should be configured at the messag
 * ActiveMQ Artemis: `deserializationAllowList` / `deserializationDenyList` (see the Artemis docs)
 * ActiveMQ Classic: the `org.apache.activemq.SERIALIZABLE_PACKAGES` system property
 
+=== camel-kamelet
+
+Kamelet endpoint URIs constructed from YAML DSL `parameters:` blocks are no longer URL-encoded at runtime.
+Previously, property values containing special characters (such as `/`) were incorrectly URL-encoded
+(e.g., `application/json` became `application%2Fjson`), which caused issues because the Kamelet component
+uses raw URIs and does not decode them. This fix aligns the YAML DSL `parameters:` handling with how
+inline kamelet URIs (e.g., `kamelet:myKamelet?key=value`) already work.
+
+If you have workarounds in place to deal with encoded kamelet property values, they can be removed.
+
 === camel-jms
 
 JMS `ObjectMessage` support is now disabled by default. Java object serialization is a recurring source

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/java/org/apache/camel/dsl/yaml/YamlRoutesBuilderLoader.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/main/java/org/apache/camel/dsl/yaml/YamlRoutesBuilderLoader.java
@@ -603,7 +603,8 @@ public class YamlRoutesBuilderLoader extends YamlRoutesBuilderLoaderSupport {
         }
 
         if (params != null && !params.isEmpty()) {
-            String query = URISupport.createQueryString(params);
+            // kamelet uses useRawUri so parameters should not be encoded
+            String query = URISupport.createQueryString(params, !kamelet);
             // CAMEL-23284: restore property placeholders that were URL-encoded
             query = query.replace("%7B%7B", "{{").replace("%7D%7D", "}}");
             uri = uri + "?" + query;

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/KameletTest.groovy
@@ -390,4 +390,35 @@ class KameletTest extends YamlTestSupport {
         then:
             MockEndpoint.assertIsSatisfied(context)
     }
+
+    def "kamelet (properties not url encoded)"() {
+        setup:
+            addTemplate('setPayloadWithType') {
+                from('kamelet:source')
+                    .setBody().simple('{{contentType}}')
+                    .to("kamelet:sink")
+            }
+
+            loadRoutes '''
+                - from:
+                    uri: "direct:start"
+                    steps:
+                      - kamelet:
+                          name: "setPayloadWithType"
+                          parameters:
+                            contentType: "application/json"
+                      - to: "mock:result"
+            '''
+
+            withMock('mock:result') {
+                expectedMessageCount 1
+                expectedBodiesReceived 'application/json'
+            }
+        when:
+            withTemplate {
+                to('direct:start').withBody('hello').send()
+            }
+        then:
+            MockEndpoint.assertIsSatisfied(context)
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/PipeLoaderErrorHandlerTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/PipeLoaderErrorHandlerTest.groovy
@@ -79,11 +79,11 @@ class PipeLoaderErrorHandlerTest extends YamlTestSupport {
             errorHandlerFactory != null
             errorHandlerFactory instanceof DeadLetterChannelDefinition
             var eh = errorHandlerFactory as DeadLetterChannelDefinition
-            eh.deadLetterUri == 'kamelet:error-handler?kafkaTopic=my-first-test&logMessage=ERROR%21&kafkaServiceAccountId=scott&kafkaBrokers=my-broker&kafkaServiceAccountSecret=tiger'
+            eh.deadLetterUri == 'kamelet:error-handler?kafkaTopic=my-first-test&logMessage=ERROR!&kafkaServiceAccountId=scott&kafkaBrokers=my-broker&kafkaServiceAccountSecret=tiger'
             eh.redeliveryPolicy.maximumRedeliveries == "1"
             eh.redeliveryPolicy.redeliveryDelay == "2000"
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'kamelet:log-sink'
@@ -189,7 +189,7 @@ class PipeLoaderErrorHandlerTest extends YamlTestSupport {
             eh.redeliveryPolicy.redeliveryDelay == "2000"
             eh.getUseOriginalMessage() == "true"
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'kamelet:log-sink'
@@ -231,7 +231,7 @@ class PipeLoaderErrorHandlerTest extends YamlTestSupport {
             errorHandlerFactory != null
             errorHandlerFactory instanceof NoErrorHandlerDefinition
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'kamelet:log-sink'

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/PipeLoaderTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/PipeLoaderTest.groovy
@@ -53,7 +53,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
             with (context.routeDefinitions[0]) {
                 routeId == 'timer-event-source'
-                input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+                input.endpointUri == 'kamelet:timer-source?message=Hello world!'
                 input.lineNumber == 7
                 outputs.size() == 1
                 with (outputs[0], ToDefinition) {
@@ -294,7 +294,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'kafka:my-topic'
@@ -352,11 +352,11 @@ class PipeLoaderTest extends YamlTestSupport {
             errorHandlerFactory != null
             errorHandlerFactory instanceof DeadLetterChannelDefinition
             var eh = errorHandlerFactory as DeadLetterChannelDefinition
-            eh.deadLetterUri == 'kamelet:error-handler?kafkaTopic=my-first-test&logMessage=ERROR%21&kafkaServiceAccountId=scott&kafkaBrokers=my-broker&kafkaServiceAccountSecret=tiger'
+            eh.deadLetterUri == 'kamelet:error-handler?kafkaTopic=my-first-test&logMessage=ERROR!&kafkaServiceAccountId=scott&kafkaBrokers=my-broker&kafkaServiceAccountSecret=tiger'
             eh.redeliveryPolicy.maximumRedeliveries == "1"
             eh.redeliveryPolicy.redeliveryDelay == "2000"
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'kamelet:log-sink'
@@ -395,7 +395,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'knative:channel/my-messages'
@@ -475,7 +475,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             outputs.size() == 1
             with (outputs[0], ToDefinition) {
                 endpointUri == 'knative:event/org.apache.camel.event.messages?kind=Broker&name=foo-broker'
@@ -585,7 +585,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             input.lineNumber == 7
             outputs.size() == 1
             with (outputs[0], KameletDefinition) {
@@ -627,7 +627,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             input.lineNumber == 7
             inputType.urn == 'text/plain'
             outputType.urn == 'application/octet-stream'
@@ -673,7 +673,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             input.lineNumber == 7
             inputType.urn == 'camel:text/plain'
             outputType.urn == 'camel:application/octet-stream'
@@ -717,7 +717,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             input.lineNumber == 7
             outputs.size() == 3
             with (outputs[0], TransformDataTypeDefinition) {
@@ -769,7 +769,7 @@ class PipeLoaderTest extends YamlTestSupport {
 
         with (context.routeDefinitions[0]) {
             routeId == 'timer-event-source'
-            input.endpointUri == 'kamelet:timer-source?message=Hello+world%21'
+            input.endpointUri == 'kamelet:timer-source?message=Hello world!'
             input.lineNumber == 7
             outputs.size() == 3
             with (outputs[0], TransformDataTypeDefinition) {


### PR DESCRIPTION
## Summary

- Fix kamelet parameter values being URL-encoded by the YAML DSL but never decoded, because `KameletComponent` uses `useRawUri()=true`. Values like `application/json` were arriving as `application%2Fjson` in kamelet templates, causing HTTP 415 errors in kamelet integration tests.
- The root cause is `YamlRoutesBuilderLoader` calling `URISupport.createQueryString(params)` which defaults to `encode=true`. Changed to `createQueryString(params, !kamelet)` to skip encoding for kamelet URIs, matching what `KameletDeserializer` and `YamlSupport` already do.
- Added test in `KameletTest.groovy` verifying that property values containing `/` pass through YAML `parameters:` block to kamelet templates unencoded.

Supersedes #23391 with a source-level fix instead of decoding at the destination.

## Test plan

- [x] `KameletTest` suite passes (14 tests including new encoding test)
- [ ] CI validates `camel-yaml-dsl` and `camel-kamelet` modules
- [ ] Verify kamelet integration tests in `camel-kamelets` repo no longer fail with URL-encoded content types

_Claude Code on behalf of Claus Ibsen_