### PR TITLE
CAMEL-23899: Fix flaky test LogWriterRollOverUpdateAsyncWithContentionTest

### DIFF
--- a/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncBase.java
+++ b/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncBase.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -34,12 +34,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 abstract class LogWriterRollOverUpdateAsyncBase extends LogTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(LogWriterRollOverUpdateAsyncBase.class);
     protected BlockingQueue<EntryInfo.CachedEntryInfo> entryInfos;
-    protected CountDownLatch latch = new CountDownLatch(1);
     LogWriter logWriter;
     File reportFile;
 
@@ -84,7 +84,24 @@ abstract class LogWriterRollOverUpdateAsyncBase extends LogTestBase {
 
         final Future<?> updateTask = executorService.submit(this::markRecordsAsCommitted);
 
-        Assertions.assertTrue(latch.await(1, TimeUnit.MINUTES), "Failed to generate records within 1 minute");
+        executorService.shutdown();
+
+        // Wait for both tasks to complete using Awaitility instead of only
+        // waiting for the generate task via a latch, which left a race window
+        // where the update task could still be running when verification began.
+        await().atMost(2, TimeUnit.MINUTES)
+                .until(executorService::isTerminated);
+
+        // Propagate any exceptions from the tasks
+        try {
+            generateTask.get();
+            updateTask.get();
+        } catch (ExecutionException e) {
+            Assertions.fail("Task failed: " + e.getCause().getMessage(), e.getCause());
+        }
+
+        // Flush to ensure all data is persisted to disk before verification
+        logWriter.flush();
 
         try (LogReader reader = new LogReader(reportFile, (int) RECORD_COUNT * 100)) {
 

--- a/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncBase.java
+++ b/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncBase.java
@@ -86,11 +86,18 @@ abstract class LogWriterRollOverUpdateAsyncBase extends LogTestBase {
 
         executorService.shutdown();
 
-        // Wait for both tasks to complete using Awaitility instead of only
-        // waiting for the generate task via a latch, which left a race window
-        // where the update task could still be running when verification began.
-        await().atMost(2, TimeUnit.MINUTES)
-                .until(executorService::isTerminated);
+        try {
+            // Wait for both tasks to complete using Awaitility instead of only
+            // waiting for the generate task via a latch, which left a race window
+            // where the update task could still be running when verification began.
+            await().atMost(2, TimeUnit.MINUTES)
+                    .until(executorService::isTerminated);
+        } finally {
+            if (!executorService.isTerminated()) {
+                executorService.shutdownNow();
+                executorService.awaitTermination(30, TimeUnit.SECONDS);
+            }
+        }
 
         // Propagate any exceptions from the tasks
         try {

--- a/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncBase.java
+++ b/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncBase.java
@@ -79,65 +79,62 @@ abstract class LogWriterRollOverUpdateAsyncBase extends LogTestBase {
         entryInfos = new ArrayBlockingQueue<>(queueCapacity);
 
         final ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-        final Future<?> generateTask = executorService.submit(this::asyncGenerate);
-
-        final Future<?> updateTask = executorService.submit(this::markRecordsAsCommitted);
-
-        executorService.shutdown();
-
         try {
+            final Future<?> generateTask = executorService.submit(this::asyncGenerate);
+
+            final Future<?> updateTask = executorService.submit(this::markRecordsAsCommitted);
+
+            executorService.shutdown();
+
             // Wait for both tasks to complete using Awaitility instead of only
             // waiting for the generate task via a latch, which left a race window
             // where the update task could still be running when verification began.
             await().atMost(2, TimeUnit.MINUTES)
                     .until(executorService::isTerminated);
+
+            // Propagate any exceptions from the tasks
+            try {
+                generateTask.get();
+                updateTask.get();
+            } catch (ExecutionException e) {
+                Assertions.fail("Task failed: " + e.getCause().getMessage(), e.getCause());
+            }
+
+            // Flush to ensure all data is persisted to disk before verification
+            logWriter.flush();
+
+            try (LogReader reader = new LogReader(reportFile, (int) RECORD_COUNT * 100)) {
+
+                Header fileHeader = reader.getHeader();
+                assertEquals(Header.FORMAT_NAME, fileHeader.getFormatName().trim());
+                assertEquals(Header.CURRENT_FILE_VERSION, fileHeader.getFileVersion());
+
+                int count = 0;
+                PersistedLogEntry entry = reader.readEntry();
+                while (entry != null) {
+                    LOG.debug("Read state: {}", entry.getEntryState());
+                    assertEquals(LogEntry.EntryState.PROCESSED, entry.getEntryState());
+                    assertEquals(0, entry.getKeyMetadata());
+                    assertEquals(0, entry.getValueMetadata());
+
+                    String key = new String(entry.getKey());
+                    LOG.debug("Read record: {}", key);
+                    Assertions.assertTrue(key.startsWith("record-"));
+
+                    ByteBuffer buffer = ByteBuffer.wrap(entry.getValue());
+
+                    Assertions.assertTrue(buffer.getLong() > 0);
+
+                    count++;
+
+                    entry = reader.readEntry();
+                }
+
+                Assertions.assertEquals(100, count, "The number of records don't match");
+            }
         } finally {
-            if (!executorService.isTerminated()) {
-                executorService.shutdownNow();
-                executorService.awaitTermination(30, TimeUnit.SECONDS);
-            }
-        }
-
-        // Propagate any exceptions from the tasks
-        try {
-            generateTask.get();
-            updateTask.get();
-        } catch (ExecutionException e) {
-            Assertions.fail("Task failed: " + e.getCause().getMessage(), e.getCause());
-        }
-
-        // Flush to ensure all data is persisted to disk before verification
-        logWriter.flush();
-
-        try (LogReader reader = new LogReader(reportFile, (int) RECORD_COUNT * 100)) {
-
-            Header fileHeader = reader.getHeader();
-            assertEquals(Header.FORMAT_NAME, fileHeader.getFormatName().trim());
-            assertEquals(Header.CURRENT_FILE_VERSION, fileHeader.getFileVersion());
-
-            int count = 0;
-            PersistedLogEntry entry = reader.readEntry();
-            while (entry != null) {
-                LOG.debug("Read state: {}", entry.getEntryState());
-                assertEquals(LogEntry.EntryState.PROCESSED, entry.getEntryState());
-                assertEquals(0, entry.getKeyMetadata());
-                assertEquals(0, entry.getValueMetadata());
-
-                String key = new String(entry.getKey());
-                LOG.debug("Read record: {}", key);
-                Assertions.assertTrue(key.startsWith("record-"));
-
-                ByteBuffer buffer = ByteBuffer.wrap(entry.getValue());
-
-                Assertions.assertTrue(buffer.getLong() > 0);
-
-                count++;
-
-                entry = reader.readEntry();
-            }
-
-            Assertions.assertEquals(100, count, "The number of records don't match");
+            executorService.shutdownNow();
+            executorService.awaitTermination(5, TimeUnit.SECONDS);
         }
     }
 

--- a/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncTest.java
+++ b/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncTest.java
@@ -38,8 +38,6 @@ public class LogWriterRollOverUpdateAsyncTest extends LogWriterRollOverUpdateAsy
         } catch (IOException e) {
             LOG.error("Failed to generate records: {}", e.getMessage(), e);
             throw new RuntimeException(e);
-        } finally {
-            latch.countDown();
         }
     }
 

--- a/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncWithContentionTest.java
+++ b/components/camel-wal/src/test/java/org/apache/camel/component/wal/LogWriterRollOverUpdateAsyncWithContentionTest.java
@@ -44,8 +44,6 @@ public class LogWriterRollOverUpdateAsyncWithContentionTest extends LogWriterRol
         } catch (IOException e) {
             LOG.error("Failed to generate records: {}", e.getMessage(), e);
             throw new RuntimeException(e);
-        } finally {
-            latch.countDown();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the flaky test `LogWriterRollOverUpdateAsyncWithContentionTest.testReadWriteUpdateRecordsWithRollOver` in camel-wal.

**Root cause:** `runTest()` only waited for the generate task to complete (via a `CountDownLatch`) before reading the log file and asserting all entries were in `PROCESSED` state. The update task — which marks records as committed — could still be running, causing assertions to fail on entries still in `NEW` state. This was especially pronounced with larger queue capacities (3000, 4000) where the producer finishes quickly while the consumer is still draining the queue.

**Fix:**
- Replace the insufficient latch-based synchronization with **Awaitility** to wait for both the generate and update tasks to complete via `ExecutorService` termination
- Flush the `LogWriter` before reading to ensure all data is persisted to disk before verification
- Wrap the test body in a try-finally to ensure executor shutdown and prevent thread leaks on failure
- Remove the now-unused `CountDownLatch` field and `latch.countDown()` calls from both subclass tests

## Test plan

- [x] `LogWriterRollOverUpdateAsyncWithContentionTest` passes all 8 parameterized cases
- [x] Ran the flaky test 6 times (48 total cases) with 0 failures
- [x] `LogWriterRollOverUpdateAsyncTest` (sibling test) passes without regression
- [x] Full camel-wal test suite passes (23 tests, 0 failures)

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.ai/code)