### PR TITLE
CAMEL-23897: Add RuntimePropertiesProvider SPI for PropertiesDevConsole

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/spi/RuntimePropertiesProvider.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RuntimePropertiesProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spi;
+
+import java.util.Map;
+
+/**
+ * SPI that allows runtimes (Spring Boot, Quarkus, etc.) to contribute application properties for display purposes, such
+ * as the Properties dev console.
+ * <p>
+ * Camel's {@link PropertiesComponent#loadProperties()} only returns properties from Camel's own sources (initial
+ * properties, .properties files, override properties). Application properties managed by external configuration systems
+ * (e.g. Spring {@code Environment}, SmallRye {@code Config}) are not included.
+ * <p>
+ * This SPI bridges that gap: runtimes register an implementation that enumerates their properties, and the dev console
+ * merges them with the Camel-managed properties. The properties returned by this SPI are read-only and are NOT used for
+ * placeholder resolution — they are purely for display and introspection.
+ *
+ * @since 4.22
+ */
+public interface RuntimePropertiesProvider {
+
+    /**
+     * Returns the name of the runtime or source providing these properties (e.g. "Spring Boot", "Quarkus").
+     */
+    String getSource();
+
+    /**
+     * Enumerates application properties from the runtime's configuration system.
+     *
+     * @return a map of property key to value (never null)
+     */
+    Map<String, Object> getProperties();
+}

--- a/core/camel-api/src/main/java/org/apache/camel/spi/RuntimePropertiesProvider.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/RuntimePropertiesProvider.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.spi;
 
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * SPI that allows runtimes (Spring Boot, Quarkus, etc.) to contribute application properties for display purposes, such
@@ -35,14 +35,20 @@ import java.util.Map;
 public interface RuntimePropertiesProvider {
 
     /**
-     * Returns the name of the runtime or source providing these properties (e.g. "Spring Boot", "Quarkus").
+     * A single property with its key, value, and the source it came from.
+     *
+     * @param key    the property key
+     * @param value  the property value
+     * @param source the source (e.g. "Spring Boot", "ENV", "JVM")
+     * @since        4.22
      */
-    String getSource();
+    record Property(String key, Object value, String source) {
+    }
 
     /**
      * Enumerates application properties from the runtime's configuration system.
      *
-     * @return a map of property key to value (never null)
+     * @return a collection of properties with their sources (never null)
      */
-    Map<String, Object> getProperties();
+    Collection<Property> getProperties();
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/PropertiesDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/PropertiesDevConsole.java
@@ -18,8 +18,10 @@ package org.apache.camel.impl.console;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.camel.spi.PropertiesComponent;
+import org.apache.camel.spi.RuntimePropertiesProvider;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.OrderedLocationProperties;
@@ -62,6 +64,27 @@ public class PropertiesDevConsole extends AbstractDevConsole {
         }
         sb.append("\n");
 
+        // include properties from runtime providers (Spring Boot, Quarkus, etc.)
+        Set<RuntimePropertiesProvider> providers
+                = getCamelContext().getRegistry().findByType(RuntimePropertiesProvider.class);
+        for (RuntimePropertiesProvider provider : providers) {
+            Map<String, Object> runtimeProps = provider.getProperties();
+            if (runtimeProps != null && !runtimeProps.isEmpty()) {
+                sb.append(String.format("Properties from %s:", provider.getSource()));
+                sb.append("\n");
+                for (var entry : runtimeProps.entrySet()) {
+                    String k = entry.getKey();
+                    Object v = entry.getValue();
+                    if (SensitiveUtils.containsSensitive(k)) {
+                        sb.append(String.format("    %s = xxxxxx%n", k));
+                    } else {
+                        sb.append(String.format("    %s = %s%n", k, v));
+                    }
+                }
+                sb.append("\n");
+            }
+        }
+
         return sb.toString();
     }
 
@@ -80,6 +103,28 @@ public class PropertiesDevConsole extends AbstractDevConsole {
         }
         if (!arr.isEmpty()) {
             root.put("properties", arr);
+        }
+
+        // include properties from runtime providers (Spring Boot, Quarkus, etc.)
+        Set<RuntimePropertiesProvider> providers
+                = getCamelContext().getRegistry().findByType(RuntimePropertiesProvider.class);
+        for (RuntimePropertiesProvider provider : providers) {
+            Map<String, Object> runtimeProps = provider.getProperties();
+            if (runtimeProps != null && !runtimeProps.isEmpty()) {
+                for (var entry : runtimeProps.entrySet()) {
+                    String k = entry.getKey();
+                    Object v = entry.getValue();
+                    boolean sensitive = SensitiveUtils.containsSensitive(k);
+                    JsonObject jo = new JsonObject();
+                    jo.put("key", k);
+                    jo.put("value", sensitive ? "xxxxxx" : v);
+                    jo.put("source", provider.getSource());
+                    arr.add(jo);
+                }
+                if (!root.containsKey("properties")) {
+                    root.put("properties", arr);
+                }
+            }
         }
 
         return root;

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/PropertiesDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/PropertiesDevConsole.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -68,17 +69,13 @@ public class PropertiesDevConsole extends AbstractDevConsole {
         Set<RuntimePropertiesProvider> providers
                 = getCamelContext().getRegistry().findByType(RuntimePropertiesProvider.class);
         for (RuntimePropertiesProvider provider : providers) {
-            Map<String, Object> runtimeProps = provider.getProperties();
+            Collection<RuntimePropertiesProvider.Property> runtimeProps = provider.getProperties();
             if (runtimeProps != null && !runtimeProps.isEmpty()) {
-                sb.append(String.format("Properties from %s:", provider.getSource()));
-                sb.append("\n");
-                for (var entry : runtimeProps.entrySet()) {
-                    String k = entry.getKey();
-                    Object v = entry.getValue();
-                    if (SensitiveUtils.containsSensitive(k)) {
-                        sb.append(String.format("    %s = xxxxxx%n", k));
+                for (RuntimePropertiesProvider.Property prop : runtimeProps) {
+                    if (SensitiveUtils.containsSensitive(prop.key())) {
+                        sb.append(String.format("    %s %s = xxxxxx%n", prop.source(), prop.key()));
                     } else {
-                        sb.append(String.format("    %s = %s%n", k, v));
+                        sb.append(String.format("    %s %s = %s%n", prop.source(), prop.key(), prop.value()));
                     }
                 }
                 sb.append("\n");
@@ -109,16 +106,14 @@ public class PropertiesDevConsole extends AbstractDevConsole {
         Set<RuntimePropertiesProvider> providers
                 = getCamelContext().getRegistry().findByType(RuntimePropertiesProvider.class);
         for (RuntimePropertiesProvider provider : providers) {
-            Map<String, Object> runtimeProps = provider.getProperties();
+            Collection<RuntimePropertiesProvider.Property> runtimeProps = provider.getProperties();
             if (runtimeProps != null && !runtimeProps.isEmpty()) {
-                for (var entry : runtimeProps.entrySet()) {
-                    String k = entry.getKey();
-                    Object v = entry.getValue();
-                    boolean sensitive = SensitiveUtils.containsSensitive(k);
+                for (RuntimePropertiesProvider.Property prop : runtimeProps) {
+                    boolean sensitive = SensitiveUtils.containsSensitive(prop.key());
                     JsonObject jo = new JsonObject();
-                    jo.put("key", k);
-                    jo.put("value", sensitive ? "xxxxxx" : v);
-                    jo.put("source", provider.getSource());
+                    jo.put("key", prop.key());
+                    jo.put("value", sensitive ? "xxxxxx" : prop.value());
+                    jo.put("source", prop.source());
                     arr.add(jo);
                 }
                 if (!root.containsKey("properties")) {


### PR DESCRIPTION
## Summary

- Adds `RuntimePropertiesProvider` SPI in `camel-api` that allows runtimes (Spring Boot, Quarkus) to contribute application properties for display in the Properties dev console
- Updates `PropertiesDevConsole` to query all `RuntimePropertiesProvider` beans from the registry and merge their properties into text and JSON output
- The SPI is read-only and does not affect placeholder resolution

The Spring Boot implementation is in a companion PR in `camel-spring-boot`.
Quarkus follow-up: https://github.com/apache/camel-quarkus/issues/8825

## Test plan

- [x] `camel-api` builds
- [x] `camel-console` builds
- [ ] Verified with TUI showing Spring Boot app properties in Configuration tab

_Claude Code on behalf of Claus Ibsen_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>