### PR TITLE
CAMEL-23688: camel-jbang - add unit tests for action reader CLI commands

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/ActionCommandTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/ActionCommandTestSupport.java
@@ -17,11 +17,13 @@
 package org.apache.camel.dsl.jbang.core.commands.action;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.MockedStatic;
 
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -114,6 +117,37 @@ abstract class ActionCommandTestSupport extends CamelCommandBaseTestSupport {
             mocked.when(ProcessHandle::current).thenReturn(current);
             mocked.when(ProcessHandle::allProcesses).thenAnswer(inv -> Stream.of(ph));
             return command.doCall();
+        }
+    }
+
+    /**
+     * Runs a request/response reader command end to end. Mocks a single discoverable process (TEST_PID) and, in a
+     * background thread, simulates the running Camel writing {@code response} to its output file once the command has
+     * written its action request.
+     * <p>
+     * The reader commands delete any stale output file <em>before</em> writing the action file and only then poll for
+     * the output, so the responder waits for the action file to appear: that guarantees the response lands after the
+     * command's own delete and cannot be wiped out. No {@code Thread.sleep} is used; the wait is driven by Awaitility.
+     *
+     * @return the command exit code; rendered output can be asserted afterwards via {@code printer.getOutput()}
+     */
+    protected int callWithResponse(CamelCommand command, JsonObject response) throws Exception {
+        Path actionFile = CommandLineHelper.getCamelDir().resolve(TEST_PID + "-action.json");
+        Path outputFile = CommandLineHelper.getCamelDir().resolve(TEST_PID + "-output.json");
+        Thread responder = new Thread(() -> {
+            await().atMost(5, TimeUnit.SECONDS).until(() -> Files.exists(actionFile));
+            try {
+                Files.writeString(outputFile, response.toJson());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }, "test-camel-responder");
+        responder.setDaemon(true);
+        responder.start();
+        try {
+            return callWithSingleProcess(command);
+        } finally {
+            responder.join(TimeUnit.SECONDS.toMillis(10));
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDumpTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDumpTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.action;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class CamelBeanDumpTest extends ActionCommandTestSupport {
+
+    @Test
+    void testRequestsBeanDumpAndRendersBeans() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelBeanDump command = new CamelBeanDump(new CamelJBangMain().withPrinter(printer));
+        command.name = "myApp";
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.filter = "all";
+        command.sort = "name";
+        command.properties = true;
+
+        int exit = callWithResponse(command, singleBeanResponse());
+
+        assertEquals(0, exit);
+
+        JsonObject action = readActionFile(TEST_PID);
+        assertNotNull(action, "action file should be written for the matched process");
+        assertEquals("bean", action.getString("action"));
+
+        String out = printer.getOutput();
+        assertTrue(out.contains("BEAN: myBean"), "should print the bean name, was: " + out);
+        assertTrue(out.contains("com.foo.MyBean"), "should print the bean type, was: " + out);
+        assertTrue(out.contains("greeting"), "should print the bean property name, was: " + out);
+        assertTrue(out.contains("helloWorld"), "should print the bean property value, was: " + out);
+    }
+
+    @Test
+    void testReturnsErrorWhenNameDoesNotMatch() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelBeanDump command = new CamelBeanDump(new CamelJBangMain().withPrinter(printer));
+        command.name = "doesNotExist";
+
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(1, exit);
+        assertTrue(printer.getOutput().isEmpty(), "nothing should be rendered when no process matches");
+    }
+
+    private static JsonObject singleBeanResponse() {
+        JsonObject property = new JsonObject();
+        property.put("name", "greeting");
+        property.put("type", "java.lang.String");
+        property.put("value", "helloWorld");
+        JsonArray properties = new JsonArray();
+        properties.add(property);
+
+        JsonObject bean = new JsonObject();
+        bean.put("name", "myBean");
+        bean.put("type", "com.foo.MyBean");
+        bean.put("properties", properties);
+
+        JsonObject beans = new JsonObject();
+        beans.put("myBean", bean);
+
+        JsonObject response = new JsonObject();
+        response.put("beans", beans);
+        return response;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelGCActionTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelGCActionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.action;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+class CamelGCActionTest extends ActionCommandTestSupport {
+
+    @Test
+    void testWritesGcActionForMatchingName() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelGCAction command = new CamelGCAction(new CamelJBangMain().withPrinter(printer));
+        command.name = "myApp";
+
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(0, exit);
+        JsonObject action = readActionFile(TEST_PID);
+        assertNotNull(action, "action file should be written for the matched process");
+        assertEquals("gc", action.getString("action"));
+    }
+
+    @Test
+    void testNoActionWhenNameDoesNotMatch() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelGCAction command = new CamelGCAction(new CamelJBangMain().withPrinter(printer));
+        command.name = "doesNotExist";
+
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(0, exit);
+        assertNull(readActionFile(TEST_PID), "no action file should be written when no process matches");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDumpActionTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelRouteDumpActionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.action;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class CamelRouteDumpActionTest extends ActionCommandTestSupport {
+
+    @Test
+    void testRequestsRouteDumpAndRendersSource() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelRouteDumpAction command = new CamelRouteDumpAction(new CamelJBangMain().withPrinter(printer));
+        command.name = "myApp";
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.format = "yaml";
+        command.sort = "name";
+
+        int exit = callWithResponse(command, singleRouteResponse());
+
+        assertEquals(0, exit);
+
+        // the command must request a route-dump with the default yaml format
+        JsonObject action = readActionFile(TEST_PID);
+        assertNotNull(action, "action file should be written for the matched process");
+        assertEquals("route-dump", action.getString("action"));
+        assertEquals("yaml", action.getString("format"));
+
+        // the simulated response must be rendered as source code
+        String out = printer.getOutput();
+        assertTrue(out.contains("Source: myroute.yaml"), "should print the source filename, was: " + out);
+        assertTrue(out.contains("from uri: timer:foo"), "should print the route code, was: " + out);
+    }
+
+    @Test
+    void testReturnsErrorWhenNameDoesNotMatch() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelRouteDumpAction command = new CamelRouteDumpAction(new CamelJBangMain().withPrinter(printer));
+        command.name = "doesNotExist";
+
+        // no process matches, so the command returns before requesting any output
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(1, exit);
+        assertTrue(printer.getOutput().isEmpty(), "nothing should be rendered when no process matches");
+    }
+
+    private static JsonObject singleRouteResponse() {
+        JsonObject code = new JsonObject();
+        code.put("line", 1);
+        code.put("code", "from uri: timer:foo");
+        JsonArray codeLines = new JsonArray();
+        codeLines.add(code);
+
+        JsonObject route = new JsonObject();
+        route.put("source", "myroute.yaml");
+        route.put("routeId", "myRoute");
+        route.put("code", codeLines);
+        JsonArray routes = new JsonArray();
+        routes.add(route);
+
+        JsonObject response = new JsonObject();
+        response.put("routes", routes);
+        return response;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceTopTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSourceTopTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.action;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class CamelSourceTopTest extends ActionCommandTestSupport {
+
+    @Test
+    void testRequestsTopProcessorsAndRendersRows() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelSourceTop command = new CamelSourceTop(new CamelJBangMain().withPrinter(printer));
+        command.name = "myApp";
+
+        int exit = callWithResponse(command, singleProcessorResponse());
+
+        assertEquals(0, exit);
+
+        JsonObject action = readActionFile(TEST_PID);
+        assertNotNull(action, "action file should be written for the matched process");
+        assertEquals("top-processors", action.getString("action"));
+
+        String out = printer.getOutput();
+        assertTrue(out.contains("Route: myRoute"), "should print the route id, was: " + out);
+        assertTrue(out.contains("Total: 5"), "should print the processor statistics, was: " + out);
+    }
+
+    @Test
+    void testReturnsErrorWhenNameDoesNotMatch() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelSourceTop command = new CamelSourceTop(new CamelJBangMain().withPrinter(printer));
+        command.name = "doesNotExist";
+
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(1, exit);
+        assertTrue(printer.getOutput().isEmpty(), "nothing should be rendered when no process matches");
+    }
+
+    private static JsonObject singleProcessorResponse() {
+        JsonObject stats = new JsonObject();
+        stats.put("exchangesTotal", 5);
+        stats.put("meanProcessingTime", 2);
+        stats.put("maxProcessingTime", 3);
+        stats.put("minProcessingTime", 1);
+        stats.put("lastProcessingTime", 2);
+
+        JsonObject processor = new JsonObject();
+        processor.put("processorId", "myProcessor");
+        processor.put("routeId", "myRoute");
+        processor.put("location", "myroute.yaml");
+        processor.put("statistics", stats);
+
+        JsonArray processors = new JsonArray();
+        processors.add(processor);
+
+        JsonObject response = new JsonObject();
+        response.put("processors", processors);
+        return response;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDumpTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelThreadDumpTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.action;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class CamelThreadDumpTest extends ActionCommandTestSupport {
+
+    @Test
+    void testRequestsThreadDumpAndRendersThreads() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelThreadDump command = new CamelThreadDump(new CamelJBangMain().withPrinter(printer));
+        command.name = "myApp";
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.filters = new String[] { "all" };
+        command.sort = "id";
+        command.depth = 1;
+
+        int exit = callWithResponse(command, singleThreadResponse());
+
+        assertEquals(0, exit);
+
+        JsonObject action = readActionFile(TEST_PID);
+        assertNotNull(action, "action file should be written for the matched process");
+        assertEquals("thread-dump", action.getString("action"));
+
+        String out = printer.getOutput();
+        assertTrue(out.contains("PID: " + TEST_PID), "should print the pid header, was: " + out);
+        assertTrue(out.contains("Camel-thread-1"), "should print the thread name, was: " + out);
+        assertTrue(out.contains("RUNNABLE"), "should print the thread state, was: " + out);
+    }
+
+    @Test
+    void testReturnsErrorWhenNameDoesNotMatch() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        CamelThreadDump command = new CamelThreadDump(new CamelJBangMain().withPrinter(printer));
+        command.name = "doesNotExist";
+
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(1, exit);
+        assertTrue(printer.getOutput().isEmpty(), "nothing should be rendered when no process matches");
+    }
+
+    private static JsonObject singleThreadResponse() {
+        JsonObject thread = new JsonObject();
+        thread.put("id", 1);
+        thread.put("name", "Camel-thread-1");
+        thread.put("state", "RUNNABLE");
+        thread.put("waitedCount", 0);
+        thread.put("waitedTime", 0);
+        thread.put("blockedCount", 0);
+        thread.put("blockedTime", 0);
+        thread.put("stackTrace", new JsonArray());
+
+        JsonArray threads = new JsonArray();
+        threads.add(thread);
+
+        JsonObject response = new JsonObject();
+        response.put("threadCount", 1);
+        response.put("peakThreadCount", 2);
+        response.put("threads", threads);
+        return response;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerActionTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/RouteControllerActionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.action;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class RouteControllerActionTest extends ActionCommandTestSupport {
+
+    @Test
+    void testRequestsRouteControllerAndRendersRoutes() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        RouteControllerAction command = new RouteControllerAction(new CamelJBangMain().withPrinter(printer));
+        command.name = "myApp";
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "id";
+        command.header = true;
+
+        int exit = callWithResponse(command, defaultControllerResponse());
+
+        assertEquals(0, exit);
+
+        JsonObject action = readActionFile(TEST_PID);
+        assertNotNull(action, "action file should be written for the matched process");
+        assertEquals("route-controller", action.getString("action"));
+
+        String out = printer.getOutput();
+        assertTrue(out.contains("Default Route Controller"), "should print the controller header, was: " + out);
+        assertTrue(out.contains("myRoute"), "should print the route id, was: " + out);
+    }
+
+    @Test
+    void testReturnsErrorWhenNameDoesNotMatch() throws Exception {
+        writeStatusFile(TEST_PID, "myApp");
+
+        RouteControllerAction command = new RouteControllerAction(new CamelJBangMain().withPrinter(printer));
+        command.name = "doesNotExist";
+
+        int exit = callWithSingleProcess(command);
+
+        assertEquals(1, exit);
+        assertTrue(printer.getOutput().isEmpty(), "nothing should be rendered when no process matches");
+    }
+
+    private static JsonObject defaultControllerResponse() {
+        JsonObject route = new JsonObject();
+        route.put("routeId", "myRoute");
+        route.put("uri", "timer://foo");
+        route.put("status", "Started");
+        JsonArray routes = new JsonArray();
+        routes.add(route);
+
+        JsonObject response = new JsonObject();
+        response.put("controller", "DefaultRouteController");
+        response.put("startingRoutes", false);
+        response.put("totalRoutes", 1);
+        response.put("routes", routes);
+        return response;
+    }
+}


### PR DESCRIPTION
# Description

Follow-up to #24188 (action-writer command tests, merged), continuing the [CAMEL-23688](https://issues.apache.org/jira/browse/CAMEL-23688) effort to build a regression safety net around the `camel-jbang` CLI `action` commands before refactoring.

This batch covers the **request/response "reader" commands**: those that write an action request to `<pid>-action.json`, then poll `<pid>-output.json` for the running Camel's response and render it to the console.

New test infrastructure (`ActionCommandTestSupport`): `callWithResponse(command, response)` runs a reader command end to end. It starts a background "responder" thread that waits (via Awaitility) for the command to write its action request, then writes the simulated output file.

**Commands covered** (one `*Test` each, all in `commands/action/`):

| Command | Action verb | Kind |
|---------|-------------|------|
| `CamelGCAction` | `gc` | fire-and-forget writer |
| `CamelRouteDumpAction` | `route-dump` | reader |
| `CamelBeanDump` | `bean` | reader |
| `CamelThreadDump` | `thread-dump` | reader |
| `CamelSourceTop` | `top-processors` | reader |
| `RouteControllerAction` | `route-controller` | reader |

Each test asserts both the action-request payload the command writes **and** the rendered console output from a simulated response, plus a no-match path (no running process resolved). Process discovery is mocked with a static `ProcessHandle` mock, matching the existing tests in this package.

This is a **test-only** change: no production code is touched and there is no user-visible behavior change.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

---

_Claude Code on behalf of Adriano Machado_