### PR TITLE
CAMEL-23905: Fix flaky LRAFailuresIT by replacing setResultWaitTime with Awaitility

### DIFF
--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAFailuresIT.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAFailuresIT.java
@@ -16,12 +16,15 @@
  */
 package org.apache.camel.service.lra;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 public class LRAFailuresIT extends AbstractLRATestSupport {
 
@@ -33,11 +36,11 @@ public class LRAFailuresIT extends AbstractLRATestSupport {
 
         MockEndpoint compensate = getMockEndpoint("mock:compensate");
         compensate.expectedMessageCount(1);
-        compensate.setResultWaitTime(20000);
 
         sendBody("direct:saga-compensate", "hello");
 
-        compensate.assertIsSatisfied();
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(compensate::assertIsSatisfied);
     }
 
     @Test
@@ -46,15 +49,17 @@ public class LRAFailuresIT extends AbstractLRATestSupport {
 
         MockEndpoint complete = getMockEndpoint("mock:complete");
         complete.expectedMessageCount(1);
-        complete.setResultWaitTime(20000);
 
         MockEndpoint end = getMockEndpoint("mock:end");
         end.expectedBodiesReceived("hello");
 
         sendBody("direct:saga-complete", "hello");
 
-        complete.assertIsSatisfied();
-        end.assertIsSatisfied();
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    complete.assertIsSatisfied();
+                    end.assertIsSatisfied();
+                });
     }
 
     @Override

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAFailuresIT.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAFailuresIT.java
@@ -40,7 +40,8 @@ public class LRAFailuresIT extends AbstractLRATestSupport {
         sendBody("direct:saga-compensate", "hello");
 
         await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(compensate::assertIsSatisfied);
+                .until(() -> compensate.getReceivedCounter() >= 1);
+        compensate.assertIsSatisfied();
     }
 
     @Test
@@ -56,10 +57,10 @@ public class LRAFailuresIT extends AbstractLRATestSupport {
         sendBody("direct:saga-complete", "hello");
 
         await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    complete.assertIsSatisfied();
-                    end.assertIsSatisfied();
-                });
+                .until(() -> complete.getReceivedCounter() >= 1
+                        && end.getReceivedCounter() >= 1);
+        complete.assertIsSatisfied();
+        end.assertIsSatisfied();
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes flaky `LRAFailuresIT.testCompletionAfterFailures` (and `testCompensationAfterFailures`) in the `camel-lra` module.

**Root cause:** Both tests used `MockEndpoint.setResultWaitTime(20000)` + `assertIsSatisfied()`, which performs a single check at the deadline. Since LRA saga completion/compensation callbacks are asynchronous (HTTP retries via the LRA coordinator), this pattern is timing-sensitive and fails intermittently on JDK 17.

**Fix:** Replace with Awaitility polling on `getReceivedCounter()` (non-blocking), followed by a single `assertIsSatisfied()` call once messages have arrived. This avoids `MockEndpoint`'s internal 10-second latch wait (which would block each Awaitility poll attempt) and makes the tests:
- **More reliable**: polls every 100ms via Awaitility until messages arrive
- **Faster**: passes as soon as the condition is met, not after the full wait
- **Consistent**: follows the same Awaitility pattern used by other LRA integration tests (e.g., `LRACreditIT`)

## Changes

- `LRAFailuresIT.java`: Replaced `setResultWaitTime()` + `assertIsSatisfied()` with Awaitility `await().until(getReceivedCounter)` + final `assertIsSatisfied()` in both test methods

## Test plan

- [x] Module builds successfully (`mvn -DskipTests install`)
- [x] Unit tests pass (21/21)
- [ ] Integration tests pass in CI (require LRA coordinator container)

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)