### PR TITLE
CAMEL-23900: Fix flaky RecipientListParallelStreamingTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/RecipientListParallelStreamingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RecipientListParallelStreamingTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class RecipientListParallelStreamingTest extends ContextTestSupport {
 
@@ -30,14 +34,17 @@ public class RecipientListParallelStreamingTest extends ContextTestSupport {
 
         template.sendBodyAndHeader("direct:start", "Hello World", "foo", "direct:a,direct:b,direct:c");
 
-        assertMockEndpointsSatisfied();
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> mock.assertIsSatisfied());
+    }
 
-        mock.reset();
+    @Test
+    public void testRecipientListParallelStreaming() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("b");
 
         template.sendBodyAndHeader("direct:streaming", "Hello World", "foo", "direct:a,direct:b,direct:c");
 
-        assertMockEndpointsSatisfied();
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> mock.assertIsSatisfied());
     }
 
     @Override
@@ -49,8 +56,8 @@ public class RecipientListParallelStreamingTest extends ContextTestSupport {
 
                 from("direct:streaming").recipientList(header("foo")).parallelProcessing().streaming().to("mock:result");
 
-                from("direct:a").delay(100).syncDelayed().transform(constant("a"));
-                from("direct:b").delay(500).syncDelayed().transform(constant("b"));
+                from("direct:a").delay(500).syncDelayed().transform(constant("a"));
+                from("direct:b").delay(2000).syncDelayed().transform(constant("b"));
                 from("direct:c").transform(constant("c"));
             }
         };


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix flaky `RecipientListParallelStreamingTest#testRecipientListParallel` that fails on both JDK 17 and JDK 25.

- **Split** the single test method into two isolated methods (`testRecipientListParallel` and `testRecipientListParallelStreaming`) to eliminate mock state contamination via `reset()`
- **Increase delay gaps** from 100ms/500ms to 500ms/2000ms so the completion ordering for the streaming case is deterministic even on busy CI systems (matching the pattern used in `MulticastParallelStreamingTest`)
- **Replace** `assertMockEndpointsSatisfied()` with Awaitility `await().untilAsserted()` per project testing guidelines

### Root cause

The streaming test relies on `direct:b` (previously 500ms delay) being the last recipient to complete so that `UseLatestAggregationStrategy` picks body `"b"`. With only a 400ms gap over `direct:a` (100ms delay), CI thread scheduling jitter could collapse the gap and produce the wrong aggregation result.

## Test plan

- [x] `RecipientListParallelStreamingTest` passes reliably (verified 5 consecutive runs)
- [x] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)