### PR TITLE
CAMEL-23896: Fix flaky SqlFunctionDataSourceTest MariaDB startup timeout

### DIFF
--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/stored/SqlFunctionDataSourceTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/stored/SqlFunctionDataSourceTest.java
@@ -81,21 +81,24 @@ public class SqlFunctionDataSourceTest extends CamelTestSupport {
         timeoutField.setInt(db, MARIADB_START_TIMEOUT_MS);
 
         db.start();
-        // Only assign to static field after successful start, so that surefire retries
-        // will re-attempt initialization if start() fails
-        sharedMariaDb = db;
 
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
         dataSource.setDriverClassName("org.mariadb.jdbc.Driver");
-        dataSource.setUrl(sharedMariaDb.getConfiguration().getURL(DB_NAME));
+        dataSource.setUrl(db.getConfiguration().getURL(DB_NAME));
         dataSource.setUsername("root");
         dataSource.setPassword("");
-        sharedDataSource = dataSource;
 
         ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
         populator.addScript(new ClassPathResource("sql/storedFunctionMariaDB.sql"));
         populator.setSeparator("$$");
-        populator.execute(sharedDataSource);
+        populator.execute(dataSource);
+
+        // Only assign to static fields after all initialization succeeds (start,
+        // DataSource creation, schema population), so that surefire retries will
+        // re-attempt the full initialization if any step fails
+        sharedMariaDb = db;
+        sharedDataSource = dataSource;
+        jdbcTemplate = new JdbcTemplate(sharedDataSource);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             if (sharedMariaDb != null) {
@@ -106,7 +109,6 @@ public class SqlFunctionDataSourceTest extends CamelTestSupport {
                 }
             }
         }));
-        jdbcTemplate = new JdbcTemplate(sharedDataSource);
     }
 
     /** Initialize the database for the tests. */

--- a/components/camel-sql/src/test/java/org/apache/camel/component/sql/stored/SqlFunctionDataSourceTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/component/sql/stored/SqlFunctionDataSourceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.sql.stored;
 
+import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,12 +62,28 @@ public class SqlFunctionDataSourceTest extends CamelTestSupport {
     private static JdbcTemplate jdbcTemplate;
     private TemplateParser templateParser;
 
+    /**
+     * MariaDB startup timeout in milliseconds. The default 30s in MariaDB4j is too short for CI environments under
+     * load, where InnoDB initialization can take longer. 120s provides a comfortable margin.
+     */
+    private static final int MARIADB_START_TIMEOUT_MS = 120_000;
+
     /** Initialize the shared MariaDB database for the tests. */
     private static void initSharedMariaDb() throws Exception {
         DBConfigurationBuilder config = DBConfigurationBuilder.newBuilder();
         config.setPort(0);
-        sharedMariaDb = DB.newEmbeddedDB(config.build());
-        sharedMariaDb.start();
+        DB db = DB.newEmbeddedDB(config.build());
+
+        // Increase the startup timeout from the default 30s — CI machines under load
+        // may need more time for InnoDB initialization before "ready for connections"
+        Field timeoutField = DB.class.getDeclaredField("dbStartMaxWaitInMS");
+        timeoutField.setAccessible(true);
+        timeoutField.setInt(db, MARIADB_START_TIMEOUT_MS);
+
+        db.start();
+        // Only assign to static field after successful start, so that surefire retries
+        // will re-attempt initialization if start() fails
+        sharedMariaDb = db;
 
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
         dataSource.setDriverClassName("org.mariadb.jdbc.Driver");


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fixes https://issues.apache.org/jira/browse/CAMEL-23896

The `SqlFunctionDataSourceTest` fails intermittently in CI because the embedded MariaDB4j database has a hardcoded 30s startup timeout (`dbStartMaxWaitInMS`) that is too short when CI machines are under load. Observed in [PR #24374 CI run](https://github.com/apache/camel/actions/runs/28641667625) on JDK 17.

**Root cause analysis:**

1. **Timeout too short**: MariaDB4j waits for the "ready for connections" magic string in console output, with a default 30s deadline. On loaded CI machines, InnoDB initialization (buffer pool, undo tablespaces, temp files) can exceed this. The CI log showed MariaDB was progressing normally but hadn't finished within 30s.

2. **Broken retry logic**: When any initialization step failed (start, DataSource creation, or schema population), `sharedMariaDb` was already assigned, so surefire retries skipped `initSharedMariaDb()` and failed with "DataSource must be configured" — a cascading failure.

**Fixes applied:**

- Increase the MariaDB startup timeout from 30s to 120s via reflection on the `protected` `dbStartMaxWaitInMS` field (MariaDB4j provides no public API for this)
- Move `sharedMariaDb`/`sharedDataSource` sentinel assignment to after **all** initialization steps succeed (start, DataSource creation, schema population), so retries re-attempt the full initialization flow

## Test plan
- [x] `SqlFunctionDataSourceTest` passes (2 tests)
- [x] All 233 camel-sql unit tests pass (`mvn test`)
- [x] Code formatting verified (`mvn formatter:format impsort:sort` — no changes needed)
- [x] CI passes on JDK 17 and JDK 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)