### PR TITLE
CAMEL-19528: Replace CountDownLatch with Awaitility in camel-jpa tests

### DIFF
--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaTest.java
@@ -18,7 +18,6 @@ package org.apache.camel.component.jpa;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.EntityManager;
@@ -41,6 +40,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,8 +55,7 @@ public class JpaTest {
     protected EntityManager entityManager;
     protected TransactionTemplate transactionTemplate;
     protected Consumer consumer;
-    protected Exchange receivedExchange;
-    protected CountDownLatch latch = new CountDownLatch(1);
+    protected volatile Exchange receivedExchange;
     protected String entityName = SendEmail.class.getName();
     protected String queryText = "select o from " + entityName + " o";
 
@@ -80,20 +79,19 @@ public class JpaTest {
             public void process(Exchange e) {
                 LOG.info("Received exchange: {}", e.getIn());
                 receivedExchange = e;
-                // should have a EntityManager
-                EntityManager entityManager = e.getIn().getHeader(JpaConstants.ENTITY_MANAGER, EntityManager.class);
-                assertNotNull(entityManager, "Should have a EntityManager as header");
-                latch.countDown();
             }
         });
         consumer.start();
 
-        assertTrue(latch.await(50, TimeUnit.SECONDS));
-
-        assertNotNull(receivedExchange);
-        SendEmail result = receivedExchange.getIn().getBody(SendEmail.class);
-        assertNotNull(result, "Received a POJO");
-        assertEquals("foo@bar.com", result.getAddress(), "address property");
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertNotNull(receivedExchange);
+            // should have a EntityManager
+            EntityManager em = receivedExchange.getIn().getHeader(JpaConstants.ENTITY_MANAGER, EntityManager.class);
+            assertNotNull(em, "Should have a EntityManager as header");
+            SendEmail result = receivedExchange.getIn().getBody(SendEmail.class);
+            assertNotNull(result, "Received a POJO");
+            assertEquals("foo@bar.com", result.getAddress(), "address property");
+        });
     }
 
     @Test

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNamedQueryAndParametersTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNamedQueryAndParametersTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.component.jpa;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.EntityManager;
@@ -42,6 +41,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,8 +56,7 @@ public class JpaWithNamedQueryAndParametersTest {
     protected EntityManager entityManager;
     protected TransactionTemplate transactionTemplate;
     protected Consumer consumer;
-    protected Exchange receivedExchange;
-    protected CountDownLatch latch = new CountDownLatch(1);
+    protected volatile Exchange receivedExchange;
     protected String entityName = Customer.class.getName();
     protected String queryText = "select o from " + entityName + " o where o.name like 'Willem'";
 
@@ -99,14 +98,12 @@ public class JpaWithNamedQueryAndParametersTest {
             public void process(Exchange e) {
                 LOG.info("Received exchange: {}", e.getIn());
                 receivedExchange = e;
-                latch.countDown();
             }
         });
         consumer.start();
 
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-
-        assertReceivedResult(receivedExchange);
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertReceivedResult(receivedExchange));
 
         JpaConsumer jpaConsumer = (JpaConsumer) consumer;
         assertURIQueryOption(jpaConsumer);

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNamedQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNamedQueryTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.jpa;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.EntityManager;
@@ -57,8 +56,7 @@ public class JpaWithNamedQueryTest {
     protected EntityManager entityManager;
     protected TransactionTemplate transactionTemplate;
     protected Consumer consumer;
-    protected Exchange receivedExchange;
-    protected CountDownLatch latch = new CountDownLatch(1);
+    protected volatile Exchange receivedExchange;
     protected String entityName = MultiSteps.class.getName();
     protected String queryText = "select o from " + entityName + " o where o.step = 1";
 
@@ -100,14 +98,12 @@ public class JpaWithNamedQueryTest {
                 LOG.info("Received exchange: {}", e.getIn());
                 // make defensive copy
                 receivedExchange = e.copy();
-                latch.countDown();
             }
         });
         consumer.start();
 
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-
-        assertReceivedResult(receivedExchange);
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertReceivedResult(receivedExchange));
 
         // lets now test that the database is updated.
         // the consumer updates the row from within its own transaction, so we poll until that

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryTest.java
@@ -19,14 +19,11 @@ package org.apache.camel.component.jpa;
 import org.apache.camel.Exchange;
 import org.apache.camel.examples.MultiSteps;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Timeout(30)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
-                          disabledReason = "Apache CI is hanging on this test")
 public class JpaWithNativeQueryTest extends JpaWithNamedQueryTest {
 
     /**

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryWithResultClassTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithNativeQueryWithResultClassTest.java
@@ -18,13 +18,12 @@ package org.apache.camel.component.jpa;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.examples.MultiSteps;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
-                          disabledReason = "Apache CI is hanging on this test")
+@Timeout(30)
 public class JpaWithNativeQueryWithResultClassTest extends JpaWithNamedQueryTest {
 
     /**

--- a/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithQueryTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/component/jpa/JpaWithQueryTest.java
@@ -18,13 +18,10 @@ package org.apache.camel.component.jpa;
 
 import org.apache.camel.examples.MultiSteps;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(30)
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
-                          disabledReason = "Apache CI is hanging on this test")
 public class JpaWithQueryTest extends JpaWithNamedQueryTest {
 
     @Override


### PR DESCRIPTION
## Summary

- Replace flaky `CountDownLatch`-based synchronization with Awaitility `await().untilAsserted()` in JPA consumer tests (`JpaWithNamedQueryTest`, `JpaTest`, `JpaWithNamedQueryAndParametersTest`)
- Re-enable 3 tests previously disabled on CI (`JpaWithQueryTest`, `JpaWithNativeQueryTest`, `JpaWithNativeQueryWithResultClassTest`) by removing `@DisabledIfSystemProperty` annotations — the underlying timing issue in their parent class is now fixed
- Mark `receivedExchange` fields as `volatile` for correct cross-thread visibility

**Root cause:** The `CountDownLatch` + `latch.await(timeout)` pattern in consumer tests was timing-sensitive. The JPA consumer uses scheduled polling (1s initial delay, 500ms interval), and under CI load the consumer poll could arrive after the fixed deadline, causing hangs or assertion failures. Awaitility's polling approach retries the assertion until it passes, making the tests resilient to scheduling jitter.

## Test plan

- [x] All 96 camel-jpa tests pass locally (including the 3 re-enabled tests)
- [x] No `Thread.sleep` or `CountDownLatch` remaining in modified test files
- [x] Code formatted with `mvn formatter:format impsort:sort`

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)