### PR TITLE
CAMEL-23851: camel-debug - Fix breakpoint on first EIP incorrectly stopping at route input

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultChannel.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultChannel.java
@@ -347,10 +347,14 @@ public class DefaultChannel extends CamelInternalProcessor implements Channel {
         // setup initial breakpoints
         if (debugger.getInitialBreakpoints() != null) {
             boolean match = false;
+            boolean allRoutes = false;
             String id = definition.getId();
             for (String pattern : debugger.getInitialBreakpoints().split(",")) {
                 pattern = pattern.trim();
-                match |= BacklogDebugger.BREAKPOINT_ALL_ROUTES.equals(pattern) && first;
+                if (BacklogDebugger.BREAKPOINT_ALL_ROUTES.equals(pattern) && first) {
+                    match = true;
+                    allRoutes = true;
+                }
                 if (!match) {
                     match = PatternHelper.matchPattern(id, pattern);
                 }
@@ -387,13 +391,12 @@ public class DefaultChannel extends CamelInternalProcessor implements Channel {
                 }
             }
             if (match) {
-                if (first && debugger.isSingleStepIncludeStartEnd()) {
-                    // we want route to be breakpoint (use input)
+                if (allRoutes && first && debugger.isSingleStepIncludeStartEnd()) {
+                    // all routes breakpoint: we want route to be breakpoint (use input)
                     id = routeDefinition.getInput().getId();
                     debugger.addBreakpoint(id);
                     LOG.debug("BacklogDebugger added breakpoint: {}", id);
                 } else {
-                    // first output should also be breakpoint
                     id = targetOutputDef.getId();
                     debugger.addBreakpoint(id);
                     LOG.debug("BacklogDebugger added breakpoint: {}", id);


### PR DESCRIPTION
## Summary

- Fix bug where `camel debug --breakpoint=setBody` stops at the route input (timer/from) instead of the `setBody` EIP when it is the first step in the route
- The `singleStepIncludeStartEnd` route-input replacement now only applies to `_all_routes_` breakpoints, not explicit user-specified breakpoints

## Root cause

In `DefaultChannel.backlogDebuggerSetupInitialBreakpoints()`, when a breakpoint pattern matches and the matched node is the first output in the route, the code replaces the breakpoint target with the route input node (the `from`). This was intended for `_all_routes_` breakpoints (where you want to start from the beginning of each route) but was incorrectly applied to all breakpoints including explicit ones like `setBody`.

## Fix

Added an `allRoutes` flag to track whether the match came from `_all_routes_`. The route-input replacement now requires `allRoutes && first && singleStepIncludeStartEnd`.

## Test plan

- [x] Verified manually with `camel debug route.yaml --breakpoint=setBody` — now stops at `setBody` instead of the timer

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>