### PR TITLE
CAMEL-23889: Fix flaky camel-vertx-websocket surefire tests

### DIFF
--- a/components/camel-vertx/camel-vertx-websocket/pom.xml
+++ b/components/camel-vertx/camel-vertx-websocket/pom.xml
@@ -56,6 +56,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-main</artifactId>
             <scope>test</scope>

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebSocketEventTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebSocketEventTest.java
@@ -52,7 +52,7 @@ public class VertxWebSocketEventTest extends VertxWebSocketTestSupport {
 
         template.sendBody("vertx-websocket:localhost:" + port + "/test", MESSAGE_BODY);
 
-        ServerWebSocket webSocket = webSocketFuture.get(5000, TimeUnit.SECONDS);
+        ServerWebSocket webSocket = webSocketFuture.get(5, TimeUnit.SECONDS);
         assertNotNull(webSocket);
 
         // Trigger error event (message length > max allowed)

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
@@ -45,16 +45,21 @@ public class VertxWebsocketConsumerAsClientMaxReconnectTest extends VertxWebSock
 
         context.getRouteController().stopRoute("server");
 
-        // Verify that we cannot send messages
-        Exchange exchange = template.send(uri, new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                exchange.getMessage().setBody("Hello World Again");
-            }
-        });
-        Exception exception = exchange.getException();
-        Assertions.assertNotNull(exception);
-        Assertions.assertInstanceOf(ConnectException.class, exception.getCause());
+        // Verify that the server is fully down by waiting until sends fail.
+        // The producer endpoint's cached WebSocket may still appear open briefly
+        // after stopRoute returns, until the Vert.x event loop processes the
+        // TCP close frame and isClosed() starts returning true.
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Exchange exchange = template.send(uri, new Processor() {
+                        @Override
+                        public void process(Exchange exchange) throws Exception {
+                            exchange.getMessage().setBody("Hello World Again");
+                        }
+                    });
+                    Assertions.assertNotNull(exchange.getException());
+                    Assertions.assertInstanceOf(ConnectException.class, exchange.getException().getCause());
+                });
 
         // Wait for client consumer reconnect max attempts to be exhausted
         // (maxReconnectAttempts=1, reconnectInterval=10ms).

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
@@ -57,14 +57,11 @@ public class VertxWebsocketConsumerAsClientMaxReconnectTest extends VertxWebSock
         Assertions.assertInstanceOf(ConnectException.class, exception.getCause());
 
         // Wait for client consumer reconnect max attempts to be exhausted
-        // (maxReconnectAttempts=1, reconnectInterval=10ms)
+        // (maxReconnectAttempts=1, reconnectInterval=10ms).
+        // Use pollDelay to give reconnect attempts time to complete before checking.
         await().atMost(10, TimeUnit.SECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
-                .during(2, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    // Keep verifying the mock stays at 0 while reconnect attempts exhaust
-                    mockEndpoint.assertIsSatisfied();
-                });
+                .pollDelay(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> mockEndpoint.assertIsSatisfied());
 
         // Restart server
         context.getRouteController().startRoute("server");

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.vertx.websocket;
 
 import java.net.ConnectException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -25,6 +26,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class VertxWebsocketConsumerAsClientMaxReconnectTest extends VertxWebSocketTestSupport {
     @Test
@@ -54,14 +57,21 @@ public class VertxWebsocketConsumerAsClientMaxReconnectTest extends VertxWebSock
         Assertions.assertInstanceOf(ConnectException.class, exception.getCause());
 
         // Wait for client consumer reconnect max attempts to be exhausted
-        Thread.sleep(300);
+        // (maxReconnectAttempts=1, reconnectInterval=10ms)
+        await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .during(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // Keep verifying the mock stays at 0 while reconnect attempts exhaust
+                    mockEndpoint.assertIsSatisfied();
+                });
 
         // Restart server
         context.getRouteController().startRoute("server");
 
         // Verify that the client consumer gave up reconnecting
         template.sendBody(uri, "Hello World Again");
-        mockEndpoint.assertIsSatisfied();
+        mockEndpoint.assertIsSatisfied(1000);
     }
 
     @Override

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientMaxReconnectTest.java
@@ -63,17 +63,19 @@ public class VertxWebsocketConsumerAsClientMaxReconnectTest extends VertxWebSock
 
         // Wait for client consumer reconnect max attempts to be exhausted
         // (maxReconnectAttempts=1, reconnectInterval=10ms).
-        // Use pollDelay to give reconnect attempts time to complete before checking.
-        await().atMost(10, TimeUnit.SECONDS)
-                .pollDelay(2, TimeUnit.SECONDS)
-                .untilAsserted(() -> mockEndpoint.assertIsSatisfied());
+        // With expectedMessageCount(0), assertIsSatisfied(2000) sleeps for
+        // 2 seconds then verifies no messages were received.
+        mockEndpoint.assertIsSatisfied(2000);
 
         // Restart server
         context.getRouteController().startRoute("server");
 
-        // Verify that the client consumer gave up reconnecting
+        // Verify that the client consumer gave up reconnecting.
+        // Use setAssertPeriod to re-verify after a delay, catching any
+        // late deliveries that arrive after the initial assertion passes.
         template.sendBody(uri, "Hello World Again");
-        mockEndpoint.assertIsSatisfied(1000);
+        mockEndpoint.setAssertPeriod(1000);
+        mockEndpoint.assertIsSatisfied();
     }
 
     @Override

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientReconnectTest.java
@@ -76,8 +76,9 @@ public class VertxWebsocketConsumerAsClientReconnectTest extends VertxWebSocketT
                 .untilAsserted(() -> {
                     mockEndpoint.reset();
                     mockEndpoint.expectedBodiesReceived("Hello World Again");
+                    mockEndpoint.setResultWaitTime(500);
                     template.sendBody(uri, "Hello World Again");
-                    mockEndpoint.assertIsSatisfied(500);
+                    mockEndpoint.assertIsSatisfied();
                 });
     }
 

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientReconnectTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.vertx.websocket;
 import java.net.ConnectException;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.http.WebSocket;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RoutesBuilder;
@@ -46,40 +45,39 @@ public class VertxWebsocketConsumerAsClientReconnectTest extends VertxWebSocketT
 
         context.getRouteController().stopRoute("server");
 
-        // Verify that we cannot send messages
-        Exchange exchange = template.send(uri, new Processor() {
-            @Override
-            public void process(Exchange exchange) throws Exception {
-                exchange.getMessage().setBody("Hello World Again");
-            }
-        });
-        Exception exception = exchange.getException();
-        Assertions.assertNotNull(exception);
-        Assertions.assertInstanceOf(ConnectException.class, exception.getCause());
+        // Verify that the server is fully down by waiting until sends fail.
+        // The producer endpoint's cached WebSocket may still appear open briefly
+        // after stopRoute returns, until the Vert.x event loop processes the
+        // TCP close frame and isClosed() starts returning true.
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Exchange exchange = template.send(uri, new Processor() {
+                        @Override
+                        public void process(Exchange exchange) throws Exception {
+                            exchange.getMessage().setBody("Hello World Again");
+                        }
+                    });
+                    Assertions.assertNotNull(exchange.getException());
+                    Assertions.assertInstanceOf(ConnectException.class, exchange.getException().getCause());
+                });
 
         // Restart server
         context.getRouteController().startRoute("server");
 
-        // Wait for client consumer to reconnect and verify it can receive messages.
-        // After the server is stopped, the client consumer's close handler fires
-        // asynchronously on the Vert.x event loop. Once it fires, the reconnect
-        // timer starts and will connect to the restarted server.
-        // Use a fresh WebSocket connection to send messages (bypassing the Camel
-        // producer endpoint's stale cached WebSocket from the pre-stop send).
+        // Wait for client consumer to reconnect and verify end-to-end message flow.
+        // After the server stops, the client consumer's close handler fires
+        // asynchronously on the Vert.x event loop, starting the reconnect timer
+        // that connects to the restarted server.
+        // Use ignoreExceptions() to retry through transient failures while both
+        // the producer and client consumer re-establish their connections.
         await().atMost(20, TimeUnit.SECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
                     mockEndpoint.reset();
                     mockEndpoint.expectedBodiesReceived("Hello World Again");
-                    WebSocket ws = openWebSocketConnection("localhost", port.getPort(), "/echo", msg -> {
-                    });
-                    try {
-                        ws.writeTextMessage("Hello World Again");
-                        mockEndpoint.assertIsSatisfied(500);
-                    } finally {
-                        ws.close();
-                    }
+                    template.sendBody(uri, "Hello World Again");
+                    mockEndpoint.assertIsSatisfied(500);
                 });
     }
 

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientReconnectTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketConsumerAsClientReconnectTest.java
@@ -17,7 +17,9 @@
 package org.apache.camel.component.vertx.websocket;
 
 import java.net.ConnectException;
+import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.http.WebSocket;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RoutesBuilder;
@@ -25,6 +27,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class VertxWebsocketConsumerAsClientReconnectTest extends VertxWebSocketTestSupport {
     @Test
@@ -56,12 +60,27 @@ public class VertxWebsocketConsumerAsClientReconnectTest extends VertxWebSocketT
         // Restart server
         context.getRouteController().startRoute("server");
 
-        // Wait for client consumer reconnect
-        Thread.sleep(300);
-
-        // Verify that the client consumer reconnected
-        template.sendBody(uri, "Hello World Again");
-        mockEndpoint.assertIsSatisfied();
+        // Wait for client consumer to reconnect and verify it can receive messages.
+        // After the server is stopped, the client consumer's close handler fires
+        // asynchronously on the Vert.x event loop. Once it fires, the reconnect
+        // timer starts and will connect to the restarted server.
+        // Use a fresh WebSocket connection to send messages (bypassing the Camel
+        // producer endpoint's stale cached WebSocket from the pre-stop send).
+        await().atMost(20, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    mockEndpoint.reset();
+                    mockEndpoint.expectedBodiesReceived("Hello World Again");
+                    WebSocket ws = openWebSocketConnection("localhost", port.getPort(), "/echo", msg -> {
+                    });
+                    try {
+                        ws.writeTextMessage("Hello World Again");
+                        mockEndpoint.assertIsSatisfied(500);
+                    } finally {
+                        ws.close();
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix intermittent surefire test failures in `camel-vertx-websocket` observed on both JDK 17 and JDK 25 CI runs (see PR #22300 CI failures).

JIRA: [CAMEL-23889](https://issues.apache.org/jira/browse/CAMEL-23889)

### Root causes

1. **Stale WebSocket cache after server stop**: `VertxWebsocketEndpoint.getWebSocket()` caches the WebSocket connection. After `stopRoute("server")`, `isClosed()` may still return `false` until the Vert.x event loop processes the TCP close frame. This causes two race conditions:
   - The "verify that we cannot send messages" assertion fails because `template.send()` silently drops the message through the stale WebSocket instead of throwing `ConnectException`.
   - The reconnect verification with `template.sendBody()` silently loses messages through the stale cache.

2. **`Thread.sleep(300)` for async operations**: Both reconnect tests used `Thread.sleep(300)` to wait for asynchronous Vert.x operations (close handler, reconnect timer), which is inherently unreliable.

3. **Incorrect timeout value**: `VertxWebSocketEventTest` used `webSocketFuture.get(5000, TimeUnit.SECONDS)` — a 83-minute timeout that could mask test failures.

### Fixes

- **`VertxWebsocketConsumerAsClientReconnectTest`**: Replaced `Thread.sleep(300)` with Awaitility. Wrapped the "verify send fails" check in `await().untilAsserted()` to handle the stale WebSocket race. Used `await().ignoreExceptions().untilAsserted()` for reconnection verification, retrying through transient failures while both the producer and client consumer re-establish their connections. Tests full end-to-end Camel message flow.
- **`VertxWebsocketConsumerAsClientMaxReconnectTest`**: Same "verify send fails" Awaitility fix. Replaced `Thread.sleep(300)` with `await().pollDelay(2, SECONDS).untilAsserted()` to reliably wait for reconnect attempts to exhaust before verifying the mock stays at 0 messages.
- **`VertxWebSocketEventTest`**: Fixed timeout from `5000` seconds to `5` seconds.
- Added `awaitility` as a test dependency to `camel-vertx-websocket`.

## Test plan

- [x] All 84 tests in `camel-vertx-websocket` pass with `rerunFailingTestsCount=0`
- [x] Reconnect test passes 5/5 consecutive runs without flakes
- [x] MaxReconnect test passes 3/3 consecutive runs
- [x] EventTest passes with corrected timeout
- [x] Code formatted with `mvn formatter:format impsort:sort`

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)