### PR TITLE
CAMEL-23930: Fix flaky  EventhubsReloadTriggerTask test 

### DIFF
--- a/components/camel-azure/camel-azure-key-vault/src/main/java/org/apache/camel/component/azure/key/vault/EventhubsReloadTriggerTask.java
+++ b/components/camel-azure/camel-azure-key-vault/src/main/java/org/apache/camel/component/azure/key/vault/EventhubsReloadTriggerTask.java
@@ -247,7 +247,9 @@ public class EventhubsReloadTriggerTask extends ServiceSupport implements CamelC
             return mapper.readTree(eventContext.getEventData().getBodyAsString());
         } catch (JsonProcessingException e) {
             LOG.warn("Unable to process event data body: {}", e.getMessage(), e);
-            throw new RuntimeCamelException(e);
+            // Return empty array instead of throwing exception - the calling code handles empty arrays
+            // gracefully by not executing the loop when size() is 0
+            return mapper.createArrayNode();
         }
     }
 


### PR DESCRIPTION
The Azure Key Vault event listener fails intermittently when EventHub sends malformed or non-JSON event data, causing JsonParseException and crashing the event
  processor with:
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('d' (code 100)):
Expected space separating root-level values
  
The fix returns an empty JSON array []  instead of throwing a RuntimeException.

