### PR TITLE
fix: add missing .borders(Borders.ALL) to restore TUI pane borders

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ActionsPopup.java
@@ -46,6 +46,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.input.TextInput;
 import dev.tamboui.widgets.input.TextInputState;
@@ -818,7 +819,7 @@ class ActionsPopup {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.NONE)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Actions ")
                         .build())
                 .build();
@@ -844,7 +845,7 @@ class ActionsPopup {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.AUTO_SCROLL)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Run an Example (" + exampleCatalog.size() + ") ")
                         .build())
                 .build();
@@ -910,7 +911,7 @@ class ActionsPopup {
             title = Title.from(" " + docTitle + " ");
         }
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         if (docLines != null) {
@@ -960,7 +961,7 @@ class ActionsPopup {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.AUTO_SCROLL)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Show Integration Doc ")
                         .build())
                 .build();
@@ -1331,7 +1332,7 @@ class ActionsPopup {
         frame.renderWidget(Clear.INSTANCE, popup);
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(" Run from folder ")
                 .build();
         frame.renderWidget(block, popup);
@@ -1782,7 +1783,7 @@ class ActionsPopup {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.AUTO_SCROLL)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Run Dev/Infra Service (" + available + "/" + infraCatalog.size() + ") ")
                         .build())
                 .build();
@@ -1805,7 +1806,7 @@ class ActionsPopup {
         frame.renderWidget(Clear.INSTANCE, popup);
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(" Run " + selectedInfraService.alias + " ")
                 .build();
         frame.renderWidget(block, popup);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
@@ -35,6 +35,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -185,7 +186,7 @@ class BeansTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Loading beans...", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Beans ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Beans ").build())
                             .build(),
                     area);
             return;
@@ -240,7 +241,7 @@ class BeansTab implements MonitorTab {
                         Constraint.fill())
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, tableState);
@@ -252,7 +253,8 @@ class BeansTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Select a bean", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Properties ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Properties ")
+                                    .build())
                             .build(),
                     area);
             return;
@@ -265,7 +267,7 @@ class BeansTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" No properties", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -297,7 +299,7 @@ class BeansTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -41,6 +41,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -248,7 +249,8 @@ class BrowseTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Loading browse endpoints...", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Browse ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Browse ")
+                                    .build())
                             .build(),
                     area);
             return;
@@ -296,7 +298,7 @@ class BrowseTab implements MonitorTab {
                         Constraint.length(10))
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, endpointTableState);
@@ -308,7 +310,7 @@ class BrowseTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Loading messages...", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -349,7 +351,7 @@ class BrowseTab implements MonitorTab {
                         Constraint.fill())
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, messageTableState);
@@ -361,7 +363,8 @@ class BrowseTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Select a message", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Message ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Message ")
+                                    .build())
                             .build(),
                     area);
             return;
@@ -432,7 +435,7 @@ class BrowseTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(visible))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 chunks.get(1));
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
@@ -417,7 +417,7 @@ public class CamelCatalogTui extends CamelCommand {
                         Style.EMPTY.fg(Color.CYAN)));
 
         Block headerBlock = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(" Apache Camel ")
                 .build();
 
@@ -468,7 +468,7 @@ public class CamelCatalogTui extends CamelCommand {
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .borderStyle(borderStyle)
                         .title(listTitle)
                         .build())
@@ -494,7 +494,7 @@ public class CamelCatalogTui extends CamelCommand {
                             .text(Text.from(Line.from(
                                     Span.styled(emptyMsg, Style.EMPTY.dim()))))
                             .block(Block.builder()
-                                    .borderType(BorderType.ROUNDED)
+                                    .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .borderStyle(borderStyle)
                                     .title(optTitle)
                                     .build())
@@ -527,7 +527,7 @@ public class CamelCatalogTui extends CamelCommand {
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .borderStyle(borderStyle)
                         .title(optTitle)
                         .build())
@@ -617,7 +617,7 @@ public class CamelCatalogTui extends CamelCommand {
                         .overflow(Overflow.WRAP_WORD)
                         .scroll(descriptionScroll)
                         .block(Block.builder()
-                                .borderType(BorderType.ROUNDED)
+                                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                 .title(title)
                                 .build())
                         .build(),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -65,6 +65,7 @@ import dev.tamboui.tui.event.TickEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.list.ListItem;
 import dev.tamboui.widgets.list.ListState;
@@ -1374,7 +1375,7 @@ public class CamelMonitor extends CamelCommand {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.NONE)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(Line.from(Span.styled(" More Tabs ", Style.EMPTY.fg(Color.YELLOW).bold()))))
                         .build())
                 .build();
@@ -1422,7 +1423,7 @@ public class CamelMonitor extends CamelCommand {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.NONE)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(Line.from(Span.styled(" Switch Integration ", Style.EMPTY.fg(Color.YELLOW).bold()))))
                         .build())
                 .build();
@@ -1711,7 +1712,7 @@ public class CamelMonitor extends CamelCommand {
 
         frame.renderWidget(Clear.INSTANCE, popup);
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .borderStyle(Style.EMPTY.fg(Color.LIGHT_RED))
                 .title(" Confirm Kill ")
                 .build();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -990,27 +990,18 @@ public class CamelMonitor extends CamelCommand {
             return;
         }
 
-        if (area.width() < MIN_WIDTH || area.height() < MIN_HEIGHT) {
-            renderTooSmall(frame, area);
-            return;
-        }
-
-        // Layout: header (1 row) + spacer (1 row) + tabs (2 rows) + spacer (1 row) + content (fill) + footer (1 row)
+        // Layout: header (1 row) + tabs (2 rows) + content (fill) + footer (1 row)
         List<Rect> mainChunks = Layout.vertical()
                 .constraints(
                         Constraint.length(1),
-                        Constraint.length(1),
                         Constraint.length(2),
-                        Constraint.length(1),
                         Constraint.fill(),
                         Constraint.length(1))
                 .split(area);
 
         renderHeader(frame, mainChunks.get(0));
-        // mainChunks.get(1) is the empty spacer row
-        renderTabs(frame, mainChunks.get(2));
-        // mainChunks.get(3) is the empty spacer row between tabs and content
-        Rect contentArea = mainChunks.get(4);
+        renderTabs(frame, mainChunks.get(1));
+        Rect contentArea = mainChunks.get(2);
         ctx.shellPercent = shellPanel.isOpen() ? shellPanel.panelPercent() : 0;
         if (shellPanel.isOpen()) {
             List<Rect> splitChunks = Layout.vertical()
@@ -1036,7 +1027,7 @@ public class CamelMonitor extends CamelCommand {
         if (helpOverlay.isVisible()) {
             helpOverlay.render(frame, contentArea);
         }
-        renderFooter(frame, mainChunks.get(5));
+        renderFooter(frame, mainChunks.get(3));
 
         lastBuffer = frame.buffer();
         renderGeneration++;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
@@ -33,6 +33,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.sparkline.DualSparkline;
@@ -193,7 +194,7 @@ class CircuitBreakerTab implements MonitorTab {
                         Constraint.fill())
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Circuit Breaker ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Circuit Breaker ").build())
                 .build();
 
         frame.renderStatefulWidget(table, chunks.get(0), tableState);
@@ -314,7 +315,7 @@ class CircuitBreakerTab implements MonitorTab {
 
         frame.renderWidget(Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build(), area);
     }
 
@@ -346,7 +347,7 @@ class CircuitBreakerTab implements MonitorTab {
                 Span.styled("░".repeat(empty), Style.EMPTY.dim()));
         frame.renderWidget(Paragraph.builder()
                 .text(Text.from(barLine))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Failure Rate ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Failure Rate ").build())
                 .build(), vSplit.get(0));
 
         LinkedList<Long> successHist = cbSuccessHistory.get(key);
@@ -384,7 +385,7 @@ class CircuitBreakerTab implements MonitorTab {
                 .bottomStyle(Style.EMPTY.fg(Color.LIGHT_RED))
                 .showYAxis(true)
                 .xLabels("-60s", "-45s", "-30s", "-15s", "now")
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(chartTitle)).build())
                 .build(), vSplit.get(1));
 
@@ -408,7 +409,7 @@ class CircuitBreakerTab implements MonitorTab {
                 Span.styled("fail:", dim), Span.raw(" " + lastFail));
         frame.renderWidget(Paragraph.builder()
                 .text(Text.from(Line.from(Span.raw("")), metricsLine1, metricsLine2))
-                .block(Block.builder().borderType(BorderType.ROUNDED).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).build())
                 .build(), vSplit.get(2));
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
@@ -33,6 +33,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.list.ListItem;
 import dev.tamboui.widgets.list.ListState;
 import dev.tamboui.widgets.list.ListWidget;
@@ -148,7 +149,7 @@ class ClasspathTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled("  Loading classpath...", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Classpath ").build())
                             .build(),
                     area);
@@ -160,7 +161,7 @@ class ClasspathTab implements MonitorTab {
                     Paragraph.builder()
                             .text(Text.from(Line.from(
                                     Span.styled("  " + errorMessage, Style.EMPTY.fg(Color.LIGHT_RED)))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Classpath ").build())
                             .build(),
                     area);
@@ -197,7 +198,7 @@ class ClasspathTab implements MonitorTab {
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.AUTO_SCROLL)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
         frame.renderStatefulWidget(list, area, listState);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
@@ -32,6 +32,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
@@ -114,7 +115,7 @@ class ConfigurationTab implements MonitorTab {
                     Paragraph.builder()
                             .text(Text.from(Line.from(
                                     Span.styled("  No configuration properties available.", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Configuration ").build())
                             .build(),
                     area);
@@ -134,7 +135,7 @@ class ConfigurationTab implements MonitorTab {
 
         String title = String.format(" Configuration — %d properties ", props.size());
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         Rect inner = block.inner(area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTab.java
@@ -30,6 +30,7 @@ import dev.tamboui.text.Span;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
@@ -148,7 +149,7 @@ class ConsumersTab implements MonitorTab {
                         Constraint.length(22),
                         Constraint.length(22),
                         Constraint.fill())
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Consumers sort:" + sort + " ").build())
                 .build();
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramSupport.java
@@ -42,6 +42,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
@@ -736,7 +737,7 @@ class DiagramSupport {
 
     void renderNativeDiagram(Frame frame, Rect area, Line title, boolean metrics) {
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(title))
                 .build();
         frame.renderWidget(block, area);
@@ -830,7 +831,7 @@ class DiagramSupport {
         frame.renderWidget(Clear.INSTANCE, previewRect);
 
         Block previewBlock = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(Line.from(Span.styled(" Route ", Style.EMPTY.dim()))))
                 .build();
         frame.renderWidget(previewBlock, previewRect);
@@ -1209,7 +1210,7 @@ class DiagramSupport {
             Frame frame, Rect area, Line title, boolean metrics,
             String currentRouteId, RouteDiagramLayoutEngine.LayoutRoute routeLayout) {
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(title))
                 .build();
         frame.renderWidget(block, area);
@@ -1294,7 +1295,7 @@ class DiagramSupport {
         frame.renderWidget(Clear.INSTANCE, mapRect);
 
         Block mapBlock = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(Line.from(Span.styled(" Map ", Style.EMPTY.dim()))))
                 .build();
         frame.renderWidget(mapBlock, mapRect);
@@ -1652,7 +1653,7 @@ class DiagramSupport {
         }
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(title))
                 .build();
         frame.renderWidget(block, area);
@@ -1725,7 +1726,7 @@ class DiagramSupport {
         }
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(title))
                 .build();
         frame.renderWidget(block, area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -33,6 +33,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.util.TimeUtils;
 import org.apache.camel.util.json.JsonArray;
@@ -376,7 +377,7 @@ class DiagramTab implements MonitorTab {
                         .text(Text.from(Line.from(Span.styled(
                                 "Loading diagram...",
                                 Style.EMPTY.dim()))))
-                        .block(Block.builder().borderType(BorderType.ROUNDED)
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                 .title(" Diagram ").build())
                         .build(),
                 area);
@@ -511,7 +512,7 @@ class DiagramTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Info ").build())
                 .build();
         frame.renderWidget(paragraph, area);
@@ -615,7 +616,7 @@ class DiagramTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Info ").build())
                 .build();
         frame.renderWidget(paragraph, area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -33,6 +33,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
@@ -91,7 +92,7 @@ class DoctorPopup {
         Paragraph para = Paragraph.builder()
                 .text(Text.from(lines.toArray(Line[]::new)))
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" 🩺 Doctor ")
                         .build())
                 .build();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -35,6 +35,7 @@ import dev.tamboui.text.Span;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.sparkline.DualSparkline;
@@ -225,7 +226,7 @@ class EndpointsTab implements MonitorTab {
                 .widths(widths.toArray(Constraint[]::new))
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Endpoints sort:" + sort
                                + (filter == 1 ? " filter:remote" : filter == 2 ? " filter:remote+stub" : "")
                                + " ")
@@ -409,7 +410,7 @@ class EndpointsTab implements MonitorTab {
 
         frame.renderWidget(Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(flowLines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Flow ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Flow ").build())
                 .build(), hSplit.get(0));
 
         Map<String, LinkedList<Long>> inHistMap = switch (filter) {
@@ -456,7 +457,7 @@ class EndpointsTab implements MonitorTab {
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(chartTitle)).build())
                 .build(), rightArea);
     }
@@ -520,7 +521,7 @@ class EndpointsTab implements MonitorTab {
 
         frame.renderWidget(Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(flowLines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Flow ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Flow ").build())
                 .build(), hSplit.get(0));
 
         // Per-endpoint sparkline
@@ -566,7 +567,7 @@ class EndpointsTab implements MonitorTab {
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(chartTitle)).build())
                 .build(), hSplit.get(1));
     }
@@ -605,7 +606,7 @@ class EndpointsTab implements MonitorTab {
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(chartTitle)).build())
                 .build(), area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -33,6 +33,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
 import dev.tamboui.widgets.table.Cell;
@@ -363,7 +364,7 @@ class ErrorsTab implements MonitorTab {
                         Constraint.fill())
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Errors (" + sorted.size() + ") sort:" + sort + " ").build())
                 .build();
 
@@ -584,7 +585,7 @@ class ErrorsTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled("No error selected", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Info ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Info ").build())
                             .build(),
                     area);
             return;
@@ -653,7 +654,7 @@ class ErrorsTab implements MonitorTab {
 
         Paragraph.Builder pb = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Info ").build());
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Info ").build());
         if (wordWrap) {
             pb.overflow(Overflow.WRAP_WORD);
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FilesBrowser.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FilesBrowser.java
@@ -36,6 +36,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.list.ListItem;
 import dev.tamboui.widgets.list.ListState;
@@ -192,7 +193,7 @@ class FilesBrowser {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.NONE)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(Line
                                 .from(Span.styled(" Files: " + title + " ", Style.EMPTY.fg(Color.YELLOW).bold()))))
                         .build())

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
@@ -28,6 +28,7 @@ import dev.tamboui.text.Span;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
@@ -154,7 +155,7 @@ class HealthTab implements MonitorTab {
                         Constraint.length(12),
                         Constraint.length(6),
                         Constraint.fill())
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, tableState);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
@@ -28,6 +28,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 
 import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.hint;
@@ -91,7 +92,7 @@ class HelpOverlay {
         Rect popup = new Rect(area.left() + 2, area.top() + 1, area.width() - 4, area.height() - 2);
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(" Help ")
                 .titleBottom(Title.from(Line.from(
                         Span.styled(" F1/?", MonitorContext.HINT_KEY_STYLE), Span.raw(" close "),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -45,6 +45,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
@@ -739,7 +740,7 @@ class HistoryTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled("No step selected", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Info ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Info ").build())
                             .build(),
                     area);
             return;
@@ -855,7 +856,7 @@ class HistoryTab implements MonitorTab {
         boolean wordWrap = !diagramTraceSteps.isEmpty() ? traceWordWrap : historyWordWrap;
         Paragraph.Builder pb = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Info ").build());
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Info ").build());
         if (wordWrap) {
             pb.overflow(Overflow.WRAP_WORD);
         }
@@ -1067,7 +1068,7 @@ class HistoryTab implements MonitorTab {
                         Constraint.fill())
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(traceTitle).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(traceTitle).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, traceTableState);
@@ -1114,7 +1115,7 @@ class HistoryTab implements MonitorTab {
                             .text(Text.from(Line.from(
                                     Span.styled(" Select a trace step to view details",
                                             Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).build())
                             .build(),
                     area);
             return;
@@ -1219,7 +1220,7 @@ class HistoryTab implements MonitorTab {
                     Paragraph.builder()
                             .text(Text.from(Line.from(
                                     Span.styled("  No steps to display.", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Waterfall ").build())
                             .build(),
                     area);
@@ -1242,7 +1243,7 @@ class HistoryTab implements MonitorTab {
 
         String title = String.format(" Waterfall — %d steps ", forward.size());
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         Rect inner = block.inner(area);
@@ -1384,7 +1385,7 @@ class HistoryTab implements MonitorTab {
                             .text(Text.from(Line.from(
                                     Span.styled(" Select a history entry to view details",
                                             Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Detail ").build())
                             .build(),
                     area);
@@ -1789,8 +1790,8 @@ class HistoryTab implements MonitorTab {
                 Cell.from(Span.styled("BHPV", Style.EMPTY.bold())),
                 rightCell("ELAPSED", 10, Style.EMPTY.bold()));
         Block block = title instanceof Title t
-                ? Block.builder().borderType(BorderType.ROUNDED).title(t).build()
-                : Block.builder().borderType(BorderType.ROUNDED).title(title.toString()).build();
+                ? Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(t).build()
+                : Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title.toString()).build();
         return Table.builder()
                 .rows(rows)
                 .header(header)
@@ -1977,7 +1978,7 @@ class HistoryTab implements MonitorTab {
     static void renderDetailPanel(
             Frame frame, Rect area, List<Line> lines,
             boolean wordWrap, int[] hScroll, int[] scroll, ScrollbarState scrollState) {
-        Block block = Block.builder().borderType(BorderType.ROUNDED).build();
+        Block block = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).build();
         frame.renderWidget(block, area);
 
         Rect inner = block.inner(area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
@@ -46,6 +46,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.input.TextInput;
 import dev.tamboui.widgets.input.TextInputState;
@@ -883,7 +884,7 @@ class HttpTab implements MonitorTab {
                 Span.styled(method, methodStyle(method).bold()),
                 Span.raw(" " + probePathState.text() + " ")));
 
-        Block block = Block.builder().borderType(BorderType.ROUNDED).title(title).build();
+        Block block = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build();
         frame.renderWidget(block, area);
 
         int innerX = area.left() + 2;
@@ -1018,7 +1019,7 @@ class HttpTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(placeholder, Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -1052,7 +1053,7 @@ class HttpTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }
@@ -1065,7 +1066,7 @@ class HttpTab implements MonitorTab {
                     Paragraph.builder()
                             .text(Text.from(Line.from(
                                     Span.styled(" No requests yet", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -1108,7 +1109,7 @@ class HttpTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }
@@ -1277,7 +1278,7 @@ class HttpTab implements MonitorTab {
                         Constraint.length(8))
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, tableState);
@@ -1291,7 +1292,7 @@ class HttpTab implements MonitorTab {
                             .text(Text.from(Line.from(
                                     Span.styled(" Select an endpoint to view details",
                                             Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Detail ").build())
                             .build(),
                     area);
@@ -1350,7 +1351,7 @@ class HttpTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(detailTitle).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(detailTitle).build())
                         .build(),
                 area);
     }
@@ -1523,7 +1524,7 @@ class HttpTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(visible))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
@@ -30,6 +30,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -159,7 +160,7 @@ class InflightTab implements MonitorTab {
                         Constraint.fill(),
                         Constraint.length(14),
                         Constraint.length(22))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, tableState);
@@ -179,7 +180,7 @@ class InflightTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(text)
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(" Inflight ").build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Inflight ").build())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
@@ -42,6 +42,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.list.ListItem;
 import dev.tamboui.widgets.list.ListState;
@@ -256,7 +257,7 @@ class LogTab implements MonitorTab {
 
         if (logLoading && filteredLogEntries.isEmpty()) {
             Block loadingBlock = Block.builder()
-                    .borderType(BorderType.ROUNDED)
+                    .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                     .title(" Log ")
                     .build();
             frame.renderWidget(loadingBlock, area);
@@ -290,7 +291,7 @@ class LogTab implements MonitorTab {
             titleLine = Line.from(Span.raw(logLabel + " "));
         }
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(titleLine))
                 .build();
         frame.renderWidget(block, area);
@@ -424,7 +425,7 @@ class LogTab implements MonitorTab {
                 .highlightSymbol("")
                 .scrollMode(ScrollMode.NONE)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Set Log Level ")
                         .build())
                 .build();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
@@ -32,6 +32,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.list.ListItem;
 import dev.tamboui.widgets.list.ListState;
@@ -100,7 +101,7 @@ class McpLogPopup {
 
         if (entries == null || entries.isEmpty()) {
             Block block = Block.builder()
-                    .borderType(BorderType.ROUNDED)
+                    .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                     .title(" MCP Log ")
                     .titleBottom(Title.from(Line.from(
                             Span.styled(" Esc", MonitorContext.HINT_KEY_STYLE), Span.raw(" back "))))
@@ -155,7 +156,7 @@ class McpLogPopup {
                 .highlightSymbol("▸ ")
                 .scrollMode(ScrollMode.AUTO_SCROLL)
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" MCP Log ")
                         .build())
                 .build();
@@ -179,7 +180,7 @@ class McpLogPopup {
         }
 
         Block detailBlock = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(" Detail ")
                 .build();
         frame.renderWidget(detailBlock, area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -35,6 +35,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.dsl.jbang.core.common.PathUtils;
 import org.apache.camel.util.TimeUtils;
@@ -218,7 +219,7 @@ class MemoryTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Memory ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Memory ").build())
                 .build();
 
         frame.renderWidget(paragraph, area);
@@ -233,7 +234,7 @@ class MemoryTab implements MonitorTab {
         if (hist == null || hist.isEmpty()) {
             Paragraph p = Paragraph.builder()
                     .text(Text.from(Line.from(Span.styled("  Collecting heap data...", Style.EMPTY.dim()))))
-                    .block(Block.builder().borderType(BorderType.ROUNDED).title(" Heap Usage ").build())
+                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Heap Usage ").build())
                     .build();
             frame.renderWidget(p, area);
             return;
@@ -252,7 +253,7 @@ class MemoryTab implements MonitorTab {
         String title = String.format(" Heap Usage (%s / %s committed) ", formatBytes(info.heapMemUsed), formatBytes(ceiling));
 
         // Render the block border first
-        Block block = Block.builder().borderType(BorderType.ROUNDED).title(title).build();
+        Block block = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build();
         frame.renderWidget(block, area);
         Rect inner = block.inner(area);
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -40,6 +40,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
@@ -327,7 +328,7 @@ class MetricsTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Camel ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Camel ").build())
                 .build();
         frame.renderWidget(paragraph, area);
     }
@@ -425,7 +426,7 @@ class MetricsTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" JVM ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" JVM ").build())
                 .build();
         frame.renderWidget(paragraph, area);
     }
@@ -488,7 +489,7 @@ class MetricsTab implements MonitorTab {
                         Constraint.percentage(30),
                         Constraint.fill())
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(title).build())
                 .build();
 
@@ -512,7 +513,7 @@ class MetricsTab implements MonitorTab {
         String title = " Raw Metrics (" + rawLines.size() + " lines)" + ct + " [" + (rawTitle != null ? rawTitle : "") + "] ";
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         Rect inner = block.inner(area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContext.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContext.java
@@ -31,6 +31,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.TuiRunner;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
@@ -142,7 +143,7 @@ class MonitorContext {
                         .text(Text.from(Line.from(
                                 Span.styled(" Select an integration from the Overview tab (press 1)",
                                         Style.EMPTY.dim()))))
-                        .block(Block.builder().borderType(BorderType.ROUNDED)
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                 .title(" No integration selected ").build())
                         .build(),
                 area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -341,9 +341,11 @@ class OverviewTab implements MonitorTab {
             Rect chartArea = chartHSplit.get(0);
             Rect infoArea = chartHSplit.get(1);
 
+            Rect chartInner = Block.builder().borders(Borders.ALL).build().inner(chartArea);
+
             List<Rect> vChunks = Layout.vertical()
                     .constraints(Constraint.fill(), Constraint.length(1))
-                    .split(chartArea);
+                    .split(chartInner);
 
             List<Rect> hChunks = Layout.horizontal()
                     .constraints(Constraint.length(4), Constraint.fill())
@@ -351,7 +353,7 @@ class OverviewTab implements MonitorTab {
 
             Rect barChartArea = hChunks.get(1);
 
-            int innerBarCols = Math.max(2, barChartArea.width() - 2);
+            int innerBarCols = Math.max(2, barChartArea.width());
             int renderPoints = Math.min(MAX_SPARKLINE_POINTS, innerBarCols / 2);
 
             long[] mergedTotal = new long[renderPoints];
@@ -406,6 +408,10 @@ class OverviewTab implements MonitorTab {
                         Span.raw(String.format(" fail:%d ", curFailed)));
             }
 
+            Block chartBlock = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
+                    .title(Title.from(titleLine)).build();
+            frame.renderWidget(chartBlock, chartArea);
+
             List<BarGroup> groups = new ArrayList<>();
             for (int i = 0; i < renderPoints; i++) {
                 long failed = Math.min(mergedFailed[i], mergedTotal[i]);
@@ -422,22 +428,19 @@ class OverviewTab implements MonitorTab {
                     .barWidth(1)
                     .barGap(0)
                     .groupGap(0)
-                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
-                            .title(Title.from(titleLine)).build())
                     .build();
 
             frame.renderWidget(barChart, barChartArea);
 
-            int barRows = vChunks.get(0).height() - 2;
+            int barRows = vChunks.get(0).height();
             List<Line> yLines = new ArrayList<>();
             Style dimStyle = Style.EMPTY.dim();
-            for (int row = 0; row < vChunks.get(0).height(); row++) {
-                int barRow = row - 1;
-                if (barRow == 0) {
+            for (int row = 0; row < barRows; row++) {
+                if (row == 0) {
                     yLines.add(Line.from(Span.styled(String.format("%3d", maxTp), dimStyle)));
-                } else if (barRows > 4 && barRow == barRows / 2) {
+                } else if (barRows > 4 && row == barRows / 2) {
                     yLines.add(Line.from(Span.styled(String.format("%3d", maxTp / 2), dimStyle)));
-                } else if (barRow == barRows - 1) {
+                } else if (row == barRows - 1) {
                     yLines.add(Line.from(Span.styled("  0", dimStyle)));
                 } else {
                     yLines.add(Line.from(""));
@@ -446,7 +449,7 @@ class OverviewTab implements MonitorTab {
             frame.renderWidget(Paragraph.builder().text(Text.from(yLines)).build(), hChunks.get(0));
 
             if (!vChunks.get(1).isEmpty()) {
-                int barInnerStartX = barChartArea.x() + 1;
+                int barInnerStartX = barChartArea.x();
                 int xAxisY = vChunks.get(1).y();
                 int[][] markerIndices = {
                         { 0, renderPoints },

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -38,6 +38,7 @@ import dev.tamboui.widgets.barchart.BarChart;
 import dev.tamboui.widgets.barchart.BarGroup;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
@@ -326,7 +327,7 @@ class OverviewTab implements MonitorTab {
                         Constraint.length(12))
                 .highlightStyle(overviewHighlight)
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(" Overview ").build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Overview ").build())
                 .build();
 
         frame.renderStatefulWidget(table, chunks.get(0), tableState);
@@ -421,7 +422,7 @@ class OverviewTab implements MonitorTab {
                     .barWidth(1)
                     .barGap(0)
                     .groupGap(0)
-                    .block(Block.builder().borderType(BorderType.ROUNDED)
+                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                             .title(Title.from(titleLine)).build())
                     .build();
 
@@ -485,7 +486,7 @@ class OverviewTab implements MonitorTab {
                 sel = active.get(0);
             }
         }
-        Block infoBlock = Block.builder().borderType(BorderType.ROUNDED).build();
+        Block infoBlock = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).build();
         frame.renderWidget(infoBlock, area);
         Rect inner = infoBlock.inner(area);
         List<Line> lines = new ArrayList<>();
@@ -590,7 +591,7 @@ class OverviewTab implements MonitorTab {
     }
 
     private void renderInfraInfoPanel(Frame frame, Rect area, InfraInfo infra) {
-        Block infoBlock = Block.builder().borderType(BorderType.ROUNDED).build();
+        Block infoBlock = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).build();
         frame.renderWidget(infoBlock, area);
         Rect inner = infoBlock.inner(area);
         List<Line> lines = new ArrayList<>();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
@@ -32,6 +32,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
@@ -136,7 +137,7 @@ class ProcessTab implements MonitorTab {
             }
         }
 
-        Block block = Block.builder().borderType(BorderType.ROUNDED).title(" Process ").build();
+        Block block = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Process ").build();
         frame.renderWidget(block, area);
 
         Rect inner = block.inner(area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -34,6 +34,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -484,7 +485,7 @@ class RoutesTab implements MonitorTab {
                             .text(Text.from(Line.from(Span.styled(
                                     "Loading diagram...",
                                     Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Diagram ").build())
                             .build(),
                     area);
@@ -556,7 +557,7 @@ class RoutesTab implements MonitorTab {
                             Constraint.length(12))
                     .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                     .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                    .block(Block.builder().borderType(BorderType.ROUNDED)
+                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                             .title(" Top Routes sort:" + routeTopSort + " ").build())
                     .build();
         } else {
@@ -616,7 +617,7 @@ class RoutesTab implements MonitorTab {
                             Constraint.length(12))
                     .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                     .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                    .block(Block.builder().borderType(BorderType.ROUNDED)
+                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                             .title(" Routes sort:" + routeSort + " ").build())
                     .build();
         }
@@ -634,7 +635,8 @@ class RoutesTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled("No routes", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Processors ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Processors ")
+                                    .build())
                             .build(),
                     chunks.get(1));
         }
@@ -886,7 +888,7 @@ class RoutesTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Info ").build())
                 .build();
         frame.renderWidget(paragraph, area);
@@ -990,7 +992,7 @@ class RoutesTab implements MonitorTab {
 
         Paragraph paragraph = Paragraph.builder()
                 .text(Text.from(lines))
-                .block(Block.builder().borderType(BorderType.ROUNDED)
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" Info ").build())
                 .build();
         frame.renderWidget(paragraph, area);
@@ -1087,7 +1089,7 @@ class RoutesTab implements MonitorTab {
                             Constraint.length(8),
                             Constraint.length(6),
                             Constraint.length(8))
-                    .block(Block.builder().borderType(BorderType.ROUNDED)
+                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                             .title(" Top Processors [" + route.routeId + "] sort:" + routeTopSort + " ").build())
                     .build();
         } else {
@@ -1149,7 +1151,7 @@ class RoutesTab implements MonitorTab {
                             Constraint.length(8),
                             Constraint.length(14),
                             Constraint.length(12))
-                    .block(Block.builder().borderType(BorderType.ROUNDED)
+                    .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                             .title(" Processors [" + route.routeId + "] ").build())
                     .build();
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RunOptionsForm.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RunOptionsForm.java
@@ -29,6 +29,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.input.TextInput;
 import dev.tamboui.widgets.input.TextInputState;
 import dev.tamboui.widgets.paragraph.Paragraph;
@@ -422,7 +423,7 @@ class RunOptionsForm {
         }
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         frame.renderWidget(block, popup);
@@ -487,7 +488,7 @@ class RunOptionsForm {
         frame.renderWidget(Clear.INSTANCE, popup);
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(" Run: " + exampleTitle + " — Properties (2/2) ")
                 .build();
         frame.renderWidget(block, popup);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SendMessagePopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SendMessagePopup.java
@@ -37,6 +37,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.input.TextInput;
 import dev.tamboui.widgets.input.TextInputState;
@@ -692,7 +693,7 @@ class SendMessagePopup {
         title += " ";
 
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(Line.from(Span.styled(title, Style.EMPTY.fg(Color.YELLOW).bold()))))
                 .build();
         frame.renderWidget(block, area);
@@ -843,7 +844,7 @@ class SendMessagePopup {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(placeholder, Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -876,7 +877,7 @@ class SendMessagePopup {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }
@@ -889,7 +890,7 @@ class SendMessagePopup {
                     Paragraph.builder()
                             .text(Text.from(Line.from(
                                     Span.styled(" No messages sent yet", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -937,7 +938,7 @@ class SendMessagePopup {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ShellPanel.java
@@ -40,6 +40,7 @@ import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
@@ -201,7 +202,7 @@ class ShellPanel {
 
         // Render border matching other tabs
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(Title.from(Line.from(Span.styled(" Shell ", Style.EMPTY.bold()))))
                 .build();
         frame.renderWidget(block, area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -39,6 +39,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
@@ -223,7 +224,7 @@ class SourceViewer {
 
     void render(Frame frame, Rect area) {
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(buildTitle())
                 .build();
         Rect inner = block.inner(area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
@@ -40,6 +40,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.input.TextInputState;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
@@ -276,7 +277,7 @@ class SpansTab implements MonitorTab {
                             .text(Text.from(Line.from(
                                     Span.styled("  No OTel spans captured. Use --observe flag when running.",
                                             Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" OTel Spans ").build())
                             .build(),
                     area);
@@ -382,7 +383,7 @@ class SpansTab implements MonitorTab {
                         Constraint.length(12),
                         Constraint.length(7))
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
         frame.renderStatefulWidget(table, area, traceListState);
     }
@@ -427,7 +428,7 @@ class SpansTab implements MonitorTab {
         String title = String.format(" Trace %s — %d spans, %dms ",
                 shortId(selectedTraceId), nodes.size(), traceDuration);
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         Rect inner = block.inner(area);
@@ -598,7 +599,7 @@ class SpansTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED)
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                 .title(dev.tamboui.widgets.block.Title.from(
                                         Line.from(Span.styled(" " + spanLabel(span) + " ", titleStyle))))
                                 .build())

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
@@ -35,6 +35,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
@@ -143,7 +144,7 @@ class StartupTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled("  Loading startup data...", LABEL))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Startup Timeline ").build())
                             .build(),
                     area);
@@ -155,7 +156,7 @@ class StartupTab implements MonitorTab {
                     Paragraph.builder()
                             .text(Text.from(Line.from(
                                     Span.styled("  " + errorMessage, Style.EMPTY.fg(Color.LIGHT_RED)))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Startup Timeline ").build())
                             .build(),
                     area);
@@ -169,7 +170,7 @@ class StartupTab implements MonitorTab {
                                     Span.styled(
                                             "  No startup data available. The integration may not have a startup recorder enabled.",
                                             LABEL))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED)
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Startup Timeline ").build())
                             .build(),
                     area);
@@ -178,7 +179,7 @@ class StartupTab implements MonitorTab {
 
         String title = String.format(" Startup Timeline — Total: %dms, Steps: %d ", totalDuration, steps.size());
         Block block = Block.builder()
-                .borderType(BorderType.ROUNDED)
+                .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                 .title(title)
                 .build();
         Rect inner = block.inner(area);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StopAllPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StopAllPopup.java
@@ -31,6 +31,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.Clear;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.PathUtils;
@@ -156,7 +157,7 @@ class StopAllPopup {
         Paragraph para = Paragraph.builder()
                 .text(Text.from(Line.from(""), intLine, infraLine))
                 .block(Block.builder()
-                        .borderType(BorderType.ROUNDED)
+                        .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(" 🛑 Stop All ")
                         .build())
                 .build();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
@@ -35,6 +35,7 @@ import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
@@ -189,7 +190,8 @@ class ThreadsTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Loading threads...", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Threads ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Threads ")
+                                    .build())
                             .build(),
                     area);
             return;
@@ -269,7 +271,7 @@ class ThreadsTab implements MonitorTab {
                         Constraint.length(14))
                 .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
-                .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
 
         frame.renderStatefulWidget(table, area, tableState);
@@ -281,7 +283,8 @@ class ThreadsTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" Select a thread", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(" Stack Trace ").build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(" Stack Trace ")
+                                    .build())
                             .build(),
                     area);
             return;
@@ -295,7 +298,7 @@ class ThreadsTab implements MonitorTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(Span.styled(" No stack trace available", Style.EMPTY.dim()))))
-                            .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                             .build(),
                     area);
             return;
@@ -322,7 +325,7 @@ class ThreadsTab implements MonitorTab {
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))
-                        .block(Block.builder().borderType(BorderType.ROUNDED).title(title).build())
+                        .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/BorderRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/BorderRenderTest.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.widgets.block.BorderType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates that TUI tabs render with proper rounded borders separating panes. These tests render each tab into a
+ * virtual terminal buffer and verify that the expected border box-drawing characters (╭ ╮ ╰ ╯ │ ─) appear in the
+ * correct positions.
+ */
+class BorderRenderTest {
+
+    // Rounded border characters used by BorderType.ROUNDED
+    private static final String TOP_LEFT = "╭";
+    private static final String TOP_RIGHT = "╮";
+    private static final String BOTTOM_LEFT = "╰";
+    private static final String BOTTOM_RIGHT = "╯";
+    private static final String VERTICAL = "│";
+    private static final String HORIZONTAL = "─";
+
+    private MonitorContext ctx;
+    private IntegrationInfo info;
+
+    @BeforeEach
+    void setUp() {
+        info = new IntegrationInfo();
+        info.pid = "1234";
+        info.name = "test-app";
+
+        AtomicReference<List<IntegrationInfo>> data = new AtomicReference<>(List.of(info));
+        AtomicReference<List<InfraInfo>> infraData = new AtomicReference<>(List.of());
+        ctx = new MonitorContext(data, infraData);
+        ctx.selectedPid = "1234";
+    }
+
+    // ---- Border character verification for HealthTab ----
+
+    @Test
+    void healthTabRendersTopBorderCorners() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        assertTrue(containsSymbol(buffer, TOP_LEFT),
+                "HealthTab should render top-left rounded border corner ╭");
+        assertTrue(containsSymbol(buffer, TOP_RIGHT),
+                "HealthTab should render top-right rounded border corner ╮");
+    }
+
+    @Test
+    void healthTabRendersBottomBorderCorners() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        assertTrue(containsSymbol(buffer, BOTTOM_LEFT),
+                "HealthTab should render bottom-left rounded border corner ╰");
+        assertTrue(containsSymbol(buffer, BOTTOM_RIGHT),
+                "HealthTab should render bottom-right rounded border corner ╯");
+    }
+
+    @Test
+    void healthTabRendersVerticalBorders() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        assertTrue(containsSymbol(buffer, VERTICAL),
+                "HealthTab should render vertical border │");
+    }
+
+    @Test
+    void healthTabRendersHorizontalBorders() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        assertTrue(containsSymbol(buffer, HORIZONTAL),
+                "HealthTab should render horizontal border ─");
+    }
+
+    @Test
+    void healthTabBorderFormsCompleteBox() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        // Top row should have ╭ on the left and ╮ on the right
+        assertTrue(rowContainsSymbol(buffer, 0, TOP_LEFT),
+                "Top row should contain ╭");
+        assertTrue(rowContainsSymbol(buffer, 0, TOP_RIGHT),
+                "Top row should contain ╮");
+
+        // Bottom row should have ╰ and ╯
+        int lastRow = buffer.height() - 1;
+        assertTrue(rowContainsSymbol(buffer, lastRow, BOTTOM_LEFT),
+                "Bottom row should contain ╰");
+        assertTrue(rowContainsSymbol(buffer, lastRow, BOTTOM_RIGHT),
+                "Bottom row should contain ╯");
+
+        // Middle rows should have │ on both sides
+        assertTrue(rowContainsSymbol(buffer, 1, VERTICAL),
+                "Content rows should have vertical borders │");
+    }
+
+    @Test
+    void healthTabLeftAndRightBordersAligned() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        // Find the x-coordinates of the top-left corner
+        int leftX = findSymbolX(buffer, 0, TOP_LEFT);
+        int rightX = findSymbolX(buffer, 0, TOP_RIGHT);
+        assertTrue(leftX >= 0, "Should find top-left corner");
+        assertTrue(rightX >= 0, "Should find top-right corner");
+
+        // The left vertical border should be at the same X as top-left corner
+        for (int y = 1; y < buffer.height() - 1; y++) {
+            String sym = buffer.get(leftX, y).symbol();
+            assertTrue(VERTICAL.equals(sym),
+                    "Left border at row " + y + " should be │ but was '" + sym + "'");
+        }
+
+        // The right vertical border should be at the same X as top-right corner
+        for (int y = 1; y < buffer.height() - 1; y++) {
+            String sym = buffer.get(rightX, y).symbol();
+            assertTrue(VERTICAL.equals(sym),
+                    "Right border at row " + y + " should be │ but was '" + sym + "'");
+        }
+    }
+
+    // ---- Border character verification for RoutesTab ----
+
+    @Test
+    void routesTabRendersRoundedBorderBox() {
+        addRoute("route1", "timer://tick", "Started");
+        RoutesTab tab = new RoutesTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 140, 30);
+
+        assertTrue(containsSymbol(buffer, TOP_LEFT), "RoutesTab should render ╭");
+        assertTrue(containsSymbol(buffer, TOP_RIGHT), "RoutesTab should render ╮");
+        assertTrue(containsSymbol(buffer, BOTTOM_LEFT), "RoutesTab should render ╰");
+        assertTrue(containsSymbol(buffer, BOTTOM_RIGHT), "RoutesTab should render ╯");
+        assertTrue(containsSymbol(buffer, VERTICAL), "RoutesTab should render │");
+        assertTrue(containsSymbol(buffer, HORIZONTAL), "RoutesTab should render ─");
+    }
+
+    @Test
+    void routesTabWithProcessorsHasTwoBorderBoxes() {
+        RouteInfo route = addRoute("route1", "timer://tick", "Started");
+        ProcessorInfo proc = new ProcessorInfo();
+        proc.id = "log1";
+        proc.processor = "log";
+        proc.level = 1;
+        proc.total = 50;
+        route.processors.add(proc);
+
+        RoutesTab tab = new RoutesTab(ctx);
+        Buffer buffer = renderToBuffer(tab, 140, 30);
+
+        // Count the number of ╭ corners — should be at least 2 (Routes block + Processors block)
+        int topLeftCount = countSymbol(buffer, TOP_LEFT);
+        assertTrue(topLeftCount >= 2,
+                "RoutesTab with processors should have at least 2 border boxes, found " + topLeftCount + " ╭ corners");
+    }
+
+    @Test
+    void routesTabProcessorsSectionHasSeparateBorder() {
+        RouteInfo route = addRoute("route1", "timer://tick", "Started");
+        ProcessorInfo proc = new ProcessorInfo();
+        proc.id = "log1";
+        proc.processor = "log";
+        proc.level = 1;
+        route.processors.add(proc);
+
+        RoutesTab tab = new RoutesTab(ctx);
+        String rendered = renderToString(tab, 140, 30);
+
+        // The Processors section should have its own bordered block with title
+        assertTrue(rendered.contains("Processors"),
+                "Should render Processors section with border title");
+
+        // Count ╰ (bottom-left corners) — at least 2 blocks
+        Buffer buffer = renderToBuffer(tab, 140, 30);
+        int bottomLeftCount = countSymbol(buffer, BOTTOM_LEFT);
+        assertTrue(bottomLeftCount >= 2,
+                "Should have at least 2 bottom-left corners (Routes + Processors), found " + bottomLeftCount);
+    }
+
+    // ---- Border character verification for ErrorsTab ----
+
+    @Test
+    void errorsTabRendersRoundedBorderBox() {
+        addError("ID-001", "route1", "to1", "IOException", "Connection refused", false);
+        ErrorsTab tab = new ErrorsTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 160, 30);
+
+        assertTrue(containsSymbol(buffer, TOP_LEFT), "ErrorsTab should render ╭");
+        assertTrue(containsSymbol(buffer, TOP_RIGHT), "ErrorsTab should render ╮");
+        assertTrue(containsSymbol(buffer, BOTTOM_LEFT), "ErrorsTab should render ╰");
+        assertTrue(containsSymbol(buffer, BOTTOM_RIGHT), "ErrorsTab should render ╯");
+    }
+
+    @Test
+    void errorsTabEmptyStateHasBorder() {
+        // No errors added
+        ErrorsTab tab = new ErrorsTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 160, 20);
+
+        assertTrue(containsSymbol(buffer, TOP_LEFT),
+                "ErrorsTab empty state should still have border ╭");
+        assertTrue(containsSymbol(buffer, VERTICAL),
+                "ErrorsTab empty state should still have vertical border │");
+    }
+
+    // ---- Border character verification for no-selection state ----
+
+    @Test
+    void noSelectionRendersRoundedBorder() {
+        ctx.selectedPid = null;
+
+        HealthTab tab = new HealthTab(ctx);
+        Buffer buffer = renderToBuffer(tab, 100, 10);
+
+        // The "No integration selected" block should have rounded borders
+        assertTrue(containsSymbol(buffer, VERTICAL),
+                "No-selection block should have vertical borders │");
+        assertTrue(containsSymbol(buffer, HORIZONTAL),
+                "No-selection block should have horizontal borders ─");
+    }
+
+    // ---- Border type validation ----
+
+    @Test
+    void roundedBorderTypeUsesCorrectCharacters() {
+        // Verify the border characters match what ROUNDED type produces
+        var borderSet = BorderType.ROUNDED.set();
+
+        assertTrue(borderSet.topLeft().equals(TOP_LEFT),
+                "ROUNDED topLeft should be ╭, got: " + borderSet.topLeft());
+        assertTrue(borderSet.topRight().equals(TOP_RIGHT),
+                "ROUNDED topRight should be ╮, got: " + borderSet.topRight());
+        assertTrue(borderSet.bottomLeft().equals(BOTTOM_LEFT),
+                "ROUNDED bottomLeft should be ╰, got: " + borderSet.bottomLeft());
+        assertTrue(borderSet.bottomRight().equals(BOTTOM_RIGHT),
+                "ROUNDED bottomRight should be ╯, got: " + borderSet.bottomRight());
+        assertTrue(borderSet.leftVertical().equals(VERTICAL),
+                "ROUNDED leftVertical should be │, got: " + borderSet.leftVertical());
+        assertTrue(borderSet.topHorizontal().equals(HORIZONTAL),
+                "ROUNDED topHorizontal should be ─, got: " + borderSet.topHorizontal());
+    }
+
+    // ---- ShellPanel border test ----
+
+    @Test
+    void shellPanelRendersWithBorder() {
+        ShellPanel panel = new ShellPanel();
+        panel.setContext(ctx);
+        panel.open(); // Must open before render — render returns early if !visible
+
+        Rect area = new Rect(0, 0, 80, 10);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        panel.render(frame, area);
+        panel.destroy(); // Cleanup shell process
+
+        assertTrue(containsSymbol(buffer, TOP_LEFT),
+                "ShellPanel should render with rounded border ╭");
+        assertTrue(containsSymbol(buffer, VERTICAL),
+                "ShellPanel should render with vertical border │");
+
+        String rendered = HealthTabRenderTest.bufferToString(buffer);
+        assertTrue(rendered.contains("Shell"),
+                "ShellPanel should show 'Shell' in border title");
+    }
+
+    // ---- Multiple adjacent panes maintain borders ----
+
+    @Test
+    void routesTabSplitPanesEachHaveOwnBorder() {
+        RouteInfo route = addRoute("route1", "timer://tick", "Started");
+        ProcessorInfo proc = new ProcessorInfo();
+        proc.id = "log1";
+        proc.processor = "log";
+        proc.level = 1;
+        route.processors.add(proc);
+
+        RoutesTab tab = new RoutesTab(ctx);
+        Buffer buffer = renderToBuffer(tab, 140, 30);
+
+        // Find all rows that have ╭ (top border of a pane)
+        int topBorderRowCount = 0;
+        for (int y = 0; y < buffer.height(); y++) {
+            if (rowContainsSymbol(buffer, y, TOP_LEFT)) {
+                topBorderRowCount++;
+            }
+        }
+        assertTrue(topBorderRowCount >= 2,
+                "Adjacent panes should each start with their own top border row, found " + topBorderRowCount);
+
+        // Find all rows that have ╰ (bottom border of a pane)
+        int bottomBorderRowCount = 0;
+        for (int y = 0; y < buffer.height(); y++) {
+            if (rowContainsSymbol(buffer, y, BOTTOM_LEFT)) {
+                bottomBorderRowCount++;
+            }
+        }
+        assertTrue(bottomBorderRowCount >= 2,
+                "Adjacent panes should each end with their own bottom border row, found " + bottomBorderRowCount);
+    }
+
+    @Test
+    void routesTabPaneBordersDoNotOverlap() {
+        RouteInfo route = addRoute("route1", "timer://tick", "Started");
+        ProcessorInfo proc = new ProcessorInfo();
+        proc.id = "log1";
+        proc.processor = "log";
+        proc.level = 1;
+        route.processors.add(proc);
+
+        RoutesTab tab = new RoutesTab(ctx);
+        Buffer buffer = renderToBuffer(tab, 140, 30);
+
+        // Find rows of the first ╰ (end of first pane) and second ╭ (start of second pane)
+        int firstBottomRow = -1;
+        int secondTopRow = -1;
+        int topCount = 0;
+        for (int y = 0; y < buffer.height(); y++) {
+            if (rowContainsSymbol(buffer, y, TOP_LEFT)) {
+                topCount++;
+                if (topCount == 2) {
+                    secondTopRow = y;
+                }
+            }
+            if (firstBottomRow < 0 && rowContainsSymbol(buffer, y, BOTTOM_LEFT)) {
+                firstBottomRow = y;
+            }
+        }
+
+        if (firstBottomRow >= 0 && secondTopRow >= 0) {
+            assertTrue(secondTopRow >= firstBottomRow,
+                    "Second pane's top border (row " + secondTopRow
+                                                       + ") should not start before first pane's bottom border (row "
+                                                       + firstBottomRow + ")");
+        }
+    }
+
+    @Test
+    void allBorderCornersAppearOnBoundaryRows() {
+        addHealthCheck("camel", "context", "UP");
+        HealthTab tab = new HealthTab(ctx);
+
+        Buffer buffer = renderToBuffer(tab, 120, 20);
+
+        // ╭ and ╮ should be on the same row (top border)
+        int topLeftRow = findSymbolRow(buffer, TOP_LEFT);
+        int topRightRow = findSymbolRow(buffer, TOP_RIGHT);
+        assertTrue(topLeftRow == topRightRow,
+                "╭ (row " + topLeftRow + ") and ╮ (row " + topRightRow + ") should be on the same row");
+
+        // ╰ and ╯ should be on the same row (bottom border)
+        int bottomLeftRow = findSymbolRow(buffer, BOTTOM_LEFT);
+        int bottomRightRow = findSymbolRow(buffer, BOTTOM_RIGHT);
+        assertTrue(bottomLeftRow == bottomRightRow,
+                "╰ (row " + bottomLeftRow + ") and ╯ (row " + bottomRightRow + ") should be on the same row");
+    }
+
+    // ---- Helper methods ----
+
+    private void addHealthCheck(String group, String name, String state) {
+        HealthCheckInfo hc = new HealthCheckInfo();
+        hc.group = group;
+        hc.name = name;
+        hc.state = state;
+        hc.readiness = true;
+        info.healthChecks.add(hc);
+    }
+
+    private RouteInfo addRoute(String routeId, String from, String state) {
+        RouteInfo route = new RouteInfo();
+        route.routeId = routeId;
+        route.from = from;
+        route.state = state;
+        route.uptime = "10s";
+        info.routes.add(route);
+        return route;
+    }
+
+    private void addError(
+            String exchangeId, String routeId, String nodeId,
+            String exceptionType, String message, boolean handled) {
+        ErrorInfo ei = new ErrorInfo();
+        ei.exchangeId = exchangeId;
+        ei.routeId = routeId;
+        ei.nodeId = nodeId;
+        ei.exceptionType = exceptionType;
+        ei.exceptionMessage = message;
+        ei.handled = handled;
+        ei.timestamp = System.currentTimeMillis();
+        info.errors.add(ei);
+    }
+
+    private static Buffer renderToBuffer(MonitorTab tab, int width, int height) {
+        Rect area = new Rect(0, 0, width, height);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        tab.render(frame, area);
+        return buffer;
+    }
+
+    private static String renderToString(MonitorTab tab, int width, int height) {
+        Buffer buffer = renderToBuffer(tab, width, height);
+        return HealthTabRenderTest.bufferToString(buffer);
+    }
+
+    /**
+     * Check if the buffer contains a cell with the given symbol anywhere.
+     */
+    private static boolean containsSymbol(Buffer buffer, String symbol) {
+        for (int y = 0; y < buffer.height(); y++) {
+            for (int x = 0; x < buffer.width(); x++) {
+                if (symbol.equals(buffer.get(x, y).symbol())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Count occurrences of a symbol in the buffer.
+     */
+    private static int countSymbol(Buffer buffer, String symbol) {
+        int count = 0;
+        for (int y = 0; y < buffer.height(); y++) {
+            for (int x = 0; x < buffer.width(); x++) {
+                if (symbol.equals(buffer.get(x, y).symbol())) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Check if a specific row contains the given symbol.
+     */
+    private static boolean rowContainsSymbol(Buffer buffer, int row, String symbol) {
+        for (int x = 0; x < buffer.width(); x++) {
+            if (symbol.equals(buffer.get(x, row).symbol())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Find the X coordinate of the first occurrence of a symbol in a row. Returns -1 if not found.
+     */
+    private static int findSymbolX(Buffer buffer, int row, String symbol) {
+        for (int x = 0; x < buffer.width(); x++) {
+            if (symbol.equals(buffer.get(x, row).symbol())) {
+                return x;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Find the first row containing the given symbol. Returns -1 if not found.
+     */
+    private static int findSymbolRow(Buffer buffer, String symbol) {
+        for (int y = 0; y < buffer.height(); y++) {
+            for (int x = 0; x < buffer.width(); x++) {
+                if (symbol.equals(buffer.get(x, y).symbol())) {
+                    return y;
+                }
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of forgebot_

Fixes missing pane borders in the TUI dashboard. TamboUI's `Block` widget requires **both** `.borderType()` and `.borders(Borders.ALL)` to render border characters. All 131 `Block.builder()` calls across the TUI module were missing `.borders(Borders.ALL)`, causing no rounded border box-drawing characters (`╭╮╰╯│─`) to render around any pane.

**Before (no borders):**
```
 Routes sort:name
   ROUTE   FROM      STATUS   AGE   TOTAL  FAIL
   route1  timer://  Started  10s       0     0

 Processors [route1]
   TYPE    PROCESSOR   TOTAL  FAIL
   log     log1           50     0
```

**After (borders restored):**
```
╭ Routes sort:name ────────────────────────────────────╮
│  ROUTE   FROM      STATUS   AGE   TOTAL  FAIL       │
│  route1  timer://  Started  10s       0     0        │
╰──────────────────────────────────────────────────────╯
╭ Processors [route1] ────────────────────────────────╮
│  TYPE    PROCESSOR   TOTAL  FAIL                     │
│  log     log1           50     0                     │
╰──────────────────────────────────────────────────────╯
```

### Changes
- **36 source files**: Added `.borders(Borders.ALL)` after every `.borderType(BorderType.ROUNDED)` call and added `import dev.tamboui.widgets.block.Borders`
- **1 new test file** (`BorderRenderTest.java`): 17 rendering tests that render tabs into a virtual terminal buffer via `Frame.forTesting(Buffer)` and verify border characters appear at the correct positions
- **Layout cleanup**: Removed empty spacer rows above/below the tab bar (borders provide sufficient separation), moved chart y-axis/x-axis labels inside the chart border so the panel aligns with adjacent panes

### Test Coverage (BorderRenderTest — 17 tests)
- HealthTab: top/bottom corners, vertical/horizontal borders, complete box formation, left/right border alignment
- RoutesTab: full border box, dual pane borders (routes + processors), separate borders for each pane, non-overlapping borders
- ErrorsTab: border box with data, border box in empty state
- No-selection: border in unselected state
- ShellPanel: border rendering when panel is open
- Border type validation: `BorderType.ROUNDED` characters match expected Unicode codepoints
- Corner alignment: `╭`/`╮` on same row, `╰`/`╯` on same row

## Test plan
- [x] All 248 tests pass locally (231 existing + 17 new border tests)
- [x] Rendering tests validate actual border characters (`╭╮╰╯│─`) in the virtual terminal buffer
- [x] Code formatted with `mvn formatter:format impsort:sort`
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)