### PR TITLE
[backport camel-4.18.x] CAMEL-23821: fix not finding any files in validation

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-validate/src/main/java/org/apache/camel/dsl/jbang/core/commands/validate/YamlValidateCommand.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-validate/src/main/java/org/apache/camel/dsl/jbang/core/commands/validate/YamlValidateCommand.java
@@ -17,7 +17,6 @@
 package org.apache.camel.dsl.jbang.core.commands.validate;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,7 +40,6 @@ public class YamlValidateCommand extends CamelCommand {
                             arity = "1..9",
                             paramLabel = "<files>",
                             parameterConsumer = FilesConsumer.class)
-    Path[] filePaths;
     List<String> files = new ArrayList<>();
 
     public YamlValidateCommand(CamelJBangMain main) {


### PR DESCRIPTION
## Backport of #24224

Cherry-pick of #24224 onto `camel-4.18.x`.

**Original PR:** #24224 - CAMEL-23821: fix not finding any files in validation
**Original author:** @orpiske
**Target branch:** `camel-4.18.x`

### Original description

Remove leftover Path[] filePaths field from YamlValidateCommand that shadowed the actual List<String> files parameter, causing the YAML validate command to find no files to validate.