### PR TITLE
CAMEL-23223: Stabilize flaky ManagedMessageHistoryAutoConfigIT

### DIFF
--- a/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/MemoryLogHandler.java
+++ b/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/MemoryLogHandler.java
@@ -18,11 +18,14 @@ package org.apache.camel.opentelemetry.metrics.integration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.LogRecord;
 
 public class MemoryLogHandler extends ConsoleHandler {
-    private List<LogRecord> logs = new ArrayList<>();
+    // CopyOnWriteArrayList for thread safety: publish() is called from the OTel
+    // exporter thread while hasLogs()/getLogs() are called from the test thread
+    private final List<LogRecord> logs = new CopyOnWriteArrayList<>();
 
     public MemoryLogHandler() {
         super();

--- a/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
+++ b/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
@@ -17,7 +17,6 @@
 package org.apache.camel.opentelemetry.metrics.integration.messagehistory;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.LogRecord;
@@ -83,49 +82,53 @@ public class ManagedMessageHistoryAutoConfigIT extends CamelTestSupport {
         MemoryLogHandler handler = new MemoryLogHandler();
         logger.addHandler(handler);
 
-        int count = 10;
-        getMockEndpoint("mock:foo").expectedMessageCount(count / 2);
-        getMockEndpoint("mock:bar").expectedMessageCount(count / 2);
-        getMockEndpoint("mock:baz").expectedMessageCount(count / 2);
+        try {
+            int count = 10;
+            getMockEndpoint("mock:foo").expectedMessageCount(count / 2);
+            getMockEndpoint("mock:bar").expectedMessageCount(count / 2);
+            getMockEndpoint("mock:baz").expectedMessageCount(count / 2);
 
-        for (int i = 0; i < count; i++) {
-            if (i % 2 == 0) {
-                template.sendBody("seda:foo", "Hello " + i);
-            } else {
-                template.sendBody("seda:bar", "Hello " + i);
-            }
-        }
-
-        MockEndpoint.assertIsSatisfied(context);
-
-        // Use Awaitility to retry assertions until the OTel periodic reader has exported
-        // Camel metrics. On slow CI architectures the first export may be delayed well
-        // beyond the 300ms export interval. Assert on the last exported Camel metric data
-        // because earlier exports during message processing may contain incomplete data.
-        await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> {
-            List<LogRecord> logs = new ArrayList<>(handler.getLogs());
-            assertFalse(logs.isEmpty(), "No metrics were exported");
-
-            MetricData lastCamelMetric = null;
-            for (LogRecord log : logs) {
-                if (log.getParameters() != null && log.getParameters().length > 0) {
-                    MetricData metricData = (MetricData) log.getParameters()[0];
-                    // Skip non-Camel metrics (e.g. otel.sdk.* internal metrics added in OTel 1.60+)
-                    if (!metricData.getName().startsWith("camel.")) {
-                        continue;
-                    }
-                    assertEquals(DEFAULT_CAMEL_MESSAGE_HISTORY_METER_NAME, metricData.getName());
-                    lastCamelMetric = metricData;
+            for (int i = 0; i < count; i++) {
+                if (i % 2 == 0) {
+                    template.sendBody("seda:foo", "Hello " + i);
+                } else {
+                    template.sendBody("seda:bar", "Hello " + i);
                 }
             }
-            assertThat(lastCamelMetric).as("No Camel metric data found").isNotNull();
 
-            assertPointDataForRouteId(lastCamelMetric, "route1");
+            MockEndpoint.assertIsSatisfied(context);
 
-            assertMetricDataHasNodeId(lastCamelMetric, "route1", "foo");
-            assertMetricDataHasNodeId(lastCamelMetric, "route2", "bar");
-            assertMetricDataHasNodeId(lastCamelMetric, "route2", "baz");
-        });
+            // Use Awaitility to retry assertions until the OTel periodic reader has exported
+            // Camel metrics. On slow CI architectures the first export may be delayed well
+            // beyond the 300ms export interval. Assert on the last exported Camel metric data
+            // because earlier exports during message processing may contain incomplete data.
+            await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> {
+                List<LogRecord> logs = handler.getLogs();
+                assertFalse(logs.isEmpty(), "No metrics were exported");
+
+                MetricData lastCamelMetric = null;
+                for (LogRecord log : logs) {
+                    if (log.getParameters() != null && log.getParameters().length > 0) {
+                        MetricData metricData = (MetricData) log.getParameters()[0];
+                        // Skip non-Camel metrics (e.g. otel.sdk.* internal metrics added in OTel 1.60+)
+                        if (!metricData.getName().startsWith("camel.")) {
+                            continue;
+                        }
+                        assertEquals(DEFAULT_CAMEL_MESSAGE_HISTORY_METER_NAME, metricData.getName());
+                        lastCamelMetric = metricData;
+                    }
+                }
+                assertThat(lastCamelMetric).as("No Camel metric data found").isNotNull();
+
+                assertPointDataForRouteId(lastCamelMetric, "route1");
+
+                assertMetricDataHasNodeId(lastCamelMetric, "route1", "foo");
+                assertMetricDataHasNodeId(lastCamelMetric, "route2", "bar");
+                assertMetricDataHasNodeId(lastCamelMetric, "route2", "baz");
+            });
+        } finally {
+            logger.removeHandler(handler);
+        }
     }
 
     private void assertMetricDataHasNodeId(MetricData metricData, String routeId, String nodeId) {

--- a/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
+++ b/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
@@ -98,30 +98,34 @@ public class ManagedMessageHistoryAutoConfigIT extends CamelTestSupport {
 
         MockEndpoint.assertIsSatisfied(context);
 
-        await().atMost(Duration.ofMillis(1000L)).until(handler::hasLogs);
+        // Use Awaitility to retry assertions until the OTel periodic reader has exported
+        // Camel metrics. On slow CI architectures the first export may be delayed well
+        // beyond the 300ms export interval. Assert on the last exported Camel metric data
+        // because earlier exports during message processing may contain incomplete data.
+        await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> {
+            List<LogRecord> logs = new ArrayList<>(handler.getLogs());
+            assertFalse(logs.isEmpty(), "No metrics were exported");
 
-        List<LogRecord> logs = new ArrayList<>(handler.getLogs());
-        assertFalse(logs.isEmpty(), "No metrics were exported");
-        int dataCount = 0;
-        for (LogRecord log : logs) {
-            if (log.getParameters() != null && log.getParameters().length > 0) {
-                MetricData metricData = (MetricData) log.getParameters()[0];
-                // Skip non-Camel metrics (e.g. otel.sdk.* internal metrics added in OTel 1.60+)
-                if (!metricData.getName().startsWith("camel.")) {
-                    continue;
+            MetricData lastCamelMetric = null;
+            for (LogRecord log : logs) {
+                if (log.getParameters() != null && log.getParameters().length > 0) {
+                    MetricData metricData = (MetricData) log.getParameters()[0];
+                    // Skip non-Camel metrics (e.g. otel.sdk.* internal metrics added in OTel 1.60+)
+                    if (!metricData.getName().startsWith("camel.")) {
+                        continue;
+                    }
+                    assertEquals(DEFAULT_CAMEL_MESSAGE_HISTORY_METER_NAME, metricData.getName());
+                    lastCamelMetric = metricData;
                 }
-                assertEquals(DEFAULT_CAMEL_MESSAGE_HISTORY_METER_NAME, metricData.getName());
-
-                assertPointDataForRouteId(metricData, "route1");
-
-                assertMetricDataHasNodeId(metricData, "route1", "foo");
-                assertMetricDataHasNodeId(metricData, "route2", "bar");
-                assertMetricDataHasNodeId(metricData, "route2", "baz");
-
-                dataCount++;
             }
-        }
-        assertTrue(dataCount > 0, "No metric data found");
+            assertThat(lastCamelMetric).as("No Camel metric data found").isNotNull();
+
+            assertPointDataForRouteId(lastCamelMetric, "route1");
+
+            assertMetricDataHasNodeId(lastCamelMetric, "route1", "foo");
+            assertMetricDataHasNodeId(lastCamelMetric, "route2", "bar");
+            assertMetricDataHasNodeId(lastCamelMetric, "route2", "baz");
+        });
     }
 
     private void assertMetricDataHasNodeId(MetricData metricData, String routeId, String nodeId) {


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `ManagedMessageHistoryAutoConfigIT.testMessageHistory` in `camel-opentelemetry-metrics`, reported across various CI architectures.

**Root cause:** The test used `await().atMost(1000ms).until(handler::hasLogs)` which only waited for *any* log to appear (which could be a non-Camel OTel internal metric), then immediately asserted on all metrics. On slow CI architectures (ppc64le, s390x), the Camel-specific metrics may not have been exported yet within 1 second. Additionally, early metric exports during message processing could contain incomplete data, causing the per-entry assertions to fail.

**Fix:**
- Replace the two-step approach (wait for any log → assert immediately) with `await().atMost(20s).untilAsserted(...)` that retries the full set of metric assertions until the OTel periodic reader exports Camel metrics
- Assert on the **last** exported Camel MetricData (which contains the complete accumulated histogram data), rather than asserting on every exported entry
- Make `MemoryLogHandler` thread-safe with `CopyOnWriteArrayList` since `publish()` is called from the OTel exporter thread while `getLogs()`/`hasLogs()` are called from the test thread
- Remove handler from logger in `finally` block to prevent handler accumulation across test runs in the same JVM
- Remove redundant `new ArrayList<>()` wrapper since `getLogs()` already returns a defensive copy

## Test plan

- [x] `ManagedMessageHistoryAutoConfigIT` passes consistently (verified 3 consecutive runs locally)
- [x] All 89 unit tests + integration tests pass in the module
- [ ] CI passes on all architectures

_Claude Code on behalf of @davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)