### PR TITLE
fix camel launcher issue used with kamelet

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/support/component/PropertyConfigurerSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/component/PropertyConfigurerSupport.java
@@ -96,8 +96,12 @@ public abstract class PropertyConfigurerSupport {
 
         if (value != null) {
             try {
-                if (MAGIC_VALUE.equals(value) && boolean.class == type) {
-                    value = "true";
+                if (MAGIC_VALUE.equals(value)) {
+                    if (boolean.class == type || Boolean.class == type) {
+                        value = "true";
+                    } else {
+                        return null;
+                    }
                 }
                 return camelContext.getTypeConverter().mandatoryConvertTo(type, value);
             } catch (NoTypeConversionAvailableException e) {


### PR DESCRIPTION
When an optional parameter ({{?param}}) is not provided, the export command sets it to MAGIC_VALUE (@@CamelMagicValue@@). Previously, PropertyConfigurerSupport only handled this for boolean types, causing TypeConversionException for other types like Long for replayId in kamelets/salesforce-source.kamelet.yaml. This PR for fixing export command failure with optional parameters in Kamelets.

Before fix:
`Caused by: org.apache.camel.ResolveEndpointFailedException: Failed to resolve endpoint: local-salesforce-1://subscribe:TestTopic?notifyForFields=ALL&notifyForOperationCreate=true&notifyForOperationDelete=false&notifyForOperationUndelete=false&notifyForOperationUpdate=false&rawPayload=false&replayId=%40%40CamelMagicValue%40%40&sObjectQuery=SELECT+Id+FROM+Account&updateTopic=true due to: Error binding property (replayId=@@CamelMagicValue@@) with name: replayId on bean: local-salesforce-1://subscribe:TestTopic?notifyForFields=ALL&notifyForOperationCreate=true&notifyForOperationDelete=false&notifyForOperationUndelete=false&notifyForOperationUpdate=false&rawPayload=false&replayId=%40%40CamelMagicValue%40%40&sObjectQuery=SELECT+Id+FROM+Account&updateTopic=true with value: @@CamelMagicValue@@                                        
        at org.apache.camel.impl.engine.AbstractCamelContext.doGetEndpoint(AbstractCamelContext.java:891)
        at org.apache.camel.impl.engine.AbstractCamelContext.getEndpoint(AbstractCamelContext.java:778)
        at org.apache.camel.support.CamelContextHelper.getMandatoryEndpoint(CamelContextHelper.java:94)
        at org.apache.camel.reifier.AbstractReifier.resolveEndpoint(AbstractReifier.java:250)
        at org.apache.camel.reifier.RouteReifier.doCreateRoute(RouteReifier.java:110)
        at org.apache.camel.reifier.RouteReifier.createRoute(RouteReifier.java:89)
        ... 51 more
Caused by: org.apache.camel.PropertyBindingException: Error binding property (replayId=@@CamelMagicValue@@) with name: replayId on bean: local-salesforce-1://subscribe:TestTopic?notifyForFields=ALL&notifyForOperationCreate=true&notifyForOperationDelete=false&notifyForOperationUndelete=false&notifyForOperationUpdate=false&rawPayload=false&replayId=%40%40CamelMagicValue%40%40&sObjectQuery=SELECT+Id+FROM+Account&updateTopic=true with value: @@CamelMagicValue@@                                                                                                                                                                      
        at org.apache.camel.support.PropertyBindingSupport.setSimplePropertyViaConfigurer(PropertyBindingSupport.java:806)
        at org.apache.camel.support.PropertyBindingSupport.doSetPropertyValue(PropertyBindingSupport.java:565)
        at org.apache.camel.support.PropertyBindingSupport.doBuildPropertyOgnlPath(PropertyBindingSupport.java:422)
        at org.apache.camel.support.PropertyBindingSupport.doBindProperties(PropertyBindingSupport.java:302)
        at org.apache.camel.support.PropertyBindingSupport$Builder.bind(PropertyBindingSupport.java:1990)
        at org.apache.camel.support.DefaultEndpoint.setProperties(DefaultEndpoint.java:422)
        at org.apache.camel.support.DefaultEndpoint.configureProperties(DefaultEndpoint.java:394)
        at org.apache.camel.support.DefaultComponent.setProperties(DefaultComponent.java:421)
        at org.apache.camel.component.salesforce.SalesforceComponent.createEndpoint(SalesforceComponent.java:363)
        at org.apache.camel.support.DefaultComponent.createEndpoint(DefaultComponent.java:171)
        at org.apache.camel.impl.engine.AbstractCamelContext.doGetEndpoint(AbstractCamelContext.java:857)
        ... 56 more
Caused by: org.apache.camel.TypeConversionException: Error during type conversion from type: java.lang.String to the required type: java.lang.Long with value @@CamelMagicValue@@ due to java.lang.NumberFormatException: For input string: "@@CamelMagicValue@@"                                                                                                                                                                 
        at org.apache.camel.converter.CamelBaseBulkConverterLoader.convertTo(CamelBaseBulkConverterLoader.java:61)
        at org.apache.camel.spi.BulkTypeConverters.convertTo(BulkTypeConverters.java:149)
        at org.apache.camel.impl.converter.CoreTypeConverterRegistry.tryCachedConverters(CoreTypeConverterRegistry.java:424)
        at org.apache.camel.impl.converter.CoreTypeConverterRegistry.doConvertTo(CoreTypeConverterRegistry.java:389)
        at org.apache.camel.impl.converter.CoreTypeConverterRegistry.doConvertToAndStat(CoreTypeConverterRegistry.java:284)
        at org.apache.camel.impl.converter.CoreTypeConverterRegistry.mandatoryConvertTo(CoreTypeConverterRegistry.java:201)
        at org.apache.camel.impl.converter.CoreTypeConverterRegistry.mandatoryConvertTo(CoreTypeConverterRegistry.java:188)
        at org.apache.camel.support.component.PropertyConfigurerSupport.property(PropertyConfigurerSupport.java:102)
        at org.apache.camel.component.salesforce.SalesforceEndpointConfigurer.configure(SalesforceEndpointConfigurer.java:134)
        at org.apache.camel.support.PropertyBindingSupport.setSimplePropertyViaConfigurer(PropertyBindingSupport.java:804)
        ... 66 more
Caused by: java.lang.NumberFormatException: For input string: "@@CamelMagicValue@@"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
        at java.base/java.lang.Long.parseLong(Long.java:594)
        at java.base/java.lang.Long.valueOf(Long.java:950)
        at org.apache.camel.converter.ObjectConverter.toLong(ObjectConverter.java:215)
        at org.apache.camel.converter.CamelBaseBulkConverterLoader.doConvertTo(CamelBaseBulkConverterLoader.java:292)
        at org.apache.camel.converter.CamelBaseBulkConverterLoader.convertTo(CamelBaseBulkConverterLoader.java:56)
`

After fix (ignore the authenication error as no real credential provide to access)

`org.apache.camel.FailedToStartComponentException: Failed to start component local-salesforce-1 because of org.apache.camel.component.salesforce.api.SalesforceException: {errors:[{"errorCode":"invalid_client_id","message":"Login error code:[invalid_client_id] description:[client identifier invalid]","fields":null}],statusCode:400}                                                                                       
        at org.apache.camel.impl.engine.AbstractCamelContext.doStartCamel(AbstractCamelContext.java:3108)
        at org.apache.camel.impl.engine.AbstractCamelContext.doStartContext(AbstractCamelContext.java:2812)
        at org.apache.camel.impl.engine.AbstractCamelContext.doStart(AbstractCamelContext.java:2767)
        at org.apache.camel.support.service.BaseService.start(BaseService.java:132)
        at org.apache.camel.impl.engine.AbstractCamelContext.start(AbstractCamelContext.java:2347)
        at org.apache.camel.impl.DefaultCamelContext.start(DefaultCamelContext.java:214)
        at org.apache.camel.main.KameletMain.doStart(KameletMain.java:413)
        at org.apache.camel.support.service.BaseService.start(BaseService.java:132)
        at org.apache.camel.dsl.jbang.core.commands.Run.runKameletMain(Run.java:1945)
        at org.apache.camel.dsl.jbang.core.commands.Run.run(Run.java:1253)
        at org.apache.camel.dsl.jbang.core.commands.Run.runExport(Run.java:526)
        at org.apache.camel.dsl.jbang.core.commands.ExportBaseCommand.runSilently(ExportBaseCommand.java:566)
        at org.apache.camel.dsl.jbang.core.commands.ExportQuarkus.export(ExportQuarkus.java:89)
        at org.apache.camel.dsl.jbang.core.commands.Export.export(Export.java:273)
        at org.apache.camel.dsl.jbang.core.commands.Export.doExport(Export.java:152)
        at org.apache.camel.dsl.jbang.core.commands.Export.export(Export.java:79)
        at org.apache.camel.dsl.jbang.core.commands.ExportBaseCommand.doCall(ExportBaseCommand.java:319)
        at org.apache.camel.dsl.jbang.core.commands.CamelCommand.call(CamelCommand.java:73)
        at org.apache.camel.dsl.jbang.core.commands.CamelCommand.call(CamelCommand.java:39)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2031)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.apache.camel.dsl.jbang.core.commands.CamelJBangMain.execute(CamelJBangMain.java:245)
        at org.apache.camel.dsl.jbang.launcher.CamelLauncher.main(CamelLauncher.java:49)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:106)
        at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64)
        at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40)
Caused by: org.apache.camel.RuntimeCamelException: org.apache.camel.component.salesforce.api.SalesforceException: {errors:[{"errorCode":"invalid_client_id","message":"Login error code:[invalid_client_id] description:[client identifier invalid]","fields":null}],statusCode:400}                                                                                                                                              
        at org.apache.camel.RuntimeCamelException.wrapRuntimeException(RuntimeCamelException.java:91)
        at org.apache.camel.support.service.BaseService.doFail(BaseService.java:452)
        at org.apache.camel.support.service.BaseService.fail(BaseService.java:381)
        at org.apache.camel.support.service.BaseService.start(BaseService.java:145)
        at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:129)
        at org.apache.camel.component.salesforce.SalesforceComponent.doStart(SalesforceComponent.java:471)
        at org.apache.camel.support.service.BaseService.start(BaseService.java:132)
        at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:129)
        at org.apache.camel.impl.engine.AbstractCamelContext.startService(AbstractCamelContext.java:3608)
        at org.apache.camel.impl.engine.AbstractCamelContext.doStartCamel(AbstractCamelContext.java:3106)
        ... 33 more
Caused by: org.apache.camel.component.salesforce.api.SalesforceException: {errors:[{"errorCode":"invalid_client_id","message":"Login error code:[invalid_client_id] description:[client identifier invalid]","fields":null}],statusCode:400}                                                                                                                                                                                      
        at org.apache.camel.component.salesforce.internal.SalesforceSession.parseLoginResponse(SalesforceSession.java:353)
        at org.apache.camel.component.salesforce.internal.SalesforceSession.login(SalesforceSession.java:185)
        at org.apache.camel.component.salesforce.internal.SalesforceSession.doStart(SalesforceSession.java:442)
`

