### PR TITLE
fix typo in citrusframework.org URL

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/integration-test.adoc
+++ b/docs/user-manual/modules/ROOT/pages/integration-test.adoc
@@ -9,7 +9,7 @@ NOTE: Both unit testing and integration testing are essential in software develo
 == Citrus Test Framework
 
 As an example of writing integration tests for Camel applications you can use the
-https://citfrusframework.org[Citrus] test framework.
+https://citrusframework.org[Citrus] test framework.
 
 Citrus is an Open Source Java testing framework with focus on integration testing and messaging.
 


### PR DESCRIPTION
# Description

There is a typo in the citrusframework.org url integration-test.adoc user-manual page. This PR fixes it

# Target

- [V ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [N/A] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).
  => typo

# Apache Camel coding standards and style

- [N/A ] I checked that each commit in the pull request has a meaningful subject line and body.

- [N/A ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [N/A ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

