### PR TITLE
CAMEL-23833: Add aliases field to EIP model metadata for AI discoverability

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/aggregate.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/aggregate.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "aggregate,eip,routing",
     "javaType": "org.apache.camel.model.AggregateDefinition",
+    "aliases": [ "fan-in", "reduce", "join", "merge" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/choice.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/choice.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.ChoiceDefinition",
+    "aliases": [ "router", "dispatch" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/circuitBreaker.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/circuitBreaker.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,error,resilience,routing",
     "javaType": "org.apache.camel.model.CircuitBreakerDefinition",
+    "aliases": [ "circuit-breaker" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/claimCheck.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/claimCheck.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,routing",
     "javaType": "org.apache.camel.model.ClaimCheckDefinition",
+    "aliases": [ "claim-check", "stash" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/delay.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/delay.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.DelayDefinition",
+    "aliases": [ "debounce", "delay" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/dynamicRouter.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/dynamicRouter.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.DynamicRouterDefinition",
+    "aliases": [ "dispatch" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/enrich.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/enrich.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,transformation",
     "javaType": "org.apache.camel.model.EnrichDefinition",
+    "aliases": [ "enrich", "hydrate", "augment" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/filter.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/filter.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.FilterDefinition",
+    "aliases": [ "filter" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/from.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/from.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.FromDefinition",
+    "aliases": [ "source", "ingress" ],
     "abstract": false,
     "input": false,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/idempotentConsumer.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/idempotentConsumer.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.IdempotentConsumerDefinition",
+    "aliases": [ "dedup", "deduplicate" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/loadBalance.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/loadBalance.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,loadbalancing,routing",
     "javaType": "org.apache.camel.model.LoadBalanceDefinition",
+    "aliases": [ "load-balance" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/loop.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/loop.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.LoopDefinition",
+    "aliases": [ "loop", "iterate" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/marshal.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/marshal.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,dataformat,transformation",
     "javaType": "org.apache.camel.model.MarshalDefinition",
+    "aliases": [ "serialize" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/multicast.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/multicast.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.MulticastDefinition",
+    "aliases": [ "fan-out", "broadcast" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/onFallback.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/onFallback.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,error,resilience,routing",
     "javaType": "org.apache.camel.model.OnFallbackDefinition",
+    "aliases": [ "fallback" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/pipeline.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/pipeline.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.PipelineDefinition",
+    "aliases": [ "pipeline", "chain" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/poll.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/poll.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,routing",
     "javaType": "org.apache.camel.model.PollDefinition",
+    "aliases": [ "poll", "pull" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/pollEnrich.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/pollEnrich.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,transformation",
     "javaType": "org.apache.camel.model.PollEnrichDefinition",
+    "aliases": [ "enrich", "hydrate" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/rollback.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/rollback.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,errorhandling,routing",
     "javaType": "org.apache.camel.model.RollbackDefinition",
+    "aliases": [ "rollback" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/saga.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/saga.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.SagaDefinition",
+    "aliases": [ "compensate" ],
     "abstract": true,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/sample.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/sample.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.SamplingDefinition",
+    "aliases": [ "sample" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/setBody.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/setBody.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,messaging,transformation",
     "javaType": "org.apache.camel.model.SetBodyDefinition",
+    "aliases": [ "map", "transform" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/split.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/split.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "aggregate,eip,routing",
     "javaType": "org.apache.camel.model.SplitDefinition",
+    "aliases": [ "split", "chunk" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/throttle.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/throttle.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.ThrottleDefinition",
+    "aliases": [ "rate-limit", "throttle" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/to.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/to.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.ToDefinition",
+    "aliases": [ "sink", "egress" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/toD.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/toD.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.ToDynamicDefinition",
+    "aliases": [ "sink", "egress" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/transform.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/transform.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,transformation",
     "javaType": "org.apache.camel.model.TransformDefinition",
+    "aliases": [ "map", "transform" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/unmarshal.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/unmarshal.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,dataformat,transformation",
     "javaType": "org.apache.camel.model.UnmarshalDefinition",
+    "aliases": [ "deserialize" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/validate.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/validate.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,transformation",
     "javaType": "org.apache.camel.model.ValidateDefinition",
+    "aliases": [ "validate", "guard" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/wireTap.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/models/wireTap.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.WireTapDefinition",
+    "aliases": [ "tap", "observe" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/DefaultCamelCatalog.java
+++ b/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/DefaultCamelCatalog.java
@@ -316,21 +316,35 @@ public class DefaultCamelCatalog extends AbstractCachingCamelCatalog implements 
         for (String name : names) {
             BaseModel<?> model = modelLoader.apply(name);
             if (model != null) {
-                String label = model.getLabel();
-                String[] parts = label.split(",");
-                for (String part : parts) {
-                    try {
-                        if (part.equalsIgnoreCase(filter) || CatalogHelper.matchWildcard(part, filter)
-                                || part.matches(filter)) {
-                            answer.add(name);
-                        }
-                    } catch (PatternSyntaxException e) {
-                        // ignore as filter is maybe not a pattern
-                    }
+                if (matchesFilter(model, filter)) {
+                    answer.add(name);
                 }
             }
         }
         return answer;
+    }
+
+    private static boolean matchesFilter(BaseModel<?> model, String filter) {
+        String label = model.getLabel();
+        String[] parts = label.split(",");
+        for (String part : parts) {
+            try {
+                if (part.equalsIgnoreCase(filter) || CatalogHelper.matchWildcard(part, filter)
+                        || part.matches(filter)) {
+                    return true;
+                }
+            } catch (PatternSyntaxException e) {
+                // ignore as filter is maybe not a pattern
+            }
+        }
+        String normalized = filter.toLowerCase().replace("-", "").replace("_", "");
+        for (String alias : model.getAliases()) {
+            if (alias.equalsIgnoreCase(filter)
+                    || alias.toLowerCase().replace("-", "").replace("_", "").equals(normalized)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.tooling.model.ArtifactModel;
 import org.apache.camel.tooling.model.ComponentModel;
 import org.apache.camel.tooling.model.DataFormatModel;
+import org.apache.camel.tooling.model.EipModel;
 import org.apache.camel.tooling.model.JsonMapper;
 import org.apache.camel.tooling.model.Kind;
 import org.apache.camel.tooling.model.LanguageModel;
@@ -177,6 +178,73 @@ public class CamelCatalogTest {
         assertTrue(names.contains("loadBalance"));
         assertTrue(names.contains("circuitBreaker"));
         assertTrue(names.contains("saga"));
+    }
+
+    @Test
+    public void testEipModelAliases() {
+        // verify aliases are present in the EIP model
+        EipModel multicast = catalog.eipModel("multicast");
+        assertNotNull(multicast);
+        assertNotNull(multicast.getAliases());
+        assertTrue(multicast.getAliases().contains("fan-out"));
+        assertTrue(multicast.getAliases().contains("broadcast"));
+
+        EipModel aggregate = catalog.eipModel("aggregate");
+        assertNotNull(aggregate);
+        assertTrue(aggregate.getAliases().contains("fan-in"));
+        assertTrue(aggregate.getAliases().contains("reduce"));
+
+        EipModel choice = catalog.eipModel("choice");
+        assertNotNull(choice);
+        assertTrue(choice.getAliases().contains("router"));
+        assertTrue(choice.getAliases().contains("dispatch"));
+    }
+
+    @Test
+    public void testFindModelNamesByAlias() {
+        // searching by alias should find the EIP
+        List<String> names = catalog.findModelNames("fan-out");
+        assertTrue(names.contains("multicast"), "fan-out should find multicast");
+
+        names = catalog.findModelNames("fan-in");
+        assertTrue(names.contains("aggregate"), "fan-in should find aggregate");
+
+        names = catalog.findModelNames("circuit-breaker");
+        assertTrue(names.contains("circuitBreaker"), "circuit-breaker should find circuitBreaker");
+
+        names = catalog.findModelNames("dedup");
+        assertTrue(names.contains("idempotentConsumer"), "dedup should find idempotentConsumer");
+
+        names = catalog.findModelNames("sink");
+        assertTrue(names.contains("to"), "sink should find to");
+        assertTrue(names.contains("toD"), "sink should find toD");
+    }
+
+    @Test
+    public void testFindModelNamesByAliasDashNormalized() {
+        // fan-out, fanout, fanOut should all match
+        List<String> names1 = catalog.findModelNames("fan-out");
+        List<String> names2 = catalog.findModelNames("fanout");
+        List<String> names3 = catalog.findModelNames("fanOut");
+        assertTrue(names1.contains("multicast"));
+        assertTrue(names2.contains("multicast"));
+        assertTrue(names3.contains("multicast"));
+
+        // circuit-breaker, circuitbreaker, circuitBreaker
+        names1 = catalog.findModelNames("circuit-breaker");
+        names2 = catalog.findModelNames("circuitbreaker");
+        names3 = catalog.findModelNames("circuitBreaker");
+        assertTrue(names1.contains("circuitBreaker"));
+        assertTrue(names2.contains("circuitBreaker"));
+        assertTrue(names3.contains("circuitBreaker"));
+
+        // rate-limit, ratelimit, rateLimit
+        names1 = catalog.findModelNames("rate-limit");
+        names2 = catalog.findModelNames("ratelimit");
+        names3 = catalog.findModelNames("rateLimit");
+        assertTrue(names1.contains("throttle"));
+        assertTrue(names2.contains("throttle"));
+        assertTrue(names3.contains("throttle"));
     }
 
     @Test

--- a/core/camel-api/src/generated/java/org/apache/camel/spi/Metadata.java
+++ b/core/camel-api/src/generated/java/org/apache/camel/spi/Metadata.java
@@ -216,4 +216,12 @@ public @interface Metadata {
      */
     String[] examples() default {};
 
+    /**
+     * Alternative names or common aliases for this entity.
+     *
+     * Used for AI and search tooling to discover EIPs by common terminology (e.g., "fan-out" for Multicast, "retry" for
+     * Error Handler). Aliases are descriptive names only — they cannot be used in the DSL.
+     */
+    String[] aliases() default {};
+
 }

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/aggregate.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/aggregate.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "aggregate,eip,routing",
     "javaType": "org.apache.camel.model.AggregateDefinition",
+    "aliases": [ "fan-in", "reduce", "join", "merge" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/choice.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/choice.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.ChoiceDefinition",
+    "aliases": [ "router", "dispatch" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/circuitBreaker.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/circuitBreaker.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,error,resilience,routing",
     "javaType": "org.apache.camel.model.CircuitBreakerDefinition",
+    "aliases": [ "circuit-breaker" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/claimCheck.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/claimCheck.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,routing",
     "javaType": "org.apache.camel.model.ClaimCheckDefinition",
+    "aliases": [ "claim-check", "stash" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/delay.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/delay.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.DelayDefinition",
+    "aliases": [ "debounce", "delay" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/dynamicRouter.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/dynamicRouter.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.DynamicRouterDefinition",
+    "aliases": [ "dispatch" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/enrich.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/enrich.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,transformation",
     "javaType": "org.apache.camel.model.EnrichDefinition",
+    "aliases": [ "enrich", "hydrate", "augment" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/filter.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/filter.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.FilterDefinition",
+    "aliases": [ "filter" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/from.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/from.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.FromDefinition",
+    "aliases": [ "source", "ingress" ],
     "abstract": false,
     "input": false,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/idempotentConsumer.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/idempotentConsumer.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.IdempotentConsumerDefinition",
+    "aliases": [ "dedup", "deduplicate" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/loadBalance.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/loadBalance.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,loadbalancing,routing",
     "javaType": "org.apache.camel.model.LoadBalanceDefinition",
+    "aliases": [ "load-balance" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/loop.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/loop.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.LoopDefinition",
+    "aliases": [ "loop", "iterate" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/marshal.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/marshal.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,dataformat,transformation",
     "javaType": "org.apache.camel.model.MarshalDefinition",
+    "aliases": [ "serialize" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/multicast.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/multicast.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.MulticastDefinition",
+    "aliases": [ "fan-out", "broadcast" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/onFallback.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/onFallback.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,error,resilience,routing",
     "javaType": "org.apache.camel.model.OnFallbackDefinition",
+    "aliases": [ "fallback" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/pipeline.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/pipeline.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.PipelineDefinition",
+    "aliases": [ "pipeline", "chain" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/poll.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/poll.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,routing",
     "javaType": "org.apache.camel.model.PollDefinition",
+    "aliases": [ "poll", "pull" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/pollEnrich.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/pollEnrich.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,enrichment,transformation",
     "javaType": "org.apache.camel.model.PollEnrichDefinition",
+    "aliases": [ "enrich", "hydrate" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/rollback.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/rollback.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,errorhandling,routing",
     "javaType": "org.apache.camel.model.RollbackDefinition",
+    "aliases": [ "rollback" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/saga.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/saga.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,routing",
     "javaType": "org.apache.camel.model.SagaDefinition",
+    "aliases": [ "compensate" ],
     "abstract": true,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/sample.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/sample.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.SamplingDefinition",
+    "aliases": [ "sample" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/setBody.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/setBody.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,messaging,transformation",
     "javaType": "org.apache.camel.model.SetBodyDefinition",
+    "aliases": [ "map", "transform" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/split.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/split.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "aggregate,eip,routing",
     "javaType": "org.apache.camel.model.SplitDefinition",
+    "aliases": [ "split", "chunk" ],
     "abstract": false,
     "input": true,
     "output": true

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/throttle.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/throttle.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,flowcontrol,routing",
     "javaType": "org.apache.camel.model.ThrottleDefinition",
+    "aliases": [ "rate-limit", "throttle" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/to.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/to.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.ToDefinition",
+    "aliases": [ "sink", "egress" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/toD.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/toD.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.ToDynamicDefinition",
+    "aliases": [ "sink", "egress" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/transform.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/transform.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,transformation",
     "javaType": "org.apache.camel.model.TransformDefinition",
+    "aliases": [ "map", "transform" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/unmarshal.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/unmarshal.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,dataformat,transformation",
     "javaType": "org.apache.camel.model.UnmarshalDefinition",
+    "aliases": [ "deserialize" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/validate.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/validate.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,transformation",
     "javaType": "org.apache.camel.model.ValidateDefinition",
+    "aliases": [ "validate", "guard" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/wireTap.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/model/wireTap.json
@@ -7,6 +7,7 @@
     "deprecated": false,
     "label": "eip,endpoint,routing",
     "javaType": "org.apache.camel.model.WireTapDefinition",
+    "aliases": [ "tap", "observe" ],
     "abstract": false,
     "input": true,
     "output": false

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/AggregateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/AggregateDefinition.java
@@ -47,6 +47,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * Aggregates many messages into a single message
  */
 @Metadata(label = "aggregate,eip,routing",
+          aliases = { "fan-in", "reduce", "join", "merge" },
           description = "Collects and combines related messages into a single message using a correlation expression and an aggregation strategy."
                         + " Messages are grouped into buckets by correlation key and released when a completion condition is met.")
 @XmlRootElement(name = "aggregate")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ChoiceDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ChoiceDefinition.java
@@ -41,6 +41,7 @@ import org.apache.camel.spi.Resource;
  * Route messages based on a series of predicates
  */
 @Metadata(label = "eip,routing",
+          aliases = { "router", "dispatch" },
           description = "Routes messages to different steps based on a series of conditions (predicates),"
                         + " similar to if-elseif-else in Java. Each condition is evaluated in order until one matches.")
 @XmlRootElement(name = "choice")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/CircuitBreakerDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/CircuitBreakerDefinition.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.Metadata;
  * Route messages in a fault tolerance way using Circuit Breaker
  */
 @Metadata(label = "eip,error,resilience,routing",
+          aliases = { "circuit-breaker" },
           description = "Wraps message processing with a circuit breaker for fault tolerance."
                         + " Prevents cascading failures by short-circuiting calls to an unhealthy service and routing to a fallback")
 @XmlRootElement(name = "circuitBreaker")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ClaimCheckDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ClaimCheckDefinition.java
@@ -31,6 +31,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * retrieve the message content at a later time.
  */
 @Metadata(label = "eip,enrichment,routing",
+          aliases = { "claim-check", "stash" },
           description = "Temporarily stores the message content and replaces it with a claim check key,"
                         + " allowing the content to be retrieved later in the route."
                         + " Useful for reducing memory when large payloads pass through processing steps that don't need them.")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/DelayDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/DelayDefinition.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.Metadata;
  * Delays processing for a specified length of time
  */
 @Metadata(label = "eip,flowcontrol,routing",
+          aliases = { "debounce", "delay" },
           description = "Delays message processing for a specified duration, which can be a fixed value or computed dynamically per message")
 @XmlRootElement(name = "delay")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/DynamicRouterDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/DynamicRouterDefinition.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.Metadata;
  * Route messages based on dynamic rules
  */
 @Metadata(label = "eip,routing",
+          aliases = { "dispatch" },
           description = "Routes a message step-by-step through a series of endpoints, determined dynamically by calling an expression repeatedly."
                         + " The expression is called after each hop and returns the next endpoint, or null to stop.")
 @XmlRootElement(name = "dynamicRouter")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/EnrichDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/EnrichDefinition.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * @see org.apache.camel.processor.Enricher
  */
 @Metadata(label = "eip,enrichment,transformation",
+          aliases = { "enrich", "hydrate", "augment" },
           description = "Enriches the message with additional data obtained by sending to another endpoint using request-reply."
                         + " The reply is merged into the original message using an aggregation strategy.")
 @XmlRootElement(name = "enrich")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/FilterDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/FilterDefinition.java
@@ -30,6 +30,7 @@ import org.apache.camel.spi.Metadata;
  * Filter out messages based using a predicate
  */
 @Metadata(label = "eip,routing",
+          aliases = { "filter" },
           description = "Filters messages using a predicate expression."
                         + " Messages matching the predicate continue processing; non-matching messages are skipped.")
 @AsPredicate

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/FromDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/FromDefinition.java
@@ -31,6 +31,7 @@ import org.apache.camel.spi.Metadata;
  * Act as a message source as input to a route
  */
 @Metadata(label = "eip,endpoint,routing",
+          aliases = { "source", "ingress" },
           description = "Defines the consumer endpoint that acts as the input source for a route")
 @XmlRootElement(name = "from")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/IdempotentConsumerDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/IdempotentConsumerDefinition.java
@@ -31,6 +31,7 @@ import org.apache.camel.spi.Metadata;
  * Filters out duplicate messages
  */
 @Metadata(label = "eip,flowcontrol,routing",
+          aliases = { "dedup", "deduplicate" },
           description = "Filters out duplicate messages based on a unique message identifier"
                         + " and an idempotent repository that tracks previously seen IDs")
 @XmlRootElement(name = "idempotentConsumer")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/LoadBalanceDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/LoadBalanceDefinition.java
@@ -42,6 +42,7 @@ import org.apache.camel.spi.Metadata;
  * Balances message processing among a number of nodes
  */
 @Metadata(label = "eip,loadbalancing,routing",
+          aliases = { "load-balance" },
           description = "Distributes messages across multiple endpoints using a load balancing strategy"
                         + " such as round-robin, random, failover, or weighted")
 @XmlRootElement(name = "loadBalance")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/LoopDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/LoopDefinition.java
@@ -32,6 +32,7 @@ import org.apache.camel.spi.Metadata;
  * Processes a message multiple times
  */
 @Metadata(label = "eip,flowcontrol,routing",
+          aliases = { "loop", "iterate" },
           description = "Processes the message body repeatedly for a specified number of iterations, or until a condition is met")
 @XmlRootElement(name = "loop")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/MarshalDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/MarshalDefinition.java
@@ -77,6 +77,7 @@ import org.apache.camel.spi.Metadata;
  * Marshals data into a specified format for transmission over a transport or component
  */
 @Metadata(label = "eip,dataformat,transformation",
+          aliases = { "serialize" },
           description = "Serializes the message body into a specific data format such as JSON, XML, CSV, or Protobuf for transmission or storage")
 @XmlRootElement(name = "marshal")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/MulticastDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/MulticastDefinition.java
@@ -36,6 +36,7 @@ import org.apache.camel.spi.Metadata;
  * Routes the same message to multiple paths either sequentially or in parallel.
  */
 @Metadata(label = "eip,routing",
+          aliases = { "fan-out", "broadcast" },
           description = "Sends a copy of the message to multiple fixed endpoints, processing them sequentially or in parallel,"
                         + " and optionally aggregating their replies")
 @XmlRootElement(name = "multicast")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/OnFallbackDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/OnFallbackDefinition.java
@@ -35,6 +35,7 @@ import org.apache.camel.spi.Resource;
  * Route to be executed when Circuit Breaker EIP executes fallback
  */
 @Metadata(label = "eip,error,resilience,routing",
+          aliases = { "fallback" },
           description = "Defines the fallback route that executes when the Circuit Breaker trips or the primary route fails")
 @XmlRootElement(name = "onFallback")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/PipelineDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/PipelineDefinition.java
@@ -29,6 +29,7 @@ import org.apache.camel.spi.Metadata;
  * Routes the message to a sequence of processors.
  */
 @Metadata(label = "eip,routing",
+          aliases = { "pipeline", "chain" },
           description = "Processes the message through a sequence of steps where the output of each step becomes the input of the next")
 @XmlRootElement(name = "pipeline")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/PollDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/PollDefinition.java
@@ -32,6 +32,7 @@ import org.apache.camel.util.URISupport;
  * Polls a message from a static endpoint
  */
 @Metadata(label = "eip,enrichment,routing",
+          aliases = { "poll", "pull" },
           description = "Polls a single message from a consumer endpoint and sets it as the message body."
                         + " Useful for fetching data on-demand from file, database, or messaging endpoints.")
 @XmlRootElement(name = "poll")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/PollEnrichDefinition.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * @see org.apache.camel.processor.Enricher
  */
 @Metadata(label = "eip,enrichment,transformation",
+          aliases = { "enrich", "hydrate" },
           description = "Enriches the message with additional data obtained by polling a consumer endpoint (such as a file or message queue)."
                         + " The polled data is merged using an aggregation strategy.")
 @XmlRootElement(name = "pollEnrich")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/RollbackDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/RollbackDefinition.java
@@ -28,6 +28,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * Forces a rollback by stopping routing the message
  */
 @Metadata(label = "eip,errorhandling,routing",
+          aliases = { "rollback" },
           description = "Forces a rollback of the current transaction and stops routing the message."
                         + " Can set a custom message on the exception.")
 @XmlRootElement(name = "rollback")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SagaDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SagaDefinition.java
@@ -41,6 +41,7 @@ import org.apache.camel.util.TimeUtils;
  * Enables Sagas on the route
  */
 @Metadata(label = "eip,routing",
+          aliases = { "compensate" },
           description = "Defines a Saga (long-running action) that coordinates distributed services toward a consistent outcome."
                         + " Unlike XA transactions, Sagas use compensating actions for rollback and work across heterogeneous services.")
 @XmlRootElement(name = "saga")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SamplingDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SamplingDefinition.java
@@ -31,6 +31,7 @@ import org.apache.camel.util.TimeUtils;
  * Extract a sample of the messages passing through a route
  */
 @Metadata(label = "eip,flowcontrol,routing",
+          aliases = { "sample" },
           description = "Samples a subset of messages passing through the route, either by frequency count or time interval, and discards the rest")
 @XmlRootElement(name = "sample")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SetBodyDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SetBodyDefinition.java
@@ -28,6 +28,7 @@ import org.apache.camel.spi.Metadata;
  * Sets the contents of the message body
  */
 @Metadata(label = "eip,messaging,transformation",
+          aliases = { "map", "transform" },
           description = "Sets the message body to a value computed by an expression")
 @XmlRootElement(name = "setBody")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/SplitDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/SplitDefinition.java
@@ -34,6 +34,7 @@ import org.apache.camel.spi.Metadata;
  * Splits a single message into many sub-messages.
  */
 @Metadata(label = "aggregate,eip,routing",
+          aliases = { "split", "chunk" },
           description = "Splits a message into multiple sub-messages using an expression, and processes each one individually."
                         + " Supports parallel processing and result aggregation.")
 @XmlRootElement(name = "split")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ThrottleDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ThrottleDefinition.java
@@ -35,6 +35,7 @@ import org.apache.camel.spi.Metadata;
  * Controls the rate at which messages are passed to the next node in the route
  */
 @Metadata(label = "eip,flowcontrol,routing",
+          aliases = { "rate-limit", "throttle" },
           description = "Limits the message throughput to a maximum number of messages per time period to avoid overloading downstream systems")
 @XmlRootElement(name = "throttle")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDefinition.java
@@ -31,6 +31,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * Sends the message to a static endpoint
  */
 @Metadata(label = "eip,endpoint,routing",
+          aliases = { "sink", "egress" },
           description = "Sends the message to a fixed endpoint URI")
 @XmlRootElement(name = "to")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ToDynamicDefinition.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.annotations.DslArg;
  * Sends the message to a dynamic endpoint
  */
 @Metadata(label = "eip,endpoint,routing",
+          aliases = { "sink", "egress" },
           description = "Sends the message to an endpoint URI computed dynamically from an expression,"
                         + " allowing the destination to vary per message")
 @XmlRootElement(name = "toD")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/TransformDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/TransformDefinition.java
@@ -28,6 +28,7 @@ import org.apache.camel.spi.Metadata;
  * Transforms the message body based on an expression
  */
 @Metadata(label = "eip,transformation",
+          aliases = { "map", "transform" },
           description = "Sets the message body using an expression."
                         + " Unlike setBody, transform also sets the OUT message body in InOut exchanges")
 @XmlRootElement(name = "transform")

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/UnmarshalDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/UnmarshalDefinition.java
@@ -77,6 +77,7 @@ import org.apache.camel.spi.Metadata;
  * Converts the message data received from the wire into a format that Apache Camel processors can consume
  */
 @Metadata(label = "eip,dataformat,transformation",
+          aliases = { "deserialize" },
           description = "Deserializes the message body from a specific data format such as JSON, XML, CSV, or Protobuf into a Java object")
 @XmlRootElement(name = "unmarshal")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/ValidateDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/ValidateDefinition.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.PredicateExceptionFactory;
  * Validates a message based on an expression
  */
 @Metadata(label = "eip,transformation",
+          aliases = { "validate", "guard" },
           description = "Validates the message against a predicate expression"
                         + " and throws a PredicateValidationException if the validation fails")
 @AsPredicate

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/WireTapDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/WireTapDefinition.java
@@ -33,6 +33,7 @@ import org.apache.camel.spi.Metadata;
  * message.
  */
 @Metadata(label = "eip,endpoint,routing", excludeProperties = "pattern",
+          aliases = { "tap", "observe" },
           description = "Sends a copy of the message to a secondary endpoint without affecting the original route flow."
                         + " The tapped message is sent asynchronously in a separate thread")
 @XmlRootElement(name = "wireTap")

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/CatalogTools.java
@@ -339,7 +339,7 @@ public class CatalogTools {
             List<EipInfo> eips = cat.findModelNames().stream()
                     .map(cat::eipModel)
                     .filter(m -> m != null)
-                    .filter(m -> matchesFilter(m.getName(), m.getTitle(), m.getDescription(), filter))
+                    .filter(m -> matchesFilter(m.getName(), m.getTitle(), m.getDescription(), m.getAliases(), filter))
                     .filter(m -> matchesLabel(m.getLabel(), label))
                     .map(this::toEipInfo)
                     .collect(Collectors.toList());
@@ -396,13 +396,32 @@ public class CatalogTools {
     // Helper methods
 
     private boolean matchesFilter(String name, String title, String description, String filter) {
+        return matchesFilter(name, title, description, null, filter);
+    }
+
+    private boolean matchesFilter(String name, String title, String description, List<String> aliases, String filter) {
         if (filter == null || filter.isBlank()) {
             return true;
         }
         String lowerFilter = filter.toLowerCase();
-        return (name != null && name.toLowerCase().contains(lowerFilter))
+        if ((name != null && name.toLowerCase().contains(lowerFilter))
                 || (title != null && title.toLowerCase().contains(lowerFilter))
-                || (description != null && description.toLowerCase().contains(lowerFilter));
+                || (description != null && description.toLowerCase().contains(lowerFilter))) {
+            return true;
+        }
+        if (aliases != null) {
+            String normalized = normalize(filter);
+            for (String alias : aliases) {
+                if (alias.toLowerCase().contains(lowerFilter) || normalize(alias).contains(normalized)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String normalize(String text) {
+        return text.toLowerCase().replace("-", "").replace("_", "");
     }
 
     private boolean matchesLabel(String labels, String labelFilter) {
@@ -541,7 +560,8 @@ public class CatalogTools {
         return new EipInfo(
                 model.getName(),
                 model.getTitle(),
-                model.getLabel());
+                model.getLabel(),
+                model.getAliases().isEmpty() ? null : model.getAliases());
     }
 
     private EipDetailResult toEipDetailResult(EipModel model) {
@@ -561,6 +581,7 @@ public class CatalogTools {
                 model.getTitle(),
                 model.getDescription(),
                 model.getLabel(),
+                model.getAliases().isEmpty() ? null : model.getAliases(),
                 options);
     }
 
@@ -685,11 +706,11 @@ public class CatalogTools {
     public record EipListResult(int count, List<EipInfo> eips) {
     }
 
-    public record EipInfo(String name, String title, String label) {
+    public record EipInfo(String name, String title, String label, List<String> aliases) {
     }
 
     public record EipDetailResult(String name, String title, String description, String label,
-            List<OptionInfo> options) {
+            List<String> aliases, List<OptionInfo> options) {
     }
 
     public record DataFormatDetailResult(String name, String title, String description, String label,

--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/BaseModel.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/BaseModel.java
@@ -36,6 +36,7 @@ public abstract class BaseModel<O extends BaseOptionModel> {
     protected final List<O> options = new ArrayList<>();
     protected SupportLevel supportLevel;
     protected boolean nativeSupported;
+    protected List<String> aliases = new ArrayList<>();
     protected Map<String, Object> metadata = new LinkedHashMap<>();
 
     public static Comparator<BaseModel<?>> compareTitle() {
@@ -149,6 +150,18 @@ public abstract class BaseModel<O extends BaseOptionModel> {
 
     public void setNativeSupported(boolean nativeSupported) {
         this.nativeSupported = nativeSupported;
+    }
+
+    /**
+     * Alternative names or common aliases for this entity (e.g., "fan-out" for Multicast). Aliases are descriptive only
+     * — they cannot be used in the DSL.
+     */
+    public List<String> getAliases() {
+        return aliases;
+    }
+
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
     }
 
     /**

--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/JsonMapper.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/JsonMapper.java
@@ -559,6 +559,9 @@ public final class JsonMapper {
         if (model.isNativeSupported()) {
             obj.put("nativeSupported", model.isNativeSupported());
         }
+        if (!model.getAliases().isEmpty()) {
+            obj.put("aliases", model.getAliases());
+        }
         if (!model.getMetadata().isEmpty()) {
             obj.put("metadata", model.getMetadata());
         }
@@ -582,6 +585,10 @@ public final class JsonMapper {
         model.setJavaType(mobj.getString("javaType"));
         model.setSupportLevel(SupportLevel.safeValueOf(mobj.getString("supportLevel")));
         model.setNativeSupported(mobj.getBooleanOrDefault("nativeSupported", false));
+        Collection<String> aliases = mobj.getCollection("aliases");
+        if (aliases != null) {
+            model.setAliases(aliases.stream().collect(Collectors.toList()));
+        }
         model.setMetadata(mobj.getMapOrDefault("metadata", new JsonObject()));
     }
 

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SchemaGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/SchemaGeneratorMojo.java
@@ -341,6 +341,11 @@ public class SchemaGeneratorMojo extends AbstractGeneratorMojo {
             if (!Strings.isNullOrEmpty(metadata.description())) {
                 model.setDescription(metadata.description());
             }
+            if (metadata.aliases().length > 0) {
+                ArrayList<String> aliases = new ArrayList<>();
+                Collections.addAll(aliases, metadata.aliases());
+                model.setAliases(aliases);
+            }
         }
 
         // fallback to use class javadoc as description

--- a/tooling/spi-annotations/src/main/java/org/apache/camel/spi/Metadata.java
+++ b/tooling/spi-annotations/src/main/java/org/apache/camel/spi/Metadata.java
@@ -216,4 +216,12 @@ public @interface Metadata {
      */
     String[] examples() default {};
 
+    /**
+     * Alternative names or common aliases for this entity.
+     *
+     * Used for AI and search tooling to discover EIPs by common terminology (e.g., "fan-out" for Multicast, "retry" for
+     * Error Handler). Aliases are descriptive names only — they cannot be used in the DSL.
+     */
+    String[] aliases() default {};
+
 }


### PR DESCRIPTION
## Summary

- Adds an `aliases` field to the `@Metadata` annotation and EIP model JSON so AI agents, MCP tools, and catalog search can discover EIPs using common alternative terminology (e.g., "fan-out" for Multicast, "circuit-breaker" for Circuit Breaker)
- 30 EIP Definition classes annotated with aliases matching the [AI Patterns](https://camel.apache.org/components/next/eips/ai-patterns.html) documentation page
- Search supports dash normalization — `fan-out`, `fanout`, `fanOut` all match the same alias
- Aliases are descriptive names only — they cannot be used in the DSL

## Changes

**Annotation & model pipeline:**
- `tooling/spi-annotations/.../Metadata.java` — new `String[] aliases()` field
- `tooling/camel-tooling-model/.../BaseModel.java` — `List<String> aliases` field with getter/setter
- `tooling/camel-tooling-model/.../JsonMapper.java` — serialize/deserialize aliases in model JSON
- `tooling/maven/camel-package-maven-plugin/.../SchemaGeneratorMojo.java` — read aliases from annotation

**30 EIP Definition classes** annotated (e.g., `MulticastDefinition` → fan-out/broadcast, `AggregateDefinition` → fan-in/reduce/join/merge, etc.)

**Catalog & MCP search:**
- `catalog/camel-catalog/.../DefaultCamelCatalog.java` — `findNames()` checks aliases with dash normalization
- `dsl/camel-jbang/camel-jbang-mcp/.../CatalogTools.java` — `matchesFilter()` checks aliases, `EipInfo`/`EipDetailResult` records include aliases

## Test plan

- [x] `CamelCatalogTest.testEipModelAliases` — verifies aliases present in EIP model
- [x] `CamelCatalogTest.testFindModelNamesByAlias` — verifies search by alias (fan-out→multicast, dedup→idempotentConsumer, sink→to/toD)
- [x] `CamelCatalogTest.testFindModelNamesByAliasDashNormalized` — verifies fan-out/fanout/fanOut all match, circuit-breaker/circuitbreaker/circuitBreaker all match
- [x] All 30 generated JSON files verified to contain aliases

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude <noreply@anthropic.com>