### PR TITLE
(chores): fix SonarCloud S2975 clone without super.clone

### DIFF
--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
@@ -455,7 +455,8 @@ public class MiloClientConfiguration implements Cloneable {
     public MiloClientConfiguration clone() {
         try {
             MiloClientConfiguration copy = (MiloClientConfiguration) super.clone();
-            copy.allowedSecurityPolicies = new HashSet<>(this.allowedSecurityPolicies);
+            copy.allowedSecurityPolicies
+                    = this.allowedSecurityPolicies != null ? new HashSet<>(this.allowedSecurityPolicies) : null;
             return copy;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeCamelException(e);

--- a/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
+++ b/components/camel-milo/src/main/java/org/apache/camel/component/milo/client/MiloClientConfiguration.java
@@ -453,7 +453,13 @@ public class MiloClientConfiguration implements Cloneable {
 
     @Override
     public MiloClientConfiguration clone() {
-        return new MiloClientConfiguration(this);
+        try {
+            MiloClientConfiguration copy = (MiloClientConfiguration) super.clone();
+            copy.allowedSecurityPolicies = new HashSet<>(this.allowedSecurityPolicies);
+            return copy;
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeCamelException(e);
+        }
     }
 
     public String toCacheId() {

--- a/components/camel-pdf/src/main/java/org/apache/camel/component/pdf/text/DefaultLineBuilderStrategy.java
+++ b/components/camel-pdf/src/main/java/org/apache/camel/component/pdf/text/DefaultLineBuilderStrategy.java
@@ -101,7 +101,7 @@ public class DefaultLineBuilderStrategy implements LineBuilderStrategy {
     }
 
     private boolean isWordFitInCurrentLine(LineBuilder currentLine, String word, float allowedLineWidth) throws IOException {
-        LineBuilder lineBuilder = currentLine.clone().appendWord(word);
+        LineBuilder lineBuilder = currentLine.copy().appendWord(word);
         return isLineFitInLineWidth(lineBuilder.buildLine(), allowedLineWidth);
     }
 
@@ -160,8 +160,7 @@ public class DefaultLineBuilderStrategy implements LineBuilderStrategy {
             wordsCount = 0;
         }
 
-        @Override
-        public LineBuilder clone() {
+        public LineBuilder copy() {
             return new LineBuilder(this.line.toString(), this.wordsCount);
         }
 

--- a/core/camel-api/src/main/java/org/apache/camel/spi/ThreadPoolProfile.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/ThreadPoolProfile.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
 import org.jspecify.annotations.Nullable;
 
@@ -289,17 +290,11 @@ public class ThreadPoolProfile implements Serializable, Cloneable {
 
     @Override
     public ThreadPoolProfile clone() {
-        ThreadPoolProfile cloned = new ThreadPoolProfile();
-        cloned.setDefaultProfile(defaultProfile);
-        cloned.setId(id);
-        cloned.setKeepAliveTime(keepAliveTime);
-        cloned.setMaxPoolSize(maxPoolSize);
-        cloned.setMaxQueueSize(maxQueueSize);
-        cloned.setPoolSize(poolSize);
-        cloned.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
-        cloned.setRejectedPolicy(rejectedPolicy);
-        cloned.setTimeUnit(timeUnit);
-        return cloned;
+        try {
+            return (ThreadPoolProfile) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeCamelException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix 3 `clone()` methods that don't call `super.clone()`, addressing SonarCloud rule [java:S2975](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&rules=java%3AS2975&id=apache_camel).

### Why SonarCloud flags these

SonarCloud rule S2975 ("clone should not be overridden") fires on **any** override of `clone()`. The rationale (from Joshua Bloch's *Effective Java*) is that `Object.clone()` has a fundamentally broken contract:

- **Shallow copy pitfall**: `super.clone()` only creates a shallow copy — mutable fields are shared between original and clone, so mutating one silently corrupts the other.
- **Constructor bypass**: `Object.clone()` creates objects without calling any constructor, violating the invariant that all objects should be built through constructors.
- **Fragile inheritance chain**: if any class in the hierarchy uses `new` instead of `super.clone()`, subclass clones get the wrong runtime type.

The 3 files fixed here had the most concrete violation — they **didn't call `super.clone()` at all**, using `new` instead.

### Changes

| File | Problem | Fix |
|---|---|---|
| `MiloClientConfiguration` | `clone()` used `new MiloClientConfiguration(this)` — breaks subclass cloning and the `Cloneable` contract | Use `super.clone()` + deep-copy of mutable `allowedSecurityPolicies` HashSet |
| `ThreadPoolProfile` | `clone()` used `new ThreadPoolProfile()` + manual field-by-field copy — same subclass problem, plus was already missing the `sessionTimeout` field | Use `super.clone()` (all fields are immutable primitives/wrappers/enums/String) |
| `DefaultLineBuilderStrategy.LineBuilder` | `clone()` used `new LineBuilder(...)` — overrides `Object.clone()` without implementing `Cloneable` | Rename `clone()` to `copy()` since this private inner class doesn't need `Cloneable` |

### Note on the remaining 7 SonarCloud S2975 issues

The remaining 7 flagged files (`Transcribe2Configuration`, 5× Infinispan configs, `ComponentModel.ApiOptionModel`) already call `super.clone()` correctly. SonarCloud still flags them because S2975 fires on **any** `clone()` override — its position is that `clone()` shouldn't be used at all. However, these are `Cloneable` configuration classes used throughout Camel's component framework for endpoint creation. Removing `clone()` would be a breaking API change with no functional benefit, since they already follow the `super.clone()` contract correctly.

## Test plan

- [x] `mvn test` passes in `core/camel-api`
- [x] `mvn test` passes in `components/camel-milo` (43 tests, 0 failures)
- [x] `mvn test` passes in `components/camel-pdf` (10 tests, 0 failures)
- [x] `mvn formatter:format impsort:sort` applied on all 3 modules
- [x] CI failure is in unrelated `camel-vertx-websocket` (flaky test), not in any changed module

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)