### PR TITLE
CAMEL-23223: Fix flaky ManagedMessageHistoryAutoConfigIT

### DIFF
--- a/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
+++ b/components/camel-opentelemetry-metrics/src/test/java/org/apache/camel/opentelemetry/metrics/integration/messagehistory/ManagedMessageHistoryAutoConfigIT.java
@@ -60,7 +60,11 @@ public class ManagedMessageHistoryAutoConfigIT extends CamelTestSupport {
         System.setProperty("otel.traces.exporter", "none");
         System.setProperty("otel.logs.exporter", "none");
         System.setProperty("otel.propagators", "tracecontext");
-        System.setProperty("otel.metric.export.interval", "300");
+        // Use a long export interval so the first periodic export fires well after all
+        // messages have been processed. With a short interval (e.g. 300ms), the exporter
+        // fires during message processing and the last exported MetricData may contain
+        // incomplete point data, causing the assertion to fail intermittently on slow CI.
+        System.setProperty("otel.metric.export.interval", "5000");
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary

_Claude Code on behalf of apupier_

Fix flaky `ManagedMessageHistoryAutoConfigIT` which has a **70% flaky rate** (113/161 runs fail) per the [Develocity dashboard](https://develocity.apache.org/scans/tests?search.rootProjectNames=camel&tests.sortField=FLAKY).

### Root cause

The OTel periodic metric exporter was configured with a very short export interval (300ms). On slow CI machines, the exporter fires during message processing, and the **last exported `MetricData`** may contain incomplete point data. The test's `assertPointDataForRouteId` assertion then fails because the last metric snapshot doesn't yet include all route data.

PR #24425 previously added `CopyOnWriteArrayList` thread-safety and Awaitility-based polling, but did **not** address the core timing issue — the export interval was still 300ms.

### Fix

Increase the `otel.metric.export.interval` from **300ms → 5000ms** so the first periodic export fires well after all messages have been processed (message processing takes <1s). This eliminates the race where an intermediate export captures partial data that becomes the "last" Camel metric seen by the Awaitility assertion.

### Validation

Ran the test **12+ consecutive times** locally — all passed. With the prior 70% failure rate, the probability of 12 consecutive passes by chance is 0.3^12 ≈ 5.3e-7, providing strong statistical evidence that the fix resolves the flakiness.

🤖 Generated with [Claude Code](https://claude.ai/code)