### PR TITLE
CAMEL-23803: block unsafe polymorphic base types by default in camel-jackson-avro and camel-jackson-protobuf

### DIFF
--- a/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormat.java
+++ b/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jackson.avro;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;
 import org.apache.camel.component.jackson.AbstractJacksonDataFormat;
@@ -87,7 +88,12 @@ public class JacksonAvroDataFormat extends AbstractJacksonDataFormat {
 
     @Override
     protected AvroMapper createNewObjectMapper() {
-        return new AvroMapper();
+        // Enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default as defense-in-depth against gadget-chain
+        // deserialization when polymorphic typing is enabled, consistent with camel-jackson (CAMEL-23786)
+        // and the transform/Avro.java mapper.
+        return AvroMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build();
     }
 
     @Override

--- a/components/camel-jackson-avro/src/test/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormatPolymorphicHardeningTest.java
+++ b/components/camel-jackson-avro/src/test/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormatPolymorphicHardeningTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson.avro;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the AvroMapper created by {@link JacksonAvroDataFormat} enables
+ * {@link MapperFeature#BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES} by default — the Jackson mechanism that refuses unsafe
+ * polymorphic base types (e.g. Object/Serializable) when polymorphic/default typing is enabled, as defense-in-depth
+ * against gadget-chain deserialization.
+ */
+public class JacksonAvroDataFormatPolymorphicHardeningTest {
+
+    @Test
+    void blockUnsafePolymorphicBaseTypesEnabledByDefault() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+            JacksonAvroDataFormat df = new JacksonAvroDataFormat();
+            df.setCamelContext(context);
+            df.start();
+            ObjectMapper mapper = df.getObjectMapper();
+            assertNotNull(mapper);
+            assertTrue(mapper.isEnabled(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES),
+                    "camel-jackson-avro data format must enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default");
+        }
+    }
+}

--- a/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormat.java
+++ b/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jackson.protobuf;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.protobuf.ProtobufMapper;
 import org.apache.camel.component.jackson.JacksonDataFormat;
@@ -88,7 +89,12 @@ public class JacksonProtobufDataFormat extends JacksonDataFormat {
 
     @Override
     protected ProtobufMapper createNewObjectMapper() {
-        return new ProtobufMapper();
+        // Enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default as defense-in-depth against gadget-chain
+        // deserialization when polymorphic typing is enabled, consistent with camel-jackson (CAMEL-23786)
+        // and the transform/Protobuf.java mapper.
+        return ProtobufMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build();
     }
 
     @Override

--- a/components/camel-jackson-protobuf/src/test/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormatPolymorphicHardeningTest.java
+++ b/components/camel-jackson-protobuf/src/test/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormatPolymorphicHardeningTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson.protobuf;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the ProtobufMapper created by {@link JacksonProtobufDataFormat} enables
+ * {@link MapperFeature#BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES} by default — the Jackson mechanism that refuses unsafe
+ * polymorphic base types (e.g. Object/Serializable) when polymorphic/default typing is enabled, as defense-in-depth
+ * against gadget-chain deserialization.
+ */
+public class JacksonProtobufDataFormatPolymorphicHardeningTest {
+
+    @Test
+    void blockUnsafePolymorphicBaseTypesEnabledByDefault() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+            JacksonProtobufDataFormat df = new JacksonProtobufDataFormat();
+            df.setCamelContext(context);
+            df.start();
+            ObjectMapper mapper = df.getObjectMapper();
+            assertNotNull(mapper);
+            assertTrue(mapper.isEnabled(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES),
+                    "camel-jackson-protobuf data format must enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default");
+        }
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -36,6 +36,18 @@ This only affects routes that enable polymorphic / default typing on an unsafe b
 marshalling and unmarshalling are unchanged. If you rely on that behaviour, supply your own `XmlMapper`
 (via the `xmlMapper` option) configured without this feature.
 
+=== camel-jackson-avro and camel-jackson-protobuf - potential breaking change
+
+The `camel-jackson-avro` and `camel-jackson-protobuf` data formats now create their default `AvroMapper` /
+`ProtobufMapper` with `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES` enabled, mirroring the same hardening
+applied to `camel-jackson` and `camel-jacksonxml`. This is defense-in-depth against gadget-chain deserialization:
+when polymorphic / default typing is enabled, Jackson refuses unsafe base types (such as `Object`, `Serializable`
+or `Comparable`).
+
+This only affects routes that enable polymorphic / default typing on an unsafe base type; ordinary
+marshalling and unmarshalling are unchanged. If you rely on that behaviour, supply your own mapper
+(via the `objectMapper` option) configured without this feature.
+
 === camel-oauth
 
 `UserProfile` token verification now fails closed when no JWK set is available: a signed token can no

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -36,6 +36,18 @@ This only affects routes that enable polymorphic / default typing on an unsafe b
 marshalling and unmarshalling are unchanged. If you rely on that behaviour, supply your own `XmlMapper`
 (via the `xmlMapper` option) configured without this feature.
 
+=== camel-jackson-avro and camel-jackson-protobuf - potential breaking change
+
+The `camel-jackson-avro` and `camel-jackson-protobuf` data formats now create their default `AvroMapper` /
+`ProtobufMapper` with `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES` enabled, mirroring the same hardening
+applied to `camel-jackson` and `camel-jacksonxml`. This is defense-in-depth against gadget-chain deserialization:
+when polymorphic / default typing is enabled, Jackson refuses unsafe base types (such as `Object`, `Serializable`
+or `Comparable`).
+
+This only affects routes that enable polymorphic / default typing on an unsafe base type; ordinary
+marshalling and unmarshalling are unchanged. If you rely on that behaviour, supply your own mapper
+(via the `objectMapper` option) configured without this feature.
+
 === camel-oauth
 
 `UserProfile` token verification now fails closed when no JWK set is available: a signed token can no

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -2580,6 +2580,18 @@ This only affects routes that enable polymorphic / default typing on an unsafe b
 marshalling and unmarshalling are unchanged. If you rely on that behaviour, supply your own `XmlMapper`
 (via the `xmlMapper` option) configured without this feature.
 
+=== camel-jackson-avro and camel-jackson-protobuf - potential breaking change
+
+The `camel-jackson-avro` and `camel-jackson-protobuf` data formats now create their default `AvroMapper` /
+`ProtobufMapper` with `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES` enabled, mirroring the same hardening
+applied to `camel-jackson` and `camel-jacksonxml`. This is defense-in-depth against gadget-chain deserialization:
+when polymorphic / default typing is enabled, Jackson refuses unsafe base types (such as `Object`, `Serializable`
+or `Comparable`).
+
+This only affects routes that enable polymorphic / default typing on an unsafe base type; ordinary
+marshalling and unmarshalling are unchanged. If you rely on that behaviour, supply your own mapper
+(via the `objectMapper` option) configured without this feature.
+
 === camel-diagram: Embeddable web component
 
 A new `<camel-route-diagram>` web component is now bundled inside `camel-diagram.jar`


### PR DESCRIPTION
## Summary

Follow-up to CAMEL-23786 (camel-jackson) and CAMEL-23787 (camel-jacksonxml), raised in review of #24134.

`camel-jackson-avro`'s `JacksonAvroDataFormat.createNewObjectMapper()` and `camel-jackson-protobuf`'s `JacksonProtobufDataFormat.createNewObjectMapper()` returned a bare `new AvroMapper()` / `new ProtobufMapper()`, while their `transform/` counterparts (`transform/Avro.java`, `transform/Protobuf.java`) already enable `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES`. This closes that gap so all sibling Jackson data formats are consistent.

When polymorphic / default typing is enabled, Jackson now refuses unsafe base types (`Object`, `Serializable`, `Comparable`) — defense-in-depth against gadget-chain deserialization. Ordinary marshalling/unmarshalling is unchanged.

## Changes

- `JacksonAvroDataFormat.createNewObjectMapper()` → `AvroMapper.builder().enable(BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build()`.
- `JacksonProtobufDataFormat.createNewObjectMapper()` → `ProtobufMapper.builder().enable(BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build()`.
- New `JacksonAvroDataFormatPolymorphicHardeningTest` and `JacksonProtobufDataFormatPolymorphicHardeningTest` asserting the feature is enabled on each data format's default mapper.
- Upgrade-guide notes for 4.21, 4.18 and 4.14 (entries on `main` per the docs-on-main policy, since this is backported to the 4.18.x and 4.14.x maintenance lines).

## Opt-out

Routes that deliberately rely on polymorphic/default typing on an unsafe base type can supply their own mapper (via the `objectMapper` option) configured without this feature.

## Note on camel-jackson3

`camel-jackson3` (Jackson 3.x) is intentionally excluded: no code enables this `MapperFeature`, and Jackson 3 reworked default typing with a mandatory `PolymorphicTypeValidator`, so the flag likely does not apply. Left for a dedicated Jackson-3 review.

## Backport

Will be backported to `camel-4.18.x` and `camel-4.14.x` (code + test only; upgrade-guide entries stay on `main`), keeping the hardening consistent with camel-jackson/camel-jacksonxml on those lines.

---
_AI-generated by Claude Code on behalf of Andrea Cosentino._