### PR TITLE
CAMEL-21438: Harden container-exception retry logic and isolate IggyConsumerOffsetIT

### DIFF
--- a/components/camel-iggy/src/test/java/org/apache/camel/component/iggy/IggyConsumerOffsetIT.java
+++ b/components/camel-iggy/src/test/java/org/apache/camel/component/iggy/IggyConsumerOffsetIT.java
@@ -16,15 +16,22 @@
  */
 package org.apache.camel.component.iggy;
 
+import java.util.stream.IntStream;
+
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*",
                           disabledReason = "Iggy 0.6.0+ requires io_uring which is not available on CI environments")
 public class IggyConsumerOffsetIT extends IggyTestBase {
+
+    private static final String OFFSET_TOPIC = "test-topic-offset";
+    private static final String OFFSET_STREAM = "test-stream-offset";
+    private static final String OFFSET_CONSUMER_GROUP = "test-consumer-group-offset";
 
     int startingOffset = 5;
 
@@ -35,10 +42,17 @@ public class IggyConsumerOffsetIT extends IggyTestBase {
         mockEndpoint.expectedMessageCount(messages - startingOffset);
 
         for (int i = 0; i < messages; i++) {
-            sendMessage("Message " + i);
+            sendMessage(OFFSET_STREAM, OFFSET_TOPIC, "Message " + i);
         }
 
         mockEndpoint.assertIsSatisfied();
+        Assertions.assertEquals(
+                IntStream.range(startingOffset, messages)
+                        .mapToObj(i -> "Message " + i)
+                        .toList(),
+                mockEndpoint.getExchanges().stream()
+                        .map(exchange -> exchange.getMessage().getBody(String.class))
+                        .toList());
 
         // send more messages to check offset update
         int newMessages = 20;
@@ -46,10 +60,17 @@ public class IggyConsumerOffsetIT extends IggyTestBase {
         mockEndpoint.expectedMessageCount(newMessages);
 
         for (int i = 0; i < newMessages; i++) {
-            sendMessage("Second Message " + i);
+            sendMessage(OFFSET_STREAM, OFFSET_TOPIC, "Second Message " + i);
         }
 
         mockEndpoint.assertIsSatisfied();
+        Assertions.assertEquals(
+                IntStream.range(0, newMessages)
+                        .mapToObj(i -> "Second Message " + i)
+                        .toList(),
+                mockEndpoint.getExchanges().stream()
+                        .map(exchange -> exchange.getMessage().getBody(String.class))
+                        .toList());
     }
 
     @Override
@@ -58,13 +79,13 @@ public class IggyConsumerOffsetIT extends IggyTestBase {
             @Override
             public void configure() {
                 fromF("iggy:%s?username=%s&password=%s&streamName=%s&host=%s&port=%d&consumerGroupName=%s&autoCommit=false&startingOffset=%d",
-                        TOPIC,
+                        OFFSET_TOPIC,
                         iggyService.username(),
                         iggyService.password(),
-                        STREAM,
+                        OFFSET_STREAM,
                         iggyService.host(),
                         iggyService.port(),
-                        CONSUMER_GROUP,
+                        OFFSET_CONSUMER_GROUP,
                         startingOffset)
                         .to("mock:result");
             }

--- a/components/camel-iggy/src/test/java/org/apache/camel/component/iggy/IggyTestBase.java
+++ b/components/camel-iggy/src/test/java/org/apache/camel/component/iggy/IggyTestBase.java
@@ -70,9 +70,13 @@ public abstract class IggyTestBase {
     }
 
     protected void sendMessage(String message) {
+        sendMessage(STREAM, TOPIC, message);
+    }
+
+    protected void sendMessage(String stream, String topic, String message) {
         client.messages().sendMessages(
-                StreamId.of(STREAM),
-                TopicId.of(TOPIC),
+                StreamId.of(stream),
+                TopicId.of(topic),
                 Partitioning.balanced(),
                 Collections.singletonList(Message.of(message)));
     }

--- a/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/TestServiceUtil.java
+++ b/test-infra/camel-test-infra-common/src/main/java/org/apache/camel/test/infra/common/services/TestServiceUtil.java
@@ -69,6 +69,11 @@ public final class TestServiceUtil {
 
     private static boolean isRetryableContainerException(Throwable e) {
         for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t.getClass().getName().contains("NoHttpResponseException")) {
+                return false;
+            }
+        }
+        for (Throwable t = e; t != null; t = t.getCause()) {
             if (t instanceof ContainerFetchException || t instanceof ContainerLaunchException) {
                 return true;
             }

--- a/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestServiceUtilRetryTest.java
+++ b/test-infra/camel-test-infra-common/src/test/java/org/apache/camel/test/infra/common/services/TestServiceUtilRetryTest.java
@@ -97,6 +97,23 @@ class TestServiceUtilRetryTest {
     }
 
     @Test
+    void failsImmediatelyOnDockerDaemonNoHttpResponse() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        Throwable noHttpResponse = (Throwable) Class.forName(
+                "com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.NoHttpResponseException")
+                .getConstructor(String.class)
+                .newInstance("localhost:2375 failed to respond");
+
+        TestService service = new StubTestService(() -> {
+            attempts.incrementAndGet();
+            throw new ContainerLaunchException("Could not start container", noHttpResponse);
+        });
+
+        assertThrows(ContainerLaunchException.class, () -> TestServiceUtil.tryInitialize(service, null));
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
     void succeedsOnFirstAttempt() {
         AtomicInteger attempts = new AtomicInteger();
 


### PR DESCRIPTION
# Description

Two related fixes to integration-test reliability, tracked under CAMEL-21438.

**1. Fix `isRetryableContainerException` short-circuiting on `NoHttpResponseException`**

`TestServiceUtil.isRetryableContainerException` walked the exception cause chain and, in the same loop pass, checked for both `NoHttpResponseException` and `ContainerFetchException`/`ContainerLaunchException`. Because testcontainers always wraps docker-java failures as the *cause* of a `ContainerFetchException`/`ContainerLaunchException`, the outer container-exception check matched first and returned `true` before the loop ever reached the nested `NoHttpResponseException`. As a result a dead or unresponsive Docker daemon was retried instead of failing fast. The fix walks the chain for `NoHttpResponseException` in a separate pass first, so that condition wins. The test is updated to wrap `NoHttpResponseException` inside a `ContainerLaunchException`, matching how testcontainers actually throws it.

**2. Isolate `IggyConsumerOffsetIT` on a dedicated topic/stream**

`IggyConsumerOffsetIT` reused the shared `TOPIC`/`STREAM`/`CONSUMER_GROUP` constants that other IT classes share through the same static `IggyService`/client, which allowed cross-test interference. It now uses dedicated `OFFSET_TOPIC`/`OFFSET_STREAM`/`OFFSET_CONSUMER_GROUP` names and asserts the exact ordered message bodies received after each batch, confirming the offset-based consumption behaves correctly.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

---

_AI-assisted with Claude Code on behalf of ammachado._
