### PR TITLE
CAMEL-23457: camel-docling - document OCR header/footer FURNITURE-layer limitation and pin test

### DIFF
--- a/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
+++ b/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
@@ -298,6 +298,22 @@ YAML::
 ----
 ====
 
+=== OCR and page headers/footers
+
+Docling recognizes page headers and footers (page numbers, copyright lines, running titles, footnotes, and similar
+content) during OCR, but it classifies them as page _furniture_: they are assigned to docling's `FURNITURE` content
+layer rather than the document `BODY`. Docling's Markdown, text and HTML exports include only the `BODY` layer by
+default, so header and footer text is omitted from the converted output even though the OCR engine read it correctly.
+
+When using `useDoclingServe=true`, the component cannot currently change this, because the docling-serve API does not
+expose an option to choose which content layers are included in the export — even though docling's Python library can
+include the `FURNITURE` layer. This is tracked upstream in
+https://github.com/docling-project/docling-serve/issues/271[docling-serve#271]. The docling CLI
+(`useDoclingServe=false`) has the same limitation.
+
+If you need header or footer content in the output, restructure the source document so the text is part of the body,
+or track the upstream issue for a future option to include the furniture layer.
+
 === Using headers to control processing
 
 [tabs]

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -178,10 +179,15 @@ class OcrExtractionIT extends CamelTestSupport {
         assertTrue(foundFirst && foundSecond,
                 "OCR should extract at least some of the expected text. Got: " + result);
 
-        // TODO: footer is not found by the ocr by Camel docling
-        //        boolean foundFooter = resultLower.contains("footer");
-        //        assertTrue(foundFooter,
-        //                "OCR should extract at least some of the expected text from the footer. Got: " + result);
+        // The footer is recognized by OCR, but docling classifies it as a page_footer, which lives in the
+        // FURNITURE content layer. docling's default body export (Markdown/text/HTML) excludes that layer, and
+        // docling-serve exposes no option to include it (upstream: https://github.com/docling-project/docling-serve/issues/271).
+        // The footer text is therefore absent from the result. See the "OCR and page headers/footers" note in
+        // docling-component.adoc. This assertion documents and pins that behavior; it will start failing if a
+        // future docling release includes page furniture in the body export, prompting us to revisit the limitation.
+        boolean foundFooter = resultLower.contains("footer");
+        assertFalse(foundFooter,
+                "Footer text is page furniture and is excluded from the docling body export. Got: " + result);
 
         LOG.info("OCR extraction with multiple text blocks result:\n{}", result);
         LOG.info("Successfully extracted text from image with multiple text blocks");


### PR DESCRIPTION
### Summary

`OcrExtractionIT` carried a long-standing TODO noting that OCR never returned the footer of a scanned
image (`// TODO: footer is not found by the ocr by Camel docling`). This PR resolves
[CAMEL-23457](https://issues.apache.org/jira/browse/CAMEL-23457) by identifying the behavior as an
**upstream docling limitation**, documenting it, and turning the TODO into an explicit, self-documenting
characterization test.

### Root cause

docling *does* OCR header/footer text, but classifies it as page _furniture_ (e.g. `page_footer`)
belonging to docling's **`FURNITURE` content layer**. docling's Markdown / text / HTML exports emit only
the `BODY` layer by default, so footer text is dropped from the converted output even though OCR read it
correctly.

docling's Python library can include the furniture layer via `include_layers`, but the **docling-serve
API does not expose that option**, and the docling CLI has the same limitation. camel-docling therefore
has no knob it could set to recover the footer on either the `useDoclingServe=true` or the CLI path. This
is tracked upstream at
[docling-project/docling-serve#271](https://github.com/docling-project/docling-serve/issues/271)
("Footnotes Missing from Markdown Output Due to Inability to Include FURNITURE Layer", currently open).

### Changes

- **`docling-component.adoc`** — new *"OCR and page headers/footers"* section explaining the
  FURNITURE-layer behavior and linking the upstream issue, so users understand why footer/header text is
  absent and what their options are.
- **`OcrExtractionIT.java`** — removes the TODO and pins the current behavior with
  `assertFalse(result contains "footer")` plus an explanatory comment. The assertion is intentionally a
  tripwire: if a future docling release starts including page furniture in the body export, the test will
  fail and prompt us to revisit and lift the documented limitation.

This matches the issue's acceptance criterion for the upstream-only case ("file an upstream issue and
document the workaround/limitation in `docling-component.adoc`").

### Verification

- Confirmed upstream docling-serve#271 exists and is open, matching the root cause.
- Confirmed `DoclingConfiguration` exposes no content-layer option and `DoclingProducer`'s CLI flag
  whitelist has no furniture/layer flag (`--show-layout` is unrelated bounding-box layout).
- Full reactor build (`mvn clean install -DskipTests`) passes; `formatter:format` / `impsort:sort` leave
  no diff.
- Note: `OcrExtractionIT` is `@DisabledIfSystemProperty(named = "ci.env.name")` and requires a
  docling-serve container, so it does not execute in CI.

No public API change, no new option, no behavior change — this purely documents pre-existing behavior —
so no upgrade-guide entry is required.

---
_Submitted by Claude Code on behalf of Andrea Cosentino._
