### PR TITLE
[backport camel-4.14.x] CAMEL-23765: remote-file consumers - contain localWorkDirectory downloads within the work directory

### DIFF
--- a/components/camel-azure/camel-azure-files/src/main/java/org/apache/camel/component/file/azure/FilesOperations.java
+++ b/components/camel-azure/camel-azure-files/src/main/java/org/apache/camel/component/file/azure/FilesOperations.java
@@ -47,6 +47,7 @@ import org.apache.camel.component.file.FileComponent;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileExist;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.remote.RemoteFile;
 import org.apache.camel.component.file.remote.RemoteFileConfiguration;
@@ -301,8 +302,15 @@ public class FilesOperations extends NormalizedOperations {
                     "Exchange should have the " + FileComponent.FILE_EXCHANGE_FILE + " set");
             String relativeName = target.getRelativeFilePath();
 
+            File localWorkDir = local;
             inProgress = new File(local, relativeName + ".inprogress");
             local = new File(local, relativeName);
+
+            // ensure the local work file stays within the local work directory (CAMEL-23765)
+            if (endpoint.isJailStartingDirectory()) {
+                GenericFileHelper.jailToLocalWorkDirectory(inProgress, localWorkDir);
+                GenericFileHelper.jailToLocalWorkDirectory(local, localWorkDir);
+            }
 
             // create directory to local work file
             boolean result = local.mkdirs();

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
@@ -16,14 +16,37 @@
  */
 package org.apache.camel.component.file;
 
+import java.io.File;
 import java.util.function.Supplier;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.support.MessageHelper;
+import org.apache.camel.util.FileUtil;
 
 public final class GenericFileHelper {
 
     private GenericFileHelper() {
+    }
+
+    /**
+     * Ensures the resolved local work file stays within the configured local work directory. The remote file name used
+     * to build the local work file path may contain {@code ../} sequences that would otherwise resolve to a path
+     * outside the work directory.
+     *
+     * @param  target                              the resolved local work file (or its in-progress temp file)
+     * @param  localWorkDirectory                  the local work directory the file must stay within
+     * @throws GenericFileOperationFailedException if the target resolves outside the local work directory
+     */
+    public static void jailToLocalWorkDirectory(File target, File localWorkDirectory) {
+        // compact first as the remote relative name can use ../ etc
+        String compactTarget = FileUtil.compactPath(target.getPath());
+        String compactWork = FileUtil.compactPath(localWorkDirectory.getPath());
+        if (!compactTarget.startsWith(compactWork)) {
+            throw new GenericFileOperationFailedException(
+                    "Cannot retrieve file to local work file: " + compactTarget
+                                                          + " as it is jailed to the local work directory: "
+                                                          + compactWork);
+        }
     }
 
     public static String asExclusiveReadLockKey(GenericFile file, String key) {

--- a/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
+++ b/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GenericFileHelperTest {
+
+    private final File workDir = new File("target/localwork");
+
+    @Test
+    public void shouldAllowFilesWithinLocalWorkDirectory() {
+        // a plain name, a nested name, and a ../ that still resolves within the work directory are all allowed
+        assertDoesNotThrow(() -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "file.txt"), workDir));
+        assertDoesNotThrow(() -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "sub/dir/file.txt"), workDir));
+        assertDoesNotThrow(() -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "sub/../file.txt"), workDir));
+    }
+
+    @Test
+    public void shouldRejectFilesEscapingLocalWorkDirectory() {
+        // a remote file name that resolves outside the configured local work directory must be rejected
+        assertThrows(GenericFileOperationFailedException.class,
+                () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "../escape.txt"), workDir));
+        assertThrows(GenericFileOperationFailedException.class,
+                () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "../../etc/passwd"), workDir));
+        assertThrows(GenericFileOperationFailedException.class,
+                () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "sub/../../escape.txt"), workDir));
+    }
+}

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpOperations.java
@@ -32,6 +32,7 @@ import org.apache.camel.component.file.FileComponent;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileExist;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.support.ObjectHelper;
 import org.apache.camel.support.task.BlockingTask;
@@ -525,8 +526,15 @@ public class FtpOperations implements RemoteFileOperations<FTPFile> {
                     "Exchange should have the " + FileComponent.FILE_EXCHANGE_FILE + " set");
             String relativeName = target.getRelativeFilePath();
 
+            File localWorkDir = local;
             temp = new File(local, relativeName + ".inprogress");
             local = new File(local, relativeName);
+
+            // ensure the local work file stays within the local work directory (CAMEL-23765)
+            if (endpoint.isJailStartingDirectory()) {
+                GenericFileHelper.jailToLocalWorkDirectory(temp, localWorkDir);
+                GenericFileHelper.jailToLocalWorkDirectory(local, localWorkDir);
+            }
 
             // create directory to local work file
             boolean result = local.mkdirs();

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -55,6 +55,7 @@ import org.apache.camel.component.file.FileComponent;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileExist;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.spi.CamelLogger;
 import org.apache.camel.support.ResourceHelper;
@@ -935,8 +936,15 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
             // use relative filename in local work directory
             String relativeName = file.getRelativeFilePath();
 
+            File localWorkDir = local;
             temp = new File(local, relativeName + ".inprogress");
             local = new File(local, relativeName);
+
+            // ensure the local work file stays within the local work directory (CAMEL-23765)
+            if (endpoint.isJailStartingDirectory()) {
+                GenericFileHelper.jailToLocalWorkDirectory(temp, localWorkDir);
+                GenericFileHelper.jailToLocalWorkDirectory(local, localWorkDir);
+            }
 
             // create directory to local work file
             local.mkdirs();

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -44,6 +44,7 @@ import org.apache.camel.component.file.FileComponent;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileExist;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
@@ -291,11 +292,18 @@ public class SmbOperations implements SmbFileOperations {
             // use relative filename in local work directory
             String relativeName = file.getRelativeFilePath();
 
+            java.io.File localWorkDir = local;
             temp = new java.io.File(local, relativeName + ".inprogress");
+            local = new java.io.File(local, relativeName);
+
+            // ensure the local work file stays within the local work directory (CAMEL-23765)
+            if (endpoint.isJailStartingDirectory()) {
+                GenericFileHelper.jailToLocalWorkDirectory(temp, localWorkDir);
+                GenericFileHelper.jailToLocalWorkDirectory(local, localWorkDir);
+            }
 
             // create directory to local work file
-            local.mkdirs();
-            local = new java.io.File(local, relativeName);
+            localWorkDir.mkdirs();
 
             // delete any existing files
             if (temp.exists()) {


### PR DESCRIPTION
Backport of #24180 (CAMEL-23765) to `camel-4.14.x`.

## What

When `localWorkDirectory` is enabled, the remote-file consumers built the local work file path from the remote file name without ensuring it stayed within the configured work directory — a remote name containing `../` could resolve outside it. A shared `GenericFileHelper.jailToLocalWorkDirectory` check (`compactPath` + `startsWith`, mirroring the file producer's jail) is now applied to the temp and final files, **before `mkdirs`**, in `FtpOperations`, `SftpOperations`, `FilesOperations` and `SmbOperations`. It reuses the existing `jailStartingDirectory` option (default `true`).

## Scope notes

- **camel-mina-sftp does not exist on `camel-4.14.x`** (added in a later release), so the main PR's `MinaSftpOperations` change is not applicable here.
- **Source-only backport**: the main PR's `jailStartingDirectory` `producer`→`common` relabel and its regenerated metadata are intentionally omitted to keep the maintenance-branch change minimal; the upgrade-guide entry lives on `main`.

## Tests

- `GenericFileHelperTest` (2 tests) passes; the 4 components compile on `4.14.8-SNAPSHOT`.

---
_Claude Code on behalf of Andrea Cosentino_