### PR TITLE
CAMEL-23891: camel-mail - upgrade-guide notes for MimeMultipartDataFormat header filtering (4.14.9, 4.18.4)

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -11,6 +11,18 @@ Note that manual migration is still required.
 See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 ====
 
+== Upgrading from 4.14.8 to 4.14.9
+
+=== camel-mail - MimeMultipartDataFormat inbound header filtering
+
+When unmarshalling a MIME message with `headersInline=true`, the `mime-multipart` data format now applies a
+`HeaderFilterStrategy` to the headers copied from the MIME content onto the Camel message. Camel-internal headers
+(the `Camel*` namespace, matched case-insensitively) present in the external MIME headers are no longer copied onto
+the message, consistent with the inbound header filtering already performed by the camel-mail consumer.
+
+Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
+content, set them explicitly after unmarshalling.
+
 == Upgrading from 4.14.3 to 4.14.8
 
 === camel-jackson - potential breaking change

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -11,6 +11,18 @@ Note that manual migration is still required.
 See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 ====
 
+== Upgrading from 4.18.3 to 4.18.4
+
+=== camel-mail - MimeMultipartDataFormat inbound header filtering
+
+When unmarshalling a MIME message with `headersInline=true`, the `mime-multipart` data format now applies a
+`HeaderFilterStrategy` to the headers copied from the MIME content onto the Camel message. Camel-internal headers
+(the `Camel*` namespace, matched case-insensitively) present in the external MIME headers are no longer copied onto
+the message, consistent with the inbound header filtering already performed by the camel-mail consumer.
+
+Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
+content, set them explicitly after unmarshalling.
+
 == Upgrading from 4.18.1 to 4.18.3
 
 === camel-jackson - potential breaking change


### PR DESCRIPTION
## Upgrade-guide doc-sync for CAMEL-23891 backports

The CAMEL-23891 fix — `MimeMultipartDataFormat` now applies a `HeaderFilterStrategy` on `headersInline=true` unmarshal, so `Camel*` headers from inline MIME content are no longer copied onto the message — was backported to:

- `camel-4.18.x` → **4.18.4** (#24409 + follow-up #24454)
- `camel-4.14.x` → **4.14.9** (#24445)

Per the project's upgrade-guide policy, the guide history is canonical on `main`. The original fix (#24406) already added the note to `camel-4x-upgrade-guide-4_22.adoc`; this PR adds the matching behavior-change notes to the maintenance guides on `main`:

- `camel-4x-upgrade-guide-4_18.adoc` → new `== Upgrading from 4.18.3 to 4.18.4` section
- `camel-4x-upgrade-guide-4_14.adoc` → new `== Upgrading from 4.14.8 to 4.14.9` section

Docs only; no code change. Same wording as the 4_22 note for consistency.

JIRA: https://issues.apache.org/jira/browse/CAMEL-23891

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Andrea Cosentino