### PR TITLE
CAMEL-23912: Address review feedback on ThemeTest fix

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import dev.tamboui.css.Styleable;
 import dev.tamboui.css.engine.StyleEngine;
@@ -73,7 +73,7 @@ final class Theme {
     private static final Style FALLBACK_MCP_DOWN = Style.EMPTY.fg(Color.LIGHT_RED);
     private static final Color FALLBACK_ZEBRA = Color.rgb(0x1C, 0x1C, 0x1C);
 
-    private static final Map<String, Style> CACHE = new ConcurrentHashMap<>();
+    private static final Map<String, Style> CACHE = new HashMap<>();
 
     private static boolean initialized;
     private static boolean fallbackLogged;
@@ -262,14 +262,19 @@ final class Theme {
     }
 
     /**
-     * Reads a CSS resource from the classpath using this class's own classloader, which is guaranteed to have access to
-     * project resources regardless of classloader hierarchy.
+     * Reads a CSS resource from the classpath using this class's own classloader, which in the normal Camel
+     * class-loading hierarchy has access to project resources. Falls back to the thread-context classloader when the
+     * primary lookup returns null (e.g., in OSGi or custom classloader setups) or when the class is bootstrap-loaded.
      */
     private static String loadCssResource(String path) throws IOException {
-        InputStream is = Theme.class.getClassLoader().getResourceAsStream(path);
+        InputStream is = null;
+        ClassLoader cl = Theme.class.getClassLoader();
+        if (cl != null) {
+            is = cl.getResourceAsStream(path);
+        }
         if (is == null) {
             // Fallback to the thread context classloader in case the class's own classloader
-            // doesn't have visibility (e.g., in OSGi or custom classloader setups).
+            // doesn't have visibility or is null (bootstrap-loaded classes).
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             if (tccl != null) {
                 is = tccl.getResourceAsStream(path);


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

Follow-up to #24475 — addresses review feedback from Copilot and @ammachado that landed after the original PR was merged.

**Changes:**

- **Handle null classloader** (Copilot): `Theme.class.getClassLoader()` can legally return `null` for bootstrap-loaded classes. Now null-checked before calling `getResourceAsStream()`, falling through to the TCCL fallback instead of throwing an NPE.
- **Soften javadoc wording** (@ammachado suggestion #1): Changed from "guaranteed to have access" to accurately describe the fallback behavior, so a future reader doesn't strip the TCCL fallback as dead code.
- **Revert `ConcurrentHashMap` to `HashMap`** (@ammachado suggestion #2): All `CACHE` access is already inside `synchronized` methods, so the concurrent map added no real safety — just a misleading signal.

## Test plan

- [x] All 6 `ThemeTest` tests pass.
- [x] `mvn formatter:format impsort:sort` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)