### PR TITLE
Use a shallow git clone on Jenkins when possible for main build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,24 @@ pipeline {
                         steps {
                             cleanWs()
                             sh 'rm -rvf /home/jenkins/.m2/repository/org/apache/camel'
-                            checkout scm
+                            script {
+                                // Use full clone for JDK 21 on ubuntu-avx (needed for Sonar analysis)
+                                // Use shallow clone for all other combinations
+                                if ("${PLATFORM}" == "ubuntu-avx" && "${JDK_NAME}" == "jdk_21_latest") {
+                                    echo "Using full clone for ${PLATFORM}-${JDK_NAME} (required for code coverage and Sonar)"
+                                    checkout scm
+                                } else {
+                                    echo "Using shallow clone for ${PLATFORM}-${JDK_NAME}"
+                                    checkout([
+                                        $class: 'GitSCM',
+                                        branches: scm.branches,
+                                        extensions: [
+                                            [$class: 'CloneOption', depth: 1, noTags: true, shallow: true]
+                                        ],
+                                        userRemoteConfigs: scm.userRemoteConfigs
+                                    ])
+                                }
+                            }
                         }
                     }
 

--- a/Jenkinsfile.jdk26
+++ b/Jenkinsfile.jdk26
@@ -96,7 +96,14 @@ pipeline {
                         steps {
                             cleanWs()
                             sh 'rm -rvf /home/jenkins/.m2/repository/org/apache/camel'
-                            checkout scm
+                            checkout([
+                                $class: 'GitSCM',
+                                branches: scm.branches,
+                                extensions: [
+                                    [$class: 'CloneOption', depth: 1, noTags: true, shallow: true]
+                                ],
+                                userRemoteConfigs: scm.userRemoteConfigs
+                            ])
                         }
                     }
 


### PR DESCRIPTION
there are currently issues with disk space available on the Jenkins nodes.
Camel is one of the most consuming one. Each of its workspace for Camel core is taking 4.4G, it includes 1.4G for the .git folder. Using a shallow clone should reduce the 1.4G to 63M and gain few minutes to the build too.

Co-authored-by: IBM Bob IDE 1.0.3

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

