### PR TITLE
CAMEL-19542: Fix flaky camel-sjms surefire tests

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOnlyConsumerAsyncFalseTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOnlyConsumerAsyncFalseTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -46,9 +48,7 @@ public class InOnlyConsumerAsyncFalseTest extends JmsTestSupport {
         // the reason is that the first message is processed asynchronously
         // and it takes 2 sec to complete, so in between we have time to
         // process the 2nd message on the queue
-        Thread.sleep(3000);
-
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
         assertEquals(beforeThreadName, afterThreadName);
     }
 

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOnlyConsumerTopicTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOnlyConsumerTopicTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -35,7 +37,7 @@ public class InOnlyConsumerTopicTest extends JmsTestSupport {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello Camel", "Hello World");
         template.sendBody("sjms:topic:in.only.InOnlyConsumerTopicTest.topic", "Hello Camel");
         template.sendBody("sjms:topic:in.only.InOnlyConsumerTopicTest.topic", "Hello World");
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConcurrentConsumerTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConcurrentConsumerTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
@@ -58,7 +59,7 @@ public class InOutConcurrentConsumerTest extends JmsTestSupport {
             futures.add(out);
         }
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
 
         for (int i = 0; i < futures.size(); i++) {
             Object out = futures.get(i).get();

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerQueueAsyncTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerQueueAsyncTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
@@ -40,7 +42,7 @@ public class InOutConsumerQueueAsyncTest extends JmsCommonTestSupport {
         template.sendBody("sjms:start.queue.InOutConsumerQueueAsyncTest", "Hello Camel");
         template.sendBody("sjms:start.queue.InOutConsumerQueueAsyncTest", "Hello World");
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerQueueTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerQueueTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -32,7 +34,7 @@ public class InOutConsumerQueueTest extends JmsTestSupport {
         template.sendBody("sjms:start.queue.InOutConsumerQueueTest", "Hello Camel");
         template.sendBody("sjms:start.queue.InOutConsumerQueueTest", "Hello World");
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerTempQueueAsyncTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerTempQueueAsyncTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
@@ -33,7 +35,7 @@ public class InOutConsumerTempQueueAsyncTest extends JmsTestSupport {
         template.sendBody("sjms:start.queue.InOutConsumerTempQueueAsyncTest", "Hello Camel");
         template.sendBody("sjms:start.queue.InOutConsumerTempQueueAsyncTest", "Hello World");
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerTempQueueTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerTempQueueTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -31,7 +33,7 @@ public class InOutConsumerTempQueueTest extends JmsTestSupport {
 
         template.sendBody("sjms:start.queue.InOutConsumerTempQueueTest", "Hello Camel");
         template.sendBody("sjms:start.queue.InOutConsumerTempQueueTest", "Hello World");
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerTopicTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/consumer/InOutConsumerTopicTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.consumer;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
@@ -35,8 +37,7 @@ public class InOutConsumerTopicTest extends JmsTestSupport {
         getMockEndpoint("mock:result").expectedBodiesReceived("Hello Camel", "Hello World");
         template.sendBody("sjms:topic:start.topic.InOutConsumerTopicTest", "Hello Camel");
         template.sendBody("sjms:topic:start.topic.InOutConsumerTopicTest", "Hello World");
-        Thread.sleep(3000);
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 20, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/QueueProducerQoSTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/QueueProducerQoSTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.sjms.producer;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.jms.Connection;
 import jakarta.jms.Session;
 
@@ -35,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -93,8 +96,10 @@ public class QueueProducerQoSTest extends CamelTestSupport {
 
         mockExpiredAdvisory.assertIsSatisfied(10_000);
 
-        assertEquals(0, service.countMessages(TEST_INOUT_DESTINATION_NAME),
-                "There were unexpected messages left in the queue: " + TEST_INOUT_DESTINATION_NAME);
+        // The broker may need a moment to finish removing the expired message from the original queue
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+                () -> assertEquals(0, service.countMessages(TEST_INOUT_DESTINATION_NAME),
+                        "There were unexpected messages left in the queue: " + TEST_INOUT_DESTINATION_NAME));
     }
 
     @Test
@@ -106,8 +111,10 @@ public class QueueProducerQoSTest extends CamelTestSupport {
 
         mockExpiredAdvisory.assertIsSatisfied(10_000);
 
-        assertEquals(0, service.countMessages(TEST_INONLY_DESTINATION_NAME),
-                "There were unexpected messages left in the queue: " + TEST_INONLY_DESTINATION_NAME);
+        // The broker may need a moment to finish removing the expired message from the original queue
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+                () -> assertEquals(0, service.countMessages(TEST_INONLY_DESTINATION_NAME),
+                        "There were unexpected messages left in the queue: " + TEST_INONLY_DESTINATION_NAME));
     }
 
     private static Configuration configureArtemis(Configuration configuration) {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix intermittent CI failures in `camel-sjms` surefire tests (observed on JDK 25 builds) by replacing fixed `Thread.sleep()` waits with proper assertion timeouts and Awaitility.

### Root cause

- `MockEndpoint.assertIsSatisfied(context)` without explicit timeout defaults to only **10 seconds**, which is insufficient when route processors include 2-second simulated processing delays and CI machines are under load
- `Thread.sleep(3000)` in test methods (`InOutConsumerTopicTest`, `InOnlyConsumerAsyncFalseTest`) used fixed waits for async message processing completion — brittle on slow CI
- `QueueProducerQoSTest` asserted message queue counts immediately after mock satisfaction, but the broker may not have finished cleaning up expired messages yet

### Changes

- **Remove `Thread.sleep(3000)` from test methods** in `InOutConsumerTopicTest` and `InOnlyConsumerAsyncFalseTest` — these waited for async processing that `assertIsSatisfied` already handles with proper timeout
- **Add explicit 20-second timeout** to `MockEndpoint.assertIsSatisfied()` in 8 consumer tests whose route processors have deliberate `Thread.sleep(2000)` delays simulating slow work
- **Replace immediate queue-count assertions** with `Awaitility.await()` in `QueueProducerQoSTest` to handle the race between broker message expiry and queue metric updates

### Files changed (9)

| File | Change |
|------|--------|
| `InOutConsumerTopicTest` | Remove `Thread.sleep(3000)`, add 20s assertion timeout |
| `InOnlyConsumerAsyncFalseTest` | Remove `Thread.sleep(3000)`, add 20s assertion timeout |
| `InOnlyConsumerTopicTest` | Add 20s assertion timeout |
| `InOutConsumerQueueTest` | Add 20s assertion timeout |
| `InOutConsumerQueueAsyncTest` | Add 20s assertion timeout |
| `InOutConsumerTempQueueTest` | Add 20s assertion timeout |
| `InOutConsumerTempQueueAsyncTest` | Add 20s assertion timeout |
| `InOutConcurrentConsumerTest` | Add 20s assertion timeout |
| `QueueProducerQoSTest` | Replace immediate `assertEquals` with `Awaitility.await()` |

## Test plan

- [x] All 8 modified consumer tests pass locally
- [x] `QueueProducerQoSTest` passes consistently (verified 5 consecutive runs)
- [x] Full `camel-sjms` test suite passes (122/122 tests, excluding Docker-dependent `SjmsConnectionRecoveryTest`)
- [ ] CI build passes on JDK 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)