### PR TITLE
CAMEL-23884: Fix flaky NatsConsumerWithRedeliveryIT by using Awaitility

### DIFF
--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerWithRedeliveryIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerWithRedeliveryIT.java
@@ -16,12 +16,17 @@
  */
 package org.apache.camel.component.nats.integration;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.EndpointInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NatsConsumerWithRedeliveryIT extends NatsITSupport {
 
@@ -36,16 +41,18 @@ public class NatsConsumerWithRedeliveryIT extends NatsITSupport {
     @Test
     public void testConsumer() throws Exception {
         mockResultEndpoint.setExpectedMessageCount(1);
-        mockResultEndpoint.setAssertPeriod(1000);
+        exception.setExpectedMessageCount(1);
 
         template.sendBody("direct:send", "test");
         template.sendBody("direct:send", "golang");
 
-        exception.setExpectedMessageCount(1);
-
-        exception.assertIsSatisfied();
-
-        mockResultEndpoint.assertIsSatisfied();
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertEquals(1, exception.getReceivedCounter(),
+                            "mock:exception should have received the message after redelivery exhaustion");
+                    assertEquals(1, mockResultEndpoint.getReceivedCounter(),
+                            "mock:result should have received the non-failing message");
+                });
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix the intermittently failing `NatsConsumerWithRedeliveryIT.testConsumer` which fails in CI with:
```
mock://exception Received message count. Expected: <1> but was: <0>
```

### Root cause

The test had two timing problems:

1. **Latch race condition**: The mock expectation for `mock:exception` was set _after_ messages were sent to NATS (`exception.setExpectedMessageCount(1)` on line 44, after `sendBody` calls on lines 41-42). `setExpectedMessageCount` creates a new `CountDownLatch` — if the async NATS consumer had already delivered the message through its full redelivery cycle before this call, the new latch would never count down.

2. **Fixed 10-second wait**: `MockEndpoint.waitForCompleteLatch(0)` defaults to a 10-second timeout. On loaded CI servers, the entire processing chain (NATS pub/sub roundtrip → exception → 2 redeliveries with 10ms delays → exhaustion → `mock:exception`) could exceed this window.

### Fix

- Move all `setExpectedMessageCount` calls **before** message sends, so the latch is ready before messages can arrive
- Replace `assertIsSatisfied()` / `setAssertPeriod(1000)` with **Awaitility** (`await().atMost(30, TimeUnit.SECONDS).untilAsserted(...)`) for adaptive polling instead of fixed timing assumptions
- This follows the [project guidelines](https://github.com/apache/camel/blob/main/CLAUDE.md) which require Awaitility instead of `Thread.sleep()` / fixed timing in tests

## Test plan

- [x] Compiles successfully
- [x] Code formatting passes (`mvn formatter:format impsort:sort`)
- [x] Integration test passes in CI with NATS testcontainer (JDK 17 + JDK 25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)