### PR TITLE
CAMEL-23902: Fix flaky UndertowWsConsumerRouteTest

### DIFF
--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -128,6 +128,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>jetty-http2-client</artifactId>
             <version>${jetty-version}</version>

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -168,11 +169,15 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient1.connect();
 
         wsclient1.sendTextMessage("Test1");
+        // Wait for the first echo before sending the next message to avoid
+        // IllegalStateException from JDK WebSocket when a send is still pending
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(wsclient1.getReceived(String.class).contains("Test1")));
+
         wsclient1.sendTextMessage("Test2");
-
-        assertTrue(wsclient1.await(10));
-
-        assertEquals(Arrays.asList("Test1", "Test2"), wsclient1.getReceived(String.class));
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> assertEquals(Arrays.asList("Test1", "Test2"), wsclient1.getReceived(String.class)));
 
         wsclient1.close();
     }
@@ -187,11 +192,11 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient1.sendTextMessage("Gambas");
         wsclient2.sendTextMessage("Calamares");
 
-        assertTrue(wsclient1.await(10));
-        assertTrue(wsclient2.await(10));
-
-        assertEquals(List.of("Gambas"), wsclient1.getReceived(String.class));
-        assertEquals(List.of("Calamares"), wsclient2.getReceived(String.class));
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertEquals(List.of("Gambas"), wsclient1.getReceived(String.class));
+                    assertEquals(List.of("Calamares"), wsclient2.getReceived(String.class));
+                });
 
         wsclient1.close();
         wsclient2.close();
@@ -207,19 +212,18 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient1.sendTextMessage("Gambas");
         wsclient2.sendTextMessage("Calamares");
 
-        assertTrue(wsclient1.await(10));
-        assertTrue(wsclient2.await(10));
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    List<String> received1 = wsclient1.getReceived(String.class);
+                    assertEquals(2, received1.size());
+                    assertTrue(received1.contains("Gambas"));
+                    assertTrue(received1.contains("Calamares"));
 
-        List<String> received1 = wsclient1.getReceived(String.class);
-        assertEquals(2, received1.size());
-
-        assertTrue(received1.contains("Gambas"));
-        assertTrue(received1.contains("Calamares"));
-
-        List<String> received2 = wsclient2.getReceived(String.class);
-        assertEquals(2, received2.size());
-        assertTrue(received2.contains("Gambas"));
-        assertTrue(received2.contains("Calamares"));
+                    List<String> received2 = wsclient2.getReceived(String.class);
+                    assertEquals(2, received2.size());
+                    assertTrue(received2.contains("Gambas"));
+                    assertTrue(received2.contains("Calamares"));
+                });
 
         wsclient1.close();
         wsclient2.close();
@@ -292,12 +296,15 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient2.connect();
         wsclient3.connect();
 
-        wsclient1.await(10);
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertConnected(wsclient1));
         final String connectionKey1 = assertConnected(wsclient1);
         assertNotNull(connectionKey1);
-        wsclient2.await(10);
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertConnected(wsclient2));
         final String connectionKey2 = assertConnected(wsclient2);
-        wsclient3.await(10);
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertConnected(wsclient3));
         final String connectionKey3 = assertConnected(wsclient3);
 
         wsclient1.reset(1);
@@ -305,14 +312,18 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient3.reset(1);
         final String broadcastMsg = BROADCAST_MESSAGE_PREFIX + connectionKey2 + " " + connectionKey3;
         wsclient1.sendTextMessage(broadcastMsg); // this one should go to wsclient2 and wsclient3
-        wsclient1.sendTextMessage("private"); // this one should go to wsclient1 only
+        // Wait for broadcast delivery before sending the next message to avoid
+        // IllegalStateException from JDK WebSocket when a send is still pending
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertEquals(broadcastMsg, wsclient2.getReceived(String.class).get(0));
+                    assertEquals(broadcastMsg, wsclient3.getReceived(String.class).get(0));
+                });
 
-        wsclient2.await(10);
-        assertEquals(broadcastMsg, wsclient2.getReceived(String.class).get(0));
-        wsclient3.await(10);
-        assertEquals(broadcastMsg, wsclient3.getReceived(String.class).get(0));
-        wsclient1.await(10);
-        assertEquals("private", wsclient1.getReceived(String.class).get(0));
+        wsclient1.sendTextMessage("private"); // this one should go to wsclient1 only
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> assertEquals("private", wsclient1.getReceived(String.class).get(0)));
 
         wsclient1.close();
         wsclient2.close();

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/ws/UndertowWsConsumerRouteTest.java
@@ -170,14 +170,16 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
 
         wsclient1.sendTextMessage("Test1");
         // Wait for the first echo before sending the next message to avoid
-        // IllegalStateException from JDK WebSocket when a send is still pending
+        // IllegalStateException from JDK WebSocket when a send is still pending.
+        // Poll using size() to avoid iterating the non-thread-safe received list.
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertTrue(wsclient1.getReceived(String.class).contains("Test1")));
+                .until(() -> wsclient1.getReceived().size() >= 1);
 
         wsclient1.sendTextMessage("Test2");
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> assertEquals(Arrays.asList("Test1", "Test2"), wsclient1.getReceived(String.class)));
+                .until(() -> wsclient1.getReceived().size() >= 2);
+
+        assertEquals(Arrays.asList("Test1", "Test2"), wsclient1.getReceived(String.class));
 
         wsclient1.close();
     }
@@ -192,11 +194,12 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient1.sendTextMessage("Gambas");
         wsclient2.sendTextMessage("Calamares");
 
+        // Poll using size() to avoid iterating the non-thread-safe received list
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertEquals(List.of("Gambas"), wsclient1.getReceived(String.class));
-                    assertEquals(List.of("Calamares"), wsclient2.getReceived(String.class));
-                });
+                .until(() -> wsclient1.getReceived().size() >= 1 && wsclient2.getReceived().size() >= 1);
+
+        assertEquals(List.of("Gambas"), wsclient1.getReceived(String.class));
+        assertEquals(List.of("Calamares"), wsclient2.getReceived(String.class));
 
         wsclient1.close();
         wsclient2.close();
@@ -212,18 +215,19 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient1.sendTextMessage("Gambas");
         wsclient2.sendTextMessage("Calamares");
 
+        // Poll using size() to avoid iterating the non-thread-safe received list
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    List<String> received1 = wsclient1.getReceived(String.class);
-                    assertEquals(2, received1.size());
-                    assertTrue(received1.contains("Gambas"));
-                    assertTrue(received1.contains("Calamares"));
+                .until(() -> wsclient1.getReceived().size() >= 2 && wsclient2.getReceived().size() >= 2);
 
-                    List<String> received2 = wsclient2.getReceived(String.class);
-                    assertEquals(2, received2.size());
-                    assertTrue(received2.contains("Gambas"));
-                    assertTrue(received2.contains("Calamares"));
-                });
+        List<String> received1 = wsclient1.getReceived(String.class);
+        assertEquals(2, received1.size());
+        assertTrue(received1.contains("Gambas"));
+        assertTrue(received1.contains("Calamares"));
+
+        List<String> received2 = wsclient2.getReceived(String.class);
+        assertEquals(2, received2.size());
+        assertTrue(received2.contains("Gambas"));
+        assertTrue(received2.contains("Calamares"));
 
         wsclient1.close();
         wsclient2.close();
@@ -296,15 +300,16 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         wsclient2.connect();
         wsclient3.connect();
 
+        // Poll using size() to avoid iterating the non-thread-safe received list
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertConnected(wsclient1));
+                .until(() -> wsclient1.getReceived().size() >= 1);
         final String connectionKey1 = assertConnected(wsclient1);
         assertNotNull(connectionKey1);
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertConnected(wsclient2));
+                .until(() -> wsclient2.getReceived().size() >= 1);
         final String connectionKey2 = assertConnected(wsclient2);
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertConnected(wsclient3));
+                .until(() -> wsclient3.getReceived().size() >= 1);
         final String connectionKey3 = assertConnected(wsclient3);
 
         wsclient1.reset(1);
@@ -315,15 +320,14 @@ public class UndertowWsConsumerRouteTest extends BaseUndertowTest {
         // Wait for broadcast delivery before sending the next message to avoid
         // IllegalStateException from JDK WebSocket when a send is still pending
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertEquals(broadcastMsg, wsclient2.getReceived(String.class).get(0));
-                    assertEquals(broadcastMsg, wsclient3.getReceived(String.class).get(0));
-                });
+                .until(() -> wsclient2.getReceived().size() >= 1 && wsclient3.getReceived().size() >= 1);
+        assertEquals(broadcastMsg, wsclient2.getReceived(String.class).get(0));
+        assertEquals(broadcastMsg, wsclient3.getReceived(String.class).get(0));
 
         wsclient1.sendTextMessage("private"); // this one should go to wsclient1 only
         await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> assertEquals("private", wsclient1.getReceived(String.class).get(0)));
+                .until(() -> wsclient1.getReceived().size() >= 1);
+        assertEquals("private", wsclient1.getReceived(String.class).get(0));
 
         wsclient1.close();
         wsclient2.close();


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix flaky WebSocket tests in `UndertowWsConsumerRouteTest` that fail intermittently on JDK 17.

**Root cause**: JDK's `WebSocket.sendText()` returns a `CompletableFuture` that must complete before the next send. When two messages are sent in rapid succession on the same connection, the second send fails silently with `IllegalStateException` because `WebsocketTestClient.sendTextMessage()` ignores the returned future.

**Fix**:
- Replace `CountDownLatch`-based `assertTrue(await(10))` + subsequent assertions with **Awaitility** polling in `echo()`, `echoMulti()`, `sendToAll()`, and `connectionKeyList()`
- Poll using `getReceived().size()` (index-based, no iterator) to avoid `ConcurrentModificationException` on the non-thread-safe `ArrayList` during concurrent polling. Content assertions via `getReceived(String.class)` are only called after the size check confirms all expected messages arrived.
- For tests sending multiple messages on the same connection (`echo`, `connectionKeyList`), wait for the echo of the first message before sending the next, avoiding the JDK WebSocket pending-send conflict
- Add `awaitility` test dependency to `camel-undertow`

## Test plan

- [x] `UndertowWsConsumerRouteTest` passes (all 10 tests, 0 flakes)
- [x] Ran `echo()` test 3x consecutively — all green
- [x] Code formatting verified (`mvn formatter:format impsort:sort` — no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)