### PR TITLE
CAMEL-23787: block unsafe polymorphic base types by default in camel-jacksonxml XmlMapper (backport to 4.18.x)

### DIFF
--- a/components/camel-jacksonxml/src/main/java/org/apache/camel/component/jacksonxml/JacksonXMLDataFormat.java
+++ b/components/camel-jacksonxml/src/main/java/org/apache/camel/component/jacksonxml/JacksonXMLDataFormat.java
@@ -542,7 +542,11 @@ public class JacksonXMLDataFormat extends ServiceSupport
     }
 
     protected XmlMapper createNewXmlMapper() {
-        XmlMapper xm = new XmlMapper();
+        // Enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default as defense-in-depth against gadget-chain
+        // deserialization when polymorphic typing is enabled, consistent with camel-jackson (CAMEL-23786).
+        XmlMapper xm = XmlMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build();
         int len = getMaxStringLength();
         if (len > 0) {
             LOG.debug("Creating XmlMapper with maxStringLength: {}", len);

--- a/components/camel-jacksonxml/src/test/java/org/apache/camel/component/jacksonxml/JacksonXMLDataFormatPolymorphicHardeningTest.java
+++ b/components/camel-jacksonxml/src/test/java/org/apache/camel/component/jacksonxml/JacksonXMLDataFormatPolymorphicHardeningTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jacksonxml;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the XmlMapper created by {@link JacksonXMLDataFormat} enables
+ * {@link MapperFeature#BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES} by default — the Jackson mechanism that refuses unsafe
+ * polymorphic base types (e.g. Object/Serializable) when polymorphic/default typing is enabled, as defense-in-depth
+ * against gadget-chain deserialization.
+ */
+public class JacksonXMLDataFormatPolymorphicHardeningTest {
+
+    @Test
+    void blockUnsafePolymorphicBaseTypesEnabledByDefault() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+            JacksonXMLDataFormat df = new JacksonXMLDataFormat();
+            df.setCamelContext(context);
+            df.start();
+            XmlMapper xm = df.getXmlMapper();
+            assertNotNull(xm);
+            assertTrue(xm.isEnabled(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES),
+                    "camel-jacksonxml data format must enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default");
+        }
+    }
+}


### PR DESCRIPTION
Backport of #24177 to `camel-4.18.x`.

`camel-jacksonxml`'s default `XmlMapper` now enables `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES`, mirroring the hardening applied to `camel-jackson` (CAMEL-23786). Defense-in-depth against gadget-chain deserialization: when polymorphic / default typing is enabled, Jackson refuses unsafe base types (`Object`, `Serializable`, `Comparable`). Ordinary marshalling/unmarshalling is unchanged; opt out by supplying your own `XmlMapper` via the `xmlMapper` option.

Code + test only — the upgrade-guide entry lives on `main` (per the docs-on-main policy).

---
_AI-generated by Claude Code on behalf of Andrea Cosentino._