### PR TITLE
CAMEL-23834: camel-smb - Fix forward slashes rejected on Windows during atomic rename

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -237,7 +237,8 @@ public class SmbOperations implements SmbFileOperations {
     public boolean atomicRenameFile(File src, String to)
             throws GenericFileOperationFailedException {
         try {
-            src.rename(to);
+            // SMB protocol requires backslashes as path separators
+            src.rename(to.replace('/', '\\'));
             LOG.debug("Renamed file: {} to: {} using atomic rename", src.getUncPath(), to);
             return true;
         } catch (SMBRuntimeException e) {


### PR DESCRIPTION
_Claude Code on behalf of Claus Ibsen_

## Summary

Fix regression introduced in CAMEL-22740 where the `atomicRenameFile()` method in `SmbOperations` passes forward-slash paths directly to smbj's `DiskEntry.rename()`. Unlike `DiskShare.openFile()` which internally normalizes `/` to `\` via `SmbPath.rewritePath()`, the `rename()` method sends the path as-is to the Windows SMB server, which strictly rejects forward slashes with `STATUS_OBJECT_NAME_INVALID (0xc0000033)`.

The fix converts forward slashes to backslashes before calling `src.rename()`, matching the SMB protocol requirement.

- Worked in Camel 4.14.x (which only used copy-and-delete via `share.openFile()`)
- Broken since 4.18.x (when atomic rename was introduced in CAMEL-22740)
- Workaround: `copyAndDeleteOnRenameFail=true` (falls back to `share.openFile()` which normalizes paths)

## Test plan

- [x] Existing `SmbAtomicRenameBehaviorIT` and `SmbCopyAndDeleteOnRenameFailIT` integration tests pass
- [ ] Manual verification against a Windows SMB server with `moveTo` paths containing forward slashes (e.g., `inprocess/test.xml`)

Co-Authored-By: Claude <noreply@anthropic.com>