### PR TITLE
CAMEL-23820: support custom directories in YAML DSL validator plugin

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-yaml-dsl-validator-maven-plugin.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-yaml-dsl-validator-maven-plugin.adoc
@@ -26,7 +26,7 @@ You can also enable the plugin to run automatically as part of the build to catc
 ----
 <plugin>
   <groupId>org.apache.camel</groupId>
-  <artifactId>camel-yaml-dsl-validate-maven-plugin</artifactId>
+  <artifactId>camel-yaml-dsl-validator-maven-plugin</artifactId>
   <executions>
     <execution>
       <phase>process-classes</phase>
@@ -48,7 +48,7 @@ changed accordingly to `process-test-classes` as shown below:
 ----
 <plugin>
   <groupId>org.apache.camel</groupId>
-  <artifactId>camel-yaml-dsl-validate-maven-plugin</artifactId>
+  <artifactId>camel-yaml-dsl-validator-maven-plugin</artifactId>
   <executions>
     <execution>
       <configuration>
@@ -102,6 +102,7 @@ The maven plugin *validate* goal supports the following options which can be con
 | includes | | To filter the names of YAML files to only include files matching any of the given list of patterns (wildcard and regular expression). Multiple values can be separated by comma.
 | excludes | | To filter the names of YAML files to exclude files matching any of the given list of patterns (wildcard and regular expression). Multiple values can be separated by comma.
 | onlyCamelYamlExt | false | Whether to only accept files with xxx.camel.yaml as file name. By default, all .yaml files are accepted.
+| directories | | Additional directories to scan for YAML files. By default, only the project's resource directories are scanned.
 |===
 
 For example to excludes a specific file:
@@ -112,6 +113,34 @@ mvn camel-yaml-dsl-validator:validate -Dcamel.excludes=cheese.yaml
 ----
 
 Notice that you must prefix the `-D` command argument with `camel.`, eg `camel.excludes` as the option name.
+
+=== Validating with additional directories
+
+If your YAML route files are stored in a location outside the standard Maven resource directories, you can specify additional directories to scan:
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.apache.camel</groupId>
+  <artifactId>camel-yaml-dsl-validator-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <configuration>
+        <directories>
+          <directory>src/main/routes</directory>
+          <directory>src/main/camel</directory>
+        </directories>
+      </configuration>
+      <phase>process-classes</phase>
+      <goals>
+        <goal>validate</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+----
+
+Both relative and absolute paths are supported. Relative paths are resolved against the project base directory.
 
 === Validating include test
 

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/pom.xml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/pom.xml
@@ -85,6 +85,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/main/docs/camel-yaml-dsl-validator-maven-plugin.adoc
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/main/docs/camel-yaml-dsl-validator-maven-plugin.adoc
@@ -26,7 +26,7 @@ You can also enable the plugin to run automatically as part of the build to catc
 ----
 <plugin>
   <groupId>org.apache.camel</groupId>
-  <artifactId>camel-yaml-dsl-validate-maven-plugin</artifactId>
+  <artifactId>camel-yaml-dsl-validator-maven-plugin</artifactId>
   <executions>
     <execution>
       <phase>process-classes</phase>
@@ -48,7 +48,7 @@ changed accordingly to `process-test-classes` as shown below:
 ----
 <plugin>
   <groupId>org.apache.camel</groupId>
-  <artifactId>camel-yaml-dsl-validate-maven-plugin</artifactId>
+  <artifactId>camel-yaml-dsl-validator-maven-plugin</artifactId>
   <executions>
     <execution>
       <configuration>
@@ -122,7 +122,7 @@ If your YAML route files are stored in a location outside the standard Maven res
 ----
 <plugin>
   <groupId>org.apache.camel</groupId>
-  <artifactId>camel-yaml-dsl-validate-maven-plugin</artifactId>
+  <artifactId>camel-yaml-dsl-validator-maven-plugin</artifactId>
   <executions>
     <execution>
       <configuration>

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/main/docs/camel-yaml-dsl-validator-maven-plugin.adoc
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/main/docs/camel-yaml-dsl-validator-maven-plugin.adoc
@@ -102,6 +102,7 @@ The maven plugin *validate* goal supports the following options which can be con
 | includes | | To filter the names of YAML files to only include files matching any of the given list of patterns (wildcard and regular expression). Multiple values can be separated by comma.
 | excludes | | To filter the names of YAML files to exclude files matching any of the given list of patterns (wildcard and regular expression). Multiple values can be separated by comma.
 | onlyCamelYamlExt | false | Whether to only accept files with xxx.camel.yaml as file name. By default, all .yaml files are accepted.
+| directories | | Additional directories to scan for YAML files. By default, only the project's resource directories are scanned.
 |===
 
 For example to excludes a specific file:
@@ -112,6 +113,34 @@ mvn camel-yaml-dsl-validator:validate -Dcamel.excludes=cheese.yaml
 ----
 
 Notice that you must prefix the `-D` command argument with `camel.`, eg `camel.excludes` as the option name.
+
+=== Validating with additional directories
+
+If your YAML route files are stored in a location outside the standard Maven resource directories, you can specify additional directories to scan:
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.apache.camel</groupId>
+  <artifactId>camel-yaml-dsl-validate-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <configuration>
+        <directories>
+          <directory>src/main/routes</directory>
+          <directory>src/main/camel</directory>
+        </directories>
+      </configuration>
+      <phase>process-classes</phase>
+      <goals>
+        <goal>validate</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+----
+
+Both relative and absolute paths are supported. Relative paths are resolved against the project base directory.
 
 === Validating include test
 

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/main/java/org/apache/camel/dsl/yaml/validator/ValidateMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/main/java/org/apache/camel/dsl/yaml/validator/ValidateMojo.java
@@ -84,6 +84,12 @@ public class ValidateMojo extends AbstractMojo {
     private boolean includeTest;
 
     /**
+     * Additional directories to scan for YAML files. By default, only the project's resource directories are scanned.
+     */
+    @Parameter(property = "camel.directories")
+    private List<String> directories;
+
+    /**
      * To filter the names of YAML files to only include files matching any of the given list of patterns (wildcard and
      * regular expression). Multiple values can be separated by comma.
      */
@@ -121,7 +127,7 @@ public class ValidateMojo extends AbstractMojo {
 
         // find all XML routes
         String ext = onlyCamelYamlExt ? ".camel.yaml" : ".yaml";
-        findYamlRouters(yamlFiles, includeTest, ext, project);
+        findYamlRouters(yamlFiles, includeTest, ext, directories, project);
         getLog().debug("Found " + yamlFiles.size() + " YAML files ...");
 
         Map<File, List<Error>> reports = new LinkedHashMap<>();
@@ -264,13 +270,24 @@ public class ValidateMojo extends AbstractMojo {
         return answer;
     }
 
-    private static void findYamlRouters(Set<File> yamlFiles, boolean includeTest, String ext, MavenProject project) {
+    static void findYamlRouters(
+            Set<File> yamlFiles, boolean includeTest, String ext,
+            List<String> directories, MavenProject project) {
         for (Resource dir : project.getResources()) {
             finYamlFiles(new File(dir.getDirectory()), ext, yamlFiles);
         }
         if (includeTest) {
             for (Resource dir : project.getTestResources()) {
                 finYamlFiles(new File(dir.getDirectory()), ext, yamlFiles);
+            }
+        }
+        if (directories != null) {
+            for (String dir : directories) {
+                File d = new File(dir);
+                if (!d.isAbsolute()) {
+                    d = new File(project.getBasedir(), dir);
+                }
+                finYamlFiles(d, ext, yamlFiles);
             }
         }
     }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/test/java/org/apache/camel/dsl/yaml/validator/ValidateMojoTest.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator-maven-plugin/src/test/java/org/apache/camel/dsl/yaml/validator/ValidateMojoTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.yaml.validator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValidateMojoTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void findYamlRoutersScansCustomDirectories() throws IOException {
+        Path customDir = tempDir.resolve("custom-routes");
+        Files.createDirectories(customDir);
+        Files.writeString(customDir.resolve("my-route.yaml"), "- route:\n    from:\n      uri: timer:yaml\n");
+
+        MavenProject project = new MavenProject();
+        project.setFile(new File(tempDir.toFile(), "pom.xml"));
+
+        Set<File> yamlFiles = new LinkedHashSet<>();
+        ValidateMojo.findYamlRouters(
+                yamlFiles, false, ".yaml",
+                List.of(customDir.toString()), project);
+
+        assertEquals(1, yamlFiles.size());
+        assertTrue(yamlFiles.iterator().next().getName().endsWith("my-route.yaml"));
+    }
+
+    @Test
+    void findYamlRoutersScansRelativeCustomDirectories() throws IOException {
+        Path customDir = tempDir.resolve("src/main/routes");
+        Files.createDirectories(customDir);
+        Files.writeString(customDir.resolve("route.yaml"), "- route:\n    from:\n      uri: timer:yaml\n");
+
+        MavenProject project = new MavenProject();
+        project.setFile(new File(tempDir.toFile(), "pom.xml"));
+
+        Set<File> yamlFiles = new LinkedHashSet<>();
+        ValidateMojo.findYamlRouters(
+                yamlFiles, false, ".yaml",
+                List.of("src/main/routes"), project);
+
+        assertEquals(1, yamlFiles.size());
+        assertTrue(yamlFiles.iterator().next().getName().endsWith("route.yaml"));
+    }
+
+    @Test
+    void findYamlRoutersWithNullDirectories() {
+        MavenProject project = new MavenProject();
+        project.setFile(new File(tempDir.toFile(), "pom.xml"));
+
+        Set<File> yamlFiles = new LinkedHashSet<>();
+        ValidateMojo.findYamlRouters(
+                yamlFiles, false, ".yaml",
+                null, project);
+
+        assertTrue(yamlFiles.isEmpty());
+    }
+
+    @Test
+    void findYamlRoutersScansResourcesAndCustomDirectories() throws IOException {
+        Path resourceDir = tempDir.resolve("src/main/resources");
+        Files.createDirectories(resourceDir);
+        Files.writeString(resourceDir.resolve("resource-route.yaml"), "- route:\n    from:\n      uri: timer:yaml\n");
+
+        Path customDir = tempDir.resolve("custom");
+        Files.createDirectories(customDir);
+        Files.writeString(customDir.resolve("custom-route.yaml"), "- route:\n    from:\n      uri: timer:yaml\n");
+
+        MavenProject project = new MavenProject();
+        project.setFile(new File(tempDir.toFile(), "pom.xml"));
+
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        project.addResource(resource);
+
+        Set<File> yamlFiles = new LinkedHashSet<>();
+        ValidateMojo.findYamlRouters(
+                yamlFiles, false, ".yaml",
+                List.of(customDir.toString()), project);
+
+        assertEquals(2, yamlFiles.size());
+    }
+
+    @Test
+    void findYamlRoutersFiltersByCamelYamlExtension() throws IOException {
+        Path customDir = tempDir.resolve("routes");
+        Files.createDirectories(customDir);
+        Files.writeString(customDir.resolve("my-route.camel.yaml"), "- route:\n    from:\n      uri: timer:yaml\n");
+        Files.writeString(customDir.resolve("other.yaml"), "key: value\n");
+
+        MavenProject project = new MavenProject();
+        project.setFile(new File(tempDir.toFile(), "pom.xml"));
+
+        Set<File> yamlFiles = new LinkedHashSet<>();
+        ValidateMojo.findYamlRouters(
+                yamlFiles, false, ".camel.yaml",
+                List.of(customDir.toString()), project);
+
+        assertEquals(1, yamlFiles.size());
+        assertTrue(yamlFiles.iterator().next().getName().endsWith("my-route.camel.yaml"));
+    }
+}


### PR DESCRIPTION
## Summary

Add a `directories` parameter to the `camel-yaml-dsl-validator-maven-plugin` that allows users to specify additional directories to scan for YAML files, beyond the default Maven resource directories.

This addresses [CAMEL-23820](https://issues.apache.org/jira/browse/CAMEL-23820), where the plugin only supported files in Maven resource directories, preventing usage in projects that store YAML routes in other locations.

## Changes

- Added `directories` parameter (`@Parameter(property = "camel.directories")`) accepting a list of directory paths
- Both relative and absolute paths are supported; relative paths are resolved against the project base directory
- Custom directories are scanned **in addition to** the default resource directories (backward compatible)
- Updated the documentation with the new option and a usage example
- Fixed pre-existing `artifactId` typo in doc examples (`camel-yaml-dsl-validate-maven-plugin` -> `camel-yaml-dsl-validator-maven-plugin`)
- Synced the generated docs copy at `docs/user-manual/`
- Added unit tests covering: absolute paths, relative paths, null directories, combined resources + custom dirs, and `.camel.yaml` extension filtering

## Test plan

- [x] Unit tests pass (5 new tests in `ValidateMojoTest`)
- [x] Module build passes (`mvn verify`)
- [x] Full root build passes (`mvnd -Dquickly clean install`)
- [x] Generated docs copy synced and committed

_Claude Code on behalf of Otavio Rodolfo Piske_