### PR TITLE
CAMEL-23835: camel-launcher - set classloader on embedded plugins so TUI ServiceLoader works in fat-jar

### DIFF
--- a/dsl/camel-jbang/camel-launcher/src/main/java/org/apache/camel/dsl/jbang/launcher/CamelLauncherMain.java
+++ b/dsl/camel-jbang/camel-launcher/src/main/java/org/apache/camel/dsl/jbang/launcher/CamelLauncherMain.java
@@ -16,12 +16,15 @@
  */
 package org.apache.camel.dsl.jbang.launcher;
 
+import java.util.List;
+
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.generate.GeneratePlugin;
 import org.apache.camel.dsl.jbang.core.commands.kubernetes.KubernetesPlugin;
 import org.apache.camel.dsl.jbang.core.commands.test.TestPlugin;
 import org.apache.camel.dsl.jbang.core.commands.tui.TuiPlugin;
 import org.apache.camel.dsl.jbang.core.commands.validate.ValidatePlugin;
+import org.apache.camel.dsl.jbang.core.common.Plugin;
 import picocli.CommandLine;
 
 /**
@@ -31,12 +34,23 @@ public class CamelLauncherMain extends CamelJBangMain {
 
     @Override
     public void postAddCommands(CommandLine commandLine, String[] args) {
-        // install embedded plugins
-        new GeneratePlugin().customize(commandLine, this);
-        new KubernetesPlugin().customize(commandLine, this);
-        new TuiPlugin().customize(commandLine, this);
-        new ValidatePlugin().customize(commandLine, this);
-        new TestPlugin().customize(commandLine, this);
+        // Install embedded plugins. Each plugin must be given the classloader that loaded it (this
+        // class's classloader, i.e. the fat-jar classloader) so that plugins relying on ServiceLoader
+        // discovery can see the dependencies bundled in the launcher. The TUI plugin installs this
+        // classloader as the thread-context classloader so tamboui can discover its terminal backend;
+        // without it the discovery falls back to the system classloader, which cannot see the nested
+        // BOOT-INF/lib jars of the Spring Boot fat-jar, and the TUI fails with "No BackendProvider found".
+        ClassLoader classLoader = getClass().getClassLoader();
+        List<Plugin> plugins = List.of(
+                new GeneratePlugin(),
+                new KubernetesPlugin(),
+                new TuiPlugin(),
+                new ValidatePlugin(),
+                new TestPlugin());
+        for (Plugin plugin : plugins) {
+            plugin.setClassLoader(classLoader);
+            plugin.customize(commandLine, this);
+        }
     }
 
 }

--- a/dsl/camel-jbang/camel-launcher/src/test/java/org/apache/camel/dsl/jbang/launcher/CamelLauncherTest.java
+++ b/dsl/camel-jbang/camel-launcher/src/test/java/org/apache/camel/dsl/jbang/launcher/CamelLauncherTest.java
@@ -18,12 +18,16 @@ package org.apache.camel.dsl.jbang.launcher;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.dsl.jbang.core.common.Printer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -85,6 +89,38 @@ public class CamelLauncherTest {
 
         String output = baos.toString();
         assertTrue(output.contains("Camel CLI version:"), "Output should contain version information");
+    }
+
+    @Test
+    public void testEmbeddedTuiPluginReceivesClassLoader() throws Exception {
+        // Regression for the launcher TUI failure "No BackendProvider found on classpath".
+        // The launcher installs embedded plugins directly in postAddCommands. Each plugin must be
+        // given the fat-jar classloader so that the TUI can install it as the thread-context
+        // classloader for tamboui's ServiceLoader-based terminal backend discovery. Without it the
+        // discovery falls back to the system classloader, which cannot see the nested BOOT-INF/lib
+        // jars of the Spring Boot fat-jar.
+        CamelLauncherMain main = new CamelLauncherMain();
+
+        CommandLine commandLine = new CommandLine(main);
+        main.postAddCommands(commandLine, new String[] { "tui" });
+
+        CommandLine tui = commandLine.getSubcommands().get("tui");
+        assertNotNull(tui, "tui command should be registered by the launcher");
+        CommandLine monitor = tui.getSubcommands().get("monitor");
+        assertNotNull(monitor, "tui monitor subcommand should be registered");
+
+        ClassLoader pluginClassLoader = readClassLoaderField(monitor.getCommand());
+        assertNotNull(pluginClassLoader,
+                "embedded TUI plugin must receive a non-null classloader (else tamboui ServiceLoader breaks in the fat-jar)");
+        // The classloader handed to the plugin must be able to resolve tamboui's backend SPI.
+        assertDoesNotThrow(() -> pluginClassLoader.loadClass("dev.tamboui.terminal.BackendProvider"),
+                "the plugin classloader must be able to load tamboui's BackendProvider");
+    }
+
+    private static ClassLoader readClassLoaderField(Object command) throws Exception {
+        Field field = command.getClass().getDeclaredField("classLoader");
+        field.setAccessible(true);
+        return (ClassLoader) field.get(command);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Running the TUI from the `camel-launcher` fat-jar (`java -jar camel-launcher-*.jar tui`, `./camel.sh tui`, or `podman run camel-launcher tui`) fails immediately with:

```
dev.tamboui.terminal.BackendException: No BackendProvider found on classpath.
Add a backend dependency such as tamboui-jline3-backend or tamboui-panama-backend.
	at dev.tamboui.terminal.BackendFactory.tryProviders(BackendFactory.java:139)
	at dev.tamboui.terminal.BackendFactory.create(BackendFactory.java:91)
	at dev.tamboui.tui.TuiRunner.create(TuiRunner.java:186)
	at org.apache.camel.dsl.jbang.core.commands.tui.TuiBackendHelper.createTuiRunner(TuiBackendHelper.java:36)
	...
```

The same command works under JBang. This is **not** a packaging problem: `tamboui-jline3-backend` and its `META-INF/services/dev.tamboui.terminal.BackendProvider` SPI entry are correctly bundled under `BOOT-INF/lib/`.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23835

## Root cause

tamboui discovers its terminal backend via `ServiceLoader.load(BackendProvider.class)`, which keys off the **thread-context classloader** (TCCL). The TUI deliberately installs its plugin classloader as the TCCL before starting (`CamelMonitor.java:266-267`):

```java
// to make ServiceLoader work with tamboui for downloaded JARs
Thread.currentThread().setContextClassLoader(classLoader);
```

The launcher registers its bundled plugins in `CamelLauncherMain.postAddCommands` by instantiating them directly and calling `customize(...)`, but **never calling `setClassLoader`**:

```java
new TuiPlugin().customize(commandLine, this);   // classLoader stays null
```

So `TuiPlugin.classLoader` (and the `CamelMonitor` it creates) is `null`, the TCCL is set to `null`, and `ServiceLoader` falls back to the system class loader (`AppClassLoader`). In a Spring Boot fat-jar that loader cannot see the nested `BOOT-INF/lib/*.jar` (only `LaunchedClassLoader` can), so the backend is never found. tamboui's `SafeServiceLoader.load(Class)` then swallows the resulting `ServiceConfigurationError`/`LinkageError` (it passes a `null` error handler), producing the misleading "No BackendProvider found".

Evidence gathered inside the actual fat-jar:

```
launcher CL: LaunchedClassLoader
[TCCL=null]     SPI class not visible: ClassNotFoundException: dev.tamboui.terminal.BackendProvider  -> providers=0
[TCCL=launched] providers=1
```

The embedded-plugin *scanning* path (`PluginHelper.addEmbeddedPlugins`) is not involved here: it finds the service resources but their nested URLs (`jar:nested:.../fat.jar/!BOOT-INF/lib/...`) make `new JarFile(...)` throw, so it silently registers nothing. The launcher relies entirely on `postAddCommands`. JBang works because there the TUI plugin is a *downloaded* plugin loaded through a path that already calls `setClassLoader(...)`.

## Fix

`CamelLauncherMain.postAddCommands` now sets the fat-jar classloader (this class's classloader, i.e. `LaunchedClassLoader`) on each embedded plugin before customizing it:

```java
ClassLoader classLoader = getClass().getClassLoader();
for (Plugin plugin : List.of(new GeneratePlugin(), new KubernetesPlugin(),
        new TuiPlugin(), new ValidatePlugin(), new TestPlugin())) {
    plugin.setClassLoader(classLoader);
    plugin.customize(commandLine, this);
}
```

`Plugin.setClassLoader` is a `default` no-op, so this is harmless for the other bundled plugins.

## Verification

- **End-to-end against the rebuilt fat-jar:** `java -jar camel-launcher-*.jar tui` no longer throws `BackendException` (zero occurrences of "No BackendProvider found"); JLine's terminal provider initializes and the TUI enters raw mode and renders.
- **Regression test:** `CamelLauncherTest#testEmbeddedTuiPluginReceivesClassLoader` drives `postAddCommands` and asserts the registered TUI `monitor` command received a non-null classloader that can load `dev.tamboui.terminal.BackendProvider`. Verified it fails without the fix (`expected: not <null>`) and passes with it. Full `CamelLauncherTest` green.

## Notes

- The misleading error message originates upstream in tamboui (`SafeServiceLoader.load(Class)` discards the real `LinkageError`/`ServiceConfigurationError`). Worth reporting to tamboui separately; out of scope here.
- No upgrade-guide entry: pure bug fix with nothing to migrate.

_Claude Code on behalf of Adriano Machado_

🤖 Generated with [Claude Code](https://claude.com/claude-code)