### PR TITLE
CAMEL-23502 - Disable Observability plugin in OpenSearch container used for integration tests

### DIFF
--- a/test-infra/camel-test-infra-opensearch/src/main/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-opensearch/src/main/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerInfraService.java
@@ -66,6 +66,10 @@ public class OpenSearchLocalContainerInfraService implements OpenSearchInfraServ
 
                 withLogConsumer(new Slf4jLogConsumer(LOG));
 
+                // Disable the observability plugin to avoid startup issues (CAMEL-23502)
+                withEnv("OPENSEARCH_JAVA_OPTS",
+                        "-Dopensearch.cgroups.hierarchy.override=/ -Dopensearch.plugin.disable=opensearch-observability");
+
                 ContainerEnvironmentUtil.configurePort(this, fixedPort, OPEN_SEARCH_PORT);
             }
         }


### PR DESCRIPTION
for integration tests

this plugin requires 50% of the disk space available. this is something which is not often available on CI. The camel integration is not interacting with the observability part of the OpenSearch server.

Co-authored-by: IBM Bob IDE 2.0.0

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

