### PR TITLE
CAMEL-23803: block unsafe polymorphic base types by default in camel-jackson-avro and camel-jackson-protobuf (backport to 4.18.x)

### DIFF
--- a/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormat.java
+++ b/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jackson.avro;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;
 import org.apache.camel.component.jackson.AbstractJacksonDataFormat;
@@ -87,7 +88,12 @@ public class JacksonAvroDataFormat extends AbstractJacksonDataFormat {
 
     @Override
     protected AvroMapper createNewObjectMapper() {
-        return new AvroMapper();
+        // Enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default as defense-in-depth against gadget-chain
+        // deserialization when polymorphic typing is enabled, consistent with camel-jackson (CAMEL-23786)
+        // and the transform/Avro.java mapper.
+        return AvroMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build();
     }
 
     @Override

--- a/components/camel-jackson-avro/src/test/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormatPolymorphicHardeningTest.java
+++ b/components/camel-jackson-avro/src/test/java/org/apache/camel/component/jackson/avro/JacksonAvroDataFormatPolymorphicHardeningTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson.avro;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the AvroMapper created by {@link JacksonAvroDataFormat} enables
+ * {@link MapperFeature#BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES} by default — the Jackson mechanism that refuses unsafe
+ * polymorphic base types (e.g. Object/Serializable) when polymorphic/default typing is enabled, as defense-in-depth
+ * against gadget-chain deserialization.
+ */
+public class JacksonAvroDataFormatPolymorphicHardeningTest {
+
+    @Test
+    void blockUnsafePolymorphicBaseTypesEnabledByDefault() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+            JacksonAvroDataFormat df = new JacksonAvroDataFormat();
+            df.setCamelContext(context);
+            df.start();
+            ObjectMapper mapper = df.getObjectMapper();
+            assertNotNull(mapper);
+            assertTrue(mapper.isEnabled(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES),
+                    "camel-jackson-avro data format must enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default");
+        }
+    }
+}

--- a/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormat.java
+++ b/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.jackson.protobuf;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.protobuf.ProtobufMapper;
 import org.apache.camel.component.jackson.JacksonDataFormat;
@@ -88,7 +89,12 @@ public class JacksonProtobufDataFormat extends JacksonDataFormat {
 
     @Override
     protected ProtobufMapper createNewObjectMapper() {
-        return new ProtobufMapper();
+        // Enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default as defense-in-depth against gadget-chain
+        // deserialization when polymorphic typing is enabled, consistent with camel-jackson (CAMEL-23786)
+        // and the transform/Protobuf.java mapper.
+        return ProtobufMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build();
     }
 
     @Override

--- a/components/camel-jackson-protobuf/src/test/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormatPolymorphicHardeningTest.java
+++ b/components/camel-jackson-protobuf/src/test/java/org/apache/camel/component/jackson/protobuf/JacksonProtobufDataFormatPolymorphicHardeningTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson.protobuf;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the ProtobufMapper created by {@link JacksonProtobufDataFormat} enables
+ * {@link MapperFeature#BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES} by default — the Jackson mechanism that refuses unsafe
+ * polymorphic base types (e.g. Object/Serializable) when polymorphic/default typing is enabled, as defense-in-depth
+ * against gadget-chain deserialization.
+ */
+public class JacksonProtobufDataFormatPolymorphicHardeningTest {
+
+    @Test
+    void blockUnsafePolymorphicBaseTypesEnabledByDefault() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+            JacksonProtobufDataFormat df = new JacksonProtobufDataFormat();
+            df.setCamelContext(context);
+            df.start();
+            ObjectMapper mapper = df.getObjectMapper();
+            assertNotNull(mapper);
+            assertTrue(mapper.isEnabled(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES),
+                    "camel-jackson-protobuf data format must enable BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES by default");
+        }
+    }
+}


### PR DESCRIPTION
Backport of #24195 to `camel-4.18.x`.

`camel-jackson-avro`'s and `camel-jackson-protobuf`'s `createNewObjectMapper()` now build their default `AvroMapper` / `ProtobufMapper` with `MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES` enabled, mirroring the hardening applied to `camel-jackson` (CAMEL-23786) and `camel-jacksonxml` (CAMEL-23787) and to their respective `transform/` mappers. Defense-in-depth against gadget-chain deserialization; ordinary marshalling/unmarshalling is unchanged. Opt out via the `objectMapper` option.

Code + test only — the upgrade-guide entry lives on `main` (per the docs-on-main policy).

---
_AI-generated by Claude Code on behalf of Andrea Cosentino._