### PR TITLE
Change assertion in TransformMessageITCase to accept different state outputs

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/TransformMessageITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/TransformMessageITCase.java
@@ -62,7 +62,7 @@ public class TransformMessageITCase extends JBangTestSupport {
     }
 
     private void runTransformation(String command) {
-        checkCommandOutputs(command, "Camel Main: transform (state: Running)");
+        checkCommandOutputsPattern(command, "Camel Main: transform \\(state: (Running|Starting)\\)");
     }
 
     private void checkOutputFile(String contains) throws IOException {


### PR DESCRIPTION
The command can output different statuses, added cover for both
