### PR TITLE
camel-a2a: Reduce log verbosity on A2A endpoint startup

### DIFF
--- a/components/camel-ai/camel-a2a/src/main/java/org/apache/camel/component/a2a/A2AConsumer.java
+++ b/components/camel-ai/camel-a2a/src/main/java/org/apache/camel/component/a2a/A2AConsumer.java
@@ -134,7 +134,7 @@ public class A2AConsumer extends DefaultConsumer {
 
         AgentCard card = getEndpoint().getResolvedCard();
         String agentName = card != null ? card.getName() : "unknown";
-        LOG.info("A2A Consumer starting for agent: {}", agentName);
+        LOG.debug("A2A Consumer starting for agent: {}", agentName);
 
         RestConsumerFactory factory = A2AHttpTransportSupport.resolveRestConsumerFactory(getEndpoint(), LOG);
         if (factory == null) {
@@ -224,7 +224,7 @@ public class A2AConsumer extends DefaultConsumer {
                 ServiceHelper.startService(consumer);
             }
 
-            LOG.info("A2A Consumer registered {} HTTP endpoint(s) for agent '{}'",
+            LOG.debug("A2A Consumer registered {} HTTP endpoint(s) for agent '{}'",
                     httpConsumers.size(), agentName);
         } catch (Exception e) {
             cleanupConsumerResources(true);

--- a/components/camel-ai/camel-a2a/src/main/java/org/apache/camel/component/a2a/A2AEndpoint.java
+++ b/components/camel-ai/camel-a2a/src/main/java/org/apache/camel/component/a2a/A2AEndpoint.java
@@ -161,7 +161,7 @@ public class A2AEndpoint extends DefaultEndpoint {
                     taskStore = new GuardedTaskStore(taskStore, configuration.isAllowLocalWebhookUrls());
                     taskStoreOwned = false;
                 } else {
-                    LOG.info("No A2ATaskStore found in registry, creating InMemoryTaskStore");
+                    LOG.debug("No A2ATaskStore found in registry, creating InMemoryTaskStore");
                     InMemoryTaskStore memStore = new InMemoryTaskStore();
                     memStore.setCompletedTaskTtlMs(configuration.getCompletedTaskTtl());
                     memStore.setAllowLocalWebhookUrls(configuration.isAllowLocalWebhookUrls());
@@ -305,7 +305,7 @@ public class A2AEndpoint extends DefaultEndpoint {
             String uri = handler.extensionUri();
             if (uri != null && !uri.isBlank()) {
                 handlerMap.put(uri, handler);
-                LOG.info("Registered custom A2AExtensionHandler for extension URI: {}", uri);
+                LOG.debug("Registered custom A2AExtensionHandler for extension URI: {}", uri);
             }
         }
         return handlerMap;


### PR DESCRIPTION
If you have many a2a routes, then these messages are quite spammy on app startup.