### PR TITLE
CAMEL-23901: Fix flaky MulticastParallelStreamingTimeoutTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
@@ -42,6 +42,9 @@ public class MulticastParallelStreamingTimeoutTest extends ContextTestSupport {
         mock.message(0).body().not(body().contains("A"));
         mock.message(0).body().contains("B");
         mock.message(0).body().contains("C");
+        // Use a short result wait time so each Awaitility attempt checks quickly
+        // without blocking (default 0 maps to 10s internally in MockEndpoint)
+        mock.setResultWaitTime(100);
 
         template.sendBody("direct:start", "Hello");
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastParallelStreamingTimeoutTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.AggregationStrategy;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -23,7 +25,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.awaitility.Awaitility.await;
+
+@Isolated("Short timeouts cause problems with parallel test execution")
 @DisabledOnOs(architectures = { "s390x" },
               disabledReason = "This test does not run reliably on s390x (see CAMEL-21438)")
 public class MulticastParallelStreamingTimeoutTest extends ContextTestSupport {
@@ -31,13 +37,16 @@ public class MulticastParallelStreamingTimeoutTest extends ContextTestSupport {
     @Test
     public void testMulticastParallelStreamingTimeout() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
-        // A will timeout so we only get B and C (C is faster than B)
-        mock.expectedBodiesReceived("CB");
-        mock.setResultWaitTime(20000);
+        // A will timeout so we only get B and C (order may vary)
+        mock.expectedMessageCount(1);
+        mock.message(0).body().not(body().contains("A"));
+        mock.message(0).body().contains("B");
+        mock.message(0).body().contains("C");
 
         template.sendBody("direct:start", "Hello");
 
-        assertMockEndpointsSatisfied();
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertMockEndpointsSatisfied());
     }
 
     @Override


### PR DESCRIPTION
## Summary

Stabilize the flaky `MulticastParallelStreamingTimeoutTest` in `camel-core`.

The test `testMulticastParallelStreamingTimeout` was failing intermittently on JDK 17 in CI due to two issues:

1. **Exact ordering assertion** — The test asserted `mock.expectedBodiesReceived("CB")`, which assumes C (no delay) always completes before B (500ms delay) in the parallel streaming multicast. Under heavy CI load, thread scheduling can make B's result arrive at the aggregation strategy before C's, flipping the order to "BC" and causing the assertion to fail.

2. **Missing `@Isolated` annotation** — Related tests (`MulticastParallelTimeoutTest`, `MulticastParallelStreamingTwoTimeoutTest`) use `@Isolated` to prevent interference from parallel test execution.

### Changes

- **Order-independent assertions**: Replaced `mock.expectedBodiesReceived("CB")` with content-based checks that verify the result contains B and C but not A, regardless of order (consistent with the approach used in `MulticastParallelTimeoutTest`)
- **Awaitility**: Replaced `mock.setResultWaitTime(20000)` + `assertMockEndpointsSatisfied()` with `await().atMost(20, TimeUnit.SECONDS).untilAsserted(...)` per project guidelines. Set `mock.setResultWaitTime(100)` to avoid double-wait (MockEndpoint defaults to 10s internal latch wait when resultWaitTime is 0)
- **`@Isolated` annotation**: Added to prevent flakiness from parallel test execution (matches sibling test classes)

## Test plan

- [x] `MulticastParallelStreamingTimeoutTest` passes locally
- [x] Code formatted with `mvn formatter:format impsort:sort`
- [x] CI build passes

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)