### PR TITLE
CAMEL-23933: Remove deprecated maven-resolver-supplier dependency

### DIFF
--- a/tooling/camel-tooling-maven/pom.xml
+++ b/tooling/camel-tooling-maven/pom.xml
@@ -66,11 +66,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-supplier</artifactId>
-            <version>${maven-resolver-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
             <artifactId>maven-resolver-util</artifactId>
             <version>${maven-resolver-version}</version>
         </dependency>


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Remove the deprecated `maven-resolver-supplier` dependency from `camel-tooling-maven`
- This artifact is unused — MIMA handles `RepositorySystem` creation internally
- It was accidentally re-added in CAMEL-23145 after the MIMA migration (CAMEL-19329) had already removed it
- The stale 1.9.x artifact conflicts at runtime with `maven-resolver-supplier-mvn3:2.0.x` in downstream projects, causing `NoClassDefFoundError` for `DefaultTrackingFileManager`

## Test plan

- [x] `mvn verify` passes in `tooling/camel-tooling-maven`
- [x] Full reactor build (`mvn clean install -DskipTests`) passes from root
- [x] Verified no Java code imports from `org.eclipse.aether.supplier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>