### PR TITLE
CAMEL-23827: Deprecate camel-threadpoolfactory-vertx

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/threadpoolfactory-vertx.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/threadpoolfactory-vertx.json
@@ -4,7 +4,7 @@
     "name": "threadpoolfactory-vertx",
     "title": "ThreadPoolFactory Vert.x",
     "description": "ThreadPoolFactory for camel-core using Vert.x",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "3.5.0",
     "label": "reactive",
     "supportLevel": "Experimental",

--- a/components/camel-threadpoolfactory-vertx/pom.xml
+++ b/components/camel-threadpoolfactory-vertx/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>camel-threadpoolfactory-vertx</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: Thread Pool Factory :: Vert.x</name>
+    <name>Camel :: Thread Pool Factory :: Vert.x (deprecated)</name>
     <description>ThreadPoolFactory for camel-core using Vert.x</description>
 
     <properties>

--- a/components/camel-threadpoolfactory-vertx/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-threadpoolfactory-vertx/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -3,5 +3,5 @@ name=threadpoolfactory-vertx
 groupId=org.apache.camel
 artifactId=camel-threadpoolfactory-vertx
 version=4.21.0-SNAPSHOT
-projectName=Camel :: Thread Pool Factory :: Vert.x
+projectName=Camel :: Thread Pool Factory :: Vert.x (deprecated)
 projectDescription=ThreadPoolFactory for camel-core using Vert.x

--- a/components/camel-threadpoolfactory-vertx/src/generated/resources/threadpoolfactory-vertx.json
+++ b/components/camel-threadpoolfactory-vertx/src/generated/resources/threadpoolfactory-vertx.json
@@ -4,7 +4,7 @@
     "name": "threadpoolfactory-vertx",
     "title": "ThreadPoolFactory Vert.x",
     "description": "ThreadPoolFactory for camel-core using Vert.x",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "3.5.0",
     "label": "reactive",
     "supportLevel": "Experimental",

--- a/components/camel-threadpoolfactory-vertx/src/main/docs/threadpoolfactory-vertx.adoc
+++ b/components/camel-threadpoolfactory-vertx/src/main/docs/threadpoolfactory-vertx.adoc
@@ -1,10 +1,11 @@
-= ThreadPoolFactory Vert.x Component
+= ThreadPoolFactory Vert.x Component (deprecated)
 :doctitle: ThreadPoolFactory Vert.x
 :shortname: threadpoolfactory-vertx
 :artifactid: camel-threadpoolfactory-vertx
 :description: ThreadPoolFactory for camel-core using Vert.x
 :since: 3.5
-:supportlevel: Experimental
+:supportlevel: Experimental-deprecated
+:deprecated: *deprecated*
 :tabs-sync-option:
 
 *Since Camel {since}*

--- a/components/camel-threadpoolfactory-vertx/src/main/java/org/apache/camel/reactive/vertx/VertXThreadPoolFactory.java
+++ b/components/camel-threadpoolfactory-vertx/src/main/java/org/apache/camel/reactive/vertx/VertXThreadPoolFactory.java
@@ -38,6 +38,7 @@ import org.apache.camel.support.DefaultThreadPoolFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(since = "4.21.0")
 @JdkService(ThreadPoolFactory.FACTORY)
 public class VertXThreadPoolFactory extends DefaultThreadPoolFactory implements ThreadPoolFactory {
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -649,10 +649,6 @@ keep the previous text behavior. XML and JSON files (`application/xml`, `applica
 
 The `sse` `transportType` is deprecated. it is recommended to switch to `streamableHttp`.
 
-=== camel-reactive-executor-vertx deprecated
-
-The `camel-reactive-executor-vertx` component has been deprecated. The component has been in an experimental state for a long time and no user feedback has been received to justify continued maintenance.
-
 === camel-stomp removal
 
 Camel stomp was deprecated with Camel 4.17. The stomp library didn't have any activities in the last 10 years. The component is now removed.
@@ -2326,6 +2322,14 @@ project — the core implementation now provides equivalent or better performanc
 === Deprecation of camel-paho
 
 The components camel-paho is deprecated. There were no new release since 2020 of the Java client, last non-regulatory commit was in 2022.
+
+=== Deprecation of camel-reactive-executor-vertx
+
+The `camel-reactive-executor-vertx` component has been deprecated. The component has been in an experimental state for a long time and no user feedback has been received to justify continued maintenance.
+
+=== Deprecation of camel-threadpoolfactory-vertx
+
+The component camel-threadpoolfactory-vertx is deprecated. The component has been in an experimental state for a long time and no user feedback has been received to justify continued maintenance.
 
 === Tightened default ObjectInputFilter across deserialization sites - potential breaking change
 


### PR DESCRIPTION
Also tidies up the `camel-reactive-executor-vertx deprecated` migration guide note so it's in the same section as the other component deprecation notices.