### PR TITLE
Fix S5783: extract setup code from assertThrows lambdas

### DIFF
--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerRestDslTest.java
@@ -133,17 +133,17 @@ public class PlatformHttpRestOpenApiConsumerRestDslTest {
         final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    rest().openApi("openapi-v3.json");
+
+                    from("direct:getPetById")
+                            .setBody().constant("{\"pet\": \"tony the tiger\"}");
+                }
+            });
+
             assertThrows(Exception.class, () -> {
-                context.addRoutes(new RouteBuilder() {
-                    @Override
-                    public void configure() {
-                        rest().openApi("openapi-v3.json");
-
-                        from("direct:getPetById")
-                                .setBody().constant("{\"pet\": \"tony the tiger\"}");
-                    }
-                });
-
                 VertxPlatformHttpEngineTest.startCamelContext(context);
             }, "OpenAPI specification has 18 unmapped operations to corresponding routes");
         } finally {

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/PlatformHttpRestOpenApiConsumerTest.java
@@ -135,18 +135,18 @@ public class PlatformHttpRestOpenApiConsumerTest {
         final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
 
         try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("rest-openapi:classpath:openapi-v3.json?missingOperation=fail")
+                            .log("dummy");
+
+                    from("direct:getPetById")
+                            .setBody().constant("{\"pet\": \"tony the tiger\"}");
+                }
+            });
+
             assertThrows(Exception.class, () -> {
-                context.addRoutes(new RouteBuilder() {
-                    @Override
-                    public void configure() {
-                        from("rest-openapi:classpath:openapi-v3.json?missingOperation=fail")
-                                .log("dummy");
-
-                        from("direct:getPetById")
-                                .setBody().constant("{\"pet\": \"tony the tiger\"}");
-                    }
-                });
-
                 VertxPlatformHttpEngineTest.startCamelContext(context);
             }, "OpenAPI specification has 18 unmapped operations to corresponding routes");
         } finally {

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpOAuthProfileTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpOAuthProfileTest.java
@@ -181,29 +181,27 @@ class PlatformHttpOAuthProfileTest {
     }
 
     @Test
-    void oauthProfileSpecificWrongTypeValidationFactoryBeanFailsStartup() {
+    void oauthProfileSpecificWrongTypeValidationFactoryBeanFailsStartup() throws Exception {
         CapturingEngine engine = new CapturingEngine();
 
-        assertThrows(Exception.class, () -> {
-            try (DefaultCamelContext context = new DefaultCamelContext()) {
-                context.getRegistry().bind("profileFactory", "not a token validation factory");
-                context.getPropertiesComponent().addInitialProperty(
-                        "camel.oauth.myprofile.validation-factory", "#bean:profileFactory");
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.getRegistry().bind("profileFactory", "not a token validation factory");
+            context.getPropertiesComponent().addInitialProperty(
+                    "camel.oauth.myprofile.validation-factory", "#bean:profileFactory");
 
-                PlatformHttpComponent component = new PlatformHttpComponent();
-                component.setEngine(engine);
-                context.addComponent("platform-http", component);
-                context.addRoutes(new RouteBuilder() {
-                    @Override
-                    public void configure() {
-                        from("platform-http:/secure?oauthProfile=myprofile")
-                                .setBody().constant("secured");
-                    }
-                });
+            PlatformHttpComponent component = new PlatformHttpComponent();
+            component.setEngine(engine);
+            context.addComponent("platform-http", component);
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/secure?oauthProfile=myprofile")
+                            .setBody().constant("secured");
+                }
+            });
 
-                context.start();
-            }
-        });
+            assertThrows(Exception.class, () -> context.start());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix SonarCloud S5783 (only one method invocation expected in assertThrows) in 3 platform-http test files.

### Changes
Extract setup code out of `assertThrows` lambdas so only the single call expected to throw remains inside:

- **`PlatformHttpOAuthProfileTest.java`**: Moved context setup (registry bind, property config, route addition) outside assertThrows; only `context.start()` inside
- **`PlatformHttpRestOpenApiConsumerRestDslTest.java`**: Moved `context.addRoutes()` before assertThrows; only `startCamelContext()` inside
- **`PlatformHttpRestOpenApiConsumerTest.java`**: Same pattern

S2119 (Random scope) changes split out into a separate PR per reviewer feedback.

## Test plan
- [ ] CI passes
- [ ] SonarCloud S5783 count drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)