### PR TITLE
CAMEL-23868: camel-file - make local work directory / starting directory containment checks path-boundary aware

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
@@ -41,12 +41,36 @@ public final class GenericFileHelper {
         // compact first as the remote relative name can use ../ etc
         String compactTarget = FileUtil.compactPath(target.getPath());
         String compactWork = FileUtil.compactPath(localWorkDirectory.getPath());
-        if (!compactTarget.startsWith(compactWork)) {
+        if (!isWithinDirectory(compactTarget, compactWork)) {
             throw new GenericFileOperationFailedException(
                     "Cannot retrieve file to local work file: " + compactTarget
                                                           + " as it is jailed to the local work directory: "
                                                           + compactWork);
         }
+    }
+
+    /**
+     * Determines whether a compacted target path is contained within a compacted directory path, using a path-segment
+     * boundary comparison. Unlike a bare string prefix test, a sibling directory whose name merely extends the
+     * directory name (for example {@code /work} versus {@code /workspace}) is not considered contained. A trailing
+     * separator on the directory is tolerated, and an empty directory imposes no boundary.
+     *
+     * @param  compactTarget the compacted target path (see {@link FileUtil#compactPath(String)})
+     * @param  compactDir    the compacted directory the target must stay within
+     * @return               {@code true} if the target is the directory itself or a path inside it
+     */
+    public static boolean isWithinDirectory(String compactTarget, String compactDir) {
+        if (compactDir.isEmpty()) {
+            // no directory boundary configured
+            return true;
+        }
+        // drop a trailing separator (if any) so the boundary comparison is exact, regardless of whether the
+        // directory path was supplied with or without one
+        String dir = compactDir;
+        if (dir.charAt(dir.length() - 1) == File.separatorChar) {
+            dir = dir.substring(0, dir.length() - 1);
+        }
+        return compactTarget.equals(dir) || compactTarget.startsWith(dir + File.separator);
     }
 
     public static String asExclusiveReadLockKey(GenericFile file, String key) {

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -432,7 +432,7 @@ public class GenericFileProducer<T> extends DefaultAsyncProducer {
         // first as the name can be using relative paths via ../ etc)
         String compatchAnswer = FileUtil.compactPath(answer);
         String compatchBaseDir = FileUtil.compactPath(baseDir);
-        if (!compatchAnswer.startsWith(compatchBaseDir)) {
+        if (!GenericFileHelper.isWithinDirectory(compatchAnswer, compatchBaseDir)) {
             throw new IllegalArgumentException(
                     "Cannot write file with name: " + compatchAnswer
                                                + " as the filename is jailed to the starting directory: "

--- a/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
+++ b/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
@@ -21,7 +21,9 @@ import java.io.File;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GenericFileHelperTest {
 
@@ -44,5 +46,29 @@ public class GenericFileHelperTest {
                 () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "../../etc/passwd"), workDir));
         assertThrows(GenericFileOperationFailedException.class,
                 () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "sub/../../escape.txt"), workDir));
+        // a sibling directory whose name merely extends the work directory name must also be rejected
+        assertThrows(GenericFileOperationFailedException.class,
+                () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "../localworkEVIL/file.txt"), workDir));
+    }
+
+    @Test
+    public void isWithinDirectoryRespectsPathBoundaries() {
+        String sep = File.separator;
+        String work = sep + "data" + sep + "work";
+
+        // the directory itself and real children are contained
+        assertTrue(GenericFileHelper.isWithinDirectory(work, work));
+        assertTrue(GenericFileHelper.isWithinDirectory(work + sep + "a.txt", work));
+        assertTrue(GenericFileHelper.isWithinDirectory(work + sep + "sub" + sep + "a.txt", work));
+
+        // a trailing separator on the directory (as supplied by the file producer) is tolerated
+        assertTrue(GenericFileHelper.isWithinDirectory(work + sep + "a.txt", work + sep));
+
+        // a sibling whose name merely extends the directory name is NOT contained
+        assertFalse(GenericFileHelper.isWithinDirectory(sep + "data" + sep + "workspace" + sep + "a.txt", work));
+        assertFalse(GenericFileHelper.isWithinDirectory(sep + "data" + sep + "workspace" + sep + "a.txt", work + sep));
+
+        // an empty directory imposes no boundary
+        assertTrue(GenericFileHelper.isWithinDirectory("anything.txt", ""));
     }
 }


### PR DESCRIPTION
## What

`GenericFileHelper.jailToLocalWorkDirectory` (added in CAMEL-23765 to keep remote-file
`localWorkDirectory` downloads inside the configured work directory) and
`GenericFileProducer.jailedCheck` (the `jailStartingDirectory` producer check) both decided
containment with a bare `String.startsWith` prefix test.

A bare prefix test ignores path-segment boundaries. When the compacted directory string has no
trailing separator — which is what `jailToLocalWorkDirectory` gets from `File.getPath()` — a
sibling directory whose name merely *extends* the configured directory's name (for example
`.../localwork` vs `.../localworkEVIL`) also satisfies the prefix and is wrongly treated as
contained. `jailedCheck` avoids this today only incidentally, because the producer always hands it
a `baseDir` that carries a trailing separator.

## Change

- Add a shared, boundary-aware `GenericFileHelper.isWithinDirectory(compactTarget, compactDir)` and
  route both containment checks through it, so the two can no longer drift apart.
- The helper compares on path-segment boundaries (`equals`, or `startsWith(dir + File.separator)`),
  tolerates a trailing separator on the directory (the producer supplies one), and treats an empty
  directory as "no boundary" — preserving the existing behaviour for all legitimate cases.

## Tests

- `GenericFileHelperTest`: a name-prefixed sibling (`../localworkEVIL/...`) is now rejected, and a
  new test locks the shared helper's boundary, trailing-separator and empty-directory behaviour.

Continues the containment work from CAMEL-23765.

Issue: https://issues.apache.org/jira/browse/CAMEL-23868

_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
