### PR TITLE
CAMEL-19531: Remove unnecessary Thread.sleep calls from leveldb tests

### DIFF
--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateConcurrentDifferentGroupsTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateConcurrentDifferentGroupsTest.java
@@ -63,8 +63,6 @@ public class LevelDBAggregateConcurrentDifferentGroupsTest extends LevelDBTestSu
                 public Object call() throws Exception {
                     String id = index % 2 == 0 ? "A" : "B";
                     template.sendBodyAndHeader("direct:start", index, "id", id);
-                    // simulate a little delay
-                    Thread.sleep(3);
                     return null;
                 }
             });

--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateConcurrentSameGroupTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateConcurrentSameGroupTest.java
@@ -62,8 +62,6 @@ public class LevelDBAggregateConcurrentSameGroupTest extends LevelDBTestSupport 
             executor.submit(new Callable<Object>() {
                 public Object call() throws Exception {
                     template.sendBodyAndHeader("direct:start", index, "id", 123);
-                    // simulate a little delay
-                    Thread.sleep(3);
                     return null;
                 }
             });

--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateLoadAndRecoverTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateLoadAndRecoverTest.java
@@ -65,8 +65,6 @@ public class LevelDBAggregateLoadAndRecoverTest extends LevelDBTestSupport {
             headers.put("seq", i);
             LOG.debug("Sending {} with id {}", value, id);
             template.sendBodyAndHeaders("seda:start", value, headers);
-            // simulate a little delay
-            Thread.sleep(5);
         }
 
         LOG.info("Sending all {} message done. Now waiting for aggregation to complete.", SIZE);

--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateLoadConcurrentTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregateLoadConcurrentTest.java
@@ -62,8 +62,6 @@ public class LevelDBAggregateLoadConcurrentTest extends LevelDBTestSupport {
                     char id = KEYS[key];
                     LOG.debug("Sending {} with id {}", value, id);
                     template.sendBodyAndHeader("direct:start", value, "id", Character.toString(id));
-                    // simulate a little delay
-                    Thread.sleep(3);
                     return null;
                 }
             });

--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregationRepositoryLoadExistingTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregationRepositoryLoadExistingTest.java
@@ -63,8 +63,6 @@ public class LevelDBAggregationRepositoryLoadExistingTest extends LevelDBTestSup
         // stop the repo
         levelDBFile.stop();
 
-        Thread.sleep(1000);
-
         // load the repo again
         levelDBFile.start();
 

--- a/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregationRepositoryRecoverExistingTest.java
+++ b/components/camel-leveldb/src/test/java/org/apache/camel/component/leveldb/LevelDBAggregationRepositoryRecoverExistingTest.java
@@ -65,8 +65,6 @@ public class LevelDBAggregationRepositoryRecoverExistingTest extends LevelDBTest
         // stop the repo
         repo.stop();
 
-        Thread.sleep(1000);
-
         // load the repo again
         repo.start();
 


### PR DESCRIPTION
### Motivation

Some leveldb tests contain unnecessary `Thread.sleep()` calls that increase test execution time without contributing to the behavior being verified.

### Modifications

* Removed unnecessary `Thread.sleep()` calls from leveldb tests.
* Kept the existing test assertions and behavior unchanged.

### Result

The tests continue to pass while avoiding unnecessary waiting, resulting in faster and more efficient test execution.
