### PR TITLE
CAMEL-23905: Fix flaky LRAFailuresIT

### DIFF
--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
@@ -59,7 +59,7 @@ public abstract class AbstractLRATestSupport extends CamelTestSupport {
 
     @AfterEach
     public void checkActiveLRAs() throws IOException, InterruptedException {
-        await().atMost(2, SECONDS).until(() -> getNumberOfActiveLRAs(), equalTo(activeLRAs));
+        await().atMost(20, SECONDS).until(() -> getNumberOfActiveLRAs(), equalTo(activeLRAs));
         assertEquals(activeLRAs, getNumberOfActiveLRAs(), "Some LRA have been left pending");
     }
 

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
@@ -59,7 +59,7 @@ public abstract class AbstractLRATestSupport extends CamelTestSupport {
     @AfterEach
     public void checkActiveLRAs() throws IOException, InterruptedException {
         await().atMost(20, SECONDS)
-                .failMessage("Some LRA have been left pending")
+                .alias("Some LRA have been left pending")
                 .until(() -> getNumberOfActiveLRAs(), equalTo(activeLRAs));
     }
 

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/AbstractLRATestSupport.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Base class for LRA based tests.
@@ -59,8 +58,9 @@ public abstract class AbstractLRATestSupport extends CamelTestSupport {
 
     @AfterEach
     public void checkActiveLRAs() throws IOException, InterruptedException {
-        await().atMost(20, SECONDS).until(() -> getNumberOfActiveLRAs(), equalTo(activeLRAs));
-        assertEquals(activeLRAs, getNumberOfActiveLRAs(), "Some LRA have been left pending");
+        await().atMost(20, SECONDS)
+                .failMessage("Some LRA have been left pending")
+                .until(() -> getNumberOfActiveLRAs(), equalTo(activeLRAs));
     }
 
     @Override

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAFailuresIT.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAFailuresIT.java
@@ -39,7 +39,7 @@ public class LRAFailuresIT extends AbstractLRATestSupport {
 
         sendBody("direct:saga-compensate", "hello");
 
-        await().atMost(20, TimeUnit.SECONDS)
+        await().atMost(60, TimeUnit.SECONDS)
                 .until(() -> compensate.getReceivedCounter() >= 1);
         compensate.assertIsSatisfied();
     }
@@ -56,7 +56,7 @@ public class LRAFailuresIT extends AbstractLRATestSupport {
 
         sendBody("direct:saga-complete", "hello");
 
-        await().atMost(20, TimeUnit.SECONDS)
+        await().atMost(60, TimeUnit.SECONDS)
                 .until(() -> complete.getReceivedCounter() >= 1
                         && end.getReceivedCounter() >= 1);
         complete.assertIsSatisfied();

--- a/test-infra/camel-test-infra-microprofile-lra/src/main/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRALocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-microprofile-lra/src/main/java/org/apache/camel/test/infra/microprofile/lra/services/MicroprofileLRALocalContainerInfraService.java
@@ -64,6 +64,12 @@ public class MicroprofileLRALocalContainerInfraService
                 super(DockerImageName.parse(imageName));
 
                 withNetworkAliases(networkAlias)
+                        // Shorten the Narayana recovery period so that failed LRA
+                        // participant callbacks are retried quickly in tests
+                        // (default: periodicRecoveryPeriod=120s, recoveryBackoffPeriod=10s).
+                        .withEnv("JAVA_TOOL_OPTIONS",
+                                "-Dcom.arjuna.ats.arjuna.recovery.periodicRecoveryPeriod=2 "
+                                                      + "-Dcom.arjuna.ats.arjuna.recovery.recoveryBackoffPeriod=1")
                         .waitingFor(Wait.forListeningPort())
                         .waitingFor(Wait.forLogMessage(".*lra-coordinator-quarkus.*Listening on.*", 1));
 


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

Fix the flaky `LRAFailuresIT` test which has a **97% failure rate** ([Develocity dashboard](https://develocity.apache.org/scans/tests?search.rootProjectNames=camel&tests.sortField=FLAKY) — 126/130 runs failing).

## Root Cause

The test depends on the Narayana LRA coordinator (running in Docker via Testcontainers) to **retry failed compensation/completion callbacks**. The compensation/completion handler is configured to fail once then succeed, so the coordinator must retry after the first failure.

The Narayana recovery manager uses a default `periodicRecoveryPeriod` of **120 seconds** with a `recoveryBackoffPeriod` of **10 seconds** (total cycle ~130s). The test's Awaitility timeout was only **20 seconds** — far too short for the coordinator's retry to occur. The test only passed (~3% of the time) when it happened to start right before a recovery scan.

PR #24418 changed the timing mechanism from `setResultWaitTime` to Awaitility but did not address the underlying coordinator retry timing.

## Fix

- **Configure the LRA coordinator container** with shortened Narayana recovery periods via `JAVA_TOOL_OPTIONS`:
  - `periodicRecoveryPeriod=2` (down from 120s)
  - `recoveryBackoffPeriod=1` (down from 10s)
  - This makes the coordinator retry failed participant callbacks within ~3 seconds instead of ~130 seconds
- **Increase `LRAFailuresIT` Awaitility timeout** from 20s to 60s as a safety margin
- **Increase `AbstractLRATestSupport.checkActiveLRAs()` timeout** from 2s to 20s to accommodate recovery-driven LRA cleanup
- **Remove redundant `assertEquals` call** in `checkActiveLRAs()` that made a second HTTP call after Awaitility had already confirmed the condition (could reintroduce flakiness via race condition)

## Files Changed

| File | Change |
|------|--------|
| `test-infra/.../MicroprofileLRALocalContainerInfraService.java` | Add `JAVA_TOOL_OPTIONS` env var to shorten recovery period |
| `components/camel-lra/.../LRAFailuresIT.java` | Increase Awaitility timeout from 20s to 60s |
| `components/camel-lra/.../AbstractLRATestSupport.java` | Increase `checkActiveLRAs` timeout from 2s to 20s, remove redundant assertEquals |

## Test Plan

- [ ] CI integration tests pass (LRAFailuresIT specifically)
- [ ] Other LRA integration tests (LRACreditIT, LRAManualIT, LRAOptionsIT, LRATimeoutIT) still pass
- [ ] No regression in test-infra module