### PR TITLE
CAMEL-23688: camel-jbang - add unit tests for catalog listing commands

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogBaseCommand.java
@@ -129,8 +129,9 @@ public abstract class CatalogBaseCommand extends CamelCommand {
             rows = rows.stream()
                     .filter(
                             r -> r.name.equalsIgnoreCase(filterName)
-                                    || r.description.toLowerCase(Locale.ROOT).contains(filterName)
-                                    || r.label.toLowerCase(Locale.ROOT).contains(filterName))
+                                    || (r.description != null
+                                            && r.description.toLowerCase(Locale.ROOT).contains(filterName))
+                                    || (r.label != null && r.label.toLowerCase(Locale.ROOT).contains(filterName)))
                     .collect(Collectors.toList());
         }
         if (sinceBefore != null) {

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogComponentTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogComponentTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.catalog;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTestSupport;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.Jsoner;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogComponentTest extends CamelCommandBaseTestSupport {
+
+    @Test
+    void shouldListComponentsFromCatalog() throws Exception {
+        CatalogComponent command = createCommand();
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        assertTrue(printer.getOutput().contains("kafka"),
+                "default listing should include the kafka component, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldNarrowToFilteredComponent() throws Exception {
+        CatalogComponent command = createCommand();
+        command.filterName = "kafka";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("kafka"), "filtered listing should include kafka, was: " + out);
+        assertFalse(out.contains("timer"), "filtered listing should exclude unrelated components, was: " + out);
+    }
+
+    @Test
+    void shouldRenderJsonOutput() throws Exception {
+        CatalogComponent command = createCommand();
+        command.filterName = "kafka";
+        command.jsonOutput = true;
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        JsonArray rows = (JsonArray) Jsoner.deserialize(printer.getOutput());
+        assertTrue(rows.stream()
+                .map(JsonObject.class::cast)
+                .anyMatch(row -> "kafka".equals(row.getString("name"))),
+                "JSON output should contain a row with name kafka, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldSuggestSimilarWhenFilterHasNoMatch() throws Exception {
+        CatalogComponent command = createCommand();
+        command.filterName = "kafkaa";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("No results for filter: kafkaa"),
+                "should report no results for an unknown filter, was: " + out);
+        assertTrue(out.contains("camel doc kafkaa"),
+                "should suggest the doc command for the filter, was: " + out);
+    }
+
+    private CatalogComponent createCommand() {
+        CatalogComponent command = new CatalogComponent(new CamelJBangMain().withPrinter(printer));
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "name";
+        command.mavenResolver = new MavenResolverMixin();
+        return command;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDataFormatTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDataFormatTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.catalog;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTestSupport;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogDataFormatTest extends CamelCommandBaseTestSupport {
+
+    @Test
+    void shouldListDataFormatsFromCatalog() throws Exception {
+        CatalogDataFormat command = createCommand();
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        assertTrue(printer.getOutput().contains("jaxb"),
+                "default listing should include the jaxb data format, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldNarrowToFilteredDataFormat() throws Exception {
+        CatalogDataFormat command = createCommand();
+        command.filterName = "jaxb";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("jaxb"), "filtered listing should include jaxb, was: " + out);
+        assertFalse(out.contains("csv"), "filtered listing should exclude unrelated data formats, was: " + out);
+    }
+
+    private CatalogDataFormat createCommand() {
+        CatalogDataFormat command = new CatalogDataFormat(new CamelJBangMain().withPrinter(printer));
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "name";
+        command.mavenResolver = new MavenResolverMixin();
+        return command;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDevConsoleTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogDevConsoleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.catalog;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTestSupport;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogDevConsoleTest extends CamelCommandBaseTestSupport {
+
+    @Test
+    void shouldListDevConsolesFromCatalog() throws Exception {
+        CatalogDevConsole command = createCommand();
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        assertTrue(printer.getOutput().contains("context"),
+                "default listing should include the context dev-console, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldNarrowToFilteredDevConsole() throws Exception {
+        CatalogDevConsole command = createCommand();
+        command.filterName = "context";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("context"), "filtered listing should include context, was: " + out);
+        assertFalse(out.contains("gc"), "filtered listing should exclude unrelated dev-consoles, was: " + out);
+    }
+
+    private CatalogDevConsole createCommand() {
+        CatalogDevConsole command = new CatalogDevConsole(new CamelJBangMain().withPrinter(printer));
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "name";
+        command.mavenResolver = new MavenResolverMixin();
+        return command;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogLanguageTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogLanguageTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.catalog;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTestSupport;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogLanguageTest extends CamelCommandBaseTestSupport {
+
+    @Test
+    void shouldListLanguagesFromCatalog() throws Exception {
+        CatalogLanguage command = createCommand();
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        assertTrue(printer.getOutput().contains("simple"),
+                "default listing should include the simple language, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldNarrowToFilteredLanguage() throws Exception {
+        CatalogLanguage command = createCommand();
+        command.filterName = "simple";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("simple"), "filtered listing should include simple, was: " + out);
+        assertFalse(out.contains("xpath"), "filtered listing should exclude unrelated languages, was: " + out);
+    }
+
+    private CatalogLanguage createCommand() {
+        CatalogLanguage command = new CatalogLanguage(new CamelJBangMain().withPrinter(printer));
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "name";
+        command.mavenResolver = new MavenResolverMixin();
+        return command;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogOtherTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogOtherTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.catalog;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTestSupport;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogOtherTest extends CamelCommandBaseTestSupport {
+
+    @Test
+    void shouldListOtherArtifactsFromCatalog() throws Exception {
+        CatalogOther command = createCommand();
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        assertTrue(printer.getOutput().contains("cli-connector"),
+                "default listing should include the cli-connector artifact, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldNarrowToFilteredArtifact() throws Exception {
+        CatalogOther command = createCommand();
+        command.filterName = "cli-connector";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("cli-connector"), "filtered listing should include cli-connector, was: " + out);
+        assertFalse(out.contains("cloudevents"), "filtered listing should exclude unrelated artifacts, was: " + out);
+    }
+
+    private CatalogOther createCommand() {
+        CatalogOther command = new CatalogOther(new CamelJBangMain().withPrinter(printer));
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "name";
+        command.mavenResolver = new MavenResolverMixin();
+        return command;
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogTransformerTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/catalog/CatalogTransformerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.catalog;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelCommandBaseTestSupport;
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.MavenResolverMixin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogTransformerTest extends CamelCommandBaseTestSupport {
+
+    @Test
+    void shouldListTransformersFromCatalog() throws Exception {
+        CatalogTransformer command = createCommand();
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        assertTrue(printer.getOutput().contains("application-octet-stream"),
+                "default listing should include the application-octet-stream transformer, was: " + printer.getOutput());
+    }
+
+    @Test
+    void shouldNarrowToFilteredTransformer() throws Exception {
+        CatalogTransformer command = createCommand();
+        command.filterName = "application-octet-stream";
+
+        int exit = command.doCall();
+
+        assertEquals(0, exit);
+        String out = printer.getOutput();
+        assertTrue(out.contains("application-octet-stream"),
+                "filtered listing should include application-octet-stream, was: " + out);
+        assertFalse(out.contains("avro-binary"), "filtered listing should exclude unrelated transformers, was: " + out);
+    }
+
+    private CatalogTransformer createCommand() {
+        CatalogTransformer command = new CatalogTransformer(new CamelJBangMain().withPrinter(printer));
+        // options are normally defaulted by picocli; set them as we construct the command directly
+        command.sort = "name";
+        command.mavenResolver = new MavenResolverMixin();
+        return command;
+    }
+}


### PR DESCRIPTION
# Description

Continues the CAMEL-23688 effort to build a regression safety net around the `camel-jbang` CLI commands before a planned refactor. After the `action/` package was covered (PRs #24188, #24189, #24199), this PR moves to the next-largest untested cluster, `commands/catalog/`, which previously had a single test (`CatalogDocTest`).

Adds unit tests for the six offline catalog listing commands, each extending `CatalogBaseCommand` and loading the bundled `DefaultCamelCatalog`:

- `CatalogComponentTest` (component) - lists `kafka`; `--filter` narrowing; `--json` output; no-match `--filter` suggestion branch.
- `CatalogDataFormatTest` (dataformat) - lists `jaxb`; `--filter` narrowing.
- `CatalogLanguageTest` (language) - lists `simple`; `--filter` narrowing.
- `CatalogOtherTest` (other) - lists `cli-connector`; `--filter` narrowing.
- `CatalogTransformerTest` (transformer) - lists `application-octet-stream`; `--filter` narrowing.
- `CatalogDevConsoleTest` (dev-console) - lists `context`; `--filter` narrowing.

The tests need no `ProcessHandle`/status-file harness: they construct the command directly (mirroring `CatalogDocTest`), set the `--sort` option that picocli would otherwise default, run `doCall()`, and assert specific catalog entries in the rendered output.

## Bug fixed

The transformer `--filter` test surfaced a real, pre-existing `NullPointerException`: `camel catalog transformer --filter=<anything>` crashed because `CatalogBaseCommand`'s filter predicate dereferenced the row's `description` and `label` without a null check. Transformer catalog models legitimately have a `null` description and label (unlike component/dataformat/language/other/dev-console), so the command was unusable with a filter. The filter now null-guards both fields, which covers all six listing commands and any future `collectRows` implementation.

## Out of scope (deferred)

`CatalogKamelet` downloads `camel-kamelets-catalog` from Maven and reflectively loads `KameletsCatalog`; offline, a unit test reaches only its `catch -> return 1` branch, so it needs an integration-style test and is not included here.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

---

_Claude Code on behalf of Adriano Machado_