### PR TITLE
CAMEL-23906: Fix flaky DelayerWhileShutdownTest on JDK 25

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/DelayerWhileShutdownTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/DelayerWhileShutdownTest.java
@@ -16,44 +16,45 @@
  */
 package org.apache.camel.processor;
 
-import java.util.concurrent.Phaser;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Delayer while shutting down so its interrupted and will also stop.
  */
 public class DelayerWhileShutdownTest extends ContextTestSupport {
 
-    private final Phaser phaser = new Phaser(2);
-
-    @BeforeEach
-    void sendEarly() {
-        template.sendBody("seda:a", "Long delay");
-        template.sendBody("seda:b", "Short delay");
-    }
+    private final CountDownLatch shortDelayStarted = new CountDownLatch(1);
 
     @Test
     public void testSendingMessageGetsDelayed() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedBodiesReceived("Short delay");
 
-        phaser.awaitAdvanceInterruptibly(0, 5000, TimeUnit.SECONDS);
+        template.sendBody("seda:a", "Long delay");
+        template.sendBody("seda:b", "Short delay");
 
-        assertMockEndpointsSatisfied();
+        // Wait until the short-delay route has entered the delay phase,
+        // ensuring both routes are actively processing
+        shortDelayStarted.await(5, TimeUnit.SECONDS);
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertMockEndpointsSatisfied());
     }
 
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("seda:a").process(e -> phaser.arriveAndAwaitAdvance()).delay(1000).to("mock:result");
-                from("seda:b").process(e -> phaser.arriveAndAwaitAdvance()).delay(1).to("mock:result");
+                from("seda:a").delay(5000).to("mock:result");
+                from("seda:b").process(e -> shortDelayStarted.countDown()).delay(1).to("mock:result");
             }
         };
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/DelayerWhileShutdownTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/DelayerWhileShutdownTest.java
@@ -25,13 +25,14 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Delayer while shutting down so its interrupted and will also stop.
  */
 public class DelayerWhileShutdownTest extends ContextTestSupport {
 
-    private final CountDownLatch shortDelayStarted = new CountDownLatch(1);
+    private final CountDownLatch shortRouteStarted = new CountDownLatch(1);
 
     @Test
     public void testSendingMessageGetsDelayed() throws Exception {
@@ -41,9 +42,9 @@ public class DelayerWhileShutdownTest extends ContextTestSupport {
         template.sendBody("seda:a", "Long delay");
         template.sendBody("seda:b", "Short delay");
 
-        // Wait until the short-delay route has entered the delay phase,
-        // ensuring both routes are actively processing
-        shortDelayStarted.await(5, TimeUnit.SECONDS);
+        // Wait until the short-delay route has started processing its message
+        assertTrue(shortRouteStarted.await(5, TimeUnit.SECONDS),
+                "Short-delay route should have started processing within 5 seconds");
 
         await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertMockEndpointsSatisfied());
@@ -53,8 +54,10 @@ public class DelayerWhileShutdownTest extends ContextTestSupport {
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             public void configure() {
-                from("seda:a").delay(5000).to("mock:result");
-                from("seda:b").process(e -> shortDelayStarted.countDown()).delay(1).to("mock:result");
+                // Long delay must be well above the assertion timeout (5s) to ensure
+                // the context shutdown always interrupts it before it completes
+                from("seda:a").delay(30000).to("mock:result");
+                from("seda:b").process(e -> shortRouteStarted.countDown()).delay(1).to("mock:result");
             }
         };
     }


### PR DESCRIPTION
## Summary

- Replace `Phaser`-based synchronization with a simpler `CountDownLatch` and use Awaitility for the mock endpoint assertion
- The `Phaser` approach was timing-sensitive under JDK 25's thread scheduling, causing `testSendingMessageGetsDelayed` to fail intermittently
- The new approach uses a latch to signal when the short-delay route starts processing and increases the long delay to 30s to ensure context shutdown always interrupts it before completion

## What changed

The original test used a `Phaser(2)` to synchronize both SEDA routes before they entered their delay phases, then immediately called `assertMockEndpointsSatisfied()`. On JDK 25, different thread scheduling could cause the short-delay message (1ms) to not have arrived at `mock:result` by the time of assertion.

The fix:
1. **Replaces `Phaser` with `CountDownLatch`** — simpler synchronization; the latch signals when the short-delay route begins processing, with an assertion on the return value for fast failure if the route never starts
2. **Uses `Awaitility.await()`** — replaces the direct `assertMockEndpointsSatisfied()` call with `await().atMost(5, SECONDS).untilAsserted(...)`, making the assertion resilient to scheduling variations
3. **Increases long delay to 30000ms** — well above the 5-second assertion timeout, ensuring the context shutdown always interrupts the long-delay route even under heavy CI load

## Test plan

- [x] `DelayerWhileShutdownTest` passes consistently (verified multiple consecutive runs)
- [ ] CI passes on JDK 17 and JDK 25

_Claude Code on behalf of [@oscerd](https://github.com/oscerd)_