### PR TITLE
ci: run Scalpel shadow comparison for all PRs, add depth=50 step

### DIFF
--- a/.github/CI-ARCHITECTURE.md
+++ b/.github/CI-ARCHITECTURE.md
@@ -176,7 +176,7 @@ The shadow comparison section shows:
 
 The script overrides `fullBuildTriggers` to empty (`-Dscalpel.fullBuildTriggers=`) because Scalpel's default (`.mvn/**`) would trigger a full build whenever `.mvn/extensions.xml` itself changes (e.g., Dependabot bumping Scalpel).
 
-The grep-based script fetches the PR diff via the GitHub REST API (unchanged). Scalpel uses local git history to compare effective POM models — the CI workflow pre-fetches the base branch (`git fetch --deepen=200` + fetch of `origin/main`) so Scalpel's JGit can find the merge-base. Scalpel disables its built-in JGit fetch (`-Dscalpel.fetchBaseBranch=false`) to avoid JGit issues in shallow CI clones. The `--deepen=200` fetches only commit metadata (not file blobs), adding ~2-3 seconds to the job.
+The grep-based script fetches the PR diff via the GitHub REST API (unchanged). Scalpel uses local git history to compare effective POM models and detect source file changes — the CI workflow progressively deepens the shallow clone (`50 → 200 → 1000 → full`) until the merge-base is reachable. Scalpel runs for **all PRs** (not just POM changes) so the shadow comparison covers source-only changes too, building confidence for a future switch to Scalpel-driven builds. Scalpel disables its built-in JGit fetch (`-Dscalpel.fetchBaseBranch=false`) because the CI workflow already pre-fetches the base branch with native git (Scalpel uses JGit 5.x which has limited shallow clone support).
 
 ## Manual Integration Test Advisories
 

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -261,7 +261,7 @@ runScalpelDetection() {
   local base_branch="origin/${GITHUB_BASE_REF:-main}"
   local scalpel_args="-Dscalpel.enabled=true -Dscalpel.mode=report -Dscalpel.fullBuildTriggers= -Dscalpel.fetchBaseBranch=false -Dscalpel.baseBranch=${base_branch} -Dscalpel.excludePaths=.github/** -Dscalpel.skipTestsForDownstreamModules=${skip_downstream}"
 
-  # Verify merge base is reachable before running Scalpel
+  # Verify merge base is reachable (pre-fetched by the CI workflow step)
   if ! git merge-base HEAD "${base_branch}" >/dev/null 2>&1; then
     echo "  WARNING: merge base between HEAD and ${base_branch} is not reachable"
     echo "  HEAD=$(git rev-parse HEAD 2>/dev/null), ${base_branch}=$(git rev-parse ${base_branch} 2>/dev/null || echo 'NOT FOUND')"
@@ -744,18 +744,16 @@ main() {
     done <<< "$pom_files"
   fi
 
-  # Step 2b: Scalpel detection (for parent or module pom.xml changes)
-  # Scalpel uses effective POM model comparison — catches managed deps,
-  # plugin changes, and transitive impacts that grep misses.
-  # Skip when only the root pom.xml changed — it contains build-infrastructure
-  # config (license plugin, checkstyle, etc.) that doesn't affect module
-  # compilation or test behavior. Without this filter, Scalpel reports every
-  # module as affected because they all inherit from the root POM.
-  if echo "$diff_body" | sed -n 's|^diff --git a/\(.*\) b/.*|\1|p' | grep -q '.*/pom\.xml$'; then
-    echo ""
-    echo "Running Scalpel POM analysis..."
-    runScalpelDetection
-  fi
+  # Step 2b: Scalpel detection (all PRs)
+  # Scalpel uses effective POM model comparison and source-set analysis —
+  # catches managed deps, plugin changes, transitive impacts, and
+  # distinguishes main vs test-only source changes.
+  # Runs in report (shadow) mode: observes what it would do, does not
+  # affect actual test execution. Results appear in the PR comment for
+  # comparison with the grep-based approach.
+  echo ""
+  echo "Running Scalpel change detection..."
+  runScalpelDetection
 
   # Save grep-only results for comment attribution (before merging with Scalpel).
   # The comment's top section shows only what the current grep mechanism detected;

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -84,13 +84,12 @@ jobs:
         if: ${{ !inputs.skip_full_build }}
         run: |
           # Scalpel needs the merge base between HEAD and the base branch.
-          # The checkout is depth=1, so we progressively deepen until the
-          # merge base is reachable: 200 → 1000 → full history.
+          # The checkout is depth=1; progressively deepen: 50 → 200 → 1000 → full.
           # Scalpel is observational — fetch failures must not break the build.
           BASE_REF="${GITHUB_BASE_REF:-main}"
-          for depth in 200 1000; do
+          for depth in 50 200 1000; do
             git fetch --deepen=$depth 2>/dev/null || true
-            git fetch --no-tags --depth=$depth origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" || true
+            git fetch --no-tags --depth=$depth origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
             if git merge-base HEAD "origin/${BASE_REF}" >/dev/null 2>&1; then
               echo "Merge base reachable at depth $depth"
               break
@@ -101,7 +100,7 @@ jobs:
           if ! git merge-base HEAD "origin/${BASE_REF}" >/dev/null 2>&1; then
             echo "Merge base still not reachable, fetching full history"
             git fetch --unshallow 2>/dev/null || true
-            git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" || true
+            git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
           fi
       - id: install-packages
         uses: ./.github/actions/install-packages


### PR DESCRIPTION
## Summary

- **Run Scalpel for all PRs** — not just those changing `pom.xml`. Scalpel detects source file changes (`SOURCE_CHANGE`, `TEST_CHANGE`) and distinguishes test-only changes from main source changes, building confidence for a future switch to Scalpel-driven builds.
- **Add depth=50 first step** — recent PRs where the merge base is close avoid fetching 200 commits upfront. Progressive depths: `50 → 200 → 1000 → full`.
- **Fix Scalpel comparison** — compare against full current detection (file-path + grep + `-amd`), not just grep POM. Show modules each approach finds that the other misses.
- **Fix reactor list parsing** — long module names (e.g. "CSimple Maven Plugin (deprecated)") had no dots in Maven output, leaving `SUCCESS`/`FAILURE` attached to the name → duplicates in the "All tested modules" list.

## One-line summary format

The Scalpel shadow comparison now shows:

> 🔬 Scalpel shadow comparison — Scalpel: 10 tested, 29 compile-only — current: 39 all tested

This tells reviewers at a glance: Scalpel would only run tests on 10 modules instead of 39, skipping tests for 29 meta/generated modules while still compiling them.

## Changes

| File | Change |
|------|--------|
| `pr-build-main.yml` | Deepening with `50 → 200 → 1000 → full` (was `200 → 1000 → full`) |
| `incremental-build.sh` | Remove `pom.xml` condition — Scalpel runs for every PR. Fix comparison to use full reactor. Fix reactor name parsing. |
| `CI-ARCHITECTURE.md` | Update docs |

## Test plan

- [ ] Java-only PR: verify Scalpel shadow comparison appears, no duplicates in module list
- [ ] POM-changing PR: verify Scalpel comparison shows correct set differences

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)