### PR TITLE
chore: print a confirmation when adding a camel-jbang plugin

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginAdd.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginAdd.java
@@ -160,6 +160,7 @@ public class PluginAdd extends PluginBaseCommand {
         plugins.put(name, plugin);
 
         saveConfig(pluginConfig);
+        printer().printf("Plugin %s added%n", name);
         return 0;
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginAddTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/plugin/PluginAddTest.java
@@ -41,7 +41,7 @@ class PluginAddTest extends CamelCommandBaseTestSupport {
         command.name = "kubernetes";
         command.doCall();
 
-        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertEquals("Plugin kubernetes added", printer.getOutput());
 
         Assertions.assertEquals(
                 "{\"plugins\":{\"kubernetes\":{\"name\":\"kubernetes\",\"command\":\"kubernetes\",\"firstVersion\":\"4.8.0\",\"description\":\"%s\"}}}"
@@ -58,7 +58,7 @@ class PluginAddTest extends CamelCommandBaseTestSupport {
         command.firstVersion = "1.2.3";
         command.doCall();
 
-        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertEquals("Plugin foo-plugin added", printer.getOutput());
 
         Assertions.assertEquals("{\"plugins\":{\"foo-plugin\":{\"name\":\"foo-plugin\",\"command\":\"foo\"," +
                                 "\"firstVersion\":\"1.2.3\",\"description\":\"Some plugin\"}}}",
@@ -71,7 +71,7 @@ class PluginAddTest extends CamelCommandBaseTestSupport {
         command.name = "foo";
         command.doCall();
 
-        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertEquals("Plugin foo added", printer.getOutput());
 
         Assertions.assertEquals("{\"plugins\":{\"foo\":{\"name\":\"foo\",\"command\":\"foo\"," +
                                 "\"description\":\"Plugin foo called with command foo\"}}}",
@@ -86,7 +86,7 @@ class PluginAddTest extends CamelCommandBaseTestSupport {
         command.gav = "org.apache.camel:foo-plugin:1.0.0";
         command.doCall();
 
-        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertEquals("Plugin foo-plugin added", printer.getOutput());
 
         Assertions.assertEquals("{\"plugins\":{\"foo-plugin\":{\"name\":\"foo-plugin\",\"command\":\"foo\"," +
                                 "\"description\":\"Plugin foo-plugin called with command foo\",\"dependency\":\"org.apache.camel:foo-plugin:1.0.0\"}}}",
@@ -103,7 +103,7 @@ class PluginAddTest extends CamelCommandBaseTestSupport {
         command.version = "1.0.0";
         command.doCall();
 
-        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertEquals("Plugin foo-plugin added", printer.getOutput());
 
         Assertions.assertEquals("{\"plugins\":{\"foo-plugin\":{\"name\":\"foo-plugin\",\"command\":\"foo\"," +
                                 "\"firstVersion\":\"1.0.0\",\"description\":\"Plugin foo-plugin called with command foo\"" +


### PR DESCRIPTION
# Description

`PluginAdd` (the `camel plugin add` command) now prints a `Plugin <name> added` message after saving the plugin configuration, so adding or upgrading a plugin gives visible feedback on the terminal.

This restores symmetry with `PluginDelete`, which already prints a `Plugin <name> removed` confirmation.

The `PluginAddTest` assertions were updated accordingly: they previously expected empty output and now assert the confirmation message.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!-- Trivial UX-feedback change; no JIRA issue required. -->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code (Opus 4.8) on behalf of Adriano Machado_

🤖 Generated with [Claude Code](https://claude.com/claude-code)