### PR TITLE
CAMEL-23865: Use EWMA smoothing for throughput and fix TUI sparkline scaling

### DIFF
--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/LoadThroughput.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/LoadThroughput.java
@@ -48,7 +48,7 @@ public final class LoadThroughput {
             if (time > 0) {
                 long delta = currentReading - last;
                 // instantaneous rate in exchanges/second for this interval
-                double instantRate = (1000d / time) * delta;
+                double instantRate = Math.max(0, (1000d / time) * delta);
                 // apply EWMA smoothing
                 thp = instantRate + EXP_1 * (thp - instantRate);
             }
@@ -61,6 +61,7 @@ public final class LoadThroughput {
     }
 
     public void reset() {
+        watch.stop();
         last = 0;
         thp = 0;
     }

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/LoadThroughput.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/LoadThroughput.java
@@ -19,18 +19,25 @@ package org.apache.camel.management.mbean;
 import org.apache.camel.util.StopWatch;
 
 /**
- * Holds the load throughput messages/second
+ * Holds the throughput (messages/second) using EWMA (exponentially weighted moving average) smoothing, modeled after
+ * Unix load averages (same approach as {@link LoadTriplet}).
+ *
+ * The instantaneous rate from each 1-second sampling interval is smoothed with a 1-minute decay window so that the
+ * reported value converges to the true average rate instead of oscillating between 0 and spike values.
  */
 public final class LoadThroughput {
+
+    // EWMA exponent for a 1-minute decay window, sampled every 1 second
+    private static final double EXP_1 = Math.exp(-1.0 / 60.0);
 
     private final StopWatch watch = new StopWatch(false);
     private long last;
     private double thp;
 
     /**
-     * Update the load statistics
+     * Update the throughput statistics
      *
-     * @param currentReading the current reading
+     * @param currentReading the current cumulative exchange count
      */
     public void update(long currentReading) {
         if (!watch.isStarted()) {
@@ -40,14 +47,10 @@ public final class LoadThroughput {
             long time = watch.takenAndRestart();
             if (time > 0) {
                 long delta = currentReading - last;
-                if (delta > 0) {
-                    // need to calculate with fractions
-                    thp = (1000d / time) * delta;
-                } else {
-                    thp = 0;
-                }
-            } else {
-                thp = 0;
+                // instantaneous rate in exchanges/second for this interval
+                double instantRate = (1000d / time) * delta;
+                // apply EWMA smoothing
+                thp = instantRate + EXP_1 * (thp - instantRate);
             }
         }
         last = currentReading;

--- a/core/camel-management/src/test/java/org/apache/camel/management/LoadThroughputTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/LoadThroughputTest.java
@@ -16,15 +16,17 @@
  */
 package org.apache.camel.management;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.camel.management.mbean.LoadThroughput;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledOnOs(OS.AIX)
 public class LoadThroughputTest {
 
     @Test
@@ -34,56 +36,55 @@ public class LoadThroughputTest {
     }
 
     @Test
-    public void testConvergesToSteadyRate() throws Exception {
+    public void testConvergesToSteadyRate() {
         LoadThroughput t = new LoadThroughput();
+        AtomicLong total = new AtomicLong(0);
+        t.update(total.get());
 
-        // simulate 1 exchange per second for 120 seconds (well past 1-minute EWMA window)
-        long total = 0;
-        t.update(total);
-        Thread.sleep(10);
-        for (int i = 0; i < 120; i++) {
-            total++;
-            Thread.sleep(10);
-            t.update(total);
-        }
-
-        // should converge close to the steady rate
-        assertTrue(t.getThroughput() > 0, "Throughput should be positive for steady input");
+        await().pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    total.incrementAndGet();
+                    t.update(total.get());
+                    assertTrue(t.getThroughput() > 5.0,
+                            "Throughput should converge toward steady rate: " + t.getThroughput());
+                });
     }
 
     @Test
-    public void testSmoothing() throws Exception {
+    public void testSmoothing() {
         LoadThroughput t = new LoadThroughput();
+        AtomicLong total = new AtomicLong(0);
+        AtomicInteger count = new AtomicInteger(0);
+        t.update(total.get());
 
-        // simulate a timer that fires every 5th update (like a 5s timer with 1s sampling)
-        // with 10ms sleep, effective rate is 1 exchange per 50ms ≈ 20 exchanges/sec
-        long total = 0;
-        t.update(total);
-        Thread.sleep(10);
-        for (int i = 1; i <= 100; i++) {
-            if (i % 5 == 0) {
-                total++;
-            }
-            Thread.sleep(10);
-            t.update(total);
-        }
-
-        double thp = t.getThroughput();
-        // the smoothed value should be positive and converging toward the average rate (~20/s)
-        // rather than oscillating between 0 and ~100 (the instantaneous spike)
-        assertTrue(thp > 1.0, "Smoothed throughput should be well above zero: " + thp);
-        assertTrue(thp < 80.0, "Smoothed throughput should be below the instantaneous spike: " + thp);
+        await().pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    int i = count.incrementAndGet();
+                    if (i % 5 == 0) {
+                        total.incrementAndGet();
+                    }
+                    t.update(total.get());
+                    double thp = t.getThroughput();
+                    assertTrue(thp > 1.0, "Smoothed throughput should be well above zero: " + thp);
+                    assertTrue(thp < 80.0, "Smoothed throughput should be below the instantaneous spike: " + thp);
+                });
     }
 
     @Test
-    public void testReset() throws Exception {
+    public void testReset() {
         LoadThroughput t = new LoadThroughput();
+        AtomicLong total = new AtomicLong(0);
+        t.update(total.get());
 
-        t.update(0);
-        Thread.sleep(10);
-        t.update(10);
-
-        assertTrue(t.getThroughput() > 0);
+        await().pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    total.addAndGet(10);
+                    t.update(total.get());
+                    assertTrue(t.getThroughput() > 0);
+                });
 
         t.reset();
         assertEquals(0.0, t.getThroughput());

--- a/core/camel-management/src/test/java/org/apache/camel/management/LoadThroughputTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/LoadThroughputTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.management;
+
+import org.apache.camel.management.mbean.LoadThroughput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisabledOnOs(OS.AIX)
+public class LoadThroughputTest {
+
+    @Test
+    public void testInitialValueIsZero() {
+        LoadThroughput t = new LoadThroughput();
+        assertEquals(0.0, t.getThroughput());
+    }
+
+    @Test
+    public void testConvergesToSteadyRate() throws Exception {
+        LoadThroughput t = new LoadThroughput();
+
+        // simulate 1 exchange per second for 120 seconds (well past 1-minute EWMA window)
+        long total = 0;
+        t.update(total);
+        Thread.sleep(10);
+        for (int i = 0; i < 120; i++) {
+            total++;
+            Thread.sleep(10);
+            t.update(total);
+        }
+
+        // should converge close to the steady rate
+        assertTrue(t.getThroughput() > 0, "Throughput should be positive for steady input");
+    }
+
+    @Test
+    public void testSmoothing() throws Exception {
+        LoadThroughput t = new LoadThroughput();
+
+        // simulate a timer that fires every 5th update (like a 5s timer with 1s sampling)
+        // with 10ms sleep, effective rate is 1 exchange per 50ms ≈ 20 exchanges/sec
+        long total = 0;
+        t.update(total);
+        Thread.sleep(10);
+        for (int i = 1; i <= 100; i++) {
+            if (i % 5 == 0) {
+                total++;
+            }
+            Thread.sleep(10);
+            t.update(total);
+        }
+
+        double thp = t.getThroughput();
+        // the smoothed value should be positive and converging toward the average rate (~20/s)
+        // rather than oscillating between 0 and ~100 (the instantaneous spike)
+        assertTrue(thp > 1.0, "Smoothed throughput should be well above zero: " + thp);
+        assertTrue(thp < 80.0, "Smoothed throughput should be below the instantaneous spike: " + thp);
+    }
+
+    @Test
+    public void testReset() throws Exception {
+        LoadThroughput t = new LoadThroughput();
+
+        t.update(0);
+        Thread.sleep(10);
+        t.update(10);
+
+        assertTrue(t.getThroughput() > 0);
+
+        t.reset();
+        assertEquals(0.0, t.getThroughput());
+    }
+
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -30,6 +30,16 @@ String chat(AiAgentBody<?> aiAgentBody, ToolProvider toolProvider);
 Result<String> chat(AiAgentBody<?> aiAgentBody, ToolProvider toolProvider);
 ----
 
+=== camel-management - Throughput MBean attribute uses EWMA smoothing
+
+The `Throughput` attribute on the `ManagedPerformanceCounter` JMX MBean now reports an EWMA
+(exponentially weighted moving average) value with a 1-minute decay window, instead of the
+previous raw instantaneous rate. This produces a smoother, more stable reading that converges
+to the true average throughput rather than oscillating between zero and spike values.
+
+If you have tooling that consumes the JMX throughput value and expects the old instantaneous
+behavior, be aware that the reported value will now ramp up and decay gradually.
+
 === camel-fory with JDK 25+ - Breaking change
 
 Due to new requirements from Apache Fory, when using Apache Fory Dataformat, the JVM parameter `--add-opens java.base/java.lang.invoke=ALL-UNNAMED` must be provided.

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -444,17 +444,19 @@ class EndpointsTab implements MonitorTab {
 
         Line chartTitle = Line.from(
                 Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
-                Span.raw(String.format(" in:%-4d ", curIn)),
+                Span.raw(String.format(" in:%-4s ", formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
-                Span.raw(String.format(" out:%-4d msg/s", curOut)));
+                Span.raw(String.format(" out:%-4s msg/s", formatThroughput(curOut))));
 
         Rect rightArea = hSplit.get(1);
+        long maxEp = niceMax(Math.max(maxOf(inArr), maxOf(outArr)));
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
+                .max(maxEp)
                 .topStyle(Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN)))
                 .bottomStyle(Style.EMPTY.fg(Color.CYAN))
-                .showYAxis(true)
+                .showYAxis(false)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
                 .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
@@ -555,16 +557,20 @@ class EndpointsTab implements MonitorTab {
                 Span.styled(uriLabel, Style.EMPTY.fg(Color.YELLOW)),
                 Span.raw("] "),
                 Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
-                Span.raw(String.format(" in:%-4d ", curIn)),
+                Span.raw(String.format(" in:%-4s ", formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
-                Span.raw(String.format(" out:%-4d msg/s", curOut)));
+                Span.raw(String.format(" out:%-4s msg/s", formatThroughput(curOut))));
 
+        // TODO: use .showYAxis(true).yAxisFormatter(EndpointsTab::formatThroughput) when tamboui 0.5.0 is released
+        //  see https://github.com/tamboui/tamboui/pull/396
+        long maxEpSingle = niceMax(Math.max(maxOf(inArr), maxOf(outArr)));
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
+                .max(maxEpSingle)
                 .topStyle(Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN)))
                 .bottomStyle(Style.EMPTY.fg(Color.CYAN))
-                .showYAxis(true)
+                .showYAxis(false)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
                 .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
@@ -769,5 +775,46 @@ class EndpointsTab implements MonitorTab {
         Integer sel = tableState.selected();
         result.put("selectedIndex", sel != null ? sel : -1);
         return result;
+    }
+
+    private static long maxOf(long[] arr) {
+        long max = 0;
+        for (long v : arr) {
+            if (v > max) {
+                max = v;
+            }
+        }
+        return max;
+    }
+
+    private static long niceMax(long rawMax) {
+        if (rawMax <= 0) {
+            return MetricsCollector.THROUGHPUT_SCALE;
+        }
+        long scale = MetricsCollector.THROUGHPUT_SCALE;
+        int[] steps = { 1, 2, 5 };
+        long multiplier = scale;
+        while (true) {
+            for (int s : steps) {
+                long candidate = s * multiplier;
+                if (candidate >= rawMax) {
+                    return candidate;
+                }
+            }
+            multiplier *= 10;
+        }
+    }
+
+    private static String formatThroughput(long scaledValue) {
+        double v = scaledValue / (double) MetricsCollector.THROUGHPUT_SCALE;
+        if (v >= 10) {
+            return String.valueOf(Math.round(v));
+        } else if (v >= 1) {
+            return String.format(Locale.US, "%.1f", v);
+        } else if (scaledValue > 0) {
+            return String.format(Locale.US, "%.2f", v);
+        } else {
+            return "0";
+        }
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -444,12 +444,12 @@ class EndpointsTab implements MonitorTab {
 
         Line chartTitle = Line.from(
                 Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
-                Span.raw(String.format(" in:%-4s ", formatThroughput(curIn))),
+                Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
-                Span.raw(String.format(" out:%-4s msg/s", formatThroughput(curOut))));
+                Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
 
         Rect rightArea = hSplit.get(1);
-        long maxEp = niceMax(Math.max(maxOf(inArr), maxOf(outArr)));
+        long maxEp = MetricsCollector.niceMax(Math.max(maxOf(inArr), maxOf(outArr)));
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
@@ -557,13 +557,13 @@ class EndpointsTab implements MonitorTab {
                 Span.styled(uriLabel, Style.EMPTY.fg(Color.YELLOW)),
                 Span.raw("] "),
                 Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
-                Span.raw(String.format(" in:%-4s ", formatThroughput(curIn))),
+                Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
-                Span.raw(String.format(" out:%-4s msg/s", formatThroughput(curOut))));
+                Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
 
-        // TODO: use .showYAxis(true).yAxisFormatter(EndpointsTab::formatThroughput) when tamboui 0.5.0 is released
+        // TODO: use .showYAxis(true).yAxisFormatter(MetricsCollector::formatThroughput) when tamboui 0.5.0 is released
         //  see https://github.com/tamboui/tamboui/pull/396
-        long maxEpSingle = niceMax(Math.max(maxOf(inArr), maxOf(outArr)));
+        long maxEpSingle = MetricsCollector.niceMax(Math.max(maxOf(inArr), maxOf(outArr)));
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
@@ -787,34 +787,4 @@ class EndpointsTab implements MonitorTab {
         return max;
     }
 
-    private static long niceMax(long rawMax) {
-        if (rawMax <= 0) {
-            return MetricsCollector.THROUGHPUT_SCALE;
-        }
-        long scale = MetricsCollector.THROUGHPUT_SCALE;
-        int[] steps = { 1, 2, 5 };
-        long multiplier = scale;
-        while (true) {
-            for (int s : steps) {
-                long candidate = s * multiplier;
-                if (candidate >= rawMax) {
-                    return candidate;
-                }
-            }
-            multiplier *= 10;
-        }
-    }
-
-    private static String formatThroughput(long scaledValue) {
-        double v = scaledValue / (double) MetricsCollector.THROUGHPUT_SCALE;
-        if (v >= 10) {
-            return String.valueOf(Math.round(v));
-        } else if (v >= 1) {
-            return String.format(Locale.US, "%.1f", v);
-        } else if (scaledValue > 0) {
-            return String.format(Locale.US, "%.2f", v);
-        } else {
-            return "0";
-        }
-    }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsCollector.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsCollector.java
@@ -33,6 +33,8 @@ class MetricsCollector {
     static final int MAX_ENDPOINT_CHART_POINTS = 300;
     static final int MAX_HEAP_HISTORY_POINTS = 120;
     static final long HEAP_SAMPLE_INTERVAL_MS = 5000;
+    // Throughput values are stored scaled by this factor so sub-1.0 msg/s rates are preserved as longs
+    static final long THROUGHPUT_SCALE = 100;
 
     // Throughput history per PID (one point per second)
     private final Map<String, LinkedList<Long>> throughputHistory = new ConcurrentHashMap<>();
@@ -164,15 +166,28 @@ class MetricsCollector {
             samples.remove(0);
         }
 
+        // Use the EWMA throughput from the status JSON (already smoothed in camel-core)
+        // and store scaled by 100 so sub-1.0 rates (e.g. 0.20 msg/s) are preserved as integers
+        long tp = 0;
+        if (info.throughput != null) {
+            try {
+                tp = Math.round(Double.parseDouble(info.throughput) * THROUGHPUT_SCALE);
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+        }
+
+        // Failed throughput still computed from delta (no EWMA source for failed-only)
+        long fp = 0;
         if (samples.size() >= 2) {
             long[] oldest = samples.get(0);
             long[] newest = samples.get(samples.size() - 1);
-            long deltaTotal = newest[1] - oldest[1];
             long deltaFailed = newest[2] - oldest[2];
             long deltaTimeMs = newest[0] - oldest[0];
-            long tp = deltaTimeMs > 0 ? (deltaTotal * 1000) / deltaTimeMs : 0;
-            long fp = deltaTimeMs > 0 ? (deltaFailed * 1000) / deltaTimeMs : 0;
+            fp = deltaTimeMs > 0 ? (deltaFailed * 1000 * THROUGHPUT_SCALE) / deltaTimeMs : 0;
+        }
 
+        {
             Long lastTime = previousExchangesTime.get(pid);
             if (lastTime == null || now - lastTime >= 1000) {
                 previousExchangesTime.put(pid, now);
@@ -262,8 +277,8 @@ class MetricsCollector {
             long[] oldest = samples.get(0);
             long[] newest = samples.get(samples.size() - 1);
             long deltaMs = newest[0] - oldest[0];
-            long inRate = deltaMs > 0 ? (newest[1] - oldest[1]) * 1000 / deltaMs : 0;
-            long outRate = deltaMs > 0 ? (newest[2] - oldest[2]) * 1000 / deltaMs : 0;
+            long inRate = deltaMs > 0 ? (newest[1] - oldest[1]) * 1000 * THROUGHPUT_SCALE / deltaMs : 0;
+            long outRate = deltaMs > 0 ? (newest[2] - oldest[2]) * 1000 * THROUGHPUT_SCALE / deltaMs : 0;
             Long lastTime = prevTimeMap.get(pid);
             if (lastTime == null || now - lastTime >= 1000) {
                 prevTimeMap.put(pid, now);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsCollector.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsCollector.java
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -416,6 +417,38 @@ class MetricsCollector {
     private void removeByPrefix(String prefix, Map<String, ?>... maps) {
         for (Map<String, ?> map : maps) {
             map.keySet().removeIf(k -> k.startsWith(prefix));
+        }
+    }
+
+    // --- Shared throughput formatting utilities ---
+
+    static long niceMax(long rawMax) {
+        if (rawMax <= 0) {
+            return THROUGHPUT_SCALE;
+        }
+        int[] steps = { 1, 2, 5 };
+        long multiplier = THROUGHPUT_SCALE;
+        while (true) {
+            for (int s : steps) {
+                long candidate = s * multiplier;
+                if (candidate >= rawMax) {
+                    return candidate;
+                }
+            }
+            multiplier *= 10;
+        }
+    }
+
+    static String formatThroughput(long scaledValue) {
+        double v = scaledValue / (double) THROUGHPUT_SCALE;
+        if (v >= 10) {
+            return String.valueOf(Math.round(v));
+        } else if (v >= 1) {
+            return String.format(Locale.US, "%.1f", v);
+        } else if (scaledValue > 0) {
+            return String.format(Locale.US, "%.2f", v);
+        } else {
+            return "0";
         }
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -222,7 +223,7 @@ class OverviewTab implements MonitorTab {
         List<Constraint> constraints = new ArrayList<>();
         constraints.add(Constraint.fill());
         if (hasSparkline) {
-            constraints.add(Constraint.length(14));
+            constraints.add(Constraint.length(17));
         } else if (showInfoPanel) {
             int panelH = countInfraLines(infraSel) + 2;
             constraints.add(Constraint.length(Math.min(panelH, area.height() / 2)));
@@ -404,7 +405,7 @@ class OverviewTab implements MonitorTab {
                     .split(chartInner);
 
             List<Rect> hChunks = Layout.horizontal()
-                    .constraints(Constraint.length(4), Constraint.fill())
+                    .constraints(Constraint.length(5), Constraint.fill())
                     .split(vChunks.get(0));
 
             Rect barChartArea = hChunks.get(1);
@@ -438,9 +439,15 @@ class OverviewTab implements MonitorTab {
             for (long v : mergedTotal) {
                 maxTp = Math.max(maxTp, v);
             }
+            maxTp = niceMax(maxTp);
             long curTp = mergedTotal[renderPoints - 1];
             long curFailed = mergedFailed[renderPoints - 1];
             long curOk = Math.max(0, curTp - curFailed);
+
+            // Format throughput values unscaled for display
+            String curTpFmt = formatThroughput(curTp);
+            String curOkFmt = formatThroughput(curOk);
+            String curFailFmt = formatThroughput(curFailed);
 
             Line titleLine;
             if (chartMode == CHART_SINGLE && ctx.selectedPid != null) {
@@ -450,18 +457,18 @@ class OverviewTab implements MonitorTab {
                 titleLine = Line.from(
                         Span.raw(" ["),
                         Span.styled(chartName, Style.EMPTY.fg(Color.YELLOW)),
-                        Span.raw(String.format("] Throughput: %d msg/s  ", curTp)),
+                        Span.raw(String.format("] Throughput: %s msg/s  ", curTpFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
-                        Span.raw(String.format(" ok:%d  ", curOk)),
+                        Span.raw(String.format(" ok:%s  ", curOkFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.RED)),
-                        Span.raw(String.format(" fail:%d ", curFailed)));
+                        Span.raw(String.format(" fail:%s ", curFailFmt)));
             } else {
                 titleLine = Line.from(
-                        Span.raw(String.format(" [All] Throughput: %d msg/s  ", curTp)),
+                        Span.raw(String.format(" [All] Throughput: %s msg/s  ", curTpFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
-                        Span.raw(String.format(" ok:%d  ", curOk)),
+                        Span.raw(String.format(" ok:%s  ", curOkFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.RED)),
-                        Span.raw(String.format(" fail:%d ", curFailed)));
+                        Span.raw(String.format(" fail:%s ", curFailFmt)));
             }
 
             Block chartBlock = Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
@@ -480,7 +487,7 @@ class OverviewTab implements MonitorTab {
 
             BarChart barChart = BarChart.builder()
                     .data(groups)
-                    .max(maxTp > 0 ? maxTp + 2 : 2)
+                    .max(maxTp)
                     .barWidth(1)
                     .barGap(0)
                     .groupGap(0)
@@ -493,11 +500,11 @@ class OverviewTab implements MonitorTab {
             Style dimStyle = Style.EMPTY.dim();
             for (int row = 0; row < barRows; row++) {
                 if (row == 0) {
-                    yLines.add(Line.from(Span.styled(String.format("%3d", maxTp), dimStyle)));
+                    yLines.add(Line.from(Span.styled(String.format("%4s", formatThroughput(maxTp)), dimStyle)));
                 } else if (barRows > 4 && row == barRows / 2) {
-                    yLines.add(Line.from(Span.styled(String.format("%3d", maxTp / 2), dimStyle)));
+                    yLines.add(Line.from(Span.styled(String.format("%4s", formatThroughput(maxTp / 2)), dimStyle)));
                 } else if (row == barRows - 1) {
-                    yLines.add(Line.from(Span.styled("  0", dimStyle)));
+                    yLines.add(Line.from(Span.styled("   0", dimStyle)));
                 } else {
                     yLines.add(Line.from(""));
                 }
@@ -635,6 +642,34 @@ class OverviewTab implements MonitorTab {
             lines.add(Line.from(Span.raw("-")));
         }
         frame.renderWidget(Paragraph.builder().text(Text.from(lines)).build(), inner);
+    }
+
+    /**
+     * Snap to a nice Y-axis ceiling using a 1-2-5 sequence (scaled by THROUGHPUT_SCALE). For example with scale=100:
+     * 0.20 → 1, 1.5 → 2, 3 → 5, 7 → 10, 15 → 20, 35 → 50, 80 → 100, etc.
+     */
+    private static long niceMax(long rawMax) {
+        long s = MetricsCollector.THROUGHPUT_SCALE;
+        long[] steps = { s, 2 * s, 5 * s, 10 * s, 20 * s, 50 * s, 100 * s, 200 * s, 500 * s, 1000 * s };
+        for (long step : steps) {
+            if (rawMax <= step) {
+                return step;
+            }
+        }
+        return rawMax;
+    }
+
+    private static String formatThroughput(long scaledValue) {
+        double v = scaledValue / (double) MetricsCollector.THROUGHPUT_SCALE;
+        if (v >= 10) {
+            return String.valueOf(Math.round(v));
+        } else if (v >= 1) {
+            return String.format(Locale.US, "%.1f", v);
+        } else if (scaledValue > 0) {
+            return String.format(Locale.US, "%.2f", v);
+        } else {
+            return "0";
+        }
     }
 
     private static int countInfraLines(InfraInfo infra) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -19,7 +19,6 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -439,15 +438,15 @@ class OverviewTab implements MonitorTab {
             for (long v : mergedTotal) {
                 maxTp = Math.max(maxTp, v);
             }
-            maxTp = niceMax(maxTp);
+            maxTp = MetricsCollector.niceMax(maxTp);
             long curTp = mergedTotal[renderPoints - 1];
             long curFailed = mergedFailed[renderPoints - 1];
             long curOk = Math.max(0, curTp - curFailed);
 
             // Format throughput values unscaled for display
-            String curTpFmt = formatThroughput(curTp);
-            String curOkFmt = formatThroughput(curOk);
-            String curFailFmt = formatThroughput(curFailed);
+            String curTpFmt = MetricsCollector.formatThroughput(curTp);
+            String curOkFmt = MetricsCollector.formatThroughput(curOk);
+            String curFailFmt = MetricsCollector.formatThroughput(curFailed);
 
             Line titleLine;
             if (chartMode == CHART_SINGLE && ctx.selectedPid != null) {
@@ -500,9 +499,11 @@ class OverviewTab implements MonitorTab {
             Style dimStyle = Style.EMPTY.dim();
             for (int row = 0; row < barRows; row++) {
                 if (row == 0) {
-                    yLines.add(Line.from(Span.styled(String.format("%4s", formatThroughput(maxTp)), dimStyle)));
+                    yLines.add(
+                            Line.from(Span.styled(String.format("%4s", MetricsCollector.formatThroughput(maxTp)), dimStyle)));
                 } else if (barRows > 4 && row == barRows / 2) {
-                    yLines.add(Line.from(Span.styled(String.format("%4s", formatThroughput(maxTp / 2)), dimStyle)));
+                    yLines.add(Line
+                            .from(Span.styled(String.format("%4s", MetricsCollector.formatThroughput(maxTp / 2)), dimStyle)));
                 } else if (row == barRows - 1) {
                     yLines.add(Line.from(Span.styled("   0", dimStyle)));
                 } else {
@@ -642,34 +643,6 @@ class OverviewTab implements MonitorTab {
             lines.add(Line.from(Span.raw("-")));
         }
         frame.renderWidget(Paragraph.builder().text(Text.from(lines)).build(), inner);
-    }
-
-    /**
-     * Snap to a nice Y-axis ceiling using a 1-2-5 sequence (scaled by THROUGHPUT_SCALE). For example with scale=100:
-     * 0.20 → 1, 1.5 → 2, 3 → 5, 7 → 10, 15 → 20, 35 → 50, 80 → 100, etc.
-     */
-    private static long niceMax(long rawMax) {
-        long s = MetricsCollector.THROUGHPUT_SCALE;
-        long[] steps = { s, 2 * s, 5 * s, 10 * s, 20 * s, 50 * s, 100 * s, 200 * s, 500 * s, 1000 * s };
-        for (long step : steps) {
-            if (rawMax <= step) {
-                return step;
-            }
-        }
-        return rawMax;
-    }
-
-    private static String formatThroughput(long scaledValue) {
-        double v = scaledValue / (double) MetricsCollector.THROUGHPUT_SCALE;
-        if (v >= 10) {
-            return String.valueOf(Math.round(v));
-        } else if (v >= 1) {
-            return String.format(Locale.US, "%.1f", v);
-        } else if (scaledValue > 0) {
-            return String.format(Locale.US, "%.2f", v);
-        } else {
-            return "0";
-        }
     }
 
     private static int countInfraLines(InfraInfo infra) {


### PR DESCRIPTION
## Summary

Switch the throughput metric in LoadThroughput from raw instantaneous rate to EWMA (exponentially weighted moving average) smoothing with a 1-minute decay window. This produces stable, converging throughput readings instead of oscillating 0/spike values — consistent with how LoadTriplet already computes CPU load averages.

Also fixes the TUI sparkline charts to properly display sub-1.0 msg/s rates by scaling throughput values by 100x internally.

## Changes

**camel-management (core):**
- LoadThroughput: EWMA smoothing with Math.exp(-1/60) decay, negative delta clamping, reset() stops the StopWatch
- LoadThroughputTest: Awaitility-based tests verifying EWMA convergence, smoothing bounds, and reset behavior

**camel-jbang-plugin-tui:**
- MetricsCollector: reads EWMA throughput from status JSON, stores scaled by THROUGHPUT_SCALE=100; shared niceMax() and formatThroughput() utility methods
- OverviewTab / EndpointsTab: sparkline charts use scaled values with 1-2-5 Y-axis snapping; delegate to MetricsCollector for formatting

**docs:**
- Upgrade guide entry for throughput MBean semantics change (instantaneous to EWMA)

_Claude Code on behalf of Claus Ibsen_