### PR TITLE
Document MockEndpoint timed assertions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,10 +163,37 @@ await().atMost(20, TimeUnit.SECONDS)
        .untilAsserted(() -> assertEquals(1, context.getRoutes().size()));
 ```
 
+**MockEndpoint tests — prefer built-in timed assertions:**
+
+When the wait condition is "mock expectations are met", use `MockEndpoint`'s native timed
+assertion instead of wrapping with Awaitility. It is latch-based (more efficient than polling)
+and requires no external dependency:
+
+```java
+// Preferred — native, latch-based, returns as soon as expectations are met:
+MockEndpoint.assertIsSatisfied(context, 10, TimeUnit.SECONDS);
+
+// Also available on a single endpoint:
+mock.setResultWaitTime(TimeUnit.SECONDS.toMillis(10));
+mock.assertIsSatisfied();
+
+// DO NOT wrap MockEndpoint assertions with Awaitility — it polls a mechanism that already waits:
+// await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
+```
+
+Use Awaitility only when waiting on a condition that `MockEndpoint` cannot express natively,
+such as waiting for a specific received count mid-test before performing the next action:
+
+```java
+// Awaitility IS appropriate here — no MockEndpoint API for "wait until N received" without asserting:
+await().atMost(10, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 2);
+```
+
 **Rules:**
 
 - New test code MUST NOT introduce `Thread.sleep()` calls.
-- When modifying existing test code that contains `Thread.sleep()`, migrate it to Awaitility.
+- When modifying existing test code that contains `Thread.sleep()`, migrate it to
+  `MockEndpoint`'s timed assertions (for mock-based waits) or Awaitility (for other conditions).
 - Always set an explicit `atMost` timeout to avoid hanging builds.
 - Use `untilAsserted` or `until` with a clear predicate — do not replace a sleep with a
   busy-wait loop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,9 @@ await().atMost(10, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 2)
 - New test code MUST NOT introduce `Thread.sleep()` calls.
 - When modifying existing test code that contains `Thread.sleep()`, migrate it to
   `MockEndpoint`'s timed assertions (for mock-based waits) or Awaitility (for other conditions).
+- Do NOT wrap `MockEndpoint.assertIsSatisfied()` with Awaitility — it already waits internally
+  via a `CountDownLatch`. Wrapping it with `untilAsserted` adds polling on top of a mechanism
+  that already blocks, which is redundant and less efficient.
 - Always set an explicit `atMost` timeout to avoid hanging builds.
 - Use `untilAsserted` or `until` with a clear predicate — do not replace a sleep with a
   busy-wait loop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,10 @@ mock.assertIsSatisfied();
 // await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> MockEndpoint.assertIsSatisfied(context));
 ```
 
+Note: `MockEndpoint.assertIsSatisfied(context)` (no timeout argument) already waits up to
+10 seconds internally — `waitForCompleteLatch` defaults to 10 000 ms when `resultWaitTime`
+is not set. The timed overload is only needed when you want a **different** timeout.
+
 Use Awaitility only when waiting on a condition that `MockEndpoint` cannot express natively,
 such as waiting for a specific received count mid-test before performing the next action:
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Guillaume Nodet_

- Adds guidance to the "Asynchronous Testing" section of AGENTS.md to prefer `MockEndpoint`'s
  built-in timed assertions (`assertIsSatisfied(context, timeout, unit)`) over wrapping with
  Awaitility when the wait condition is "mock expectations are met"
- Documents when Awaitility is still the right choice (mid-test synchronization on conditions
  MockEndpoint cannot express, e.g. `mock.getReceivedCounter() >= N`)
- Updates the rules to reference both mechanisms

This came up during review of #24304, where `Thread.sleep()` was being replaced with
`await().untilAsserted(() -> MockEndpoint.assertIsSatisfied(...))` — which is redundant because
MockEndpoint's assertion is already latch-based internally.

## Test plan

- [ ] Verify the markdown renders correctly
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)