### PR TITLE
CAMEL-23830: camel-jbang - Make TUI shell ANSI colors readable on dark terminals

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 import dev.tamboui.layout.Rect;
+import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
@@ -506,23 +507,63 @@ class ShellPanel {
 
         // Foreground color (if set)
         if ((y & 0x1) != 0) {
-            int fg = (int) ((attr >> 12) & 0xFFF);
-            int r = ((fg >> 8) & 0xF) * 17;
-            int g = ((fg >> 4) & 0xF) * 17;
-            int b = (fg & 0xF) * 17;
-            style = style.fg(Color.rgb(r, g, b));
+            style = style.fg(resolveColor((int) ((attr >> 12) & 0xFFF)));
         }
 
         // Background color (if set)
         if ((y & 0x2) != 0) {
-            int bg = (int) (attr & 0xFFF);
-            int r = ((bg >> 8) & 0xF) * 17;
-            int g = ((bg >> 4) & 0xF) * 17;
-            int b = (bg & 0xF) * 17;
-            style = style.bg(Color.rgb(r, g, b));
+            style = style.bg(resolveColor((int) (attr & 0xFFF)));
         }
 
         return style;
+    }
+
+    /**
+     * Converts a 12-bit (4-bit-per-channel) color value from the {@link ScreenTerminal} attribute word into a TamboUI
+     * {@link Color}.
+     * <p>
+     * When the value matches one of the 16 standard ANSI palette colors, a themed {@link Color#ansi(AnsiColor)} is
+     * returned so the host terminal applies its own scheme (keeping, for example, red error output and the command
+     * highlighter legible on dark backgrounds). Any other value is a true-color cell (such as the orange shell prompt)
+     * and is expanded to its literal RGB value.
+     */
+    static Color resolveColor(int rgb12) {
+        AnsiColor ansi = ansiColorFor(rgb12);
+        if (ansi != null) {
+            return Color.ansi(ansi);
+        }
+        // Expand each 4-bit channel back to 8 bits (0xN -> 0xNN, i.e. * 17).
+        int r = ((rgb12 >> 8) & 0xF) * 17;
+        int g = ((rgb12 >> 4) & 0xF) * 17;
+        int b = (rgb12 & 0xF) * 17;
+        return Color.rgb(r, g, b);
+    }
+
+    /**
+     * Maps a 12-bit color value to the standard ANSI palette color it encodes, or {@code null} if it does not match one
+     * of the 16 ANSI colors. The values are {@link ScreenTerminal}'s palette (xterm defaults) reduced to the top nibble
+     * of each channel, matching how {@code ScreenTerminal} stores them in the cell attribute.
+     */
+    static AnsiColor ansiColorFor(int rgb12) {
+        return switch (rgb12) {
+            case 0x000 -> AnsiColor.BLACK;
+            case 0x800 -> AnsiColor.RED;
+            case 0x080 -> AnsiColor.GREEN;
+            case 0x880 -> AnsiColor.YELLOW;
+            case 0x008 -> AnsiColor.BLUE;
+            case 0x808 -> AnsiColor.MAGENTA;
+            case 0x088 -> AnsiColor.CYAN;
+            case 0xccc -> AnsiColor.WHITE;
+            case 0x888 -> AnsiColor.BRIGHT_BLACK;
+            case 0xf00 -> AnsiColor.BRIGHT_RED;
+            case 0x0f0 -> AnsiColor.BRIGHT_GREEN;
+            case 0xff0 -> AnsiColor.BRIGHT_YELLOW;
+            case 0x00f -> AnsiColor.BRIGHT_BLUE;
+            case 0xf0f -> AnsiColor.BRIGHT_MAGENTA;
+            case 0x0ff -> AnsiColor.BRIGHT_CYAN;
+            case 0xfff -> AnsiColor.BRIGHT_WHITE;
+            default -> null;
+        };
     }
 
     private static byte[] encodeKeyEvent(KeyEvent ke) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanelColorTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanelColorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import dev.tamboui.style.AnsiColor;
+import dev.tamboui.style.Color;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ShellPanelColorTest {
+
+    // ScreenTerminal stores colors as the top nibble of each channel of its xterm palette. The 16 standard
+    // ANSI colors must be recognised and mapped to terminal-themed colors, otherwise (for example) ANSI red
+    // is reconstructed as a literal RGB(136,0,0) that is unreadable on dark backgrounds.
+
+    @Test
+    void detectsStandardAnsiColors() {
+        assertEquals(AnsiColor.BLACK, ShellPanel.ansiColorFor(0x000));
+        assertEquals(AnsiColor.RED, ShellPanel.ansiColorFor(0x800));
+        assertEquals(AnsiColor.GREEN, ShellPanel.ansiColorFor(0x080));
+        assertEquals(AnsiColor.YELLOW, ShellPanel.ansiColorFor(0x880));
+        assertEquals(AnsiColor.BLUE, ShellPanel.ansiColorFor(0x008));
+        assertEquals(AnsiColor.MAGENTA, ShellPanel.ansiColorFor(0x808));
+        assertEquals(AnsiColor.CYAN, ShellPanel.ansiColorFor(0x088));
+        assertEquals(AnsiColor.WHITE, ShellPanel.ansiColorFor(0xccc));
+    }
+
+    @Test
+    void detectsBrightAnsiColors() {
+        assertEquals(AnsiColor.BRIGHT_BLACK, ShellPanel.ansiColorFor(0x888));
+        assertEquals(AnsiColor.BRIGHT_RED, ShellPanel.ansiColorFor(0xf00));
+        assertEquals(AnsiColor.BRIGHT_GREEN, ShellPanel.ansiColorFor(0x0f0));
+        assertEquals(AnsiColor.BRIGHT_YELLOW, ShellPanel.ansiColorFor(0xff0));
+        assertEquals(AnsiColor.BRIGHT_BLUE, ShellPanel.ansiColorFor(0x00f));
+        assertEquals(AnsiColor.BRIGHT_MAGENTA, ShellPanel.ansiColorFor(0xf0f));
+        assertEquals(AnsiColor.BRIGHT_CYAN, ShellPanel.ansiColorFor(0x0ff));
+        assertEquals(AnsiColor.BRIGHT_WHITE, ShellPanel.ansiColorFor(0xfff));
+    }
+
+    @Test
+    void leavesTrueColorValuesUnmapped() {
+        // The shell prompt's orange (0xF69123) reduces to 0xf92, which is not a palette color and must stay true-color.
+        assertNull(ShellPanel.ansiColorFor(0xf92));
+        assertNull(ShellPanel.ansiColorFor(0x123));
+    }
+
+    @Test
+    void resolvesAnsiRedToThemedColorNotDimRgb() {
+        // The core of the bug fix: ANSI red must become a terminal-themed color, not the dim RGB(136,0,0)
+        // that the old code produced.
+        assertEquals(Color.ansi(AnsiColor.RED), ShellPanel.resolveColor(0x800));
+    }
+
+    @Test
+    void resolvesTrueColorToLiteralRgb() {
+        // A non-palette value keeps its literal colour, with each 4-bit channel expanded back to 8 bits (* 17).
+        assertEquals(Color.rgb(0xf * 17, 0x9 * 17, 0x2 * 17), ShellPanel.resolveColor(0xf92));
+    }
+}


### PR DESCRIPTION
# Description

Makes ANSI-colored output in the embedded shell panel of the Camel TUI readable on dark terminal themes (see [CAMEL-23830](https://issues.apache.org/jira/browse/CAMEL-23830)).

**Problem**

In the shell panel, text echoed while typing a command (the command highlighter colors unrecognized commands red) and error output such as `Unknown command: x` rendered as a dim literal `RGB(136,0,0)`, barely legible on a dark background. The prompt itself was fine (`camel` orange, version green, `>` white).

<img width="1624" height="1061" alt="Screenshot 2026-06-24 at 2 53 50 PM" src="https://github.com/user-attachments/assets/16e444d6-9263-4e20-aaef-8caae9aa0c81" />

**Root cause**

JLine's `ScreenTerminal` flattens named ANSI colors into a 12-bit (4-bit-per-channel) value stored in the cell attribute. `ShellPanel.convertAttrToStyle` expanded that value straight back into a literal RGB color, bypassing the host terminal's theme. Standard ANSI red (palette index 1, `0x800000`) therefore became a fixed dim `RGB(136,0,0)` instead of the terminal's themed, readable red.

**Fix**

When the 12-bit value matches one of the 16 standard ANSI palette colors, emit a terminal-themed `Color.ansi(AnsiColor.X)` instead of a literal RGB color, mirroring how `TuiHelper.applySgr` already maps SGR codes elsewhere in the TUI. True-color cells (such as the prompt's orange `0xF69123`) do not match the palette and keep their literal RGB value.

The 16 encodings are derived from JLine's xterm palette (`Colors.DEFAULT_COLORS_256[0..15]`) reduced via `ScreenTerminal.col24` (the top nibble of each channel), e.g. red `0x800000` -> `0x800`, bright red `0xff0000` -> `0xf00`, white `0xc0c0c0` -> `0xccc`.

**Tests**

- New `ShellPanelColorTest`: pins all 16 ANSI encodings to their `AnsiColor`, asserts true-color values (e.g. the prompt orange `0xf92`) stay unmapped, and includes a regression guard that ANSI red resolves to a themed `Color.ansi(RED)` rather than the old dim RGB.

**Docs**

- No documentation change: `camel-jbang-tui.adoc` has no shell-panel section, and this is a readability fix with no change to any default, option, or API, so it does not warrant an upgrade-guide entry.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-23830) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

---

_Submitted by Claude Code on behalf of Adriano Machado._
