### PR TITLE
Reflect output change in DependencyListITCase

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DependencyListITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DependencyListITCase.java
@@ -37,7 +37,7 @@ public class DependencyListITCase extends JBangTestSupport {
                                                               "    <version>" + version() + "</version>\n" +
                                                               "</dependency>");
         checkCommandOutputs("dependency list --runtime=spring-boot",
-                "org.apache.camel.springboot:camel-spring-boot-starter:" + version());
+                "org.apache.camel.springboot:camel-spring-boot-starter");
     }
 
     @Test


### PR DESCRIPTION
The command `camel dependency list --runtime=spring-boot` no longer outputs the artifact version. This change reflects that in the test

