### PR TITLE
fix: make TUI charts fill available width on wide terminals

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
@@ -49,7 +49,7 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.*;
 class CircuitBreakerTab implements MonitorTab {
 
     private static final String[] SORT_COLUMNS = { "route", "id", "component", "state" };
-    private static final int MAX_CHART_POINTS = 60;
+    private static final int MAX_CHART_POINTS = 300;
 
     private final MonitorContext ctx;
     private final TableState tableState = new TableState();
@@ -352,7 +352,7 @@ class CircuitBreakerTab implements MonitorTab {
 
         LinkedList<Long> successHist = cbSuccessHistory.get(key);
         LinkedList<Long> failHist = cbFailHistory.get(key);
-        int renderPoints = MAX_CHART_POINTS;
+        int renderPoints = Math.min(MAX_CHART_POINTS, Math.max(2, vSplit.get(1).width() - 6));
         long[] successArr = new long[renderPoints];
         long[] failArr = new long[renderPoints];
         if (successHist != null) {
@@ -384,7 +384,8 @@ class CircuitBreakerTab implements MonitorTab {
                 .topStyle(Style.EMPTY.fg(Color.GREEN))
                 .bottomStyle(Style.EMPTY.fg(Color.LIGHT_RED))
                 .showYAxis(true)
-                .xLabels("-60s", "-45s", "-30s", "-15s", "now")
+                .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
+                        "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
                 .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(chartTitle)).build())
                 .build(), vSplit.get(1));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -51,7 +51,7 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.MonitorContext.*;
 class EndpointsTab implements MonitorTab {
 
     private static final String[] SORT_COLUMNS = { "component", "route", "dir", "total", "body", "hdr", "uri" };
-    private static final int MAX_CHART_POINTS = 60;
+    private static final int MAX_CHART_POINTS = 300;
     private static final int CHART_ALL = 0;
     private static final int CHART_SINGLE = 1;
     private static final int CHART_OFF = 2;
@@ -426,7 +426,7 @@ class EndpointsTab implements MonitorTab {
         LinkedList<Long> inHist = inHistMap.getOrDefault(pid, new LinkedList<>());
         LinkedList<Long> outHist = outHistMap.getOrDefault(pid, new LinkedList<>());
 
-        int renderPoints = MAX_CHART_POINTS;
+        int renderPoints = Math.min(MAX_CHART_POINTS, Math.max(2, hSplit.get(1).width() - 6));
         long[] inArr = new long[renderPoints];
         long[] outArr = new long[renderPoints];
         for (int i = 0; i < renderPoints; i++) {
@@ -529,7 +529,7 @@ class EndpointsTab implements MonitorTab {
         LinkedList<Long> inHist = perEndpointInHistory.getOrDefault(key, new LinkedList<>());
         LinkedList<Long> outHist = perEndpointOutHistory.getOrDefault(key, new LinkedList<>());
 
-        int renderPoints = MAX_CHART_POINTS;
+        int renderPoints = Math.min(MAX_CHART_POINTS, Math.max(2, hSplit.get(1).width() - 6));
         long[] inArr = new long[renderPoints];
         long[] outArr = new long[renderPoints];
         for (int i = 0; i < renderPoints; i++) {
@@ -576,7 +576,7 @@ class EndpointsTab implements MonitorTab {
         LinkedList<Long> inHist = endpointInSizeHistory.getOrDefault(pid, new LinkedList<>());
         LinkedList<Long> outHist = endpointOutSizeHistory.getOrDefault(pid, new LinkedList<>());
 
-        int renderPoints = MAX_CHART_POINTS;
+        int renderPoints = Math.min(MAX_CHART_POINTS, Math.max(2, area.width() - 6));
         long[] inArr = new long[renderPoints];
         long[] outArr = new long[renderPoints];
         for (int i = 0; i < renderPoints; i++) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsCollector.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsCollector.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 class MetricsCollector {
 
-    static final int MAX_SPARKLINE_POINTS = 60;
-    static final int MAX_ENDPOINT_CHART_POINTS = 60;
+    static final int MAX_SPARKLINE_POINTS = 300;
+    static final int MAX_ENDPOINT_CHART_POINTS = 300;
     static final int MAX_HEAP_HISTORY_POINTS = 120;
     static final long HEAP_SAMPLE_INTERVAL_MS = 5000;
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -71,7 +71,7 @@ class OverviewTab implements MonitorTab {
     }
 
     private static final long VANISH_DURATION_MS = 6000;
-    private static final int MAX_SPARKLINE_POINTS = 60;
+    private static final int MAX_SPARKLINE_POINTS = 300;
     private static final String[] SORT_COLUMNS = { "pid", "name", "version", "status", "total", "fail" };
 
     static final int CHART_ALL = 0;


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Charts previously used a fixed 60-point history buffer which left significant empty space on wide terminals. This PR makes charts dynamically size to fill the available width.

### Changes
- **MetricsCollector**: Increase history buffer caps from 60 to 300 points so enough data accumulates for wider terminals
- **OverviewTab**: Increase `MAX_SPARKLINE_POINTS` from 60 to 300 (bar chart `renderPoints` was already computed dynamically from available width)
- **EndpointsTab**: Increase `MAX_CHART_POINTS` from 60 to 300 and compute `renderPoints` dynamically from the chart area width in all three chart methods (`renderEndpointFlow`, `renderSingleEndpointChart`, `renderPayloadSizeChart`)

## Test plan
- [x] Build passes locally
- [x] Verified visually — sparklines and bar charts now fill their panels on wide terminals
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)