### PR TITLE
[backport camel-4.18.x] CAMEL-23834: camel-smb - Fix forward slashes rejected on Windows during atomic rename

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -225,7 +225,8 @@ public class SmbOperations implements SmbFileOperations {
     public boolean atomicRenameFile(File src, String to)
             throws GenericFileOperationFailedException {
         try {
-            src.rename(to);
+            // SMB protocol requires backslashes as path separators
+            src.rename(to.replace('/', '\\'));
             LOG.debug("Renamed file: {} to: {} using atomic rename", src.getUncPath(), to);
             return true;
         } catch (SMBRuntimeException e) {


### PR DESCRIPTION
## Backport of #24255

Cherry-pick of #24255 onto `camel-4.18.x`.

**Original PR:** #24255 - CAMEL-23834: camel-smb - Fix forward slashes rejected on Windows during atomic rename
**Original author:** @davsclaus
**Target branch:** `camel-4.18.x`

### Original description

Fix regression introduced in CAMEL-22740 where the `atomicRenameFile()` method in `SmbOperations` passes forward-slash paths directly to smbj's `DiskEntry.rename()`. Unlike `DiskShare.openFile()` which internally normalizes `/` to `\` via `SmbPath.rewritePath()`, the `rename()` method sends the path as-is to the Windows SMB server, which strictly rejects forward slashes with `STATUS_OBJECT_NAME_INVALID (0xc0000033)`.

The fix converts forward slashes to backslashes before calling `src.rename()`, matching the SMB protocol requirement.

Co-Authored-By: Claude <noreply@anthropic.com>