### PR TITLE
CAMEL-23448: Add jolokia-agent-jvm at compile scope for launcher classpath

### DIFF
--- a/dsl/camel-jbang/camel-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-launcher/pom.xml
@@ -239,6 +239,11 @@
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-agent-jvm</artifactId>
             <version>${jolokia-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-agent-jvm</artifactId>
+            <version>${jolokia-version}</version>
             <classifier>javaagent</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
## Summary

Add `jolokia-agent-jvm` (no classifier) at compile scope so the shade plugin bundles the Jolokia API classes (`OptionsAndArgs`, `CommandDispatcher`, etc.) inside the `camel-launcher` fat JAR.

## Problem

The `camel-launcher jolokia` command fails with `NoClassDefFoundError: org/jolokia/jvmagent/client/util/OptionsAndArgs`.

PR #23043 added `findJolokiaAgentJar()` logic and shipped the `javaagent`-classified JAR alongside the launcher in `bin/`. However, `Jolokia.java:81` directly references `OptionsAndArgs` — this triggers classloading **before** the dynamic JAR lookup runs. Since the `javaagent` dependency has `<scope>provided</scope>`, the shade plugin excludes those classes from the fat JAR, causing `NoClassDefFoundError` at runtime.

## Fix

Two JARs are needed for two different purposes:
1. **Regular JAR** (no classifier, compile scope) → shaded into fat JAR → provides classpath classes for the launcher process
2. **`javaagent` JAR** (classified, provided scope) → external file in `bin/` → loaded into target JVM via attach API

This PR adds #1. The existing #2 from PR #23043 remains unchanged.

## Test plan

- [ ] Build `camel-launcher` module and verify `jolokia-agent-jvm` classes are present in the shaded JAR: `jar tf camel-launcher-*.jar | grep "org/jolokia/"`
- [ ] Run `camel-launcher jolokia <name>` — should no longer throw `NoClassDefFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)