### PR TITLE
CAMEL-23891: camel-mail - configure Camel* in-filter explicitly in MimeMultipartDataFormat (4.18.x follow-up to #24409)

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
@@ -74,7 +74,7 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
     private String includeHeaders;
     private Pattern includeHeadersPattern;
     private boolean binaryContent;
-    private final HeaderFilterStrategy headerFilterStrategy = new DefaultHeaderFilterStrategy();
+    private final HeaderFilterStrategy headerFilterStrategy = createInboundHeaderFilterStrategy();
 
     public String getMultipartSubType() {
         return multipartSubType;
@@ -122,6 +122,15 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
 
     public void setBinaryContent(boolean binaryContent) {
         this.binaryContent = binaryContent;
+    }
+
+    private static HeaderFilterStrategy createInboundHeaderFilterStrategy() {
+        DefaultHeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
+        // camel-4.18 DefaultHeaderFilterStrategy does not enable the Camel* in-filter by default (that
+        // default was introduced on a later branch), so configure it explicitly to filter the Camel*
+        // namespace on the inbound path, matching the mail consumer's HeaderFilterStrategy.
+        strategy.setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
+        return strategy;
     }
 
     @Override


### PR DESCRIPTION
## Follow-up to #24409 — makes the CAMEL-23891 fix actually filter on `camel-4.18.x`

The 4.18.x backport #24409 (merged) is a **silent no-op**: it instantiated `new DefaultHeaderFilterStrategy()` and relied on it filtering the `Camel*` namespace **by default**. That default only exists since **CAMEL-23543** (`c2ce0267`, "Centralize and harden Camel* header filtering in DefaultHeaderFilterStrategy"), which is on `main` and `camel-4.21.x` **only** — it is **not** on `camel-4.18.x`. On this branch `inFilterStartsWith` is `null` by default, so `applyFilterToExternalHeaders(...)` returns `false` for every header and `Camel*` headers from inline MIME content were still copied onto the Camel message.

### Change

Configure the in-filter explicitly on the data format's strategy:

```java
private final HeaderFilterStrategy headerFilterStrategy = createInboundHeaderFilterStrategy();

private static HeaderFilterStrategy createInboundHeaderFilterStrategy() {
    DefaultHeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
    strategy.setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH); // {"Camel","camel"}
    return strategy;
}
```

This is the same approach already merged on the `camel-4.14.x` backport (#24445). Case-insensitive matching (e.g. `CAMELBaz`) works because `lowerCase=true` and `filterOnMatch=true` are the defaults on this branch.

### Validation

- `MimeMultipartDataFormatTest` — **22 pass** (the `unmarshalInlineHeadersFiltersCamelInternalHeaders` case failed `expected <null> but was <blocked>` before this change, passes after).
- Full reactor `mvn clean install -DskipTests` — BUILD SUCCESS.

No upgrade-guide change (guide history is canonical on `main` per project policy).

JIRA: https://issues.apache.org/jira/browse/CAMEL-23891

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Andrea Cosentino