### PR TITLE
CAMEL-23926: Fix flaky Elasticsearch ITs

### DIFF
--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchBulkIT.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchBulkIT.java
@@ -180,7 +180,7 @@ class ElasticsearchBulkIT extends ElasticsearchTestSupport {
         String indexId = template.requestBody("direct:index", map, String.class);
         assertNotNull(indexId, "indexId should be set");
 
-        DeleteOperation.Builder builder = new DeleteOperation.Builder().index("twitter").id(indexId);
+        DeleteOperation.Builder builder = new DeleteOperation.Builder().index("bulk").id(indexId);
         // when
         @SuppressWarnings("unchecked")
         List<BulkResponseItem> response = template.requestBody("direct:bulk", List.of(builder), List.class);
@@ -199,7 +199,7 @@ class ElasticsearchBulkIT extends ElasticsearchTestSupport {
         String prefix = createPrefix();
 
         CreateOperation.Builder<?> builder
-                = new CreateOperation.Builder<>().index("twitter").document(Map.of(prefix + "content", prefix + "hello"));
+                = new CreateOperation.Builder<>().index("bulk").document(Map.of(prefix + "content", prefix + "hello"));
         // when
         @SuppressWarnings("unchecked")
         List<BulkResponseItem> response = template.requestBody("direct:bulk", List.of(builder), List.class);
@@ -218,7 +218,7 @@ class ElasticsearchBulkIT extends ElasticsearchTestSupport {
         assertNotNull(indexId, "indexId should be set");
 
         UpdateOperation.Builder<?, ?> builder = new UpdateOperation.Builder<>()
-                .index("twitter").id(indexId)
+                .index("bulk").id(indexId)
                 .action(
                         new UpdateAction.Builder<>()
                                 .doc(JsonData.from(
@@ -245,11 +245,11 @@ class ElasticsearchBulkIT extends ElasticsearchTestSupport {
             @Override
             public void configure() {
                 from("direct:index")
-                        .to("elasticsearch://elasticsearch?operation=Index&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Index&indexName=bulk");
                 from("direct:get")
-                        .to("elasticsearch://elasticsearch?operation=GetById&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=GetById&indexName=bulk");
                 from("direct:bulk")
-                        .to("elasticsearch://elasticsearch?operation=Bulk&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Bulk&indexName=bulk");
             }
         };
     }

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchClusterIndexIT.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchClusterIndexIT.java
@@ -38,7 +38,7 @@ class ElasticsearchClusterIndexIT extends ElasticsearchTestSupport {
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "cluster");
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "1");
 
         String indexId = template.requestBodyAndHeaders("direct:indexWithIpAndPort", map, headers, String.class);
@@ -47,7 +47,7 @@ class ElasticsearchClusterIndexIT extends ElasticsearchTestSupport {
         indexId = template.requestBodyAndHeaders("direct:indexWithIpAndPort", map, headers, String.class);
         assertNotNull(indexId, "indexId should be set");
 
-        assertTrue(client.get(new GetRequest.Builder().index("twitter").id("1").build(), ObjectNode.class).found(),
+        assertTrue(client.get(new GetRequest.Builder().index("cluster").id("1").build(), ObjectNode.class).found(),
                 "Index id 1 must exists");
     }
 
@@ -77,9 +77,9 @@ class ElasticsearchClusterIndexIT extends ElasticsearchTestSupport {
             @Override
             public void configure() {
                 from("direct:indexWithIpAndPort")
-                        .to("elasticsearch://" + clusterName + "?operation=Index&indexName=twitter");
+                        .to("elasticsearch://" + clusterName + "?operation=Index&indexName=cluster");
                 from("direct:indexWithSniffer")
-                        .to("elasticsearch://" + clusterName + "?operation=Index&indexName=twitter&enableSniffer=true");
+                        .to("elasticsearch://" + clusterName + "?operation=Index&indexName=cluster&enableSniffer=true");
             }
         };
     }

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchGetSearchDeleteExistsUpdateIT.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchGetSearchDeleteExistsUpdateIT.java
@@ -276,7 +276,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map2 = Map.of("testSearchWithMapQuery2", "bar");
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Bulk);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         template.requestBodyAndHeaders("direct:start", List.of(map1, map2), headers, String.class);
 
         // No match
@@ -315,7 +315,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map2 = Map.of("testSearchWithStringQuery2", "bar");
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Bulk);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         template.requestBodyAndHeaders("direct:start", List.of(map1, map2), headers, String.class);
 
         // No match
@@ -358,7 +358,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map2 = Map.of("testSearchWithBuilder2", "bar");
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Bulk);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         template.requestBodyAndHeaders("direct:start", List.of(map1, map2), headers,
                 String.class);
 
@@ -409,7 +409,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         product2.setName("Guinness book of records 2010");
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Bulk);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         template.requestBodyAndHeaders("direct:start", List.of(product1, product2), headers, String.class);
 
         // No match
@@ -450,7 +450,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         // the result may see stale data so use Awaitility
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             //now, verify GET succeeded
-            MsearchRequest.Builder builder = new MsearchRequest.Builder().index("twitter").searches(
+            MsearchRequest.Builder builder = new MsearchRequest.Builder().index("get-search").searches(
                     new RequestItem.Builder().header(new MultisearchHeader.Builder().build())
                             .body(new SearchRequestBody.Builder().query(b -> b.matchAll(x -> x)).build()).build(),
                     new RequestItem.Builder().header(new MultisearchHeader.Builder().build())
@@ -562,7 +562,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
 
         String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
 
@@ -579,13 +579,13 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
 
         template.requestBodyAndHeaders("direct:start", map, headers, String.class);
 
         //now, verify GET
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Exists);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         Boolean exists = template.requestBodyAndHeaders("direct:exists", "", headers, Boolean.class);
         assertNotNull(exists, "response should not be null");
         assertTrue(exists, "Index should exists");
@@ -607,7 +607,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
 
         String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
 
@@ -635,7 +635,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "123");
 
         String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
@@ -654,7 +654,7 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "get-search");
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "123");
 
         String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
@@ -937,24 +937,24 @@ class ElasticsearchGetSearchDeleteExistsUpdateIT extends ElasticsearchTestSuppor
                 from("direct:start")
                         .to("elasticsearch://elasticsearch?operation=Index");
                 from("direct:index")
-                        .to("elasticsearch://elasticsearch?operation=Index&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Index&indexName=get-search");
                 from("direct:index-product")
-                        .toF("elasticsearch://elasticsearch?operation=Index&indexName=twitter&documentClass=%s",
+                        .toF("elasticsearch://elasticsearch?operation=Index&indexName=get-search&documentClass=%s",
                                 Product.class.getName());
                 from("direct:get")
-                        .to("elasticsearch://elasticsearch?operation=GetById&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=GetById&indexName=get-search");
                 from("direct:multiget")
-                        .to("elasticsearch://elasticsearch?operation=MultiGet&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=MultiGet&indexName=get-search");
                 from("direct:delete")
-                        .to("elasticsearch://elasticsearch?operation=Delete&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Delete&indexName=get-search");
                 from("direct:search")
-                        .to("elasticsearch://elasticsearch?operation=Search&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Search&indexName=get-search");
                 from("direct:search-1")
                         .to("elasticsearch://elasticsearch?operation=Search");
                 from("direct:multiSearch")
                         .to("elasticsearch://elasticsearch?operation=MultiSearch");
                 from("direct:update")
-                        .to("elasticsearch://elasticsearch?operation=Update&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Update&indexName=get-search");
                 from("direct:exists")
                         .to("elasticsearch://elasticsearch?operation=Exists");
             }

--- a/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchIndexIT.java
+++ b/components/camel-elasticsearch/src/test/java/org/apache/camel/component/es/integration/ElasticsearchIndexIT.java
@@ -48,7 +48,7 @@ class ElasticsearchIndexIT extends ElasticsearchTestSupport {
         boolean exists = template.requestBody("direct:exists", null, Boolean.class);
         assertTrue(exists, "index should be present");
 
-        DeleteIndexRequest.Builder builder = new DeleteIndexRequest.Builder().index("twitter");
+        DeleteIndexRequest.Builder builder = new DeleteIndexRequest.Builder().index("idx");
         Boolean status = template.requestBody("direct:deleteIndex", builder, Boolean.class);
         assertEquals(true, status, "status should be 200");
 
@@ -65,7 +65,7 @@ class ElasticsearchIndexIT extends ElasticsearchTestSupport {
         boolean exists = template.requestBody("direct:exists", null, Boolean.class);
         assertTrue(exists, "index should be present");
 
-        Boolean status = template.requestBody("direct:deleteIndex", "twitter", Boolean.class);
+        Boolean status = template.requestBody("direct:deleteIndex", "idx", Boolean.class);
         assertEquals(true, status, "status should be 200");
 
         exists = template.requestBody("direct:exists", null, Boolean.class);
@@ -77,7 +77,7 @@ class ElasticsearchIndexIT extends ElasticsearchTestSupport {
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "idx");
 
         String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
         assertNotNull(indexId, "indexId should be set");
@@ -88,7 +88,7 @@ class ElasticsearchIndexIT extends ElasticsearchTestSupport {
         Map<String, String> map = createIndexedData();
         Map<String, Object> headers = new HashMap<>();
         headers.put(ElasticsearchConstants.PARAM_OPERATION, ElasticsearchOperation.Index);
-        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "twitter");
+        headers.put(ElasticsearchConstants.PARAM_INDEX_NAME, "idx");
         headers.put(ElasticsearchConstants.PARAM_INDEX_ID, "123");
 
         String indexId = template.requestBodyAndHeaders("direct:start", map, headers, String.class);
@@ -118,11 +118,11 @@ class ElasticsearchIndexIT extends ElasticsearchTestSupport {
                 from("direct:start")
                         .to("elasticsearch://elasticsearch");
                 from("direct:index")
-                        .to("elasticsearch://elasticsearch?operation=Index&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Index&indexName=idx");
                 from("direct:exists")
-                        .to("elasticsearch://elasticsearch?operation=Exists&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=Exists&indexName=idx");
                 from("direct:deleteIndex")
-                        .to("elasticsearch://elasticsearch?operation=DeleteIndex&indexName=twitter");
+                        .to("elasticsearch://elasticsearch?operation=DeleteIndex&indexName=idx");
             }
         };
     }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of apupier_

Fix flaky `ElasticsearchBulkIT` (48% flaky rate, 47/98 runs failing per [Develocity dashboard](https://develocity.apache.org/scans/tests?search.rootProjectNames=camel&tests.sortField=FLAKY)).

**Root cause:** All Elasticsearch IT classes shared a hardcoded `twitter` index name. `ElasticsearchIndexIT` explicitly deletes this index during its tests (`testIndexDeleteWithBuilder` / `testIndexDeleteWithString`), causing interference when tests run in parallel or in certain orders.

**Fix:** Each test class now uses its own unique index name to eliminate cross-class interference:
- `ElasticsearchBulkIT`: `bulk`
- `ElasticsearchIndexIT`: `idx`
- `ElasticsearchGetSearchDeleteExistsUpdateIT`: `get-search`
- `ElasticsearchClusterIndexIT`: `cluster`

Note: `ElasticsearchScrollSearchIT` and `ElasticsearchSizeLimitIT` already used unique index names (`scroll-search` / `split-scroll-search` and `size-limit` respectively) and were not affected.

## Test plan

- [ ] CI passes with all Elasticsearch integration tests green
- [ ] Verify `ElasticsearchBulkIT` no longer flaky on repeated runs
- [ ] Verify no regression in other Elasticsearch IT classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)