### PR TITLE
CAMEL-23766: camel-crypto - use constant-time comparison for HMAC verification in HMACAccumulator

### DIFF
--- a/components/camel-crypto/src/main/java/org/apache/camel/converter/crypto/HMACAccumulator.java
+++ b/components/camel-crypto/src/main/java/org/apache/camel/converter/crypto/HMACAccumulator.java
@@ -19,6 +19,7 @@ package org.apache.camel.converter.crypto;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.Key;
+import java.security.MessageDigest;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -98,13 +99,12 @@ public class HMACAccumulator {
     public void validate() {
         byte[] actual = getCalculatedMac();
         byte[] expected = getAppendedMac();
-        for (int x = 0; x < actual.length; x++) {
-            if (expected[x] != actual[x]) {
-                throw new IllegalStateException(
-                        "Expected mac did not match actual mac\nexpected:"
-                                                + byteArrayToHexString(expected) + "\n     actual:"
-                                                + byteArrayToHexString(actual));
-            }
+        // Use a constant-time comparison to avoid leaking MAC-match progress through timing (side-channel).
+        if (!MessageDigest.isEqual(expected, actual)) {
+            throw new IllegalStateException(
+                    "Expected mac did not match actual mac\nexpected:"
+                                            + byteArrayToHexString(expected) + "\n     actual:"
+                                            + byteArrayToHexString(actual));
         }
     }
 

--- a/components/camel-crypto/src/test/java/org/apache/camel/converter/crypto/HMACAccumulatorTest.java
+++ b/components/camel-crypto/src/test/java/org/apache/camel/converter/crypto/HMACAccumulatorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HMACAccumulatorTest {
     private byte[] payload = {
@@ -68,6 +69,18 @@ public class HMACAccumulatorTest {
         HMACAccumulator builder = new HMACAccumulator(key, "HmacSHA1", null, buffersize);
         builder.decryptUpdate(buffer, 40);
         validate(builder);
+    }
+
+    @Test
+    void testValidateFailsWhenAppendedMacDoesNotMatch() throws Exception {
+        int buffersize = 256;
+        byte[] buffer = initializeBuffer(buffersize);
+        // Corrupt the first byte of the appended MAC so it no longer matches the calculated MAC
+        buffer[payload.length] ^= 0x01;
+
+        HMACAccumulator builder = new HMACAccumulator(key, "HmacSHA1", null, buffersize);
+        builder.decryptUpdate(buffer, 40);
+        assertThrows(IllegalStateException.class, builder::validate);
     }
 
     @Test


### PR DESCRIPTION
## CAMEL-23766

`HMACAccumulator.validate()` compared the expected and actual MAC byte-by-byte with an early-exit loop that throws on the first differing byte. The time taken to reject a MAC therefore leaks how many leading bytes matched — a timing side-channel that can assist MAC forgery.

### Fix
Use `java.security.MessageDigest.isEqual(expected, actual)`, which performs a constant-time comparison (since JDK 6u17) and is the standard practice for MAC/signature verification. Behaviour is otherwise unchanged (same `IllegalStateException` on mismatch, same message).

### Tests
Added `testValidateFailsWhenAppendedMacDoesNotMatch` covering the mismatch case — previously only the matching path was exercised (via the `validate` helper). All `HMACAccumulatorTest` tests pass (9).

Targets `main` (4.22.0); a backport to `camel-4.18.x` (4.18.4) will follow per the issue's fix versions.

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
