### PR TITLE
CAMEL-23924: Fix flaky ServletStreamingChunkedTest

### DIFF
--- a/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/ServletStreamingChunkedTest.java
+++ b/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/ServletStreamingChunkedTest.java
@@ -42,28 +42,25 @@ public class ServletStreamingChunkedTest extends ServletCamelRouterTestSupport {
     @Test
     public void testStreaming() throws Exception {
 
+        final CountDownLatch requestStarted = new CountDownLatch(1);
         final CountDownLatch latch1 = new CountDownLatch(1);
         final CountDownLatch latch2 = new CountDownLatch(1);
 
-        // use background thread to write to stream that camel-servlet uses as reponse
+        // use background thread to write to stream that camel-servlet uses as response
         context.getExecutorServiceManager().newSingleThreadExecutor(this, "writer").execute(() -> {
             try {
-                LOG.info(">>>> sleeping <<<<");
-                Thread.sleep(500);
+                LOG.info(">>>> waiting for request <<<<");
+                requestStarted.await(5, TimeUnit.SECONDS);
                 LOG.info(">>>> writing <<<<");
                 pos.write("ABC".getBytes());
                 pos.flush();
 
                 latch1.await(5, TimeUnit.SECONDS);
-                LOG.info(">>>> sleeping <<<<");
-                Thread.sleep(500);
                 LOG.info(">>>> writing <<<<");
                 pos.write("DEF".getBytes());
                 pos.flush();
 
                 latch2.await(5, TimeUnit.SECONDS);
-                LOG.info(">>>> sleeping <<<<");
-                Thread.sleep(500);
                 LOG.info(">>>> writing <<<<");
                 pos.write("GHI".getBytes());
                 pos.flush();
@@ -83,6 +80,9 @@ public class ServletStreamingChunkedTest extends ServletCamelRouterTestSupport {
 
         assertEquals(200, response.getResponseCode());
         assertEquals("chunked", response.getHeaderField(Exchange.TRANSFER_ENCODING));
+
+        // Signal writer that the request has been processed and response is streaming
+        requestStarted.countDown();
 
         InputStream is = response.getInputStream();
         assertNotNull(is);


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

Fix flaky `ServletStreamingChunkedTest` by replacing `Thread.sleep(500)` calls with proper `CountDownLatch`-based synchronization:

- **First sleep**: replaced with a `requestStarted` CountDownLatch that the main thread counts down after the HTTP request has been processed and response headers confirmed (200, chunked). This ensures the writer only starts producing data once the servlet is actively streaming the response.
- **Second and third sleeps** (after `latch1.await`/`latch2.await`): removed entirely as the existing latches already provide the necessary synchronization between reader and writer for subsequent chunks.

The fixed-delay `Thread.sleep(500)` was unreliable on slow CI environments (not enough time) and wasteful on fast machines (unnecessary waiting).

## Test plan

- [x] `mvn test -pl components/camel-servlet -Dtest=ServletStreamingChunkedTest` — passes
- [x] Ran test 3 additional times in a loop to verify stability — all green
- [x] `mvn formatter:format impsort:sort` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)