### PR TITLE
chore: refine OSS helper rules, add attribution requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,3 +31,7 @@ You can run the aforementioned command in your module so that the build auto-for
 You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
 -->
 
+# AI-assisted contributions
+
+- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.
+

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -3,7 +3,7 @@
 This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
 
 - **Build tool:** Maven
-- **Build command:** `mvn -Dquickly install`
+- **Build command:** `mvn verify`
 - **Test command:** `mvn verify`
 - **Format command:** `cd <module> && mvn -DskipTests install`
 - **Module-specific build:** yes (always run `mvn` in the module directory where changes occurred)
@@ -12,5 +12,6 @@ This rule file contains build tools, commands, and code style constraints for th
   - Do NOT use Lombok (unless already present in the file)
   - Do NOT change public API signatures without justification
   - Do NOT add new dependencies without justification
+  - Records are allowed for internal/non-API classes; do NOT convert existing public API classes to Records
   - Maintain backwards compatibility for public APIs
 

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -3,11 +3,11 @@
 This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
 
 - **Build tool:** Maven
-- **Build command:** `mvn verify`
+- **Build command:** `mvn -Dquickly install`
 - **Test command:** `mvn verify`
 - **Format command:** `cd <module> && mvn -DskipTests install`
 - **Module-specific build:** yes (always run `mvn` in the module directory where changes occurred)
-- **Parallelized Maven:** no (resource intensive, do NOT parallelize Maven jobs)
+- **Parallelized Maven:** yes (except for running tests, which can be resource intensive)
 - **Code style restrictions:**
   - Do NOT use Lombok (unless already present in the file)
   - Do NOT change public API signatures without justification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,9 @@ camel/
 
 ## Build
 
+For project build commands, code style restrictions and other standards, check
+[`.oss-ai-helper-rules/project-standards.md`](.oss-ai-helper-rules/project-standards.md).
+
 ```bash
 mvn clean install -Dquickly          # fast build, no tests
 mvn clean install                     # full build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ These rules apply to ALL AI agents working on this codebase.
 - All AI-generated content (GitHub PR descriptions, review comments, JIRA comments) MUST clearly
   identify itself as AI-generated and mention the human operator.
   Example: "_Claude Code on behalf of [Human Name]_"
+- AI coding agents MUST be configured to add co-authorship trailers to commits
+  (e.g., `Co-authored-by`). For Claude Code, enable this via the
+  [attribution settings](https://code.claude.com/docs/en/settings#attribution-settings).
 
 ### PR Volume
 

--- a/docs/main/modules/contributing/pages/index.adoc
+++ b/docs/main/modules/contributing/pages/index.adoc
@@ -354,6 +354,14 @@ They are maintained as part of the repository so that AI-assisted contributions 
 
 The `.oss-ai-helper-rules/` files are designed for use with the https://github.com/Open-Harness-Engineering/ai-agents-oss-helper[OSS Helper] toolset, which provides ready-made skills for common contribution tasks (fixing issues, creating PRs, running CI checks, and more).
 
+=== Attribution
+
+Pull requests that include AI-generated code **must** provide proper attribution.
+AI coding agents should be configured to add co-authorship trailers to commits (e.g., `Co-authored-by`).
+For example, Claude Code supports this via its https://code.claude.com/docs/en/settings#attribution-settings[attribution settings].
+
+PR descriptions for AI-assisted contributions should also clearly identify the AI tool used.
+
 == Becoming a committer
 
 Once you have become sufficiently involved with the community, we may well invite you to be a committer. See xref:manual:faq:how-do-i-become-a-committer.adoc[How do I become a committer] for more details.


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Otavio Rodolfo Piske_

Follow-up to #24251 — addresses review feedback and adds attribution requirements for AI-assisted contributions.

### Changes

- **Build command**: use `mvn -Dquickly install` (fast build, tests covered by separate test command)
- **Parallelized Maven**: allow parallel builds (except test execution)
- **Records code style rule**: "Records are allowed for internal/non-API classes; do NOT convert existing public API classes to Records"
- **CLAUDE.md → .oss-ai-helper-rules pointer**: added reference in the Build section to reduce overlap/drift
- **Attribution requirements**:
  - Updated `AGENTS.md` to require co-authorship trailers on commits (e.g., `Co-authored-by`)
  - Added attribution subsection to the contributing guide with a link to Claude Code's attribution settings as an example
  - Added AI attribution checkbox to the PR template

## Test plan

- [x] Verify build command is `mvn -Dquickly install` in `project-standards.md`
- [x] Verify parallelized Maven is set to yes
- [x] Verify Records rule is present in code style restrictions
- [x] Verify `AGENTS.md` includes co-authorship trailer requirement
- [x] Verify contributing guide has attribution subsection
- [x] Verify PR template has AI attribution checkbox