### PR TITLE
(chores) Fix SonarCloud S2095: close remaining resource leaks

### DIFF
--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAClient.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAClient.java
@@ -201,5 +201,14 @@ public class LRAClient implements Closeable {
 
     @Override
     public void close() throws IOException {
+        if (client instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        }
     }
 }

--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAClient.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAClient.java
@@ -47,7 +47,7 @@ public class LRAClient implements Closeable {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String TEXT_PLAIN_CONTENT = "text/plain";
     private final LRASagaService sagaService;
-    private final HttpClient client;
+    private final CloseableHttpClient client;
     private final String lraUrl;
 
     private static final Logger LOG = LoggerFactory.getLogger(LRAClient.class);
@@ -62,7 +62,7 @@ public class LRAClient implements Closeable {
         }
 
         this.sagaService = sagaService;
-        this.client = client;
+        this.client = new CloseableHttpClient(client);
 
         lraUrl = new LRAUrlBuilder()
                 .host(sagaService.getCoordinatorUrl())
@@ -201,13 +201,35 @@ public class LRAClient implements Closeable {
 
     @Override
     public void close() throws IOException {
-        if (client instanceof AutoCloseable closeable) {
-            try {
-                closeable.close();
-            } catch (IOException e) {
-                throw e;
-            } catch (Exception e) {
-                throw new IOException(e);
+        client.close();
+    }
+
+    /**
+     * Wrapper that makes {@link HttpClient} usable in try-with-resources. On Java 21+ HttpClient implements
+     * AutoCloseable natively; the instanceof check future-proofs us for when the minimum JDK is raised.
+     */
+    private static final class CloseableHttpClient implements Closeable {
+        private final HttpClient httpClient;
+
+        CloseableHttpClient(HttpClient httpClient) {
+            this.httpClient = httpClient;
+        }
+
+        <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+            return httpClient.sendAsync(request, responseBodyHandler);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (httpClient instanceof AutoCloseable closeable) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new IOException(e);
+                }
             }
         }
     }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
@@ -122,8 +122,8 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             return errorJson("A JFR recording is already active. Stop it first.");
         }
 
+        Recording rec = new Recording();
         try {
-            Recording rec = new Recording();
             rec.setName("Camel OldObjectSample");
             rec.enable("jdk.OldObjectSample").withStackTrace().withPeriod(Duration.ofSeconds(1));
             rec.enable("jdk.GarbageCollection");
@@ -165,6 +165,7 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             }
             return result;
         } catch (Exception e) {
+            rec.close();
             LOG.warn("Failed to start JFR recording: {}", e.getMessage(), e);
             return errorJson("Failed to start JFR recording: " + e.getMessage());
         }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
@@ -165,6 +165,13 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             }
             return result;
         } catch (Exception e) {
+            // Clean up state in case the exception occurred after activeRecording was set
+            // (e.g. during auto-stop scheduling), so the console does not get stuck
+            // referencing a closed Recording.
+            cancelAutoStop();
+            activeRecording = null;
+            recordingStartTime = 0;
+            requestedDurationSeconds = 0;
             rec.close();
             LOG.warn("Failed to start JFR recording: {}", e.getMessage(), e);
             return errorJson("Failed to start JFR recording: " + e.getMessage());


### PR DESCRIPTION
## Summary

Fix remaining SonarCloud [S2095](https://sonarcloud.io/project/issues?id=apache_camel&rules=java:S2095&open=true) resource leaks not covered by PR #24358:

- **JfrMemoryLeakDevConsole**: In `doStart()`, if an exception occurs after creating a `Recording` but before it is stored in the `activeRecording` field, the `Recording` leaks. Fixed by moving the `Recording` creation outside the `try` block and adding `rec.close()` in the `catch` block.
- **LRAClient**: The `close()` method was empty despite holding an `HttpClient` field. Added a `CloseableHttpClient` inner wrapper class (same pattern as PR #24358) that delegates `sendAsync()` and properly closes the underlying `HttpClient` on Java 21+ where `HttpClient` natively implements `AutoCloseable`.

**Note:** The 20 `HttpClient`-related S2095 issues still shown as open in SonarCloud (in `OpenAIMock*Test`, `QdrantInfraService`, `UpdateCamelReleasesMojo`) were already fixed by merged PR #24358. They will clear from SonarCloud on the next re-scan of `main`.

## Test plan

- [x] `mvn compile` passes for `core/camel-console` and `components/camel-lra`
- [x] `mvn test` passes for `components/camel-lra` (21 tests, 0 failures)
- [x] `mvn formatter:format impsort:sort` applied
- [ ] CI build passes

_Claude Code on behalf of gnodet_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>