### PR TITLE
CAMEL-23920: Replace Thread.sleep with Awaitility in camel-ftp tests

### DIFF
--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerIdempotentIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerIdempotentIT.java
@@ -16,9 +16,13 @@
  */
 package org.apache.camel.component.file.remote.integration;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Unit test for the idempotent=true option.
@@ -41,8 +45,6 @@ public class FtpConsumerIdempotentIT extends FtpServerTestSupport {
 
         MockEndpoint.assertIsSatisfied(context);
 
-        Thread.sleep(100);
-
         // reset mock and set new expectations
         mock.reset();
         mock.expectedMessageCount(0);
@@ -50,10 +52,11 @@ public class FtpConsumerIdempotentIT extends FtpServerTestSupport {
         // move file back
         sendFile(getFtpUrl(), "Hello World", "report.txt");
 
-        // should NOT consume the file again, let 2 secs pass to let the
+        // should NOT consume the file again, let 2+ secs pass to let the
         // consumer try to consume it but it should not
-        Thread.sleep(2000);
-        MockEndpoint.assertIsSatisfied(context);
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
     }
 
     @Override

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerIdempotentRefIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpConsumerIdempotentRefIT.java
@@ -16,12 +16,15 @@
  */
 package org.apache.camel.component.file.remote.integration;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.IdempotentRepository;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -50,8 +53,6 @@ public class FtpConsumerIdempotentRefIT extends FtpServerTestSupport {
 
         MockEndpoint.assertIsSatisfied(context);
 
-        Thread.sleep(100);
-
         // reset mock and set new expectations
         mock.reset();
         mock.expectedMessageCount(0);
@@ -59,10 +60,11 @@ public class FtpConsumerIdempotentRefIT extends FtpServerTestSupport {
         // move file back
         sendFile(getFtpUrl(), "Hello World", "report.txt");
 
-        // should NOT consume the file again, let 2 secs pass to let the
+        // should NOT consume the file again, let 2+ secs pass to let the
         // consumer try to consume it but it should not
-        Thread.sleep(2000);
-        MockEndpoint.assertIsSatisfied(context);
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
 
         assertTrue(invoked, "MyIdempotentRepository should have been invoked");
     }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerTempFileExistIssueIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/integration/FtpProducerTempFileExistIssueIT.java
@@ -51,13 +51,13 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
     public void testWriteUsingTempPrefixButFileExist() throws Exception {
         template.sendBodyAndHeader(getFtpUrl(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
-        Thread.sleep(500);
+        File file = service.ftpFile("tempprefix/hello.txt").toFile();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(file.exists()));
 
         template.sendBodyAndHeader(getFtpUrl() + "&tempPrefix=foo", "Bye World", Exchange.FILE_NAME, "hello.txt");
 
-        File file = service.ftpFile("tempprefix/hello.txt").toFile();
-        await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(file.exists()));
-        assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file));
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file)));
     }
 
     @Test
@@ -65,42 +65,41 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
         template.sendBodyAndHeader(getFtpUrl(), "Hello World", Exchange.FILE_NAME, "hello.txt");
         template.sendBodyAndHeader(getFtpUrl(), "Hello World", Exchange.FILE_NAME, "foohello.txt");
 
-        Thread.sleep(500);
+        File file = service.ftpFile("tempprefix/hello.txt").toFile();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(file.exists()));
 
         template.sendBodyAndHeader(getFtpUrl() + "&tempPrefix=foo", "Bye World", Exchange.FILE_NAME, "hello.txt");
 
-        File file = service.ftpFile("tempprefix/hello.txt").toFile();
-        await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(file.exists()));
-        assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file));
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file)));
     }
 
     @Test
     public void testWriteUsingTempPrefixButFileExistOverride() throws Exception {
         template.sendBodyAndHeader(getFtpUrl(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
-        Thread.sleep(500);
+        File file = service.ftpFile("tempprefix/hello.txt").toFile();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(file.exists()));
 
         template.sendBodyAndHeader(getFtpUrl() + "&tempPrefix=foo&fileExist=Override", "Bye World", Exchange.FILE_NAME,
                 "hello.txt");
 
-        File file = service.ftpFile("tempprefix/hello.txt").toFile();
-        await().atMost(500, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> assertTrue(file.exists()));
-        assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file));
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals("Bye World", context.getTypeConverter().convertTo(String.class, file)));
     }
 
     @Test
     public void testWriteUsingTempPrefixButFileExistIgnore() throws Exception {
         template.sendBodyAndHeader(getFtpUrl(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
-        Thread.sleep(500);
+        File file = service.ftpFile("tempprefix/hello.txt").toFile();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(file.exists()));
 
         template.sendBodyAndHeader(getFtpUrl() + "&tempPrefix=foo&fileExist=Ignore", "Bye World", Exchange.FILE_NAME,
                 "hello.txt");
 
-        File file = service.ftpFile("tempprefix/hello.txt").toFile();
         // should not write new file as we should ignore
-        await().atMost(500, TimeUnit.MILLISECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertEquals("Hello World", context.getTypeConverter().convertTo(String.class, file)));
     }
 
@@ -108,7 +107,8 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
     public void testWriteUsingTempPrefixButFileExistFail() throws Exception {
         template.sendBodyAndHeader(getFtpUrl(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
-        Thread.sleep(500);
+        File file = service.ftpFile("tempprefix/hello.txt").toFile();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(file.exists()));
 
         String uri = getFtpUrl() + "&tempPrefix=foo&fileExist=Fail";
         Exception ex = assertThrows(CamelExecutionException.class,
@@ -118,9 +118,8 @@ public class FtpProducerTempFileExistIssueIT extends FtpServerTestSupport {
                 = assertIsInstanceOf(GenericFileOperationFailedException.class, ex.getCause());
         assertTrue(cause.getMessage().startsWith("File already exist"));
 
-        File file = service.ftpFile("tempprefix/hello.txt").toFile();
-        // should not write new file as we should ignore
-        await().atMost(1, TimeUnit.SECONDS)
+        // should not write new file as we should fail
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertEquals("Hello World", context.getTypeConverter().convertTo(String.class, file)));
     }
 }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Replace `Thread.sleep` calls with Awaitility-based polling in three camel-ftp test classes, following the project's testing guidelines which require Awaitility over `Thread.sleep`:

- **FtpProducerTempFileExistIssueIT**: Replace 5× `Thread.sleep(500)` with Awaitility file-existence checks before proceeding to the next send operation. Also increase existing assertion timeouts from 500ms to 5s for CI resilience.
- **FtpConsumerIdempotentIT**: Remove `Thread.sleep(100)` after initial assertion, replace `Thread.sleep(2000)` with `await().pollDelay(2, SECONDS).atMost(5, SECONDS).untilAsserted(...)` for the negative assertion (verifying idempotent consumer does NOT re-consume a file).
- **FtpConsumerIdempotentRefIT**: Same pattern as `FtpConsumerIdempotentIT`.

## Test plan

- [x] All 8 tests pass locally (`FtpProducerTempFileExistIssueIT` × 6, `FtpConsumerIdempotentIT` × 1, `FtpConsumerIdempotentRefIT` × 1)
- [ ] CI build passes
- [x] No `Thread.sleep` calls remain in the modified files
- [x] Code formatted with `mvn formatter:format impsort:sort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)