### PR TITLE
chore: Fix uncommitted formatter changes breaking CI on all PRs

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/model/app/BeansDefinition.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/app/BeansDefinition.java
@@ -143,8 +143,8 @@ public class BeansDefinition {
     }
 
     /**
-     * @deprecated use standard Camel XML DSL (camel-xml-io) instead of legacy Spring/Blueprint XML.
-     *             This feature will be removed in a future release.
+     * @deprecated use standard Camel XML DSL (camel-xml-io) instead of legacy Spring/Blueprint XML. This feature will
+     *             be removed in a future release.
      */
     @Deprecated(since = "4.22")
     public List<Element> getSpringOrBlueprintBeans() {
@@ -152,8 +152,8 @@ public class BeansDefinition {
     }
 
     /**
-     * @deprecated use standard Camel XML DSL (camel-xml-io) instead of legacy Spring/Blueprint XML.
-     *             This feature will be removed in a future release.
+     * @deprecated use standard Camel XML DSL (camel-xml-io) instead of legacy Spring/Blueprint XML. This feature will
+     *             be removed in a future release.
      */
     @Deprecated(since = "4.22")
     public void setSpringOrBlueprintBeans(List<Element> springOrBlueprintBeans) {

--- a/dsl/camel-xml-io-dsl/src/main/java/org/apache/camel/dsl/xml/io/XmlRoutesBuilderLoader.java
+++ b/dsl/camel-xml-io-dsl/src/main/java/org/apache/camel/dsl/xml/io/XmlRoutesBuilderLoader.java
@@ -398,7 +398,7 @@ public class XmlRoutesBuilderLoader extends RouteBuilderLoaderSupport {
                 springBlueprintWarned = true;
                 LOG.warn(
                         "Detected legacy Spring <beans> or OSGi <blueprint> XML. This feature is deprecated and will be removed in a future release."
-                                + " Migrate to standard Camel XML DSL (camel-xml-io).");
+                         + " Migrate to standard Camel XML DSL (camel-xml-io).");
             }
             Document doc = app.getSpringOrBlueprintBeans().get(0).getOwnerDocument();
             String ns = doc.getDocumentElement().getNamespaceURI();


### PR DESCRIPTION
## Summary

- Commit cdaf5a8b8b4 (CAMEL-19807) introduced Javadoc line wrapping and string concatenation alignment in `BeansDefinition.java` and `XmlRoutesBuilderLoader.java` that don't match what `mvn formatter:format` produces.
- The CI step **"Fail if there are uncommitted changes"** detects these differences after the build runs the formatter, causing **all PR builds to fail** regardless of what the PR changes.
- This PR runs `mvn formatter:format impsort:sort` on the two affected modules to align the committed code with the project's formatting rules.

## Changes

**`BeansDefinition.java`** — Javadoc `@deprecated` tag line wrapping (2 occurrences):
```diff
-     * @deprecated use standard Camel XML DSL (camel-xml-io) instead of legacy Spring/Blueprint XML.
-     *             This feature will be removed in a future release.
+     * @deprecated use standard Camel XML DSL (camel-xml-io) instead of legacy Spring/Blueprint XML. This feature will
+     *             be removed in a future release.
```

**`XmlRoutesBuilderLoader.java`** — String concatenation `+` alignment:
```diff
-                                + " Migrate to standard Camel XML DSL (camel-xml-io).");
+                         + " Migrate to standard Camel XML DSL (camel-xml-io).");
```

## Test plan

- [x] Verified the exact same diff appears in CI logs of failing PRs (e.g. [PR #24462 build log](https://github.com/apache/camel/actions/runs/28792084146/job/85373071265))
- [x] Ran `mvn formatter:format impsort:sort` locally and confirmed `git status` is clean after
- [ ] CI build on this PR should pass the "Fail if there are uncommitted changes" step

_Claude Code on behalf of [@aldettinger](https://github.com/aldettinger)_

🤖 Generated with [Claude Code](https://claude.ai/code)