### PR TITLE
CAMEL-23838: Fix camel-jbang TUI help (F1/? broken)

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-tui.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-tui.adoc
@@ -58,7 +58,7 @@ If an example requires infrastructure (like Kafka or a database), the TUI automa
 required Docker containers before launching the example. A notification in the footer shows the
 progress.
 
-TIP: Press *F1* on any screen for context-sensitive help.
+TIP: Press *F1* or *?* on any screen for context-sensitive help.
 Keyboard shortcuts are always shown in the footer bar.
 
 == Tabs Overview
@@ -313,7 +313,7 @@ The Doctor checks your development environment and reports issues:
 
 | *1* - *0* | Jump to tab by number
 | *Tab* / *Shift+Tab* | Next / previous tab
-| *F1* | Context-sensitive help (toggle)
+| *F1* / *?* | Context-sensitive help (toggle)
 | *F2* | Actions menu
 | *F3* | Switch between integrations (when multiple running)
 | *Shift+F5* | Take screenshot

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -610,7 +610,7 @@ public class CamelMonitor extends CamelCommand {
             takeScreenshot();
             return true;
         }
-        if (ke.isKey(KeyCode.F1)) {
+        if (ke.isKey(KeyCode.F1) || (!textEditing && ke.isChar('?'))) {
             if (helpOverlay.isVisible()) {
                 helpOverlay.close();
             } else {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -610,16 +610,14 @@ public class CamelMonitor extends CamelCommand {
             takeScreenshot();
             return true;
         }
-        if (ke.isKey(KeyCode.F1) || (!textEditing && ke.isChar('?'))) {
-            if (helpOverlay.isVisible()) {
-                helpOverlay.close();
-            } else {
-                MonitorTab tab = activeTab();
-                if (tab != null) {
-                    String help = tab.getHelpText();
-                    if (help != null) {
-                        helpOverlay.open(help);
-                    }
+        if (opensHelp(ke, textEditing)) {
+            // Only opens the overlay: while it is visible, dispatch delegates to
+            // helpOverlay.handleKeyEvent (which handles F1/?/q/Esc to close) before reaching here.
+            MonitorTab tab = activeTab();
+            if (tab != null) {
+                String help = tab.getHelpText();
+                if (help != null) {
+                    helpOverlay.open(help);
                 }
             }
             return true;
@@ -653,6 +651,14 @@ public class CamelMonitor extends CamelCommand {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Whether the key event should open the help overlay. F1 always opens it; '?' opens it too, but only when no text
+     * input is focused, so the character is not swallowed while the user is typing in a search or probe field.
+     */
+    static boolean opensHelp(KeyEvent ke, boolean textEditing) {
+        return ke.isKey(KeyCode.F1) || (!textEditing && ke.isChar('?'));
     }
 
     private boolean handleTabKeys(KeyEvent ke) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
@@ -94,7 +94,7 @@ class HelpOverlay {
                 .borderType(BorderType.ROUNDED)
                 .title(" Help ")
                 .titleBottom(Title.from(Line.from(
-                        Span.styled(" F1", MonitorContext.HINT_KEY_STYLE), Span.raw(" close "),
+                        Span.styled(" F1/?", MonitorContext.HINT_KEY_STYLE), Span.raw(" close "),
                         Span.styled(" ↑↓", MonitorContext.HINT_KEY_STYLE), Span.raw(" scroll "))))
                 .build();
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
@@ -59,7 +59,7 @@ class HelpOverlay {
         if (!visible) {
             return false;
         }
-        if (ke.isCancel() || ke.isChar('q') || ke.isKey(KeyCode.F1)) {
+        if (ke.isCancel() || ke.isChar('q') || ke.isChar('?') || ke.isKey(KeyCode.F1)) {
             close();
             return true;
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitorTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelMonitorTest {
+
+    // '?' is an alternative to F1 for opening the help overlay. Unlike F1, it must be suppressed
+    // while a text input is focused, otherwise typing '?' in a search or probe field would
+    // pop up help instead of inserting the character.
+
+    @Test
+    void f1OpensHelpEvenWhileTextEditing() {
+        assertTrue(CamelMonitor.opensHelp(KeyEvent.ofKey(KeyCode.F1), true), "F1 must open help regardless of text editing");
+        assertTrue(CamelMonitor.opensHelp(KeyEvent.ofKey(KeyCode.F1), false), "F1 must open help");
+    }
+
+    @Test
+    void questionMarkOpensHelpWhenNotTextEditing() {
+        assertTrue(CamelMonitor.opensHelp(KeyEvent.ofChar('?'), false), "'?' must open help when no input is focused");
+    }
+
+    @Test
+    void questionMarkIsSuppressedWhileTextEditing() {
+        assertFalse(CamelMonitor.opensHelp(KeyEvent.ofChar('?'), true),
+                "'?' must not open help while a text input is focused");
+    }
+
+    @Test
+    void unrelatedKeyDoesNotOpenHelp() {
+        assertFalse(CamelMonitor.opensHelp(KeyEvent.ofChar('x'), false), "an unrelated key must not open help");
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlayTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlayTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelpOverlayTest {
+
+    // The help overlay is opened with either F1 or '?'. Pressing the same keys again must close it,
+    // so the binding is a true toggle. '?' was previously ignored by the overlay (CAMEL: TUI help).
+
+    @Test
+    void questionMarkClosesOverlay() {
+        HelpOverlay overlay = new HelpOverlay();
+        overlay.open("# Help");
+        assertTrue(overlay.isVisible());
+
+        boolean handled = overlay.handleKeyEvent(KeyEvent.ofChar('?'));
+
+        assertTrue(handled, "the overlay must consume the key while visible");
+        assertFalse(overlay.isVisible(), "'?' must close the help overlay it opened");
+    }
+
+    @Test
+    void f1ClosesOverlay() {
+        HelpOverlay overlay = new HelpOverlay();
+        overlay.open("# Help");
+
+        overlay.handleKeyEvent(KeyEvent.ofKey(KeyCode.F1));
+
+        assertFalse(overlay.isVisible(), "F1 must still close the help overlay");
+    }
+
+    @Test
+    void quitKeyClosesOverlay() {
+        HelpOverlay overlay = new HelpOverlay();
+        overlay.open("# Help");
+
+        overlay.handleKeyEvent(KeyEvent.ofChar('q'));
+
+        assertFalse(overlay.isVisible(), "'q' must still close the help overlay");
+    }
+
+    @Test
+    void unrelatedKeyKeepsOverlayOpen() {
+        HelpOverlay overlay = new HelpOverlay();
+        overlay.open("# Help");
+
+        overlay.handleKeyEvent(KeyEvent.ofChar('x'));
+
+        assertTrue(overlay.isVisible(), "an unrelated key must not close the help overlay");
+    }
+}

--- a/dsl/camel-jbang/camel-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-launcher/pom.xml
@@ -54,7 +54,27 @@
         <httpcore-version>4.4.16</httpcore-version>
         <commons-codec-version>1.22.0</commons-codec-version>
         <jcl-over-slf4j-version>${slf4j-version}</jcl-over-slf4j-version>
+        <commonmark-version>0.28.0</commonmark-version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!--
+                This launcher bundles both camel-jbang-plugin-generate and camel-jbang-plugin-tui on a
+                single flat classpath. The generate plugin drags in commonmark 0.21.0 (via openapi-generator),
+                while the tui plugin (via tamboui-markdown) needs commonmark 0.28.0 and its renderer.markdown
+                classes that do not exist in 0.21.0. Without this pin Maven mediation keeps the older 0.21.0
+                core next to the 0.28.0 extensions, which makes the TUI markdown help throw NoClassDefFoundError.
+                Pin the core to 0.28.0 so it matches the commonmark-ext-* modules; openapi-generator only uses
+                the stable Parser/HtmlRenderer APIs, which are unchanged in 0.28.0.
+            -->
+            <dependency>
+                <groupId>org.commonmark</groupId>
+                <artifactId>commonmark</artifactId>
+                <version>${commonmark-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
# Description

Fixes the broken context-sensitive help in the `camel tui` (camel-jbang TUI plugin). See [CAMEL-23838](https://issues.apache.org/jira/browse/CAMEL-23838).

Two independent problems:

**1. `F1` threw `java.lang.NoClassDefFoundError: org/commonmark/renderer/markdown/MarkdownRenderer$MarkdownRendererExtension`.**

The `camel-launcher` fat-jar bundles every ASF plugin on a single flat classpath. Maven dependency mediation resolved a *split* commonmark:

- `org.commonmark:commonmark` (core) → **0.21.0**, via `camel-jbang-plugin-generate` → `openapi-generator:7.23.0` (declared first).
- `org.commonmark:commonmark-ext-*` → **0.28.0**, via `camel-jbang-plugin-tui` → `tamboui-markdown:0.4.0`.

commonmark 0.21.0 does not contain the `org.commonmark.renderer.markdown.MarkdownRenderer` class at all (added later), so the TUI markdown help view (tamboui `MarkdownView`) blew up. Fixed by pinning `org.commonmark:commonmark` to `0.28.0` in `camel-launcher`'s `dependencyManagement` so the core matches the extension modules. `openapi-generator` only uses the stable `Parser`/`HtmlRenderer` builder APIs, which are unchanged in 0.28.0, so it remains safe. The on-demand `camel-jbang-main` path was never affected, as it downloads only the requested plugin into its own classloader.

**2. `?` did nothing.**

Only `KeyCode.F1` was bound to help. `?` is now bound to open/toggle help in `CamelMonitor` (guarded so it does not trigger while typing in a search/filter input), and `HelpOverlay` also closes on `?` so the binding is a true toggle.

Also: documented the `?` shortcut in `camel-jbang-tui.adoc` and added tests (`HelpOverlayTest` for close-on-`?`, F1/`q` regression, and that an unrelated key keeps the overlay open).

## Review follow-up

Refinements from PR review:

- Extracted `CamelMonitor.opensHelp(KeyEvent, boolean)` so the F1/`?` open guard is unit-testable, and added `CamelMonitorTest` asserting `?` is suppressed while a text input is focused but `F1` is not.
- Removed an unreachable `helpOverlay.close()` branch in `handleGlobalKeys`: while the overlay is visible, dispatch already delegates to `HelpOverlay.handleKeyEvent` before reaching that code, so it only ever opened the overlay.
- Advertised `?` alongside `F1` in the overlay's close hint.
- Verified the commonmark pin at the bytecode level: openapi-generator's only commonmark consumer (`Markdown.class`) uses exactly `Parser.builder()/parse(String)` and `HtmlRenderer.builder()/render(Node)`, all present with identical signatures in 0.28.0.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code on behalf of Adriano Machado._