### PR TITLE
CAMEL-23819 fix(camel-milo): prevent NullPointerException by filtering null browse results

### DIFF
--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/browse/MiloBrowseProducer.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/browse/MiloBrowseProducer.java
@@ -112,6 +112,7 @@ public class MiloBrowseProducer extends DefaultAsyncProducer {
 
                     final List<String> expandedNodes = browseResults.values().stream()
                             .map(BrowseResult::getReferences)
+                            .filter(Objects::nonNull)
                             .flatMap(Stream::of)
                             .map(ReferenceDescription::getNodeId)
                             .map(ExpandedNodeId::toParseableString)

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/browse/MiloBrowseProducer.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/browse/MiloBrowseProducer.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.milo.browse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;


### PR DESCRIPTION

# Description

When browsing the OPC UA node tree of a Siemens S7 PLC, a NullPointerException occurred in MiloBrowseProducer. The S7's OPC UA server returns null for BrowseResult.getReferences() on certain nodes (e.g., leaf nodes or nodes without child references), rather than returning an empty array. The stream pipeline in the browse result processing did not account for this, causing a NPE when Stream::of was called on a null reference array.

# Root Cause
The code at MiloBrowseProducer.java:114 assumed that BrowseResult.getReferences() always returns a non-null array. The Siemens S7 OPC UA server implementation violates this assumption by returning null references for nodes that have no children or for which browsing is not applicable.

# Solution
A .filter(Objects::nonNull) step was added to the stream pipeline between .map(BrowseResult::getReferences) and .flatMap(Stream::of). This filters out any null reference arrays before they are passed to Stream::of, gracefully skipping nodes without references instead of crashing.


# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


_Created with help from Claude Code on behalf of Robin Mattes_