### PR TITLE
CAMEL-23354: camel-jbang use quarkus-junit for Quarkus 3.31+

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -386,6 +386,7 @@ class ExportQuarkus extends Export {
         model.put("QuarkusGroupId", quarkusCamelBom.getGroupId());
         model.put("QuarkusArtifactId", quarkusCamelBom.getArtifactId());
         model.put("QuarkusVersion", quarkusCamelBom.getVersion());
+        model.put("UseQuarkusJunit", VersionHelper.isGE(quarkusCamelBom.getVersion(), "3.31.0"));
         model.put("QuarkusPackageType", quarkusPackageType);
         model.put("JavaVersion", javaVersion);
         model.put("ProjectBuildOutputTimestamp", this.getBuildMavenProjectDate());

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-kubernetes-pom.ftl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-kubernetes-pom.ftl
@@ -127,7 +127,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+[#if UseQuarkusJunit]
+            <artifactId>quarkus-junit</artifactId>
+[#else]
             <artifactId>quarkus-junit5</artifactId>
+[/#if]
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-pom.ftl
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/templates/quarkus-pom.ftl
@@ -127,7 +127,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+[#if UseQuarkusJunit]
+            <artifactId>quarkus-junit</artifactId>
+[#else]
             <artifactId>quarkus-junit5</artifactId>
+[/#if]
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/common/TemplateHelperTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/common/TemplateHelperTest.java
@@ -299,7 +299,7 @@ class TemplateHelperTest {
     }
 
     @Test
-    void testQuarkusPomTemplate() throws IOException {
+    void testQuarkusPomTemplateOlderVersion() throws IOException {
         Map<String, Object> model = new HashMap<>();
         model.put("GroupId", "com.example");
         model.put("ArtifactId", "my-quarkus-app");
@@ -307,6 +307,7 @@ class TemplateHelperTest {
         model.put("QuarkusGroupId", "io.quarkus.platform");
         model.put("QuarkusArtifactId", "quarkus-bom");
         model.put("QuarkusVersion", "3.17.0");
+        model.put("UseQuarkusJunit", false);
         model.put("QuarkusPackageType", "uber-jar");
         model.put("JavaVersion", "21");
         model.put("ProjectBuildOutputTimestamp", "2024-01-01T00:00:00Z");
@@ -325,6 +326,42 @@ class TemplateHelperTest {
                 "Should contain QuarkusPackageType");
         // Maven ${...} should pass through
         assertTrue(result.contains("${quarkus.platform.version}"));
+        // Quarkus < 3.31 should use quarkus-junit5
+        assertTrue(result.contains("<artifactId>quarkus-junit5</artifactId>"),
+                "Should use quarkus-junit5 for Quarkus < 3.31");
+        assertFalse(result.contains("<artifactId>quarkus-junit</artifactId>"),
+                "Should not use quarkus-junit for Quarkus < 3.31");
+    }
+
+    @Test
+    void testQuarkusPomTemplateCurrentVersion() throws IOException {
+        Map<String, Object> model = new HashMap<>();
+        model.put("GroupId", "com.example");
+        model.put("ArtifactId", "my-quarkus-app");
+        model.put("Version", "1.0.0");
+        model.put("QuarkusGroupId", "io.quarkus.platform");
+        model.put("QuarkusArtifactId", "quarkus-bom");
+        model.put("QuarkusVersion", "3.36.3");
+        model.put("UseQuarkusJunit", true);
+        model.put("QuarkusPackageType", "uber-jar");
+        model.put("JavaVersion", "21");
+        model.put("ProjectBuildOutputTimestamp", "2024-01-01T00:00:00Z");
+        model.put("BuildProperties", "");
+        model.put("Repositories", List.of());
+        model.put("Dependencies", List.of());
+        model.put("JibMavenPluginVersion", "3.5.1");
+
+        String result = TemplateHelper.processTemplate("quarkus-pom.ftl", model);
+
+        assertNoLicenseHeader(result);
+        assertTrue(result.contains("io.quarkus.platform"));
+        assertTrue(result.contains("quarkus-bom"));
+        assertTrue(result.contains("3.36.3"));
+        // Quarkus >= 3.31 should use quarkus-junit
+        assertTrue(result.contains("<artifactId>quarkus-junit</artifactId>"),
+                "Should use quarkus-junit for Quarkus >= 3.31");
+        assertFalse(result.contains("<artifactId>quarkus-junit5</artifactId>"),
+                "Should not use quarkus-junit5 for Quarkus >= 3.31");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-mcp/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-mcp/pom.xml
@@ -149,7 +149,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary

- Replace deprecated `quarkus-junit5` artifact with `quarkus-junit` (renamed in [Quarkus 3.31](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31))
- Add version-conditional logic in FreeMarker templates: use `quarkus-junit` for Quarkus >= 3.31, keep `quarkus-junit5` for older versions
- Update `camel-jbang-mcp/pom.xml` directly (fixed Quarkus 3.36.3, no conditional needed)

## Changes

- `ExportQuarkus.java`: add `UseQuarkusJunit` boolean flag to template model using `VersionHelper.isGE(version, "3.31.0")`
- `quarkus-pom.ftl` / `quarkus-kubernetes-pom.ftl`: conditional artifactId based on Quarkus version
- `camel-jbang-mcp/pom.xml`: rename `quarkus-junit5` → `quarkus-junit`
- `TemplateHelperTest.java`: add tests for both pre-3.31 and current Quarkus versions

## Test plan

- [x] Existing `testQuarkusPomTemplate` renamed and updated to verify `quarkus-junit5` for Quarkus < 3.31
- [x] New `testQuarkusPomTemplateCurrentVersion` verifies `quarkus-junit` for Quarkus >= 3.31
- [x] Both modules build cleanly

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude <noreply@anthropic.com>