### PR TITLE
CAMEL-23883: Kafka producer no longer silently drops scalar Jackson ValueNode

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaProducer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -332,6 +333,10 @@ public class KafkaProducer extends DefaultAsyncProducer implements RouteIdAware 
     }
 
     private boolean isIterable(Object body) {
+        if (body instanceof JsonNode node) {
+            return node.isContainerNode();
+        }
+
         if (body instanceof Iterable || body instanceof Iterator) {
             return true;
         }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaProducerTest.java
@@ -28,6 +28,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.apache.camel.AggregationStrategy;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.CamelContext;
@@ -478,6 +481,34 @@ public class KafkaProducerTest {
                 Arrays.asList("value-1", "value-2", "value-3"));
         assertRecordMetadataExists(3);
         assertRecordMetadataExistsForEachAggregatedMessage();
+    }
+
+    @Test
+    public void processSendsMessageWithScalarJsonNode() throws Exception {
+        endpoint.getConfiguration().setTopic("sometopic");
+        Mockito.when(exchange.getIn()).thenReturn(in);
+        Mockito.when(exchange.getMessage()).thenReturn(in);
+
+        in.setBody(IntNode.valueOf(42));
+        producer.process(exchange);
+
+        verifySendMessage("sometopic");
+    }
+
+    @Test
+    public void processSendsMessagesWithJsonArrayNode() throws Exception {
+        endpoint.getConfiguration().setTopic("sometopic");
+        Mockito.when(exchange.getIn()).thenReturn(in);
+        Mockito.when(exchange.getMessage()).thenReturn(in);
+
+        ArrayNode node = JsonNodeFactory.instance.arrayNode();
+        node.add(1);
+        node.add(2);
+
+        in.setBody(node);
+        producer.process(exchange);
+
+        verifySendMessages(Arrays.asList("sometopic", "sometopic"), null);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerValueNodeIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerValueNodeIT.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kafka.integration;
+
+import java.util.Collections;
+
+import com.fasterxml.jackson.databind.node.IntNode;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class KafkaProducerValueNodeIT extends BaseKafkaTestSupport {
+
+    private static final String TOPIC = "value-node";
+
+    private static final String FROM_URI = "kafka:" + TOPIC
+                                           + "?groupId=KafkaProducerValueNodeIT&autoOffsetReset=earliest&keyDeserializer=org.apache.kafka.common.serialization.StringDeserializer&"
+                                           + "valueDeserializer=org.apache.kafka.common.serialization.StringDeserializer"
+                                           + "&autoCommitIntervalMs=1000&pollTimeoutMs=1000&autoCommitEnable=true";
+
+    @AfterEach
+    public void after() {
+        kafkaAdminClient.deleteTopics(Collections.singletonList(TOPIC));
+    }
+
+    @Test
+    public void scalarJsonNodeIsDelivered() throws Exception {
+        MockEndpoint mock = contextExtension.getMockEndpoint("mock:result");
+        mock.expectedBodiesReceived("5");
+        contextExtension.getProducerTemplate().sendBody("direct:start", IntNode.valueOf(5));
+        mock.assertIsSatisfied(5000);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").to("kafka:" + TOPIC + "?groupId=KafkaProducerValueNodeIT");
+                from(FROM_URI).to("mock:result");
+            }
+        };
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -104,3 +104,14 @@ the message, consistent with the inbound header filtering already performed by t
 
 Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
 content, set them explicitly after unmarshalling.
+
+=== camel-kafka - Producer no longer silently drops scalar Jackson nodes
+
+With `useIterator=true`, the Kafka producer splits an `Iterable` body into one record per element.
+A Jackson `JsonNode` implements `Iterable`, so a scalar value node (e.g. an `IntNode` produced by
+`transform().jq(".my-value")`) was seen as an empty iterable and produced no record, silently
+discarding the message with no exception or log.
+
+Scalar value nodes are now sent as a single record. Only container nodes (`ArrayNode`, `ObjectNode`)
+are still split, which is unchanged. Any `convertBodyTo(...)` previously used as a workaround is no
+longer required.


### PR DESCRIPTION
# Description
Fixes [CAMEL-23883](https://issues.apache.org/jira/browse/CAMEL-23883).

With `useIterator=true`, the Kafka producer splits an `Iterable` body into one record per element. A Jackson `JsonNode` implements `Iterable`, so a scalar value node (e.g. the `IntNode` from `transform().jq(".my-value")`) was seen as an empty iterable: the loop ran zero times, `send()` was never called, and the message was silently dropped with no exception or log.

This narrows `isIterable()` so a `JsonNode` counts as a batch only when it is a container node (`isContainerNode()`). Scalar nodes now take the single-message path, so they are either delivered or fail with a clear serialization error, never silently dropped. Container nodes (`ArrayNode`/`ObjectNode`) are still split, unchanged.

## Open question / possible follow-up

This fixes the reported Jackson case, but the same silent drop could recur for any body  that is `Iterable` yet yields an empty iterator. An exception isn't safe (an empty `Collection` is a legitimate no-op).  
Would be worth adding a DEBUG log when the iterable path produces zero records?  
I'm happy to add it here or in a follow-up PR.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.



- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.
