### PR TITLE
CAMEL-23812: camel-milo better username & password handling

### DIFF
--- a/components/camel-milo/src/main/docs/milo-client-component.adoc
+++ b/components/camel-milo/src/main/docs/milo-client-component.adoc
@@ -50,6 +50,20 @@ milo-client:opc.tcp://[user:password@]host:port?node=RAW(nsu=urn:foo:bar;s=item-
 
 If no user credentials are provided the client will switch to anonymous mode.
 
+As an alternative to URI-embedded credentials (`user:password`), you can provide
+credentials explicitly using the endpoint parameters `username` and `password`.
+This is recommended when credentials contain special characters (for example
+`?`, `/`, `@`, `&`, `%`(%25)) that can make URI-embedded credentials difficult to handle.
+
+For example:
+
+----
+milo-client:opc.tcp://host:port/path/to/service?node=RAW(nsu=urn:foo:bar;s=item-1)&username=RAW(my?user@name)&password=RAW(p@ss/w&rd)
+----
+
+When both styles are provided, the explicit `username`/`password` parameters take
+precedence over credentials embedded in the URI.
+
 All configuration options in the group +client+ are applicable to the shared client instance. Endpoints
 will share client instances for each endpoint URI. So the first time a request for that endpoint URI is
 made, the options of the +client+ group are applied. All further instances will be ignored.

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
@@ -116,7 +116,7 @@ public class MiloClientConfiguration implements Cloneable {
     @UriParam(label = "security")
     private String username;
 
-    @UriParam(label = "security", secret = true)
+    @UriParam(label = "security", security = "secret")
     private String password;
 
     public MiloClientConfiguration() {

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
@@ -113,6 +113,12 @@ public class MiloClientConfiguration implements Cloneable {
     @UriParam(label = "client", defaultValue = "1_000.0")
     private Double requestedPublishingInterval = DEFAULT_REQUESTED_PUBLISHING_INTERVAL;
 
+    @UriParam(label = "security")
+    private String username;
+
+    @UriParam(label = "security", secret = true)
+    private String password;
+
     public MiloClientConfiguration() {
     }
 
@@ -138,6 +144,8 @@ public class MiloClientConfiguration implements Cloneable {
         this.overrideHost = other.overrideHost;
         this.overridePort = other.overridePort;
         this.requestedPublishingInterval = other.requestedPublishingInterval;
+        this.username = other.username;
+        this.password = other.password;
     }
 
     /**
@@ -413,6 +421,30 @@ public class MiloClientConfiguration implements Cloneable {
      */
     public void setRequestedPublishingInterval(Double requestedPublishingInterval) {
         this.requestedPublishingInterval = requestedPublishingInterval;
+    }
+
+    /**
+     * The username for authentication. Use this instead of embedding credentials in the endpoint URI when the username
+     * contains special characters (such as {@code ?}, {@code /}, {@code @}, {@code &}).
+     */
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    /**
+     * The password for authentication. Use this instead of embedding credentials in the endpoint URI when the password
+     * contains special characters (such as {@code ?}, {@code /}, {@code @}, {@code &}).
+     */
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return this.password;
     }
 
     public Double getRequestedPublishingInterval() {

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientEndpoint.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientEndpoint.java
@@ -203,4 +203,25 @@ public class MiloClientEndpoint extends DefaultEndpoint {
     public void setOmitNullValues(boolean omitNullValues) {
         this.omitNullValues = omitNullValues;
     }
+
+
+    public String getUsername() {
+        return configuration != null ? configuration.getUsername() : null;
+    }
+
+    public void setUsername(String username) {
+        if (configuration != null) {
+            configuration.setUsername(username);
+        }
+    }
+
+    public String getPassword() {
+        return configuration != null ? configuration.getPassword() : null;
+    }
+
+    public void setPassword(String password) {
+        if (configuration != null) {
+            configuration.setPassword(password);
+        }
+    }
 }

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/internal/SubscriptionManager.java
@@ -694,18 +694,15 @@ public class SubscriptionManager {
     private Connected performConnect() throws Exception {
 
         // eval endpoint
-
         String discoveryUri = getEndpointDiscoveryUri();
 
         final URI uri = URI.create(getEndpointDiscoveryUri());
 
-        // milo library doesn't allow user info as a part of the uri, it has to
-        // be
-        // removed before sending to milo
+        // Extracting/removing user:password string from the full URL is error-prone with special characters,
+        // because of that the discovery URL is rebuilt from URI parts.
+        discoveryUri = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment()).toString();
         final String user = uri.getUserInfo();
-        if (user != null && !user.isEmpty()) {
-            discoveryUri = discoveryUri.replaceFirst(user + "@", "");
-        }
+
         LOG.debug("Discovering endpoints from: {}", discoveryUri);
 
         final EndpointDescription endpoint = DiscoveryClient.getEndpoints(discoveryUri).thenApply(endpoints -> {
@@ -728,14 +725,21 @@ public class SubscriptionManager {
         // set identity providers
         final List<IdentityProvider> providers = new LinkedList<>();
 
-        if (user != null && !user.isEmpty()) {
+        // prefer explicit username/password parameters over URI-embedded credentials
+        // to avoid issues with special characters in the URI
+        final String explicitUsername = this.configuration.getUsername();
+        final String explicitPassword = this.configuration.getPassword();
+        if (explicitUsername != null && !explicitUsername.isEmpty()) {
+            LOG.debug("Enable username/password provider (explicit parameter): {}", explicitUsername);
+            providers.add(new UsernameProvider(explicitUsername, explicitPassword != null ? explicitPassword : ""));
+        } else if (user != null && !user.isEmpty()) {
             final String[] creds = user.split(":", 2);
             if (creds != null) {
                 if (creds.length == 2) {
                     LOG.debug("Enable username/password provider: {}", creds[0]);
                 }
 
-                providers.add(new UsernameProvider(creds[0], creds[1]));
+                providers.add(new UsernameProvider(creds[0], creds.length == 2 ? creds[1] : ""));
             }
         }
 

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/AbstractMiloServerTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/AbstractMiloServerTest.java
@@ -44,6 +44,20 @@ public abstract class AbstractMiloServerTest extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractMiloServerTest.class);
 
+    // Password with special characters (@ $ ? & / # % (URL escaped: %25) . : * and non-ASCII ö) to verify
+    // that the credential parser handles delimiters and URI-sensitive chars correctly
+    protected static final String SPECIAL_CHAR_CREDENTIAL = "pass@$?&/#%25.:*wörd3";
+
+    // Username with special characters ($ and non-ASCII ü) to verify that usernames
+    // containing non-alphanumeric and non-ASCII characters are parsed correctly
+    protected static final String SPECIAL_CHAR_USER = "üs$er4";
+
+    // Comma-separated "user:pass" pairs: two plain, one with special-char password and special-char username
+    private static final String TEST_CREDENTIALS = String.join(",",
+            "foo:bar",
+            "foo2:bar2",
+            SPECIAL_CHAR_USER + ":" + SPECIAL_CHAR_CREDENTIAL);
+
     @RegisterExtension
     AvailablePortFinder.Port serverPortHolder = AvailablePortFinder.find();
 
@@ -109,7 +123,7 @@ public abstract class AbstractMiloServerTest extends CamelTestSupport {
     protected void configureMiloServer(final MiloServerComponent server) throws Exception {
         server.setBindAddresses("localhost");
         server.setPort(getServerPort());
-        server.setUserAuthenticationCredentials("foo:bar,foo2:bar2");
+        server.setUserAuthenticationCredentials(TEST_CREDENTIALS);
         server.setUsernameSecurityPolicyUri(SecurityPolicy.None);
         server.setSecurityPoliciesById("None");
         server.setEnableAnonymousAuthentication(true);

--- a/components/camel-milo/src/test/java/org/apache/camel/component/milo/ExplicitCredentialsTest.java
+++ b/components/camel-milo/src/test/java/org/apache/camel/component/milo/ExplicitCredentialsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.milo;
+
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.milo.server.MiloServerComponent;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.component.milo.NodeIds.nodeValue;
+
+/**
+ * Verifies that explicit username/password endpoint parameters work correctly, especially when credentials contain
+ * special characters (such as {@code ?}, {@code &}, {@code @}) that would break URI-embedded credentials.
+ */
+public class ExplicitCredentialsTest extends AbstractMiloServerTest {
+
+    private static final String MILO_SERVER_ITEM = "milo-server:myitem1";
+
+    // Use explicit username/password parameters instead of embedding in URI
+    private static final String MILO_CLIENT_ITEM
+            = "milo-client:opc.tcp://localhost:@@port@@?node="
+              + nodeValue(MiloServerComponent.DEFAULT_NAMESPACE_URI, "myitem1")
+              + "&overrideHost=true&allowedSecurityPolicies=None"
+              + "&username=RAW(" + SPECIAL_CHAR_USER + ")"
+              + "&password=RAW(" + SPECIAL_CHAR_CREDENTIAL + ")";
+
+    private static final String MOCK_RESULT = "mock:complex_credentials_result";
+
+    @Override
+    protected void configureMiloServer(final MiloServerComponent server) throws Exception {
+        server.setBindAddresses("localhost");
+        server.setPort(getServerPort());
+        // register credentials with special characters
+        server.setUserAuthenticationCredentials(SPECIAL_CHAR_USER + ":" + SPECIAL_CHAR_CREDENTIAL);
+        server.setUsernameSecurityPolicyUri(SecurityPolicy.None);
+        server.setSecurityPoliciesById("None");
+        server.setEnableAnonymousAuthentication(false);
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from(MILO_SERVER_ITEM).to(MOCK_RESULT);
+                from("direct:start").to(resolve(MILO_CLIENT_ITEM));
+            }
+        };
+    }
+
+    @Test
+    void shouldAuthenticateWithExplicitCredentialsContainingSpecialCharacters() throws Exception {
+
+        final String testBody = "test_special_chars";
+
+        MockEndpoint mock = getMockEndpoint(MOCK_RESULT);
+        mock.expectedMessageCount(1);
+        testBody(mock.message(0), assertGoodValue(testBody));
+
+        // write synchronously so the server receives the value before assertion
+        template.sendBodyAndHeader("direct:start", new Variant(testBody), "CamelMiloAwait", true);
+
+        // verify that the message sent via the client was received by the server endpoint
+        mock.assertIsSatisfied();
+    }
+}


### PR DESCRIPTION
# Description

The Camel Milo client component previously embedded authentication credentials directly in the endpoint URI using the format user:password@host. 
To prevent Milo from receiving credentials (which it doesn't handle), the component used string manipulation with `discoveryUri.replaceFirst(user + "@", "")` to strip credentials from the URL before connection. This caused issues because the `replaceFirst()` function uses regex patterns that fail with regex special characters like "$.*", and passwords containing characters like "%" cause issues with `java.net.URLDecoder.decode()` due to percent-encoding in URLs.

This approach has limitations: it fails when credentials contain special characters commonly found in auto-generated passwords, such as:

@ (breaks URI parsing)
?, & (URI query parameter delimiters)
/, # (URI structure delimiters)
$, % (encoding/variable expansion) 

For example, a password like pass@$?&/#% would cause the discovery URI reconstruction to fail or produce incorrect results.


# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.


- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


