### PR TITLE
CAMEL-23881: Fix escaped Maven property reference in TestPluginExporter

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-test/src/main/java/org/apache/camel/dsl/jbang/core/commands/test/TestPluginExporter.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-test/src/main/java/org/apache/camel/dsl/jbang/core/commands/test/TestPluginExporter.java
@@ -238,6 +238,6 @@ public class TestPluginExporter implements PluginExporter {
     }
 
     private String asDependency(String artifactName) {
-        return "mvn@test:org.citrusframework:%s:\\$\\{citrus.version}".formatted(artifactName);
+        return "mvn@test:org.citrusframework:%s:${citrus.version}".formatted(artifactName);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-test/src/test/java/org/apache/camel/dsl/jbang/core/commands/test/TestPluginTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-test/src/test/java/org/apache/camel/dsl/jbang/core/commands/test/TestPluginTest.java
@@ -17,11 +17,15 @@
 
 package org.apache.camel.dsl.jbang.core.commands.test;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.common.CommandLineHelper;
 import org.apache.camel.dsl.jbang.core.common.Printer;
+import org.apache.camel.dsl.jbang.core.common.RuntimeType;
 import org.apache.camel.dsl.jbang.core.common.StringPrinter;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.citrusframework.spi.Resources;
@@ -105,6 +109,25 @@ class TestPluginTest {
                   ]
                 }
                 """.trim(), printer.getOutput().trim());
+    }
+
+    @Test
+    public void shouldProduceValidMavenPropertyReferences() throws IOException {
+        Path testDir = Path.of(".").resolve("test");
+        Files.createDirectories(testDir);
+        try {
+            TestPluginExporter exporter = new TestPluginExporter();
+            Set<String> deps = exporter.getDependencies(RuntimeType.quarkus);
+            Assertions.assertFalse(deps.isEmpty());
+            for (String dep : deps) {
+                Assertions.assertFalse(dep.contains("\\"),
+                        "Dependency should not contain backslash escapes: " + dep);
+                Assertions.assertTrue(dep.contains("${citrus.version}"),
+                        "Dependency should contain valid Maven property reference: " + dep);
+            }
+        } finally {
+            Files.deleteIfExists(testDir);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Removes unnecessary backslash escaping in `TestPluginExporter.asDependency()` that produced literal `\${citrus.version}` instead of valid Maven property `${citrus.version}` in the generated POM
- Adds unit test verifying dependency strings contain proper Maven property references without backslash escapes

## Root Cause

`asDependency()` used `\\$\\{citrus.version}` which in Java produces the string `\${citrus.version}` with literal backslashes. The `$` does not need escaping in `String.formatted()` — only `%` is special. The backslashes were carried through MavenGav parsing and FreeMarker template rendering into the final POM XML, making it unresolvable by Maven.

## Test plan

- [x] New test `shouldProduceValidMavenPropertyReferences` verifies no backslash escapes in dependency strings
- [x] All 6 tests pass in camel-jbang-plugin-test
- [x] Full reactor build passes

🤖 Generated with [Claude Code](https://claude.ai/code) _on behalf of Claus Ibsen_

Co-Authored-By: Claude <noreply@anthropic.com>