### PR TITLE
[backport camel-4.14.x] CAMEL-23891: camel-mail - filter Camel internal headers in MimeMultipartDataFormat unmarshal

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
@@ -50,8 +50,10 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.attachment.Attachment;
 import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.attachment.DefaultAttachment;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.apache.camel.support.DefaultDataFormat;
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.IOHelper;
@@ -72,9 +74,19 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
     private String includeHeaders;
     private Pattern includeHeadersPattern;
     private boolean binaryContent;
+    private final HeaderFilterStrategy headerFilterStrategy = createInboundHeaderFilterStrategy();
 
     public void setBinaryContent(boolean binaryContent) {
         this.binaryContent = binaryContent;
+    }
+
+    private static HeaderFilterStrategy createInboundHeaderFilterStrategy() {
+        DefaultHeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
+        // camel-4.14 DefaultHeaderFilterStrategy does not enable the Camel* in-filter by default (that
+        // default was introduced on a later branch), so configure it explicitly to filter the Camel*
+        // namespace on the inbound path, matching the mail consumer's HeaderFilterStrategy.
+        strategy.setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
+        return strategy;
     }
 
     public void setHeadersInline(boolean headersInline) {
@@ -219,6 +231,12 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
                 Object ho = headersEnum.nextElement();
                 if (ho instanceof Header) {
                     Header header = (Header) ho;
+                    // filter Camel internal headers (Camel*) instead of copying them verbatim from the external
+                    // MIME headers, consistent with the inbound HeaderFilterStrategy applied by the mail consumer
+                    if (headerFilterStrategy.applyFilterToExternalHeaders(header.getName(), header.getValue(),
+                            camelMessage.getExchange())) {
+                        continue;
+                    }
                     camelMessage.setHeader(header.getName(), header.getValue());
                 }
             }

--- a/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
@@ -407,6 +407,27 @@ public class MimeMultipartDataFormatTest extends CamelTestSupport {
     }
 
     @Test
+    public void unmarshalInlineHeadersFiltersCamelInternalHeaders() {
+        // Camel-internal headers (Camel*, case-insensitive) present in the external MIME headers must not be
+        // copied onto the Camel message; ordinary application headers still pass through. This matches the
+        // inbound HeaderFilterStrategy applied by the mail consumer.
+        String mime = "CamelFoo: blocked\r\n"
+                      + "camelBar: blocked\r\n"
+                      + "CAMELBaz: blocked\r\n"
+                      + "X-Normal: keep-me\r\n"
+                      + "Content-Type: text/plain\r\n"
+                      + "\r\n"
+                      + "Body text";
+        in.setBody(mime);
+        Exchange out = template.send("direct:unmarshalonlyinlineheaders", exchange);
+        assertNotNull(out.getMessage());
+        assertEquals("keep-me", out.getMessage().getHeader("X-Normal"));
+        assertNull(out.getMessage().getHeader("CamelFoo"));
+        assertNull(out.getMessage().getHeader("camelBar"));
+        assertNull(out.getMessage().getHeader("CAMELBaz"));
+    }
+
+    @Test
     public void unmarshalRelated() throws IOException {
         in.setBody(new File("src/test/resources/multipart-related.txt"));
         Attachment dh = unmarshalAndCheckAttachmentName("950120.aaCB@XIson.com");


### PR DESCRIPTION
## Backport of #24406

Cherry-pick of #24406 onto `camel-4.14.x` (targeting the 4.14.9 release).

**Original PR:** #24406 — CAMEL-23891: camel-mail - filter Camel internal headers in MimeMultipartDataFormat unmarshal
**Original author:** @oscerd
**Target branch:** `camel-4.14.x`

### What changed

`MimeMultipartDataFormat` unmarshalling (`headersInline=true`) now aligns with the camel-mail consumer: internal Camel headers (`Camel*`, matched case-insensitively) present in the external MIME headers are no longer copied verbatim onto the Camel message. Ordinary application headers (e.g. `X-...`) continue to pass through unchanged, via `DefaultHeaderFilterStrategy.applyFilterToExternalHeaders(...)` on the inbound path — consistent with the `MailHeaderFilterStrategy` already applied by the consumer.

### Backport notes

- **Hand-ported** (not a verbatim cherry-pick): on `camel-4.14.x` the inbound header copy is still **inline** inside `unmarshal()` and uses the pre-pattern-matching `if (ho instanceof Header) { Header header = (Header) ho; ... }` form. The same filter guard (`applyFilterToExternalHeaders(...) → continue` before `setHeader`) was applied to that structure.
- **`Camel*` in-filter configured explicitly**: `DefaultHeaderFilterStrategy` on `camel-4.14.x` does **not** enable the `Camel*` in-filter by default — that default was introduced later on `main`/`camel-4.21.x` by CAMEL-23543 (`c2ce0267`), which is not on this branch. The data format therefore configures `setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH)` on its strategy so filtering behaves identically to #24406. Verified by running `MimeMultipartDataFormatTest` (22 pass).
- The unit test (`unmarshalInlineHeadersFiltersCamelInternalHeaders`) is cherry-picked verbatim and applies cleanly.
- The upgrade-guide entry is intentionally **not** included here: per project policy the upgrade-guide history is canonical on `main` (the 4.14-line note is handled as a separate doc-sync on `main`).

JIRA: https://issues.apache.org/jira/browse/CAMEL-23891

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Andrea Cosentino