### PR TITLE
CAMEL-23915: Fix flaky MockEndpointTimeClauseTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTimeClauseTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTimeClauseTest.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -28,6 +29,7 @@ import org.apache.camel.StatefulService;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -81,11 +83,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.execute(new Runnable() {
             public void run() {
-                try {
-                    Thread.sleep(50);
-                } catch (Exception e) {
-                    // ignore
-                }
+                await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 1);
                 if (isStarted(template)) {
                     template.sendBody("direct:a", "B");
                 }
@@ -141,7 +139,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         mock.message(0).arrives().noLaterThan(1).seconds().beforeNext();
 
         template.sendBody("direct:a", "A");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
         assertMockEndpointsSatisfied();
@@ -154,7 +152,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         mock.message(1).arrives().noLaterThan(1).seconds().afterPrevious();
 
         template.sendBody("direct:a", "A");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
         assertMockEndpointsSatisfied();
@@ -164,13 +162,13 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
     public void testArrivesBeforeAndAfter() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(3);
-        mock.message(1).arrives().noLaterThan(250).millis().afterPrevious();
-        mock.message(1).arrives().noLaterThan(250).millis().beforeNext();
+        mock.message(1).arrives().noLaterThan(2).seconds().afterPrevious();
+        mock.message(1).arrives().noLaterThan(2).seconds().beforeNext();
 
         template.sendBody("direct:a", "A");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 2);
         template.sendBody("direct:a", "C");
 
         assertMockEndpointsSatisfied();
@@ -180,10 +178,11 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
     public void testArrivesWithinAfterPrevious() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(2);
-        mock.message(1).arrives().between(10, 500).millis().afterPrevious();
+        mock.message(1).arrives().between(10, 2000).millis().afterPrevious();
 
         template.sendBody("direct:a", "A");
-        Thread.sleep(50);
+        await().pollDelay(20, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
+                .until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
         assertMockEndpointsSatisfied();
@@ -193,10 +192,11 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
     public void testArrivesWithinBeforeNext() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(2);
-        mock.message(0).arrives().between(10, 500).millis().beforeNext();
+        mock.message(0).arrives().between(10, 2000).millis().beforeNext();
 
         template.sendBody("direct:a", "A");
-        Thread.sleep(50);
+        await().pollDelay(20, TimeUnit.MILLISECONDS).atMost(5, TimeUnit.SECONDS)
+                .until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
         assertMockEndpointsSatisfied();
@@ -210,11 +210,11 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
 
         template.sendBody("direct:a", "A");
         template.sendBody("direct:a", "B");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 2);
         template.sendBody("direct:a", "C");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 3);
         template.sendBody("direct:a", "D");
-        Thread.sleep(50);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 4);
         template.sendBody("direct:a", "E");
 
         assertMockEndpointsSatisfied();


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Replace all 10 `Thread.sleep(50)` calls in `MockEndpointTimeClauseTest` with Awaitility-based assertions, following the project's testing guidelines that prohibit `Thread.sleep()` in test code.

### Changes
- Replace `Thread.sleep(50)` between message sends with `await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= N)` to wait for message receipt with proper timeout
- For tests with `between()` timing bounds that require a minimum inter-message gap, use `pollDelay(20, TimeUnit.MILLISECONDS)` to ensure sufficient delay for lower-bound assertions
- Widen timing assertion upper bounds (`between(10, 500)` → `between(10, 2000)`, `noLaterThan(250).millis()` → `noLaterThan(2).seconds()`) to prevent flakiness on slow CI systems
- Replace the `Thread.sleep(50)` + try/catch inside the executor thread in `testAssertPeriodSecondMessageArrives` with a direct Awaitility wait for message receipt

### Why this prevents flakiness
- `Thread.sleep(50)` is unreliable — on busy CI systems, it may sleep for much longer, causing tight timing assertions to fail
- Awaitility provides deterministic synchronization: it waits until the mock endpoint has actually received the expected messages, rather than hoping a fixed sleep is sufficient
- Widened upper bounds accommodate CI environments where GC pauses or thread scheduling delays can cause unexpected timing variations

## Test plan
- [x] All 11 tests in `MockEndpointTimeClauseTest` pass locally
- [x] Verified stability with 3 consecutive runs (0 failures)
- [x] Code formatted with `mvn formatter:format impsort:sort`
- [ ] CI passes

JIRA: [CAMEL-23915](https://issues.apache.org/jira/browse/CAMEL-23915)