### PR TITLE
CAMEL-23904: Fix CamelBeanDumpTest NPE caused by uninitialized picocli fields

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDump.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDump.java
@@ -72,11 +72,11 @@ public class CamelBeanDump extends ActionBaseCommand {
 
     @CommandLine.Option(names = { "--sort" }, completionCandidates = NameTypeCompletionCandidates.class,
                         description = "Sort by name or type", defaultValue = "name")
-    String sort;
+    String sort = "name";
 
     @CommandLine.Option(names = { "--filter" },
                         description = "Filter beans names (use all to include all beans)", defaultValue = "all")
-    String filter;
+    String filter = "all";
 
     @CommandLine.Option(names = { "--properties" },
                         description = "Show bean properties", defaultValue = "true")
@@ -89,7 +89,7 @@ public class CamelBeanDump extends ActionBaseCommand {
     @CommandLine.Option(names = { "--scope" }, completionCandidates = ScopeCompletionCandidates.class,
                         description = "Filter beans by scope: all, user (excludes Camel/Spring/Quarkus/JDK), camel, spring, quarkus",
                         defaultValue = "all")
-    String scope;
+    String scope = "all";
 
     @CommandLine.Option(names = { "--internal" },
                         description = "Include internal Camel beans", defaultValue = "false")

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDumpTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/action/CamelBeanDumpTest.java
@@ -39,7 +39,9 @@ class CamelBeanDumpTest extends ActionCommandTestSupport {
         // options are normally defaulted by picocli; set them as we construct the command directly
         command.filter = "all";
         command.sort = "name";
+        command.scope = "all";
         command.properties = true;
+        command.nulls = true;
 
         int exit = callWithResponse(command, singleBeanResponse());
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fixes https://issues.apache.org/jira/browse/CAMEL-23904

`CamelBeanDumpTest.testRequestsBeanDumpAndRendersBeans` always fails with a `NullPointerException` (ERROR, not assertion FAILURE) because the test constructs `CamelBeanDump` directly without picocli command-line parsing.

**Root cause:** Picocli's `@CommandLine.Option(defaultValue = "...")` only takes effect during command-line parsing — it does NOT set the Java field's initial value. When the command is constructed directly (as in tests), String fields remain `null`. The `scope` field being null causes a NPE in `matchesScope()`'s switch statement, since Java's `switch` on a null String throws NPE.

**Fix:**
- Add Java field initializers (`= "name"`, `= "all"`) to String fields in `CamelBeanDump` matching their picocli `defaultValue`, so the command works correctly when constructed outside of picocli parsing
- Set the missing `scope` and `nulls` fields in the test to match the picocli defaults

## Test plan

- [x] `CamelBeanDumpTest` passes (both test methods)
- [x] Module builds successfully (`mvn -DskipTests install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)