### PR TITLE
CAMEL-23903: Fix flaky test RouteIdTransactedIT in camel-jms

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/RouteIdTransactedIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/RouteIdTransactedIT.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
@@ -50,8 +49,7 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
 
         template.sendBody("activemq:queue:RouteIdTransactedTest", "Hello World");
 
-        await().atMost(30, TimeUnit.SECONDS)
-                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         String id = context.getRouteDefinitions().get(0).getId();
         assertEquals("myCoolRoute", id);
@@ -65,8 +63,7 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
 
         template.sendBody("activemq:queue:RouteIdTransactedTest", "Kaboom");
 
-        await().atMost(30, TimeUnit.SECONDS)
-                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         String id = context.getRouteDefinitions().get(0).getId();
         assertEquals("myCoolRoute", id);

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/RouteIdTransactedIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/RouteIdTransactedIT.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.integration.spring.tx;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.integration.spring.AbstractSpringJMSITSupport;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tags({ @Tag("not-parallel"), @Tag("spring"), @Tag("tx") })
@@ -47,7 +50,8 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
 
         template.sendBody("activemq:queue:RouteIdTransactedTest", "Hello World");
 
-        MockEndpoint.assertIsSatisfied(context);
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
 
         String id = context.getRouteDefinitions().get(0).getId();
         assertEquals("myCoolRoute", id);
@@ -61,7 +65,8 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
 
         template.sendBody("activemq:queue:RouteIdTransactedTest", "Kaboom");
 
-        MockEndpoint.assertIsSatisfied(context);
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
 
         String id = context.getRouteDefinitions().get(0).getId();
         assertEquals("myCoolRoute", id);


### PR DESCRIPTION
## Summary

Fix flaky `RouteIdTransactedIT.testRouteIdFailed` (and `testRouteId` for consistency) by replacing `MockEndpoint.assertIsSatisfied(context)` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`.

**Root cause:** The default `MockEndpoint` latch timeout is 10 seconds (`waitForCompleteLatch` defaults to 10s when `resultWaitTime=0`). In transacted JMS routes under CI load on JDK 17, the message processing (including transaction handling and exception routing via `onException`) can exceed this timeout, causing intermittent test failures.

**Fix:** Use the `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` overload which sets `resultWaitTime` directly on each mock's internal latch, giving transacted routes a generous 30-second window. This follows the same pattern already used in other camel-jms tests (e.g., `JmsProducerConcurrentWithReplyTest`, `JmsInOnlyWithReplyToHeaderTopicTest`).

## Test plan

- [x] `RouteIdTransactedIT` passes (2 tests, 0 failures)
- [ ] CI build passes

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)