### PR TITLE
CAMEL-23891: camel-mail - filter Camel internal headers in MimeMultipartDataFormat unmarshal

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
@@ -50,8 +50,10 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.attachment.Attachment;
 import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.attachment.DefaultAttachment;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.apache.camel.support.DefaultDataFormat;
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.IOHelper;
@@ -72,6 +74,7 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
     private String includeHeaders;
     private Pattern includeHeadersPattern;
     private boolean binaryContent;
+    private final HeaderFilterStrategy headerFilterStrategy = new DefaultHeaderFilterStrategy();
 
     public String getMultipartSubType() {
         return multipartSubType;
@@ -282,6 +285,12 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
         while (headersEnum.hasMoreElements()) {
             Object ho = headersEnum.nextElement();
             if (ho instanceof Header header) {
+                // filter Camel internal headers (Camel*) instead of copying them verbatim from the external
+                // MIME headers, consistent with the inbound HeaderFilterStrategy applied by the mail consumer
+                if (headerFilterStrategy.applyFilterToExternalHeaders(header.getName(), header.getValue(),
+                        camelMessage.getExchange())) {
+                    continue;
+                }
                 camelMessage.setHeader(header.getName(), header.getValue());
             }
         }

--- a/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
@@ -407,6 +407,27 @@ public class MimeMultipartDataFormatTest extends CamelTestSupport {
     }
 
     @Test
+    public void unmarshalInlineHeadersFiltersCamelInternalHeaders() {
+        // Camel-internal headers (Camel*, case-insensitive) present in the external MIME headers must not be
+        // copied onto the Camel message; ordinary application headers still pass through. This matches the
+        // inbound HeaderFilterStrategy applied by the mail consumer.
+        String mime = "CamelFoo: blocked\r\n"
+                      + "camelBar: blocked\r\n"
+                      + "CAMELBaz: blocked\r\n"
+                      + "X-Normal: keep-me\r\n"
+                      + "Content-Type: text/plain\r\n"
+                      + "\r\n"
+                      + "Body text";
+        in.setBody(mime);
+        Exchange out = template.send("direct:unmarshalonlyinlineheaders", exchange);
+        assertNotNull(out.getMessage());
+        assertEquals("keep-me", out.getMessage().getHeader("X-Normal"));
+        assertNull(out.getMessage().getHeader("CamelFoo"));
+        assertNull(out.getMessage().getHeader("camelBar"));
+        assertNull(out.getMessage().getHeader("CAMELBaz"));
+    }
+
+    @Test
     public void unmarshalRelated() throws IOException {
         in.setBody(new File("src/test/resources/multipart-related.txt"));
         Attachment dh = unmarshalAndCheckAttachmentName("950120.aaCB@XIson.com");

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -94,3 +94,13 @@ payloads, enable stream caching on the route.
 
 * The `bufferSize` option has been removed. It only configured the previous streaming implementation and no longer has
 any effect with authenticated encryption.
+
+=== camel-mail - MimeMultipartDataFormat inbound header filtering
+
+When unmarshalling a MIME message with `headersInline=true`, the `mime-multipart` data format now applies a
+`HeaderFilterStrategy` to the headers copied from the MIME content onto the Camel message. Camel-internal headers
+(the `Camel*` namespace, matched case-insensitively) present in the external MIME headers are no longer copied onto
+the message, consistent with the inbound header filtering already performed by the camel-mail consumer.
+
+Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
+content, set them explicitly after unmarshalling.


### PR DESCRIPTION
This aligns `MimeMultipartDataFormat` unmarshalling (`headersInline=true`) with the camel-mail consumer: internal Camel headers (`Camel*`, matched case-insensitively) present in the external MIME headers are no longer copied verbatim onto the Camel message.

### Background

Previously `copyNonStandardHeaders()` copied every MIME header (except `Message-ID`, `MIME-Version`, `Content-Type`) straight into the message header map with no `HeaderFilterStrategy`. This is inconsistent with:

- the camel-mail **consumer**, which applies `MailHeaderFilterStrategy` (extends `DefaultHeaderFilterStrategy`) and filters the `Camel*` namespace case-insensitively on the inbound direction;
- the data format's own **marshal** path, where inline headers are only copied when they match an explicit `includeHeaders` pattern.

### Change

`copyNonStandardHeaders()` now delegates to `DefaultHeaderFilterStrategy.applyFilterToExternalHeaders(...)`, so `Camel*` headers arriving in MIME content are filtered on the inbound path. Ordinary application headers (e.g. `X-...`) continue to pass through unchanged.

- Added a unit test covering prefix + case-insensitive filtering and application-header passthrough.
- Added a 4.22 upgrade-guide entry (potential behavior change).

JIRA: https://issues.apache.org/jira/browse/CAMEL-23891

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Andrea Cosentino
