### PR TITLE
chore(deps): bump JLine from 4.2.1 to 4.3.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -296,7 +296,7 @@
         <jgroups-raft-version>1.1.4.Final</jgroups-raft-version>
         <jira-rest-client-api-version>6.0.2</jira-rest-client-api-version>
         <jira-sal-api-version>7.2.1</jira-sal-api-version>
-        <jline-version>4.2.1</jline-version>
+        <jline-version>4.3.1</jline-version>
         <libthrift-version>0.23.0</libthrift-version>
         <jodatime2-version>2.14.2</jodatime2-version>
         <jolokia-version>2.6.0</jolokia-version>


### PR DESCRIPTION
## Summary

- Bump JLine from 4.2.1 to 4.3.1
- JLine 4.3.0 adds public API for `ScreenTerminal` scrollback history and cell decoding (jline/jline3#1996), enabling cleanup of reflection in the TUI shell panel (follow-up in #24328)
- JLine 4.3.1 fixes ReDoS vulnerabilities (GHSA-r2xf-8xr9-62gw, GHSA-2v9w-34q6-wpqx, GHSA-ph9c-7hw9-vhhw, GHSA-5q95-hrpc-m3w3)

## Test plan

- [x] CI build passes
- [x] TUI module compiles and tests pass

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)