### PR TITLE
ci: filter exclusion list from Scalpel shadow comparison

### DIFF
--- a/.github/CI-ARCHITECTURE.md
+++ b/.github/CI-ARCHITECTURE.md
@@ -170,7 +170,10 @@ Scalpel runs in **shadow mode**: it observes what skip-tests mode *would* have d
 The shadow comparison section shows:
 - How many modules Scalpel would test (direct + downstream)
 - How many downstream modules would have tests skipped (generated code, meta-modules)
+- Set differences: modules only Scalpel found vs modules only the current approach found
 - The full list of modules in each category
+
+The comparison is apples-to-apples: the current approach's reactor is filtered through the `EXCLUSION_LIST` before comparing, so both sides exclude the same meta/generated modules (catalog, jbang, docs, etc.).
 
 #### Configuration notes
 

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -414,9 +414,9 @@ checkManualItTests() {
 # ── Scalpel shadow comparison ──────────────────────────────────────────
 
 # Write Scalpel shadow comparison section to the PR comment.
-# Shows what Scalpel would detect vs what the current grep-based approach found,
+# Shows what Scalpel would detect vs what the current approach actually tests,
 # with a one-line diff summary. Observation only — does not affect test execution.
-# Args: $1=comment_file, $2=grep_dep_module_ids (colon-prefixed, comma-separated)
+# Args: $1=comment_file, $2=tested_reactor_ids (newline-separated, already filtered by EXCLUSION_LIST)
 writeScalpelComparison() {
   local comment_file="$1"
   local current_reactor_ids="${2:-}"
@@ -943,10 +943,19 @@ main() {
   writeComment "$comment_file" "$pl" "$grep_dep_module_ids" "$grep_changed_props" "$testedDependents" "$extraModules"
 
   # Scalpel shadow comparison (observation only — after separator)
-  # Pass reactor_ids (artifact IDs of all modules in the -amd reactor) so
-  # Scalpel can compare against the current detection and show modules it
-  # found that the current approach missed.
-  writeScalpelComparison "$comment_file" "$reactor_ids"
+  # Filter reactor_ids through EXCLUSION_LIST so the comparison is
+  # apples-to-apples: both sides exclude the same meta/generated modules.
+  local tested_reactor_ids=""
+  if [ -n "$reactor_ids" ]; then
+    local excl_set
+    excl_set=$(echo "$EXCLUSION_LIST" | sed 's/!://g' | tr ',' '\n')
+    tested_reactor_ids=$(echo "$reactor_ids" | while read -r rid; do
+      if ! echo "$excl_set" | grep -qx "$rid"; then
+        echo "$rid"
+      fi
+    done)
+  fi
+  writeScalpelComparison "$comment_file" "$tested_reactor_ids"
 
   # Check for tests disabled in CI via @DisabledIfSystemProperty(named = "ci.env.name")
   local disabled_tests

--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -495,9 +495,9 @@ writeScalpelComparison() {
   echo "[Maveniverse Scalpel](https://github.com/maveniverse/scalpel) detected **${scalpel_total} affected modules** (current approach: ${current_total})." >> "$comment_file"
   echo "" >> "$comment_file"
 
-  # Show modules only Scalpel found (current approach missed)
+  # Show modules only Scalpel found (not in current reactor)
   if [ "$only_scalpel_count" -gt 0 ]; then
-    echo "<details><summary>:warning: Modules only Scalpel found (${only_scalpel_count}) — current approach missed these</summary>" >> "$comment_file"
+    echo "<details><summary>:warning: Modules only in Scalpel (${only_scalpel_count})</summary>" >> "$comment_file"
     echo "" >> "$comment_file"
     echo "$only_in_scalpel" | while read -r m; do
       [ -n "$m" ] && echo "- \`$m\`" >> "$comment_file"
@@ -507,9 +507,9 @@ writeScalpelComparison() {
     echo "" >> "$comment_file"
   fi
 
-  # Show modules only current approach found (Scalpel missed)
+  # Show modules only current approach found (not in Scalpel)
   if [ "$only_current_count" -gt 0 ]; then
-    echo "<details><summary>Modules only current approach found (${only_current_count}) — Scalpel missed these</summary>" >> "$comment_file"
+    echo "<details><summary>Modules only in current approach (${only_current_count})</summary>" >> "$comment_file"
     echo "" >> "$comment_file"
     echo "$only_in_current" | while read -r m; do
       [ -n "$m" ] && echo "- \`$m\`" >> "$comment_file"


### PR DESCRIPTION
## Summary

Two fixes for the Scalpel shadow comparison:

**1. Exclusion list mismatch** — The comparison was apples-to-oranges:
- **Scalpel side**: already filtered via `skipTestsForDownstreamModules` (mirrors `EXCLUSION_LIST`)
- **Current side**: raw `-amd` reactor including meta/generated modules (catalog, jbang, docs, etc.)

This produced misleading results like [PR #24380](https://github.com/apache/camel/pull/24380#issuecomment-4865325425) showing "37 modules only current approach found" when those 37 modules are in the `EXCLUSION_LIST` and never actually tested.

Fix: filter `reactor_ids` through `EXCLUSION_LIST` before comparing.

**2. Biased wording** — "Scalpel missed these" implies a bug, but Scalpel may be correct (e.g. test-only changes don't need downstream testing). Changed to neutral labels: "Modules only in Scalpel" / "Modules only in current approach".

_Claude Code on behalf of @gnodet_

## Test plan
- [ ] CI comment no longer shows excluded meta-modules in the diff
- [ ] Wording is neutral — no "missed" language

🤖 Generated with [Claude Code](https://claude.com/claude-code)