### PR TITLE
CAMEL-23888: Fix flaky camel-platform-http-vertx surefire tests

### DIFF
--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformEventNotifierTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformEventNotifierTest.java
@@ -16,9 +16,8 @@
  */
 package org.apache.camel.component.platform.http.vertx;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
@@ -34,7 +33,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 
 public class VertxPlatformEventNotifierTest {
-    private final List<String> events = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> events = new CopyOnWriteArrayList<>();
 
     @Test
     void testEventNotifierOk() throws Exception {

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformEventNotifierTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformEventNotifierTest.java
@@ -17,7 +17,9 @@
 package org.apache.camel.component.platform.http.vertx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -28,10 +30,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 
 public class VertxPlatformEventNotifierTest {
-    private final List<String> events = new ArrayList<>();
+    private final List<String> events = Collections.synchronizedList(new ArrayList<>());
 
     @Test
     void testEventNotifierOk() throws Exception {
@@ -57,9 +60,13 @@ public class VertxPlatformEventNotifierTest {
                     .statusCode(200)
                     .body(is("Bye World"));
 
-            Assertions.assertEquals(2, events.size());
-            Assertions.assertEquals("ExchangeCreated (failed:false)", events.get(0));
-            Assertions.assertEquals("ExchangeCompleted (failed:false)", events.get(1));
+            // Event notification is async — the HTTP response can return before
+            // ExchangeCompleted fires, so poll with Awaitility instead of asserting immediately.
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                Assertions.assertEquals(2, events.size());
+                Assertions.assertEquals("ExchangeCreated (failed:false)", events.get(0));
+                Assertions.assertEquals("ExchangeCompleted (failed:false)", events.get(1));
+            });
         } finally {
             context.stop();
         }
@@ -89,9 +96,13 @@ public class VertxPlatformEventNotifierTest {
                     .statusCode(500)
                     .body(is(""));
 
-            Assertions.assertEquals(2, events.size());
-            Assertions.assertEquals("ExchangeCreated (failed:false)", events.get(0));
-            Assertions.assertEquals("ExchangeFailed (failed:true)", events.get(1));
+            // Event notification is async — the HTTP response can return before
+            // ExchangeFailed fires, so poll with Awaitility instead of asserting immediately.
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                Assertions.assertEquals(2, events.size());
+                Assertions.assertEquals("ExchangeCreated (failed:false)", events.get(0));
+                Assertions.assertEquals("ExchangeFailed (failed:true)", events.get(1));
+            });
         } finally {
             context.stop();
         }

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpOAuthProfileTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpOAuthProfileTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
@@ -56,24 +55,36 @@ class VertxPlatformHttpOAuthProfileTest {
             VertxPlatformHttpServer server = context.hasService(VertxPlatformHttpServer.class);
             client = server.getVertx().createHttpClient();
 
-            CompletableFuture<HttpClientResponse> responseFuture = new CompletableFuture<>();
+            // Collect status code and response body atomically inside the response
+            // handler to avoid a race where the body arrives and is discarded before
+            // the test registers a body() handler.
+            CompletableFuture<int[]> statusFuture = new CompletableFuture<>();
+            CompletableFuture<String> bodyFuture = new CompletableFuture<>();
             client.request(HttpMethod.POST, server.getPort(), "localhost", "/secure")
                     .onSuccess(request -> {
                         request.putHeader("Content-Length", "1024");
                         request.response()
-                                .onSuccess(responseFuture::complete)
-                                .onFailure(responseFuture::completeExceptionally);
-                        request.sendHead().onFailure(responseFuture::completeExceptionally);
+                                .onSuccess(response -> {
+                                    statusFuture.complete(new int[] { response.statusCode() });
+                                    response.body()
+                                            .onSuccess(buffer -> bodyFuture.complete(buffer.toString()))
+                                            .onFailure(bodyFuture::completeExceptionally);
+                                })
+                                .onFailure(t -> {
+                                    statusFuture.completeExceptionally(t);
+                                    bodyFuture.completeExceptionally(t);
+                                });
+                        request.sendHead().onFailure(t -> {
+                            statusFuture.completeExceptionally(t);
+                            bodyFuture.completeExceptionally(t);
+                        });
                     })
-                    .onFailure(responseFuture::completeExceptionally);
+                    .onFailure(t -> {
+                        statusFuture.completeExceptionally(t);
+                        bodyFuture.completeExceptionally(t);
+                    });
 
-            HttpClientResponse response = responseFuture.get(5, TimeUnit.SECONDS);
-            CompletableFuture<String> bodyFuture = new CompletableFuture<>();
-            response.body()
-                    .onSuccess(buffer -> bodyFuture.complete(buffer.toString()))
-                    .onFailure(bodyFuture::completeExceptionally);
-
-            assertEquals(401, response.statusCode());
+            assertEquals(401, statusFuture.get(5, TimeUnit.SECONDS)[0]);
             assertEquals("Unauthorized", bodyFuture.get(5, TimeUnit.SECONDS));
 
             assertEquals(0, routeInvocations.get());

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpProxyTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpProxyTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.platform.http.vertx;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -78,8 +77,9 @@ public class VertxPlatformHttpProxyTest {
 
             context.start();
 
-            // URI of proxy created with platform HTTP component
-            final var proxyURI = "http://localhost:" + RestAssured.port;
+            // URI of proxy created with platform HTTP component — use camelPort directly
+            // instead of the static RestAssured.port to avoid races with other tests.
+            final var proxyURI = "http://localhost:" + camelPort.getPort();
 
             final var originURI = "http://localhost:" + wireMockServer.port();
 

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSharedVertxTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpSharedVertxTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.platform.http.vertx;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.vertx.core.Vertx;
 import org.apache.camel.CamelContext;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.awaitility.Awaitility.await;
 
 class VertxPlatformHttpSharedVertxTest {
     @RegisterExtension
@@ -61,9 +61,10 @@ class VertxPlatformHttpSharedVertxTest {
             context.start();
         }
 
-        // Verify shutdown of VertxPlatformHttpServer did not close the shared Vertx instance
-        CountDownLatch latch = new CountDownLatch(1);
-        vertx.setTimer(1, event -> latch.countDown());
-        assertTrue(latch.await(1, TimeUnit.SECONDS));
+        // Verify shutdown of VertxPlatformHttpServer did not close the shared Vertx instance.
+        // Use Awaitility instead of a tight CountDownLatch timeout to avoid flakiness on slow CI.
+        AtomicBoolean timerFired = new AtomicBoolean(false);
+        vertx.setTimer(1, event -> timerFired.set(true));
+        await().atMost(5, TimeUnit.SECONDS).untilTrue(timerFired);
     }
 }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix four distinct flaky test patterns in `camel-platform-http-vertx` observed failing intermittently during CI on JDK 25.

- **VertxPlatformEventNotifierTest** — Event notifications fire asynchronously from the Vert.x event loop; assertions ran before events were recorded. Use Awaitility polling + `CopyOnWriteArrayList` for thread safety.
- **VertxPlatformHttpSharedVertxTest** — `CountDownLatch` with tight 1-second timeout replaced with Awaitility polling (5s timeout).
- **VertxPlatformHttpProxyTest** — Static `RestAssured.port` races with other tests; use `camelPort.getPort()` directly.
- **VertxPlatformHttpOAuthProfileTest** — Response body handler registered after response callback completed, so body data could be discarded before collection. Register body handler inside `onSuccess` callback.

## Test plan

- [x] All 118 tests in `camel-platform-http-vertx` pass consistently across multiple consecutive runs
- [x] CI passes on both JDK 17 and JDK 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)