### PR TITLE
CAMEL-23829: camel-jbang - Add scrollbar to TUI shell panel

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
@@ -41,6 +43,8 @@ import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.scrollbar.Scrollbar;
+import dev.tamboui.widgets.scrollbar.ScrollbarState;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.EnvironmentHelper;
 import org.apache.camel.dsl.jbang.core.common.Printer;
@@ -89,6 +93,7 @@ class ShellPanel {
     private int lastHistorySize;
     private Rect lastArea;
     private volatile boolean shellExited;
+    private final ScrollbarState scrollbarState = new ScrollbarState();
 
     void setContext(MonitorContext ctx) {
         this.ctx = ctx;
@@ -206,8 +211,17 @@ class ShellPanel {
         frame.renderWidget(block, area);
         Rect inner = block.inner(area);
 
-        int innerWidth = inner.width();
-        int innerHeight = inner.height();
+        // Reserve a 1-column gutter on the right for the scrollbar so shell content is never clipped
+        // underneath it. The column is reserved permanently to keep the content width stable, which
+        // avoids extra ScreenTerminal resizes.
+        List<Rect> hChunks = Layout.horizontal()
+                .constraints(Constraint.fill(), Constraint.length(1))
+                .split(inner);
+        Rect contentArea = hChunks.get(0);
+        Rect scrollbarArea = hChunks.get(1);
+
+        int innerWidth = contentArea.width();
+        int innerHeight = contentArea.height();
 
         // Start shell on first render (we now know the size)
         if (screenTerminal == null && innerWidth > 2 && innerHeight > 2) {
@@ -229,7 +243,7 @@ class ShellPanel {
             frame.renderWidget(
                     Paragraph.from(Line.from(
                             Span.styled(startError, Style.EMPTY.fg(Color.LIGHT_RED)))),
-                    inner);
+                    contentArea);
             return;
         }
 
@@ -266,7 +280,17 @@ class ShellPanel {
                         .text(Text.from(lines))
                         .overflow(Overflow.CLIP)
                         .build(),
-                inner);
+                contentArea);
+
+        // Scrollbar reflects the viewport position within the combined scrollback history + live screen.
+        // Only shown when there is scrollback history to page through.
+        int totalLines = histSize + innerHeight;
+        if (totalLines > innerHeight) {
+            scrollbarState.contentLength(totalLines);
+            scrollbarState.viewportContentLength(innerHeight);
+            scrollbarState.position(scrollbarPosition(histSize, innerHeight, scrollOffset));
+            frame.renderStatefulWidget(Scrollbar.builder().build(), scrollbarArea, scrollbarState);
+        }
     }
 
     void renderFooter(List<Span> spans) {
@@ -290,8 +314,7 @@ class ShellPanel {
             return renderLiveView(screen, width, height);
         }
 
-        int totalLines = history.size() + height;
-        int viewStart = Math.max(0, totalLines - scrollOffset - height);
+        int viewStart = scrollbarPosition(history.size(), height, scrollOffset);
 
         List<Line> lines = new ArrayList<>(height);
         for (int i = 0; i < height; i++) {
@@ -309,6 +332,21 @@ class ShellPanel {
             }
         }
         return lines;
+    }
+
+    /**
+     * Computes the index of the first visible line within the combined scrollback history and live screen buffer, given
+     * the current scrollback offset. When {@code scrollOffset} is 0 (the live view) the viewport sits at the bottom; at
+     * the maximum offset it sits at the top of the history.
+     *
+     * @param  historySize    number of lines currently held in the scrollback history
+     * @param  viewportHeight number of visible rows in the shell viewport
+     * @param  scrollOffset   how many lines the user has scrolled back from the live view
+     * @return                the index of the first line to display (clamped to be non-negative)
+     */
+    static int scrollbarPosition(int historySize, int viewportHeight, int scrollOffset) {
+        int totalLines = historySize + viewportHeight;
+        return Math.max(0, totalLines - scrollOffset - viewportHeight);
     }
 
     private static Line convertRow(long[] buffer, int offset, int width) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanelTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanelTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ShellPanelTest {
+
+    // contentLength fed to the scrollbar is historySize + viewportHeight, so the live view sits at the
+    // bottom of the track (position == historySize) and the maximum scrollback sits at the top.
+
+    @Test
+    void liveViewSitsAtBottomOfScrollback() {
+        // scrollOffset 0 means "following live output": the viewport's first line is the last history line,
+        // i.e. the thumb is pinned to the bottom of the track.
+        assertEquals(100, ShellPanel.scrollbarPosition(100, 20, 0));
+    }
+
+    @Test
+    void maxScrollbackSitsAtTop() {
+        // scrolling back by the full history size brings the very first history line into view.
+        assertEquals(0, ShellPanel.scrollbarPosition(100, 20, 100));
+    }
+
+    @Test
+    void partialScrollMovesViewportProportionally() {
+        // 100 history + 20 viewport = 120 total lines; scrolled back 30 -> first visible line is 120-30-20.
+        assertEquals(70, ShellPanel.scrollbarPosition(100, 20, 30));
+    }
+
+    @Test
+    void overScrollIsClampedToTop() {
+        // a scrollOffset larger than the history must not produce a negative position.
+        assertEquals(0, ShellPanel.scrollbarPosition(100, 20, 500));
+    }
+
+    @Test
+    void noHistoryKeepsViewportAtTop() {
+        // with no scrollback history the viewport is always pinned at the top of the live screen.
+        assertEquals(0, ShellPanel.scrollbarPosition(0, 20, 0));
+    }
+}


### PR DESCRIPTION
# Description

Adds a vertical scrollbar to the embedded JLine shell panel in the Camel TUI (`camel jbang` / `camel tui`).

The shell panel already supported scrollback through `Shift+PageUp`/`PageDown` and the mouse wheel, but it rendered no visual scrollbar, so there was no affordance showing the current position within the scrollback history (see https://issues.apache.org/jira/browse/CAMEL-23829).

**What changed**

- Render a vertical scrollbar following the same pattern already used by the other TUI tabs (`LogTab`, `SourceViewer`, `DiagramSupport`): the inner area is split into a content column (`Constraint.fill()`) and a 1-column scrollbar gutter (`Constraint.length(1)`), and the scrollbar is drawn via `renderStatefulWidget` only when there is scrollback history to page through.
- The virtual terminal is now sized to the content width (`innerWidth - 1`) so shell output is never clipped underneath the scrollbar. The gutter is reserved permanently to keep the content width stable, which avoids extra `ScreenTerminal` resizes (the source of the concurrent-resize races the class already guards against).
- The viewport position math is extracted into a small static helper `scrollbarPosition(...)`, reused by both `renderScrolledView` (which line to start drawing) and the scrollbar `position`, so the indicator can never disagree with what is actually on screen.

**Tests**

- New `ShellPanelTest` covers the `scrollbarPosition` math: live view pins the thumb to the bottom, maximum scrollback pins it to the top, partial scroll is proportional, and over-scroll / no-history are clamped.

**Docs**

- No documentation change: `camel-jbang-tui.adoc` has no shell-panel section today (the existing scrollback shortcuts are likewise undocumented), and a passive scrollbar indicator does not change any default, option, or API, so it does not warrant an upgrade-guide entry.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-23829) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

---

_Submitted by Claude Code on behalf of Adriano Machado._
