### PR TITLE
CAMEL-23765: sync localWorkDirectory containment note to the 4.18/4.14 upgrade guides on main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -55,6 +55,14 @@ longer be accepted when the configured JWK set is missing or empty, since its si
 verified in that case. Deployments with a correctly resolved JWK set are unaffected; this aligns the
 legacy `UserProfile` path with the `JwtTokenValidator` SPI path.
 
+=== camel-ftp, camel-sftp, camel-azure-files, camel-smb
+
+When `localWorkDirectory` is used, the remote-file consumers now ensure the downloaded local work file
+stays within the configured work directory, so a remote file name containing `../` sequences can no longer
+resolve to a path outside it. The containment check honours the existing `jailStartingDirectory` option
+(default `true`); set `jailStartingDirectory=false` to disable it. A remote file that resolves outside the
+local work directory is rejected with a `GenericFileOperationFailedException`.
+
 === camel-spring-ws - potential breaking change
 
 The `spring-ws` consumer now applies a `HeaderFilterStrategy` to the SOAP headers it maps onto the

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -55,6 +55,14 @@ longer be accepted when the configured JWK set is missing or empty, since its si
 verified in that case. Deployments with a correctly resolved JWK set are unaffected; this aligns the
 legacy `UserProfile` path with the `JwtTokenValidator` SPI path.
 
+=== camel-ftp, camel-sftp, camel-mina-sftp, camel-azure-files, camel-smb
+
+When `localWorkDirectory` is used, the remote-file consumers now ensure the downloaded local work file
+stays within the configured work directory, so a remote file name containing `../` sequences can no longer
+resolve to a path outside it. The containment check honours the existing `jailStartingDirectory` option
+(default `true`); set `jailStartingDirectory=false` to disable it. A remote file that resolves outside the
+local work directory is rejected with a `GenericFileOperationFailedException`.
+
 === camel-spring-ws - potential breaking change
 
 The `spring-ws` consumer now applies a `HeaderFilterStrategy` to the SOAP headers it maps onto the


### PR DESCRIPTION
Documents the `localWorkDirectory` path-traversal containment fix (CAMEL-23765) in the version-specific upgrade guides on `main`, for the backports to:
- `camel-4.18.x` — #24219
- `camel-4.14.x` — #24220

Per the backport upgrade-guide policy, all `camel-4x-upgrade-guide-4_XX.adoc` files live on `main` as the canonical history. This adds a note to the **4_18** and **4_14** guides (the 4_14 entry omits `camel-mina-sftp`, which does not exist on that branch). The 4_21 entry was already added in the main PR #24180.

Docs-only change.

---
_Claude Code on behalf of Andrea Cosentino_