### PR TITLE
CAMEL-23934: Fix light theme colors in TUI

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AbstractTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AbstractTab.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -113,7 +112,7 @@ abstract class AbstractTab implements MonitorTab {
 
     protected static Style sortStyle(String column, String currentSort) {
         return currentSort.equals(column)
-                ? Style.EMPTY.fg(Color.YELLOW).bold()
+                ? Theme.label().bold()
                 : Style.EMPTY.bold();
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiLogPopup.java
@@ -134,9 +134,9 @@ class AiLogPopup {
             Style levelStyle = switch (entry.level()) {
                 case QUESTION -> Style.EMPTY.fg(Color.CYAN);
                 case TOOL -> Theme.warning();
-                case RESULT -> Style.EMPTY.fg(Color.GREEN);
+                case RESULT -> Theme.success();
                 case RESPONSE -> Style.EMPTY.fg(Color.MAGENTA);
-                case ERROR -> Style.EMPTY.fg(Color.LIGHT_RED);
+                case ERROR -> Theme.error();
             };
             String levelTag = switch (entry.level()) {
                 case QUESTION -> " ASK      ";
@@ -177,7 +177,7 @@ class AiLogPopup {
                         entry.level() == AiPanel.LogLevel.TOOL
                                 ? TuiIcons.ARROW_RIGHT + " Arguments"
                                 : TuiIcons.ARROW_LEFT + " Result",
-                        (entry.level() == AiPanel.LogLevel.TOOL ? Theme.warning() : Style.EMPTY.fg(Color.GREEN)).bold())));
+                        (entry.level() == AiPanel.LogLevel.TOOL ? Theme.warning() : Theme.success()).bold())));
                 addJsonLines(lines, detail);
             } else {
                 lines.add(Line.from(Span.styled(TuiIcons.ARROW_RIGHT + " Content",

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiLogPopup.java
@@ -133,7 +133,7 @@ class AiLogPopup {
         for (AiPanel.LogEntry entry : entries) {
             Style levelStyle = switch (entry.level()) {
                 case QUESTION -> Style.EMPTY.fg(Color.CYAN);
-                case TOOL -> Style.EMPTY.fg(Color.YELLOW);
+                case TOOL -> Theme.warning();
                 case RESULT -> Style.EMPTY.fg(Color.GREEN);
                 case RESPONSE -> Style.EMPTY.fg(Color.MAGENTA);
                 case ERROR -> Style.EMPTY.fg(Color.LIGHT_RED);
@@ -177,7 +177,7 @@ class AiLogPopup {
                         entry.level() == AiPanel.LogLevel.TOOL
                                 ? TuiIcons.ARROW_RIGHT + " Arguments"
                                 : TuiIcons.ARROW_LEFT + " Result",
-                        Style.EMPTY.fg(entry.level() == AiPanel.LogLevel.TOOL ? Color.YELLOW : Color.GREEN).bold())));
+                        (entry.level() == AiPanel.LogLevel.TOOL ? Theme.warning() : Style.EMPTY.fg(Color.GREEN)).bold())));
                 addJsonLines(lines, detail);
             } else {
                 lines.add(Line.from(Span.styled(TuiIcons.ARROW_RIGHT + " Content",

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiLogPopup.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -132,10 +131,10 @@ class AiLogPopup {
         List<ListItem> items = new ArrayList<>();
         for (AiPanel.LogEntry entry : entries) {
             Style levelStyle = switch (entry.level()) {
-                case QUESTION -> Style.EMPTY.fg(Color.CYAN);
+                case QUESTION -> Style.EMPTY.fg(Theme.accent());
                 case TOOL -> Theme.warning();
                 case RESULT -> Theme.success();
-                case RESPONSE -> Style.EMPTY.fg(Color.MAGENTA);
+                case RESPONSE -> Theme.notice();
                 case ERROR -> Theme.error();
             };
             String levelTag = switch (entry.level()) {
@@ -181,7 +180,7 @@ class AiLogPopup {
                 addJsonLines(lines, detail);
             } else {
                 lines.add(Line.from(Span.styled(TuiIcons.ARROW_RIGHT + " Content",
-                        Style.EMPTY.fg(Color.CYAN).bold())));
+                        Style.EMPTY.fg(Theme.accent()).bold())));
                 for (String line : detail.split("\n", -1)) {
                     lines.add(Line.from(Span.styled("  " + line, Style.EMPTY.dim())));
                 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -744,7 +744,7 @@ class AiPanel {
                 Span.styled(" (in: ", dimStyle),
                 Span.styled(LlmClient.formatTokens(totalInput), Style.EMPTY.fg(Color.GREEN)),
                 Span.styled(" / out: ", dimStyle),
-                Span.styled(LlmClient.formatTokens(totalOutput), Style.EMPTY.fg(Color.YELLOW)),
+                Span.styled(LlmClient.formatTokens(totalOutput), Theme.label()),
                 Span.styled(")", dimStyle)));
         summaryLines.add(Line.from(
                 Span.styled("Avg latency: ", dimStyle),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -29,7 +29,6 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.markdown.MarkdownView;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -606,7 +605,7 @@ class AiPanel {
         String text = inputBuffer.toString();
 
         List<Span> spans = new ArrayList<>();
-        spans.add(Span.styled(prompt, Style.EMPTY.fg(Color.CYAN).bold()));
+        spans.add(Span.styled(prompt, Style.EMPTY.fg(Theme.accent()).bold()));
 
         if (thinking.get()) {
             spans.add(Span.styled(text, Style.EMPTY.dim()));
@@ -734,7 +733,7 @@ class AiPanel {
         // --- Summary ---
         Rect summaryArea = sections.get(0);
         Style dimStyle = Style.EMPTY.dim();
-        Style cyanStyle = Style.EMPTY.fg(Color.CYAN);
+        Style cyanStyle = Style.EMPTY.fg(Theme.accent());
         List<Line> summaryLines = new ArrayList<>();
         summaryLines.add(Line.from(
                 Span.styled("Requests: ", dimStyle),
@@ -808,7 +807,7 @@ class AiPanel {
                         Bar.builder()
                                 .value(turnTokens.get(i))
                                 .textValue("")
-                                .style(Style.EMPTY.fg(Color.CYAN))
+                                .style(Style.EMPTY.fg(Theme.accent()))
                                 .build()));
             }
 
@@ -831,7 +830,7 @@ class AiPanel {
         List<Line> lines = new ArrayList<>();
         for (int i = 0; i < area.height(); i++) {
             if (i >= thumbPos && i < thumbPos + thumbSize) {
-                lines.add(Line.from(Span.styled("▐", Style.EMPTY.fg(Color.CYAN))));
+                lines.add(Line.from(Span.styled("▐", Style.EMPTY.fg(Theme.accent()))));
             } else {
                 lines.add(Line.from(Span.styled("│", Style.EMPTY.dim())));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -742,7 +742,7 @@ class AiPanel {
                 Span.styled("   Total tokens: ", dimStyle),
                 Span.styled(LlmClient.formatTokens(totalTokens), cyanStyle),
                 Span.styled(" (in: ", dimStyle),
-                Span.styled(LlmClient.formatTokens(totalInput), Style.EMPTY.fg(Color.GREEN)),
+                Span.styled(LlmClient.formatTokens(totalInput), Theme.success()),
                 Span.styled(" / out: ", dimStyle),
                 Span.styled(LlmClient.formatTokens(totalOutput), Theme.label()),
                 Span.styled(")", dimStyle)));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -585,6 +585,7 @@ class AiPanel {
         MarkdownView view = MarkdownView.builder()
                 .source(source)
                 .scroll(scroll)
+                .styles(Theme.markdownStyles())
                 .build();
         frame.renderWidget(view, contentArea);
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -732,7 +732,7 @@ class AiPanel {
 
         // --- Summary ---
         Rect summaryArea = sections.get(0);
-        Style dimStyle = Style.EMPTY.dim();
+        Style dimStyle = Theme.muted();
         Style cyanStyle = Style.EMPTY.fg(Theme.accent());
         List<Line> summaryLines = new ArrayList<>();
         summaryLines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
@@ -252,14 +252,14 @@ class BeansTab extends AbstractTableTab {
         // full type
         if (bean.type != null && !bean.type.isEmpty()) {
             lines.add(Line.from(
-                    Span.styled("  Type: ", Style.EMPTY.dim()),
+                    Span.styled("  Type: ", Theme.muted()),
                     Span.styled(bean.type, Style.EMPTY.fg(Theme.baseFg()))));
         }
 
         // properties
         if (bean.properties != null && !bean.properties.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled("  Properties:", Style.EMPTY.dim())));
+            lines.add(Line.from(Span.styled("  Properties:", Theme.muted())));
 
             int maxNameLen = 0;
             for (BeanData.Property prop : bean.properties) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
@@ -307,7 +307,7 @@ class BeansTab extends AbstractTableTab {
     @Override
     public void renderFooter(List<Span> spans) {
         if (filterInputActive) {
-            spans.add(Span.styled(" /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled(" /", Theme.label().bold()));
             spans.add(Span.raw(filterInputState.text() + "█  "));
             hint(spans, "Enter", "filter");
             hintLast(spans, "Esc", "cancel");
@@ -316,7 +316,7 @@ class BeansTab extends AbstractTableTab {
         hint(spans, "Esc", filterTerm != null ? "clear" : "back");
         hint(spans, "f", "scope [" + filterModes()[filterIndex] + "]");
         if (filterTerm != null) {
-            spans.add(Span.styled("  /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled("  /", Theme.label().bold()));
             spans.add(Span.raw("\"" + filterTerm + "\"  "));
         } else {
             hint(spans, "/", "filter");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
@@ -254,7 +254,7 @@ class BeansTab extends AbstractTableTab {
         if (bean.type != null && !bean.type.isEmpty()) {
             lines.add(Line.from(
                     Span.styled("  Type: ", Style.EMPTY.dim()),
-                    Span.styled(bean.type, Style.EMPTY.fg(Color.WHITE))));
+                    Span.styled(bean.type, Style.EMPTY.fg(Theme.baseFg()))));
         }
 
         // properties
@@ -280,7 +280,7 @@ class BeansTab extends AbstractTableTab {
                         Span.styled("  " + String.format("%-" + nameWidth + "s", prop.name), Style.EMPTY.fg(Color.CYAN)),
                         Span.styled(String.format("%-15s", shortPropType), Style.EMPTY.dim()),
                         Span.styled(" = ", Style.EMPTY.dim()),
-                        Span.styled(value, "null".equals(value) ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE))));
+                        Span.styled(value, "null".equals(value) ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg()))));
             }
         } else {
             lines.add(Line.from(Span.raw("")));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BeansTab.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -201,7 +200,7 @@ class BeansTab extends AbstractTableTab {
             String shortType = dot >= 0 ? type.substring(dot + 1) : type;
 
             rows.add(Row.from(
-                    Cell.from(Span.styled(b.name != null ? b.name : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(b.name != null ? b.name : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(shortType, Style.EMPTY))));
         }
 
@@ -277,7 +276,7 @@ class BeansTab extends AbstractTableTab {
                 String value = prop.value != null ? prop.value : "null";
 
                 lines.add(Line.from(
-                        Span.styled("  " + String.format("%-" + nameWidth + "s", prop.name), Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled("  " + String.format("%-" + nameWidth + "s", prop.name), Style.EMPTY.fg(Theme.accent())),
                         Span.styled(String.format("%-15s", shortPropType), Style.EMPTY.dim()),
                         Span.styled(" = ", Style.EMPTY.dim()),
                         Span.styled(value, "null".equals(value) ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg()))));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -407,18 +407,18 @@ class BrowseTab extends AbstractTab {
 
         List<Line> lines = new ArrayList<>();
         lines.add(Line.from(
-                Span.styled("  Exchange ID: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Exchange ID: ", Theme.label().bold()),
                 Span.styled(msg.exchangeId != null ? msg.exchangeId : "", Style.EMPTY.fg(Color.WHITE))));
         if (msg.exchangePattern != null) {
             lines.add(Line.from(
-                    Span.styled("  Pattern:     ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("  Pattern:     ", Theme.label().bold()),
                     Span.styled(msg.exchangePattern, Style.EMPTY.fg(Color.WHITE))));
         }
         lines.add(Line.from(Span.raw("")));
 
         // Headers
         if (msg.headers != null && !msg.headers.isEmpty()) {
-            lines.add(Line.from(Span.styled("  Headers:", Style.EMPTY.fg(Color.YELLOW).bold())));
+            lines.add(Line.from(Span.styled("  Headers:", Theme.label().bold())));
             for (Map.Entry<String, String> entry : msg.headers.entrySet()) {
                 lines.add(Line.from(
                         Span.styled("    " + entry.getKey(), Style.EMPTY.fg(Color.CYAN)),
@@ -429,7 +429,7 @@ class BrowseTab extends AbstractTab {
         }
 
         // Body
-        lines.add(Line.from(Span.styled("  Body:", Style.EMPTY.fg(Color.YELLOW).bold())));
+        lines.add(Line.from(Span.styled("  Body:", Theme.label().bold())));
         if (msg.body != null && !msg.body.isEmpty()) {
             String bodyText = msg.body;
             if (prettyPrint) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -406,21 +406,21 @@ class BrowseTab extends AbstractTab {
 
         List<Line> lines = new ArrayList<>();
         lines.add(Line.from(
-                Span.styled("  Exchange ID: ", Theme.label().bold()),
+                Span.styled("  Exchange ID: ", Theme.muted()),
                 Span.styled(msg.exchangeId != null ? msg.exchangeId : "", Style.EMPTY.fg(Theme.baseFg()))));
         if (msg.exchangePattern != null) {
             lines.add(Line.from(
-                    Span.styled("  Pattern:     ", Theme.label().bold()),
+                    Span.styled("  Pattern:     ", Theme.muted()),
                     Span.styled(msg.exchangePattern, Style.EMPTY.fg(Theme.baseFg()))));
         }
         lines.add(Line.from(Span.raw("")));
 
         // Headers
         if (msg.headers != null && !msg.headers.isEmpty()) {
-            lines.add(Line.from(Span.styled("  Headers:", Theme.label().bold())));
+            lines.add(Line.from(Span.styled("  Headers:", Theme.muted())));
             for (Map.Entry<String, String> entry : msg.headers.entrySet()) {
                 lines.add(Line.from(
-                        Span.styled("    " + entry.getKey(), Style.EMPTY.fg(Theme.accent())),
+                        Span.styled("    " + entry.getKey(), Theme.muted()),
                         Span.styled(" = ", Style.EMPTY.dim()),
                         Span.styled(entry.getValue(), Style.EMPTY.fg(Theme.baseFg()))));
             }
@@ -428,7 +428,7 @@ class BrowseTab extends AbstractTab {
         }
 
         // Body
-        lines.add(Line.from(Span.styled("  Body:", Theme.label().bold())));
+        lines.add(Line.from(Span.styled("  Body:", Theme.muted())));
         if (msg.body != null && !msg.body.isEmpty()) {
             String bodyText = msg.body;
             if (prettyPrint) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -289,7 +288,7 @@ class BrowseTab extends AbstractTab {
             String first = ep.firstTimestamp > 0 ? formatTimestamp(ep.firstTimestamp) : "";
             String last = ep.lastTimestamp > 0 ? formatTimestamp(ep.lastTimestamp) : "";
             rows.add(Row.from(
-                    Cell.from(Span.styled(ep.uri != null ? ep.uri : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(ep.uri != null ? ep.uri : "", Style.EMPTY.fg(Theme.accent()))),
                     rightCell(String.valueOf(ep.queueSize), 8),
                     Cell.from(first),
                     Cell.from(last)));
@@ -344,7 +343,7 @@ class BrowseTab extends AbstractTab {
             String ts = msg.timestamp > 0 ? formatTimestamp(msg.timestamp) : "";
             rows.add(Row.from(
                     rightCell(String.valueOf(msg.position), 5),
-                    Cell.from(Span.styled(msg.exchangeId != null ? msg.exchangeId : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(msg.exchangeId != null ? msg.exchangeId : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(ts),
                     Cell.from(Span.styled(bodyPreview, Style.EMPTY.dim()))));
         }
@@ -421,7 +420,7 @@ class BrowseTab extends AbstractTab {
             lines.add(Line.from(Span.styled("  Headers:", Theme.label().bold())));
             for (Map.Entry<String, String> entry : msg.headers.entrySet()) {
                 lines.add(Line.from(
-                        Span.styled("    " + entry.getKey(), Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled("    " + entry.getKey(), Style.EMPTY.fg(Theme.accent())),
                         Span.styled(" = ", Style.EMPTY.dim()),
                         Span.styled(entry.getValue(), Style.EMPTY.fg(Theme.baseFg()))));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/BrowseTab.java
@@ -408,11 +408,11 @@ class BrowseTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
         lines.add(Line.from(
                 Span.styled("  Exchange ID: ", Theme.label().bold()),
-                Span.styled(msg.exchangeId != null ? msg.exchangeId : "", Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(msg.exchangeId != null ? msg.exchangeId : "", Style.EMPTY.fg(Theme.baseFg()))));
         if (msg.exchangePattern != null) {
             lines.add(Line.from(
                     Span.styled("  Pattern:     ", Theme.label().bold()),
-                    Span.styled(msg.exchangePattern, Style.EMPTY.fg(Color.WHITE))));
+                    Span.styled(msg.exchangePattern, Style.EMPTY.fg(Theme.baseFg()))));
         }
         lines.add(Line.from(Span.raw("")));
 
@@ -423,7 +423,7 @@ class BrowseTab extends AbstractTab {
                 lines.add(Line.from(
                         Span.styled("    " + entry.getKey(), Style.EMPTY.fg(Color.CYAN)),
                         Span.styled(" = ", Style.EMPTY.dim()),
-                        Span.styled(entry.getValue(), Style.EMPTY.fg(Color.WHITE))));
+                        Span.styled(entry.getValue(), Style.EMPTY.fg(Theme.baseFg()))));
             }
             lines.add(Line.from(Span.raw("")));
         }
@@ -440,7 +440,7 @@ class BrowseTab extends AbstractTab {
                 }
             }
             for (String line : bodyText.split("\n", -1)) {
-                lines.add(Line.from(Span.styled("    " + line, Style.EMPTY.fg(Color.WHITE))));
+                lines.add(Line.from(Span.styled("    " + line, Style.EMPTY.fg(Theme.baseFg()))));
             }
         } else {
             lines.add(Line.from(Span.styled("    (empty)", Style.EMPTY.dim())));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
@@ -414,7 +414,7 @@ public class CamelCatalogTui extends CamelCommand {
                 Span.styled(" Camel Catalog", Style.EMPTY.fg(Color.rgb(0xF6, 0x91, 0x23)).bold()),
                 Span.raw("  "),
                 Span.styled(filteredComponents.size() + "/" + allComponents.size() + " components",
-                        Style.EMPTY.fg(Color.CYAN)));
+                        Style.EMPTY.fg(Theme.accent())));
 
         Block headerBlock = Block.builder()
                 .borderType(BorderType.ROUNDED).borders(Borders.ALL)
@@ -440,8 +440,8 @@ public class CamelCatalogTui extends CamelCommand {
         List<Row> rows = new ArrayList<>();
         for (ComponentInfo comp : filteredComponents) {
             Style nameStyle = comp.deprecated
-                    ? Style.EMPTY.fg(Color.RED).dim()
-                    : Style.EMPTY.fg(Color.CYAN);
+                    ? Theme.error().dim()
+                    : Style.EMPTY.fg(Theme.accent());
             String label = comp.name;
             if (comp.deprecated) {
                 label = label + " (deprecated)";
@@ -626,14 +626,14 @@ public class CamelCatalogTui extends CamelCommand {
 
     private Row optionToRow(OptionInfo opt) {
         Style nameStyle = opt.required
-                ? Style.EMPTY.fg(Color.CYAN).bold()
-                : Style.EMPTY.fg(Color.CYAN);
+                ? Style.EMPTY.fg(Theme.accent()).bold()
+                : Style.EMPTY.fg(Theme.accent());
 
         return Row.from(
                 Cell.from(Span.styled(opt.name, nameStyle)),
                 Cell.from(Span.styled(opt.type, Style.EMPTY.dim())),
                 Cell.from(opt.required
-                        ? Span.styled("*", Style.EMPTY.fg(Color.RED).bold())
+                        ? Span.styled("*", Theme.error().bold())
                         : Span.raw("")),
                 Cell.from(Span.styled(opt.defaultValue, Style.EMPTY.dim())),
                 Cell.from(Span.styled(opt.kind != null ? opt.kind : "", Style.EMPTY.dim())));
@@ -690,13 +690,13 @@ public class CamelCatalogTui extends CamelCommand {
             // Apply special styling for certain values
             Style valueStyle;
             if ("DEPRECATED".equals(value)) {
-                valueStyle = Style.EMPTY.fg(Color.RED).bold();
+                valueStyle = Theme.error().bold();
             } else if (opt != null && "Required".equals(field[0]) && opt.required) {
-                valueStyle = Style.EMPTY.fg(Color.RED).bold();
+                valueStyle = Theme.error().bold();
             } else if (opt != null && "Name".equals(field[0])) {
-                valueStyle = Style.EMPTY.fg(Color.CYAN).bold();
+                valueStyle = Style.EMPTY.fg(Theme.accent()).bold();
             } else if ("Label".equals(field[0]) || "Values".equals(field[0])) {
-                valueStyle = Style.EMPTY.fg(Color.CYAN);
+                valueStyle = Style.EMPTY.fg(Theme.accent());
             } else {
                 valueStyle = Style.EMPTY;
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -411,7 +410,7 @@ public class CamelCatalogTui extends CamelCommand {
 
     private void renderHeader(Frame frame, Rect area) {
         Line titleLine = Line.from(
-                Span.styled(" Camel Catalog", Style.EMPTY.fg(Color.rgb(0xF6, 0x91, 0x23)).bold()),
+                Span.styled(" Camel Catalog", Style.EMPTY.fg(Theme.accent()).bold()),
                 Span.raw("  "),
                 Span.styled(filteredComponents.size() + "/" + allComponents.size() + " components",
                         Style.EMPTY.fg(Theme.accent())));
@@ -454,7 +453,7 @@ public class CamelCatalogTui extends CamelCommand {
         }
 
         Style borderStyle = focus == FOCUS_LIST
-                ? Style.EMPTY.fg(Color.rgb(0xF6, 0x91, 0x23))
+                ? Style.EMPTY.fg(Theme.accent())
                 : Style.EMPTY;
 
         String modePrefix = componentFullText ? "/" : "";
@@ -479,7 +478,7 @@ public class CamelCatalogTui extends CamelCommand {
 
     private void renderOptionsTable(Frame frame, Rect area) {
         Style borderStyle = focus == FOCUS_OPTIONS
-                ? Style.EMPTY.fg(Color.rgb(0xF6, 0x91, 0x23))
+                ? Style.EMPTY.fg(Theme.accent())
                 : Style.EMPTY;
 
         String optModePrefix = optionFullText ? "/" : "";

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
@@ -540,7 +540,7 @@ public class CamelCatalogTui extends CamelCommand {
         frame.renderWidget(
                 Block.builder()
                         .borders(Borders.TOP_ONLY)
-                        .borderStyle(Style.EMPTY.fg(Color.DARK_GRAY))
+                        .borderStyle(Theme.muted())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelCatalogTui.java
@@ -641,19 +641,19 @@ public class CamelCatalogTui extends CamelCommand {
 
     private void renderFooter(Frame frame, Rect area) {
         Line footer = Line.from(
-                Span.styled(" Type", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Type", Theme.label().bold()),
                 Span.raw(" name filter  "),
-                Span.styled("/", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("/", Theme.label().bold()),
                 Span.raw(" full-text  "),
-                Span.styled("Esc", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("Esc", Theme.label().bold()),
                 Span.raw(" clear/back/quit  "),
-                Span.styled("\u2191\u2193", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("\u2191\u2193", Theme.label().bold()),
                 Span.raw(" navigate  "),
-                Span.styled("\u2190\u2192", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("\u2190\u2192", Theme.label().bold()),
                 Span.raw("/"),
-                Span.styled("Tab", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("Tab", Theme.label().bold()),
                 Span.raw(" panels  "),
-                Span.styled("PgUp/Dn", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("PgUp/Dn", Theme.label().bold()),
                 Span.raw(" scroll"));
 
         frame.renderWidget(Paragraph.from(footer), area);
@@ -685,7 +685,7 @@ public class CamelCatalogTui extends CamelCommand {
                 currentSpans.add(Span.raw(" "));
             }
 
-            currentSpans.add(Span.styled(label, Style.EMPTY.fg(Color.YELLOW).bold()));
+            currentSpans.add(Span.styled(label, Theme.label().bold()));
 
             // Apply special styling for certain values
             Style valueStyle;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1393,7 +1393,7 @@ public class CamelMonitor extends CamelCommand {
     }
 
     private void computeTabBadges(String[] badgeTexts, Style[] badgeStyles) {
-        Style yellow = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style yellow = Theme.label();
         Style cyan = Style.EMPTY.fg(Color.CYAN).bold();
         Style red = Style.EMPTY.fg(Color.LIGHT_RED).bold();
         for (int j = 0; j < badgeStyles.length; j++) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1394,7 +1394,7 @@ public class CamelMonitor extends CamelCommand {
 
     private void computeTabBadges(String[] badgeTexts, Style[] badgeStyles) {
         Style yellow = Theme.label();
-        Style cyan = Style.EMPTY.fg(Color.CYAN).bold();
+        Style cyan = Style.EMPTY.fg(Theme.accent()).bold();
         Style red = Theme.error().bold();
         for (int j = 0; j < badgeStyles.length; j++) {
             badgeTexts[j] = "";

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1190,8 +1190,8 @@ public class CamelMonitor extends CamelCommand {
                         Paragraph.builder().text(Text.from(titleLine)).build(),
                         leftArea);
                 Color waveColor = activeNotificationError
-                        ? Theme.error().fg().orElse(Color.LIGHT_RED)
-                        : Theme.success().fg().orElse(Color.LIGHT_GREEN);
+                        ? Theme.error().fg().orElse(Color.RED)
+                        : Theme.success().fg().orElse(Color.GREEN);
                 WaveText wave = WaveText.builder()
                         .text(activeNotification)
                         .color(waveColor)
@@ -1395,7 +1395,7 @@ public class CamelMonitor extends CamelCommand {
     private void computeTabBadges(String[] badgeTexts, Style[] badgeStyles) {
         Style yellow = Theme.label();
         Style cyan = Style.EMPTY.fg(Color.CYAN).bold();
-        Style red = Style.EMPTY.fg(Color.LIGHT_RED).bold();
+        Style red = Theme.error().bold();
         for (int j = 0; j < badgeStyles.length; j++) {
             badgeTexts[j] = "";
             badgeStyles[j] = yellow;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1771,11 +1771,11 @@ public class CamelMonitor extends CamelCommand {
                 suffix = active ? " " + TuiIcons.SELECTED : " " + TuiIcons.IDLE;
                 mcpLabel += " (" + client + ")";
                 labelStyle = Theme.success();
-                suffixStyle = active ? Theme.mcpActive() : Theme.mcpIdle();
+                suffixStyle = active ? Theme.success() : Theme.muted();
             } else {
                 suffix = " " + TuiIcons.CROSS;
                 labelStyle = Theme.muted();
-                suffixStyle = Theme.mcpDown();
+                suffixStyle = Theme.error();
             }
             rightSpans.add(Span.styled(mcpLabel, labelStyle));
             rightSpans.add(Span.styled(suffix, suffixStyle));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1263,7 +1263,7 @@ public class CamelMonitor extends CamelCommand {
             // Infra mode: only Overview and Log tabs
             Line[] labels = {
                     Line.from(TuiIcons.primaryTabHeader(TuiIcons.TAB_OVERVIEW, "1", "Overview")),
-                    Line.from(TuiIcons.primaryTabHeader(TuiIcons.TAB_LOG, "2", "Log")),
+                    Line.from(TuiIcons.primaryTabHeader(TuiIcons.TAB_LOG, "2", "Log"))
             };
 
             // Map real tab index to infra tab index for highlight

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -1190,8 +1190,8 @@ public class CamelMonitor extends CamelCommand {
                         Paragraph.builder().text(Text.from(titleLine)).build(),
                         leftArea);
                 Color waveColor = activeNotificationError
-                        ? Theme.error().fg().orElse(Color.RED)
-                        : Theme.success().fg().orElse(Color.GREEN);
+                        ? Theme.error().fg().orElseThrow()
+                        : Theme.success().fg().orElseThrow();
                 WaveText wave = WaveText.builder()
                         .text(activeNotification)
                         .color(waveColor)
@@ -1214,7 +1214,7 @@ public class CamelMonitor extends CamelCommand {
     }
 
     private void renderTooSmall(Frame frame, Rect area) {
-        Style orange = Style.EMPTY.fg(Color.rgb(0xF6, 0x91, 0x23));
+        Style orange = Style.EMPTY.fg(Theme.accent());
         Style normal = Style.EMPTY;
         Style bold = Style.EMPTY.bold();
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CaptionOverlay.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CaptionOverlay.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -188,7 +187,7 @@ class CaptionOverlay {
     }
 
     private void renderInline(Frame frame, Rect area) {
-        Style style = Style.EMPTY.fg(Color.WHITE).bold();
+        Style style = Style.EMPTY.fg(Theme.baseFg()).bold();
         String text = inlineBuffer != null ? inlineBuffer.toString() : "";
         String display = text + "█";
 
@@ -222,7 +221,7 @@ class CaptionOverlay {
 
         Style style;
         if (captionFullyTypedTime == 0 || now - captionFullyTypedTime < HOLD_DURATION_MS) {
-            style = Style.EMPTY.fg(Color.WHITE).bold();
+            style = Style.EMPTY.fg(Theme.baseFg()).bold();
         } else {
             style = Style.EMPTY.dim();
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -93,7 +92,7 @@ class CircuitBreakerTab extends AbstractTableTab {
             String sinceLast = formatSinceLast(cb.sinceLastStarted, cb.sinceLastSuccess, cb.sinceLastFail);
 
             rows.add(Row.from(
-                    Cell.from(Span.styled(cb.routeId != null ? cb.routeId : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(cb.routeId != null ? cb.routeId : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(cb.id != null ? cb.id : ""),
                     Cell.from(cb.component != null ? cb.component : ""),
                     Cell.from(Span.styled(state, stateStyle)),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
@@ -81,7 +81,7 @@ class CircuitBreakerTab extends AbstractTableTab {
             Style stateStyle = switch (cb.state != null ? cb.state.toLowerCase() : "") {
                 case "closed" -> Style.EMPTY.fg(Color.GREEN);
                 case "open", "forced_open" -> Style.EMPTY.fg(Color.LIGHT_RED);
-                default -> Style.EMPTY.fg(Color.YELLOW);
+                default -> Theme.warning();
             };
             String state = cb.state != null ? cb.state : "";
             String pending = cb.bufferedCalls > 0 ? String.valueOf(cb.bufferedCalls) : "";
@@ -195,7 +195,7 @@ class CircuitBreakerTab extends AbstractTableTab {
 
         Style closedBox = isClosed ? Style.EMPTY.fg(Color.GREEN).bold() : Style.EMPTY;
         Style openBox = isOpen ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY;
-        Style halfOpenBox = !isClosed && !isOpen ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY;
+        Style halfOpenBox = !isClosed && !isOpen ? Theme.warning().bold() : Style.EMPTY;
         Style lbl = Style.EMPTY.dim();
 
         List<Line> lines = new ArrayList<>();
@@ -281,7 +281,7 @@ class CircuitBreakerTab extends AbstractTableTab {
         if (rate >= 80) {
             barColor = Style.EMPTY.fg(Color.LIGHT_RED);
         } else if (rate >= 50) {
-            barColor = Style.EMPTY.fg(Color.YELLOW);
+            barColor = Theme.warning();
         } else {
             barColor = Style.EMPTY.fg(Color.GREEN);
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
@@ -339,7 +339,7 @@ class CircuitBreakerTab extends AbstractTableTab {
                         .title(Title.from(chartTitle)).build())
                 .build(), vSplit.get(1));
 
-        Style dim = Style.EMPTY.dim();
+        Style dim = Theme.muted();
         Line metricsLine1 = Line.from(
                 Span.raw(" "),
                 Span.styled("total:", dim), Span.raw(cb.total + " "),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTab.java
@@ -79,8 +79,8 @@ class CircuitBreakerTab extends AbstractTableTab {
         List<Row> rows = new ArrayList<>();
         for (CircuitBreakerInfo cb : sorted) {
             Style stateStyle = switch (cb.state != null ? cb.state.toLowerCase() : "") {
-                case "closed" -> Style.EMPTY.fg(Color.GREEN);
-                case "open", "forced_open" -> Style.EMPTY.fg(Color.LIGHT_RED);
+                case "closed" -> Theme.success();
+                case "open", "forced_open" -> Theme.error();
                 default -> Theme.warning();
             };
             String state = cb.state != null ? cb.state : "";
@@ -193,8 +193,8 @@ class CircuitBreakerTab extends AbstractTableTab {
         boolean isClosed = state.equals("closed");
         boolean isOpen = state.equals("open") || state.equals("forced_open");
 
-        Style closedBox = isClosed ? Style.EMPTY.fg(Color.GREEN).bold() : Style.EMPTY;
-        Style openBox = isOpen ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY;
+        Style closedBox = isClosed ? Theme.success().bold() : Style.EMPTY;
+        Style openBox = isOpen ? Theme.error().bold() : Style.EMPTY;
         Style halfOpenBox = !isClosed && !isOpen ? Theme.warning().bold() : Style.EMPTY;
         Style lbl = Style.EMPTY.dim();
 
@@ -279,11 +279,11 @@ class CircuitBreakerTab extends AbstractTableTab {
         double rate = cb.failureRate >= 0 ? cb.failureRate : 0;
         Style barColor;
         if (rate >= 80) {
-            barColor = Style.EMPTY.fg(Color.LIGHT_RED);
+            barColor = Theme.error();
         } else if (rate >= 50) {
             barColor = Theme.warning();
         } else {
-            barColor = Style.EMPTY.fg(Color.GREEN);
+            barColor = Theme.success();
         }
         String rateLabel = String.format(" %.0f%%", Math.max(0, cb.failureRate));
         int barWidth = MAX_CHART_POINTS;
@@ -324,15 +324,15 @@ class CircuitBreakerTab extends AbstractTableTab {
         long curSuccess = successArr[renderPoints - 1];
         long curFail = failArr[renderPoints - 1];
         Line chartTitle = Line.from(
-                Span.styled("▬", Style.EMPTY.fg(Color.GREEN)),
+                Span.styled("▬", Theme.success()),
                 Span.raw(String.format(" ok:%-4d ", curSuccess)),
-                Span.styled("▬", Style.EMPTY.fg(Color.LIGHT_RED)),
+                Span.styled("▬", Theme.error()),
                 Span.raw(String.format(" fail:%-4d msg/s", curFail)));
         frame.renderWidget(DualSparkline.builder()
                 .topData(successArr)
                 .bottomData(failArr)
-                .topStyle(Style.EMPTY.fg(Color.GREEN))
-                .bottomStyle(Style.EMPTY.fg(Color.LIGHT_RED))
+                .topStyle(Theme.success())
+                .bottomStyle(Theme.error())
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -216,7 +215,7 @@ class ClasspathTab extends AbstractTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(
-                                    Span.styled("  " + errorMessage, Style.EMPTY.fg(Color.LIGHT_RED)))))
+                                    Span.styled("  " + errorMessage, Theme.error()))))
                             .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Classpath ").build())
                             .build(),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ClasspathTab.java
@@ -277,7 +277,7 @@ class ClasspathTab extends AbstractTab {
     @Override
     public void renderFooter(List<Span> spans) {
         if (filterInputActive) {
-            spans.add(Span.styled(" /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled(" /", Theme.label().bold()));
             spans.add(Span.raw(filterInputState.text() + "█  "));
             hint(spans, "Enter", "filter");
             hintLast(spans, "Esc", "cancel");
@@ -286,7 +286,7 @@ class ClasspathTab extends AbstractTab {
         hint(spans, "Esc", filterTerm != null ? "clear" : "back");
         hint(spans, "f", "scope [" + SCOPES[scopeIndex] + "]");
         if (filterTerm != null) {
-            spans.add(Span.styled("  /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled("  /", Theme.label().bold()));
             spans.add(Span.raw("\"" + filterTerm + "\"  "));
         } else {
             hint(spans, "/", "filter");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
@@ -53,7 +53,7 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.TuiHelper.*;
 
 class ConfigurationTab extends AbstractTableTab {
 
-    private static final Style SECRET_STYLE = Style.EMPTY.fg(Color.DARK_GRAY);
+    private static final Style SECRET_STYLE = Theme.muted();
 
     private int detailScroll;
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
@@ -279,7 +279,7 @@ class ConfigurationTab extends AbstractTableTab {
         if (value.length() <= maxValueLen) {
             lines.add(Line.from(
                     Span.styled(prefix, Style.EMPTY.dim()),
-                    Span.styled(value, Style.EMPTY.fg(Color.WHITE))));
+                    Span.styled(value, Style.EMPTY.fg(Theme.baseFg()))));
         } else {
             // wrap long values
             lines.add(Line.from(Span.styled(prefix, Style.EMPTY.dim())));
@@ -292,7 +292,7 @@ class ConfigurationTab extends AbstractTableTab {
             int pos = 0;
             while (pos < value.length()) {
                 int end = Math.min(pos + wrapWidth, value.length());
-                lines.add(Line.from(Span.styled(indentStr + value.substring(pos, end), Style.EMPTY.fg(Color.WHITE))));
+                lines.add(Line.from(Span.styled(indentStr + value.substring(pos, end), Style.EMPTY.fg(Theme.baseFg()))));
                 pos = end;
             }
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTab.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -156,7 +155,7 @@ class ConfigurationTab extends AbstractTableTab {
             }
 
             rows.add(Row.from(
-                    Cell.from(Span.styled(p.key, Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(p.key, Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(value, valStyle)),
                     Cell.from(Span.styled(source, Style.EMPTY.dim()))));
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTab.java
@@ -87,10 +87,10 @@ class ConsumersTab extends AbstractTableTab {
             HealthCheckInfo hc = consumerHealthCheck(info, ci);
             boolean healthDown = hc != null && "DOWN".equals(hc.state);
             Style statusStyle = healthDown
-                    ? Style.EMPTY.fg(Color.LIGHT_RED)
+                    ? Theme.error()
                     : ("Started".equals(ci.state) || "Polling".equals(status)
-                            ? Style.EMPTY.fg(Color.GREEN)
-                            : Style.EMPTY.fg(Color.LIGHT_RED));
+                            ? Theme.success()
+                            : Theme.error());
             String statusText = healthDown ? TuiIcons.HEALTH_WARN + " " + status : status;
             String type = consumerType(ci);
             String schedule = consumerSchedule(ci);
@@ -107,7 +107,7 @@ class ConsumersTab extends AbstractTableTab {
                     rightCell(ci.totalCounter != null ? String.valueOf(ci.totalCounter) : "", 8),
                     Cell.from(schedule),
                     Cell.from(sinceLast),
-                    Cell.from(Span.styled(uri, healthDown ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY))));
+                    Cell.from(Span.styled(uri, healthDown ? Theme.error() : Style.EMPTY))));
         }
 
         if (rows.isEmpty()) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTab.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Span;
@@ -100,7 +99,7 @@ class ConsumersTab extends AbstractTableTab {
                     : (ci.uri != null ? ci.uri : "");
 
             rows.add(Row.from(
-                    Cell.from(Span.styled(" " + (ci.id != null ? ci.id : ""), Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(" " + (ci.id != null ? ci.id : ""), Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(statusText, statusStyle)),
                     Cell.from(type),
                     rightCell(String.valueOf(ci.inflight), 8),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CveAuditTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CveAuditTab.java
@@ -169,7 +169,7 @@ class CveAuditTab extends AbstractTableTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(
-                                    Span.styled("  " + errorMessage, Style.EMPTY.fg(Color.LIGHT_RED)))))
+                                    Span.styled("  " + errorMessage, Theme.error()))))
                             .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" CVE Audit ").build())
                             .build(),
@@ -183,7 +183,7 @@ class CveAuditTab extends AbstractTableTab {
                             .text(Text.from(
                                     Line.from(Span.raw("")),
                                     Line.from(Span.styled("  No vulnerabilities found",
-                                            Style.EMPTY.fg(Color.GREEN))),
+                                            Theme.success())),
                                     Line.from(Span.raw("")),
                                     Line.from(Span.styled(
                                             String.format("  Scanned %d dependencies", scannedCount),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CveAuditTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CveAuditTab.java
@@ -29,7 +29,6 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.markdown.MarkdownView;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -220,7 +219,7 @@ class CveAuditTab extends AbstractTableTab {
             rows.add(Row.from(
                     Cell.from(Span.styled(group.severity != null ? group.severity : "", severityStyle(group.severity))),
                     Cell.from(Span.styled(group.canonicalId != null ? group.canonicalId : "", Style.EMPTY.bold())),
-                    Cell.from(Span.styled(artDisplay, Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(artDisplay, Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(group.summary != null ? group.summary : "", Style.EMPTY.dim()))));
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CveAuditTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CveAuditTab.java
@@ -307,6 +307,7 @@ class CveAuditTab extends AbstractTableTab {
                         .source(md.toString())
                         .scroll(detailScroll)
                         .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
+                        .styles(Theme.markdownStyles())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTab.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Span;
@@ -86,7 +85,7 @@ class DataSourceTab extends AbstractTableTab {
 
             Style activeStyle = exhausted
                     ? Theme.error()
-                    : Style.EMPTY.fg(Color.CYAN);
+                    : Style.EMPTY.fg(Theme.accent());
             Style waitingStyle = waiters
                     ? Theme.warning()
                     : Style.EMPTY;
@@ -94,7 +93,7 @@ class DataSourceTab extends AbstractTableTab {
             String poolLabel = di.poolName != null ? di.poolName : (di.poolType != null ? di.poolType : "");
 
             rows.add(Row.from(
-                    Cell.from(Span.styled(" " + (di.name != null ? di.name : ""), Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(" " + (di.name != null ? di.name : ""), Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(poolLabel),
                     rightCell(String.valueOf(di.active), 8, activeStyle),
                     rightCell(String.valueOf(di.idle), 8),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTab.java
@@ -88,7 +88,7 @@ class DataSourceTab extends AbstractTableTab {
                     ? Style.EMPTY.fg(Color.LIGHT_RED)
                     : Style.EMPTY.fg(Color.CYAN);
             Style waitingStyle = waiters
-                    ? Style.EMPTY.fg(Color.YELLOW)
+                    ? Theme.warning()
                     : Style.EMPTY;
 
             String poolLabel = di.poolName != null ? di.poolName : (di.poolType != null ? di.poolType : "");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTab.java
@@ -85,7 +85,7 @@ class DataSourceTab extends AbstractTableTab {
             boolean waiters = di.waiting > 0;
 
             Style activeStyle = exhausted
-                    ? Style.EMPTY.fg(Color.LIGHT_RED)
+                    ? Theme.error()
                     : Style.EMPTY.fg(Color.CYAN);
             Style waitingStyle = waiters
                     ? Theme.warning()

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -582,7 +582,7 @@ class DiagramTab extends AbstractTab {
             } else if (ln.treeNode != null && ln.treeNode.info.remote) {
                 String arrow = "from".equals(ln.type) ? " external → " : " → external";
                 lines.add(Line.from(
-                        Span.styled(arrow, Style.EMPTY.fg(Color.DARK_GRAY))));
+                        Span.styled(arrow, Theme.muted())));
             } else {
                 lines.add(Line.from(Span.raw("")));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -365,7 +365,7 @@ class DiagramTab extends AbstractTab {
                 if (info.name != null) {
                     title = Line.from(
                             Span.raw(" Topology ["),
-                            Span.styled(info.name, Style.EMPTY.fg(Color.YELLOW).bold()),
+                            Span.styled(info.name, Theme.label().bold()),
                             Span.raw("] "));
                 } else {
                     title = Line.from(Span.raw(" Topology "));
@@ -426,7 +426,7 @@ class DiagramTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
         if (route != null) {
             lines.add(Line.from(
-                    Span.styled(" Route: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Route: ", Theme.label().bold()),
                     Span.styled(route.routeId, Style.EMPTY.fg(Color.WHITE).bold())));
             lines.add(Line.from(
                     Span.styled(" From:  ", Style.EMPTY.dim()),
@@ -577,7 +577,7 @@ class DiagramTab extends AbstractTab {
             String linkedRoute = diagram.findLinkedRouteId(drillDownRouteId);
             if (linkedRoute != null && diagram.getRouteLayout(linkedRoute) != null) {
                 lines.add(Line.from(
-                        Span.styled(" ↵ ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                        Span.styled(" ↵ ", Theme.label().bold()),
                         Span.styled(linkedRoute, Style.EMPTY.fg(Color.WHITE))));
             } else if (ln.treeNode != null && ln.treeNode.info.remote) {
                 String arrow = "from".equals(ln.type) ? " external → " : " → external";
@@ -872,7 +872,7 @@ class DiagramTab extends AbstractTab {
     }
 
     private Line buildBreadcrumbTitle() {
-        Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style nameStyle = Theme.label().bold();
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" Route ["));
         if (routeNavigationStack.isEmpty()) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -427,7 +427,7 @@ class DiagramTab extends AbstractTab {
         if (route != null) {
             lines.add(Line.from(
                     Span.styled(" Route: ", Theme.label().bold()),
-                    Span.styled(route.routeId, Style.EMPTY.fg(Color.WHITE).bold())));
+                    Span.styled(route.routeId, Style.EMPTY.fg(Theme.baseFg()).bold())));
             lines.add(Line.from(
                     Span.styled(" From:  ", Style.EMPTY.dim()),
                     Span.raw(route.from != null ? route.from : "")));
@@ -518,7 +518,7 @@ class DiagramTab extends AbstractTab {
                         lines.add(Line.from(Span.raw("")));
                         lines.add(Line.from(
                                 Span.styled(isInbound ? " To route: " : " From route: ", Style.EMPTY.dim()),
-                                Span.styled(connectedRoute, Style.EMPTY.fg(Color.WHITE))));
+                                Span.styled(connectedRoute, Style.EMPTY.fg(Theme.baseFg()))));
                     }
                 }
                 if (topoNode.exchangesTotal > 0 || topoNode.exchangesFailed > 0) {
@@ -578,7 +578,7 @@ class DiagramTab extends AbstractTab {
             if (linkedRoute != null && diagram.getRouteLayout(linkedRoute) != null) {
                 lines.add(Line.from(
                         Span.styled(" ↵ ", Theme.label().bold()),
-                        Span.styled(linkedRoute, Style.EMPTY.fg(Color.WHITE))));
+                        Span.styled(linkedRoute, Style.EMPTY.fg(Theme.baseFg()))));
             } else if (ln.treeNode != null && ln.treeNode.info.remote) {
                 String arrow = "from".equals(ln.type) ? " external → " : " → external";
                 lines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -426,69 +426,69 @@ class DiagramTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
         if (route != null) {
             lines.add(Line.from(
-                    Span.styled(" Route: ", Theme.label().bold()),
+                    Span.styled(" Route: ", Theme.muted()),
                     Span.styled(route.routeId, Style.EMPTY.fg(Theme.baseFg()).bold())));
             lines.add(Line.from(
-                    Span.styled(" From:  ", Style.EMPTY.dim()),
+                    Span.styled(" From:  ", Theme.muted()),
                     Span.raw(route.from != null ? route.from : "")));
             String stateLabel = route.state != null ? route.state : "";
             Style stateStyle = "Started".equals(route.state) ? Theme.success() : Theme.error();
             lines.add(Line.from(
-                    Span.styled(" State: ", Style.EMPTY.dim()),
+                    Span.styled(" State: ", Theme.muted()),
                     Span.styled(stateLabel, stateStyle)));
 
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled(" Uptime:     ", Style.EMPTY.dim()),
+                    Span.styled(" Uptime:     ", Theme.muted()),
                     Span.raw(route.uptime != null ? route.uptime : "")));
             lines.add(Line.from(
-                    Span.styled(" Throughput: ", Style.EMPTY.dim()),
+                    Span.styled(" Throughput: ", Theme.muted()),
                     Span.raw(route.throughput != null ? route.throughput : "")));
             if (route.coverage != null) {
                 lines.add(Line.from(
-                        Span.styled(" Coverage:   ", Style.EMPTY.dim()),
+                        Span.styled(" Coverage:   ", Theme.muted()),
                         Span.raw(route.coverage)));
             }
 
             lines.add(Line.from(Span.raw("")));
             int w = numWidth(route.total, route.failed, route.inflight);
             lines.add(Line.from(
-                    Span.styled(" Total:    ", Style.EMPTY.dim()),
+                    Span.styled(" Total:    ", Theme.muted()),
                     Span.raw(String.format("%" + w + "d", route.total))));
             Style failStyle = route.failed > 0 ? Theme.error().bold() : Style.EMPTY;
             lines.add(Line.from(
-                    Span.styled(" Failed:   ", Style.EMPTY.dim()),
+                    Span.styled(" Failed:   ", Theme.muted()),
                     Span.styled(String.format("%" + w + "d", route.failed), failStyle)));
             lines.add(Line.from(
-                    Span.styled(" Inflight: ", Style.EMPTY.dim()),
+                    Span.styled(" Inflight: ", Theme.muted()),
                     Span.raw(String.format("%" + w + "d", route.inflight))));
 
             lines.add(Line.from(Span.raw("")));
             if (route.total > 0) {
                 int tw = numWidth(route.meanTime, route.maxTime, route.minTime);
                 lines.add(Line.from(
-                        Span.styled(" Mean: ", Style.EMPTY.dim()),
+                        Span.styled(" Mean: ", Theme.muted()),
                         Span.raw(String.format("%" + tw + "d ms", route.meanTime))));
                 lines.add(Line.from(
-                        Span.styled(" Max:  ", Style.EMPTY.dim()),
+                        Span.styled(" Max:  ", Theme.muted()),
                         Span.raw(String.format("%" + tw + "d ms", route.maxTime))));
                 lines.add(Line.from(
-                        Span.styled(" Min:  ", Style.EMPTY.dim()),
+                        Span.styled(" Min:  ", Theme.muted()),
                         Span.raw(String.format("%" + tw + "d ms", route.minTime))));
             }
 
             if (route.sinceLastCompleted != null || route.sinceLastFailed != null) {
                 lines.add(Line.from(Span.raw("")));
                 lines.add(Line.from(
-                        Span.styled(" Since last:", Style.EMPTY.dim())));
+                        Span.styled(" Since last:", Theme.muted())));
                 if (route.sinceLastCompleted != null) {
                     lines.add(Line.from(
-                            Span.styled("   success: ", Style.EMPTY.dim()),
+                            Span.styled("   success: ", Theme.muted()),
                             Span.raw(route.sinceLastCompleted)));
                 }
                 if (route.sinceLastFailed != null) {
                     lines.add(Line.from(
-                            Span.styled("   fail:    ", Style.EMPTY.dim()),
+                            Span.styled("   fail:    ", Theme.muted()),
                             Span.styled(route.sinceLastFailed,
                                     Theme.error())));
                 }
@@ -505,11 +505,11 @@ class DiagramTab extends AbstractTab {
                         Span.styled(label, Style.EMPTY.fg(Theme.accent()).bold())));
                 lines.add(Line.from(Span.raw("")));
                 lines.add(Line.from(
-                        Span.styled(" URI: ", Style.EMPTY.dim()),
+                        Span.styled(" URI: ", Theme.muted()),
                         Span.raw(topoNode.from != null ? topoNode.from : "")));
                 if (topoNode.description != null && !topoNode.description.isBlank()) {
                     lines.add(Line.from(
-                            Span.styled(" Path: ", Style.EMPTY.dim()),
+                            Span.styled(" Path: ", Theme.muted()),
                             Span.raw(topoNode.description)));
                 }
                 if (!isBridge) {
@@ -517,18 +517,18 @@ class DiagramTab extends AbstractTab {
                     if (connectedRoute != null) {
                         lines.add(Line.from(Span.raw("")));
                         lines.add(Line.from(
-                                Span.styled(isInbound ? " To route: " : " From route: ", Style.EMPTY.dim()),
+                                Span.styled(isInbound ? " To route: " : " From route: ", Theme.muted()),
                                 Span.styled(connectedRoute, Style.EMPTY.fg(Theme.baseFg()))));
                     }
                 }
                 if (topoNode.exchangesTotal > 0 || topoNode.exchangesFailed > 0) {
                     lines.add(Line.from(Span.raw("")));
                     lines.add(Line.from(
-                            Span.styled(" Total:  ", Style.EMPTY.dim()),
+                            Span.styled(" Total:  ", Theme.muted()),
                             Span.raw(String.valueOf(topoNode.exchangesTotal))));
                     if (topoNode.exchangesFailed > 0) {
                         lines.add(Line.from(
-                                Span.styled(" Failed: ", Style.EMPTY.dim()),
+                                Span.styled(" Failed: ", Theme.muted()),
                                 Span.styled(String.valueOf(topoNode.exchangesFailed),
                                         Theme.error().bold())));
                     }
@@ -569,7 +569,7 @@ class DiagramTab extends AbstractTab {
 
             if (ln.id != null) {
                 lines.add(Line.from(
-                        Span.styled(" ID: ", Style.EMPTY.dim()),
+                        Span.styled(" ID: ", Theme.muted()),
                         Span.raw(ln.id)));
             }
 
@@ -592,15 +592,15 @@ class DiagramTab extends AbstractTab {
                 lines.add(Line.from(Span.raw("")));
                 int w = numWidth(stat.exchangesTotal, stat.exchangesFailed, stat.exchangesInflight);
                 lines.add(Line.from(
-                        Span.styled(" Total:    ", Style.EMPTY.dim()),
+                        Span.styled(" Total:    ", Theme.muted()),
                         Span.raw(String.format("%" + w + "d", stat.exchangesTotal))));
                 Style failStyle = stat.exchangesFailed > 0
                         ? Theme.error().bold() : Style.EMPTY;
                 lines.add(Line.from(
-                        Span.styled(" Failed:   ", Style.EMPTY.dim()),
+                        Span.styled(" Failed:   ", Theme.muted()),
                         Span.styled(String.format("%" + w + "d", stat.exchangesFailed), failStyle)));
                 lines.add(Line.from(
-                        Span.styled(" Inflight: ", Style.EMPTY.dim()),
+                        Span.styled(" Inflight: ", Theme.muted()),
                         Span.raw(String.format("%" + w + "d", stat.exchangesInflight))));
 
                 if (stat.exchangesTotal > 0) {
@@ -608,33 +608,33 @@ class DiagramTab extends AbstractTab {
                     int tw = numWidth(stat.meanProcessingTime, stat.maxProcessingTime,
                             stat.minProcessingTime, stat.lastProcessingTime);
                     lines.add(Line.from(
-                            Span.styled(" Mean: ", Style.EMPTY.dim()),
+                            Span.styled(" Mean: ", Theme.muted()),
                             Span.raw(String.format("%" + tw + "d ms", stat.meanProcessingTime))));
                     lines.add(Line.from(
-                            Span.styled(" Max:  ", Style.EMPTY.dim()),
+                            Span.styled(" Max:  ", Theme.muted()),
                             Span.raw(String.format("%" + tw + "d ms", stat.maxProcessingTime))));
                     lines.add(Line.from(
-                            Span.styled(" Min:  ", Style.EMPTY.dim()),
+                            Span.styled(" Min:  ", Theme.muted()),
                             Span.raw(String.format("%" + tw + "d ms", stat.minProcessingTime))));
                     lines.add(Line.from(
-                            Span.styled(" Last: ", Style.EMPTY.dim()),
+                            Span.styled(" Last: ", Theme.muted()),
                             Span.raw(String.format("%" + tw + "d ms", stat.lastProcessingTime))));
 
                     if (stat.lastCompletedExchangeTimestamp > 0 || stat.lastFailedExchangeTimestamp > 0) {
                         long now = System.currentTimeMillis();
                         lines.add(Line.from(Span.raw("")));
                         lines.add(Line.from(
-                                Span.styled(" Since last:", Style.EMPTY.dim())));
+                                Span.styled(" Since last:", Theme.muted())));
                         if (stat.lastCompletedExchangeTimestamp > 0) {
                             long ago = now - stat.lastCompletedExchangeTimestamp;
                             lines.add(Line.from(
-                                    Span.styled("   success: ", Style.EMPTY.dim()),
+                                    Span.styled("   success: ", Theme.muted()),
                                     Span.raw(TimeUtils.printDuration(ago, false))));
                         }
                         if (stat.lastFailedExchangeTimestamp > 0) {
                             long ago = now - stat.lastFailedExchangeTimestamp;
                             lines.add(Line.from(
-                                    Span.styled("   fail:    ", Style.EMPTY.dim()),
+                                    Span.styled("   fail:    ", Theme.muted()),
                                     Span.styled(TimeUtils.printDuration(ago, false),
                                             Theme.error())));
                         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -502,7 +502,7 @@ class DiagramTab extends AbstractTab {
                 boolean isBridge = "external".equals(topoNode.nodeType);
                 String label = isBridge ? " External" : isInbound ? " Inbound" : " Outbound";
                 lines.add(Line.from(
-                        Span.styled(label, Style.EMPTY.fg(Color.CYAN).bold())));
+                        Span.styled(label, Style.EMPTY.fg(Theme.accent()).bold())));
                 lines.add(Line.from(Span.raw("")));
                 lines.add(Line.from(
                         Span.styled(" URI: ", Style.EMPTY.dim()),
@@ -535,7 +535,7 @@ class DiagramTab extends AbstractTab {
                 }
             } else {
                 lines.add(Line.from(
-                        Span.styled(" " + routeId, Style.EMPTY.fg(Color.CYAN).bold())));
+                        Span.styled(" " + routeId, Style.EMPTY.fg(Theme.accent()).bold())));
                 lines.add(Line.from(
                         Span.styled(" (external endpoint)", Style.EMPTY.dim())));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DiagramTab.java
@@ -432,7 +432,7 @@ class DiagramTab extends AbstractTab {
                     Span.styled(" From:  ", Style.EMPTY.dim()),
                     Span.raw(route.from != null ? route.from : "")));
             String stateLabel = route.state != null ? route.state : "";
-            Style stateStyle = "Started".equals(route.state) ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY.fg(Color.LIGHT_RED);
+            Style stateStyle = "Started".equals(route.state) ? Theme.success() : Theme.error();
             lines.add(Line.from(
                     Span.styled(" State: ", Style.EMPTY.dim()),
                     Span.styled(stateLabel, stateStyle)));
@@ -455,7 +455,7 @@ class DiagramTab extends AbstractTab {
             lines.add(Line.from(
                     Span.styled(" Total:    ", Style.EMPTY.dim()),
                     Span.raw(String.format("%" + w + "d", route.total))));
-            Style failStyle = route.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY;
+            Style failStyle = route.failed > 0 ? Theme.error().bold() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled(" Failed:   ", Style.EMPTY.dim()),
                     Span.styled(String.format("%" + w + "d", route.failed), failStyle)));
@@ -490,7 +490,7 @@ class DiagramTab extends AbstractTab {
                     lines.add(Line.from(
                             Span.styled("   fail:    ", Style.EMPTY.dim()),
                             Span.styled(route.sinceLastFailed,
-                                    Style.EMPTY.fg(Color.LIGHT_RED))));
+                                    Theme.error())));
                 }
             }
 
@@ -530,7 +530,7 @@ class DiagramTab extends AbstractTab {
                         lines.add(Line.from(
                                 Span.styled(" Failed: ", Style.EMPTY.dim()),
                                 Span.styled(String.valueOf(topoNode.exchangesFailed),
-                                        Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+                                        Theme.error().bold())));
                     }
                 }
             } else {
@@ -595,7 +595,7 @@ class DiagramTab extends AbstractTab {
                         Span.styled(" Total:    ", Style.EMPTY.dim()),
                         Span.raw(String.format("%" + w + "d", stat.exchangesTotal))));
                 Style failStyle = stat.exchangesFailed > 0
-                        ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY;
+                        ? Theme.error().bold() : Style.EMPTY;
                 lines.add(Line.from(
                         Span.styled(" Failed:   ", Style.EMPTY.dim()),
                         Span.styled(String.format("%" + w + "d", stat.exchangesFailed), failStyle)));
@@ -636,7 +636,7 @@ class DiagramTab extends AbstractTab {
                             lines.add(Line.from(
                                     Span.styled("   fail:    ", Style.EMPTY.dim()),
                                     Span.styled(TimeUtils.printDuration(ago, false),
-                                            Style.EMPTY.fg(Color.LIGHT_RED))));
+                                            Theme.error())));
                         }
                     }
                 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DocViewerPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DocViewerPopup.java
@@ -25,9 +25,7 @@ import java.util.stream.Collectors;
 
 import dev.tamboui.layout.Rect;
 import dev.tamboui.markdown.MarkdownView;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
-import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -406,7 +404,7 @@ class DocViewerPopup {
         if (docTitle != null && docTitle.startsWith("Failed:")) {
             String rest = docTitle.substring("Failed:".length());
             title = Title.from(Line.from(
-                    Span.styled(" Failed:", Style.EMPTY.fg(Color.LIGHT_RED).bold()),
+                    Span.styled(" Failed:", Theme.error().bold()),
                     Span.raw(rest + " ")));
         } else {
             title = Title.from(" " + docTitle + " ");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DocViewerPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DocViewerPopup.java
@@ -433,6 +433,7 @@ class DocViewerPopup {
                     .source(docContent)
                     .scroll(docScroll)
                     .block(block)
+                    .styles(Theme.markdownStyles())
                     .build();
             frame.renderWidget(view, popup);
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -135,7 +135,7 @@ class DoctorPopup {
         }
         result.add(Line.from(
                 Span.raw(TuiIcons.indent(TuiIcons.JAVA)),
-                Span.styled(String.format("%-14s", "Java"), Style.EMPTY.bold()),
+                Span.styled(String.format("%-14s", "Java"), Theme.muted()),
                 Span.raw(String.format("%-30s", version + " (" + vendor + ")")),
                 Span.raw(" " + emoji)));
         if (status != null) {
@@ -149,13 +149,13 @@ class DoctorPopup {
             String version = catalog.getCatalogVersion();
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.CAMEL)),
-                    Span.styled(String.format("%-14s", "Camel"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Camel"), Theme.muted()),
                     Span.raw(String.format("%-30s", version)),
                     Span.raw(" " + TuiIcons.OK)));
         } catch (Exception e) {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.CAMEL)),
-                    Span.styled(String.format("%-14s", "Camel"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Camel"), Theme.muted()),
                     Span.raw(String.format("%-30s", "Not detected")),
                     Span.raw(" " + TuiIcons.FAIL)));
         }
@@ -166,13 +166,13 @@ class DoctorPopup {
         if (version != null) {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.BUNDLED)),
-                    Span.styled(String.format("%-14s", "JBang"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "JBang"), Theme.muted()),
                     Span.raw(String.format("%-30s", version)),
                     Span.raw(" " + TuiIcons.OK)));
         } else {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.BUNDLED)),
-                    Span.styled(String.format("%-14s", "JBang"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "JBang"), Theme.muted()),
                     Span.raw(String.format("%-30s", "Not detected")),
                     Span.raw(" " + TuiIcons.WARN)));
         }
@@ -188,13 +188,13 @@ class DoctorPopup {
                     Set.of(), false, false);
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.INFRA)),
-                    Span.styled(String.format("%-14s", "Maven"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Maven"), Theme.muted()),
                     Span.raw(String.format("%-30s", "Artifact resolution")),
                     Span.raw(" " + TuiIcons.OK)));
         } catch (MavenResolutionException e) {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.INFRA)),
-                    Span.styled(String.format("%-14s", "Maven"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Maven"), Theme.muted()),
                     Span.raw(String.format("%-30s", "Resolution failed")),
                     Span.raw(" " + TuiIcons.FAIL)));
             result.add(Line.from(Span.styled("                    " + TuiHelper.truncate(e.getMessage(), 40),
@@ -202,7 +202,7 @@ class DoctorPopup {
         } catch (Exception e) {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.INFRA)),
-                    Span.styled(String.format("%-14s", "Maven"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Maven"), Theme.muted()),
                     Span.raw(String.format("%-30s", "Error")),
                     Span.raw(" " + TuiIcons.FAIL)));
             result.add(Line.from(Span.styled("                    " + TuiHelper.truncate(e.getMessage(), 40),
@@ -222,7 +222,7 @@ class DoctorPopup {
                     String name = Character.toUpperCase(cmd.charAt(0)) + cmd.substring(1);
                     result.add(Line.from(
                             Span.raw(TuiIcons.indent(TuiIcons.DOCKER)),
-                            Span.styled(String.format("%-14s", "Container"), Style.EMPTY.bold()),
+                            Span.styled(String.format("%-14s", "Container"), Theme.muted()),
                             Span.raw(String.format("%-30s", name + " running")),
                             Span.raw(" " + TuiIcons.OK)));
                     return;
@@ -233,7 +233,7 @@ class DoctorPopup {
         }
         result.add(Line.from(
                 Span.raw(TuiIcons.indent(TuiIcons.DOCKER)),
-                Span.styled(String.format("%-14s", "Container"), Style.EMPTY.bold()),
+                Span.styled(String.format("%-14s", "Container"), Theme.muted()),
                 Span.raw(String.format("%-30s", "Not found (optional)")),
                 Span.raw(" " + TuiIcons.WARN)));
     }
@@ -251,13 +251,13 @@ class DoctorPopup {
         if (!conflicts.isEmpty()) {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.ENDPOINT)),
-                    Span.styled(String.format("%-14s", "Ports"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Ports"), Theme.muted()),
                     Span.raw(String.format("%-30s", "In use: " + conflicts)),
                     Span.raw(" " + TuiIcons.WARN)));
         } else {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.ENDPOINT)),
-                    Span.styled(String.format("%-14s", "Ports"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "Ports"), Theme.muted()),
                     Span.raw(String.format("%-30s", "8080, 8443, 9090 free")),
                     Span.raw(" " + TuiIcons.OK)));
         }
@@ -291,13 +291,13 @@ class DoctorPopup {
         if (provider != null) {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.MCP)),
-                    Span.styled(String.format("%-14s", "AI"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "AI"), Theme.muted()),
                     Span.raw(String.format("%-30s", provider)),
                     Span.raw(" " + TuiIcons.OK)));
         } else {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.MCP)),
-                    Span.styled(String.format("%-14s", "AI"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "AI"), Theme.muted()),
                     Span.raw(String.format("%-30s", "No API key configured")),
                     Span.raw(" " + TuiIcons.WARN)));
             result.add(Line.from(Span.styled("                    Set ANTHROPIC_API_KEY or OPENAI_API_KEY",
@@ -311,13 +311,13 @@ class DoctorPopup {
             if (client != null) {
                 result.add(Line.from(
                         Span.raw(TuiIcons.indent(TuiIcons.MCP)),
-                        Span.styled(String.format("%-14s", "MCP"), Style.EMPTY.bold()),
+                        Span.styled(String.format("%-14s", "MCP"), Theme.muted()),
                         Span.raw(String.format("%-30s", client + " (port " + mcpPort + ")")),
                         Span.raw(" " + TuiIcons.OK)));
             } else {
                 result.add(Line.from(
                         Span.raw(TuiIcons.indent(TuiIcons.MCP)),
-                        Span.styled(String.format("%-14s", "MCP"), Style.EMPTY.bold()),
+                        Span.styled(String.format("%-14s", "MCP"), Theme.muted()),
                         Span.raw(String.format("%-30s", "Listening on port " + mcpPort)),
                         Span.raw(" " + TuiIcons.WARN)));
                 result.add(Line.from(Span.styled("                    No AI client connected",
@@ -326,7 +326,7 @@ class DoctorPopup {
         } else {
             result.add(Line.from(
                     Span.raw(TuiIcons.indent(TuiIcons.MCP)),
-                    Span.styled(String.format("%-14s", "MCP"), Style.EMPTY.bold()),
+                    Span.styled(String.format("%-14s", "MCP"), Theme.muted()),
                     Span.raw(String.format("%-30s", "Not enabled")),
                     Span.raw(" " + TuiIcons.WARN)));
             result.add(Line.from(Span.styled("                    Use --mcp to enable MCP server",
@@ -344,7 +344,7 @@ class DoctorPopup {
         long value = gb > 0 ? gb : mb;
         result.add(Line.from(
                 Span.raw(TuiIcons.indent(TuiIcons.MEMORY)),
-                Span.styled(String.format("%-14s", "Disk Space"), Style.EMPTY.bold()),
+                Span.styled(String.format("%-14s", "Disk Space"), Theme.muted()),
                 Span.raw(String.format("%-30s", value + " " + unit + " free in temp dir")),
                 Span.raw(" " + emoji)));
         if (mb <= 500) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -221,7 +221,7 @@ class EndpointsTab extends AbstractTableTab {
             Style dirStyle = switch (dir) {
                 case "in" -> Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN));
                 case "out" -> Style.EMPTY.fg(Color.CYAN);
-                default -> Style.EMPTY.fg(Color.YELLOW);
+                default -> Theme.label();
             };
             String arrow = switch (dir) {
                 case "in" -> TuiIcons.KEY_RIGHT + " ";
@@ -480,7 +480,7 @@ class EndpointsTab extends AbstractTableTab {
         flowLines.add(Line.from(
                 Span.styled(arrowStr, inStyle),
                 Span.raw(" "),
-                Span.styled(box, Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(box, Theme.label().bold()),
                 Span.raw(" "),
                 Span.styled(arrowStr, outStyle)));
         flowLines.add(Line.from(
@@ -593,7 +593,7 @@ class EndpointsTab extends AbstractTableTab {
         flowLines.add(Line.from(
                 Span.styled(arrowStr, inStyle),
                 Span.raw(" "),
-                Span.styled(box, Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(box, Theme.label().bold()),
                 Span.raw(" "),
                 Span.styled(arrowStr, outStyle)));
         flowLines.add(Line.from(
@@ -634,7 +634,7 @@ class EndpointsTab extends AbstractTableTab {
 
         Line chartTitle = Line.from(
                 Span.raw(" ["),
-                Span.styled(uriLabel, Style.EMPTY.fg(Color.YELLOW)),
+                Span.styled(uriLabel, Theme.label().bold()),
                 Span.raw("] "),
                 Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
@@ -675,7 +675,7 @@ class EndpointsTab extends AbstractTableTab {
         long curOut = outArr[renderPoints - 1];
 
         Line chartTitle = Line.from(
-                Span.styled("▬", Style.EMPTY.fg(Color.YELLOW)),
+                Span.styled("▬", Theme.label()),
                 Span.raw(String.format(" in:%-8s ", sizeToString(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.MAGENTA)),
                 Span.raw(String.format(" out:%-8s avg body", sizeToString(curOut))));
@@ -683,7 +683,7 @@ class EndpointsTab extends AbstractTableTab {
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
-                .topStyle(Style.EMPTY.fg(Color.YELLOW))
+                .topStyle(Theme.label())
                 .bottomStyle(Style.EMPTY.fg(Color.MAGENTA))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -218,7 +218,7 @@ class EndpointsTab extends AbstractTableTab {
         for (EndpointInfo ep : sortedEndpoints) {
             String dir = ep.direction != null ? ep.direction : "";
             Style dirStyle = switch (dir) {
-                case "in" -> Style.EMPTY.fg(Color.GREEN);
+                case "in" -> Theme.success();
                 case "out" -> Style.EMPTY.fg(Color.CYAN);
                 default -> Theme.label();
             };
@@ -465,7 +465,7 @@ class EndpointsTab extends AbstractTableTab {
         String inLabelStr = " ".repeat(inLabelPad) + "in" + " ".repeat(sideLen - inLabelPad - 2);
         String outLabelStr = " ".repeat(outLabelPad) + "out";
 
-        Style inStyle = Style.EMPTY.fg(Color.GREEN);
+        Style inStyle = Theme.success();
         Style outStyle = Style.EMPTY.fg(Color.CYAN);
         Style dimStyle = Style.EMPTY.dim();
 
@@ -522,7 +522,7 @@ class EndpointsTab extends AbstractTableTab {
         long curOut = outArr[renderPoints - 1];
 
         Line chartTitle = Line.from(
-                Span.styled("▬", Style.EMPTY.fg(Color.GREEN)),
+                Span.styled("▬", Theme.success()),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
                 Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
@@ -531,7 +531,7 @@ class EndpointsTab extends AbstractTableTab {
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
-                .topStyle(Style.EMPTY.fg(Color.GREEN))
+                .topStyle(Theme.success())
                 .bottomStyle(Style.EMPTY.fg(Color.CYAN))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
@@ -578,7 +578,7 @@ class EndpointsTab extends AbstractTableTab {
         String inLabelStr = " ".repeat(inLabelPad) + "in" + " ".repeat(sideLen - inLabelPad - 2);
         String outLabelStr = " ".repeat(outLabelPad) + "out";
 
-        Style inStyle = Style.EMPTY.fg(Color.GREEN);
+        Style inStyle = Theme.success();
         Style outStyle = Style.EMPTY.fg(Color.CYAN);
         Style dimStyle = Style.EMPTY.dim();
 
@@ -635,7 +635,7 @@ class EndpointsTab extends AbstractTableTab {
                 Span.raw(" ["),
                 Span.styled(uriLabel, Theme.label().bold()),
                 Span.raw("] "),
-                Span.styled("▬", Style.EMPTY.fg(Color.GREEN)),
+                Span.styled("▬", Theme.success()),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
                 Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
@@ -643,7 +643,7 @@ class EndpointsTab extends AbstractTableTab {
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
-                .topStyle(Style.EMPTY.fg(Color.GREEN))
+                .topStyle(Theme.success())
                 .bottomStyle(Style.EMPTY.fg(Color.CYAN))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -29,7 +29,6 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.markdown.MarkdownView;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.CharWidth;
@@ -219,7 +218,7 @@ class EndpointsTab extends AbstractTableTab {
             String dir = ep.direction != null ? ep.direction : "";
             Style dirStyle = switch (dir) {
                 case "in" -> Theme.success();
-                case "out" -> Style.EMPTY.fg(Color.CYAN);
+                case "out" -> Style.EMPTY.fg(Theme.accent());
                 default -> Theme.label();
             };
             String arrow = switch (dir) {
@@ -229,7 +228,7 @@ class EndpointsTab extends AbstractTableTab {
             };
 
             List<Cell> cells = new ArrayList<>();
-            cells.add(Cell.from(Span.styled(ep.component != null ? ep.component : "", Style.EMPTY.fg(Color.CYAN))));
+            cells.add(Cell.from(Span.styled(ep.component != null ? ep.component : "", Style.EMPTY.fg(Theme.accent()))));
             cells.add(Cell.from(ep.routeId != null ? ep.routeId : ""));
             cells.add(Cell.from(Span.styled(arrow + dir, dirStyle)));
             cells.add(rightCell(ep.hits > 0 ? String.valueOf(ep.hits) : "", 8));
@@ -466,7 +465,7 @@ class EndpointsTab extends AbstractTableTab {
         String outLabelStr = " ".repeat(outLabelPad) + "out";
 
         Style inStyle = Theme.success();
-        Style outStyle = Style.EMPTY.fg(Color.CYAN);
+        Style outStyle = Style.EMPTY.fg(Theme.accent());
         Style dimStyle = Style.EMPTY.dim();
 
         List<Line> flowLines = new ArrayList<>();
@@ -524,7 +523,7 @@ class EndpointsTab extends AbstractTableTab {
         Line chartTitle = Line.from(
                 Span.styled("▬", Theme.success()),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
-                Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
+                Span.styled("▬", Style.EMPTY.fg(Theme.accent())),
                 Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
 
         Rect rightArea = hParts.get(1);
@@ -532,7 +531,7 @@ class EndpointsTab extends AbstractTableTab {
                 .topData(inArr)
                 .bottomData(outArr)
                 .topStyle(Theme.success())
-                .bottomStyle(Style.EMPTY.fg(Color.CYAN))
+                .bottomStyle(Style.EMPTY.fg(Theme.accent()))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
@@ -579,7 +578,7 @@ class EndpointsTab extends AbstractTableTab {
         String outLabelStr = " ".repeat(outLabelPad) + "out";
 
         Style inStyle = Theme.success();
-        Style outStyle = Style.EMPTY.fg(Color.CYAN);
+        Style outStyle = Style.EMPTY.fg(Theme.accent());
         Style dimStyle = Style.EMPTY.dim();
 
         List<Line> flowLines = new ArrayList<>();
@@ -637,14 +636,14 @@ class EndpointsTab extends AbstractTableTab {
                 Span.raw("] "),
                 Span.styled("▬", Theme.success()),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
-                Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
+                Span.styled("▬", Style.EMPTY.fg(Theme.accent())),
                 Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
 
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
                 .topStyle(Theme.success())
-                .bottomStyle(Style.EMPTY.fg(Color.CYAN))
+                .bottomStyle(Style.EMPTY.fg(Theme.accent()))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")
@@ -676,14 +675,14 @@ class EndpointsTab extends AbstractTableTab {
         Line chartTitle = Line.from(
                 Span.styled("▬", Theme.label()),
                 Span.raw(String.format(" in:%-8s ", sizeToString(curIn))),
-                Span.styled("▬", Style.EMPTY.fg(Color.MAGENTA)),
+                Span.styled("▬", Theme.notice()),
                 Span.raw(String.format(" out:%-8s avg body", sizeToString(curOut))));
 
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
                 .topStyle(Theme.label())
-                .bottomStyle(Style.EMPTY.fg(Color.MAGENTA))
+                .bottomStyle(Theme.notice())
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
                         "-" + (renderPoints / 2) + "s", "-" + (renderPoints / 4) + "s", "now")

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -29,7 +29,6 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.markdown.MarkdownView;
-import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -219,7 +218,7 @@ class EndpointsTab extends AbstractTableTab {
         for (EndpointInfo ep : sortedEndpoints) {
             String dir = ep.direction != null ? ep.direction : "";
             Style dirStyle = switch (dir) {
-                case "in" -> Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN));
+                case "in" -> Style.EMPTY.fg(Color.GREEN);
                 case "out" -> Style.EMPTY.fg(Color.CYAN);
                 default -> Theme.label();
             };
@@ -466,7 +465,7 @@ class EndpointsTab extends AbstractTableTab {
         String inLabelStr = " ".repeat(inLabelPad) + "in" + " ".repeat(sideLen - inLabelPad - 2);
         String outLabelStr = " ".repeat(outLabelPad) + "out";
 
-        Style inStyle = Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN));
+        Style inStyle = Style.EMPTY.fg(Color.GREEN);
         Style outStyle = Style.EMPTY.fg(Color.CYAN);
         Style dimStyle = Style.EMPTY.dim();
 
@@ -523,7 +522,7 @@ class EndpointsTab extends AbstractTableTab {
         long curOut = outArr[renderPoints - 1];
 
         Line chartTitle = Line.from(
-                Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
+                Span.styled("▬", Style.EMPTY.fg(Color.GREEN)),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
                 Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
@@ -532,7 +531,7 @@ class EndpointsTab extends AbstractTableTab {
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
-                .topStyle(Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN)))
+                .topStyle(Style.EMPTY.fg(Color.GREEN))
                 .bottomStyle(Style.EMPTY.fg(Color.CYAN))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",
@@ -579,7 +578,7 @@ class EndpointsTab extends AbstractTableTab {
         String inLabelStr = " ".repeat(inLabelPad) + "in" + " ".repeat(sideLen - inLabelPad - 2);
         String outLabelStr = " ".repeat(outLabelPad) + "out";
 
-        Style inStyle = Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN));
+        Style inStyle = Style.EMPTY.fg(Color.GREEN);
         Style outStyle = Style.EMPTY.fg(Color.CYAN);
         Style dimStyle = Style.EMPTY.dim();
 
@@ -636,7 +635,7 @@ class EndpointsTab extends AbstractTableTab {
                 Span.raw(" ["),
                 Span.styled(uriLabel, Theme.label().bold()),
                 Span.raw("] "),
-                Span.styled("▬", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
+                Span.styled("▬", Style.EMPTY.fg(Color.GREEN)),
                 Span.raw(String.format(" in:%-4s ", MetricsCollector.formatThroughput(curIn))),
                 Span.styled("▬", Style.EMPTY.fg(Color.CYAN)),
                 Span.raw(String.format(" out:%-4s msg/s", MetricsCollector.formatThroughput(curOut))));
@@ -644,7 +643,7 @@ class EndpointsTab extends AbstractTableTab {
         frame.renderWidget(DualSparkline.builder()
                 .topData(inArr)
                 .bottomData(outArr)
-                .topStyle(Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN)))
+                .topStyle(Style.EMPTY.fg(Color.GREEN))
                 .bottomStyle(Style.EMPTY.fg(Color.CYAN))
                 .showYAxis(true)
                 .xLabels("-" + renderPoints + "s", "-" + (renderPoints * 3 / 4) + "s",

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTab.java
@@ -699,6 +699,7 @@ class EndpointsTab extends AbstractTableTab {
                             .source("*Select an endpoint*")
                             .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Endpoint Detail ").build())
+                            .styles(Theme.markdownStyles())
                             .build(),
                     area);
             return;
@@ -713,6 +714,7 @@ class EndpointsTab extends AbstractTableTab {
                             .source("*No endpoint URI*")
                             .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Endpoint Detail ").build())
+                            .styles(Theme.markdownStyles())
                             .build(),
                     area);
             return;
@@ -812,6 +814,7 @@ class EndpointsTab extends AbstractTableTab {
                         .scroll(detailScroll)
                         .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                 .title(title).build())
+                        .styles(Theme.markdownStyles())
                         .build(),
                 area);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -567,7 +567,7 @@ class ErrorsTab extends AbstractTableTab {
     }
 
     private Line buildErrorBreadcrumbTitle() {
-        Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style nameStyle = Theme.label().bold();
         List<Span> spans = new ArrayList<>();
         spans.add(Span.styled(" Error [", Style.EMPTY.fg(Color.WHITE)));
         var stack = diagram.getHistoryNavigationStack();
@@ -606,27 +606,27 @@ class ErrorsTab extends AbstractTableTab {
         }
 
         lines.add(Line.from(
-                Span.styled(" Exchange: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Exchange: ", Theme.label().bold()),
                 Span.raw(ei.exchangeId != null ? ei.exchangeId : "")));
         lines.add(Line.from(
-                Span.styled(" Route:    ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Route:    ", Theme.label().bold()),
                 Span.styled(ei.routeId != null ? ei.routeId : "", Style.EMPTY.fg(Color.CYAN))));
         lines.add(Line.from(
-                Span.styled(" Node:     ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Node:     ", Theme.label().bold()),
                 Span.raw(ei.nodeId != null ? ei.nodeId : "")));
         if (ei.elapsed >= 0) {
             lines.add(Line.from(
-                    Span.styled(" Elapsed:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Elapsed:  ", Theme.label().bold()),
                     Span.raw(ei.elapsed + "ms")));
         }
         if (ei.threadName != null) {
             lines.add(Line.from(
-                    Span.styled(" Thread:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Thread:   ", Theme.label().bold()),
                     Span.raw(ei.threadName)));
         }
         Style handledStyle = ei.handled ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY.fg(Color.LIGHT_RED).bold();
         lines.add(Line.from(
-                Span.styled(" Handled:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Handled:  ", Theme.label().bold()),
                 Span.styled(ei.handled ? "true" : "false", handledStyle)));
 
         if (ei.exceptionType != null) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -605,27 +605,27 @@ class ErrorsTab extends AbstractTableTab {
         }
 
         lines.add(Line.from(
-                Span.styled(" Exchange: ", Theme.label().bold()),
+                Span.styled(" Exchange: ", Theme.muted()),
                 Span.raw(ei.exchangeId != null ? ei.exchangeId : "")));
         lines.add(Line.from(
-                Span.styled(" Route:    ", Theme.label().bold()),
+                Span.styled(" Route:    ", Theme.muted()),
                 Span.styled(ei.routeId != null ? ei.routeId : "", Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
-                Span.styled(" Node:     ", Theme.label().bold()),
+                Span.styled(" Node:     ", Theme.muted()),
                 Span.raw(ei.nodeId != null ? ei.nodeId : "")));
         if (ei.elapsed >= 0) {
             lines.add(Line.from(
-                    Span.styled(" Elapsed:  ", Theme.label().bold()),
+                    Span.styled(" Elapsed:  ", Theme.muted()),
                     Span.raw(ei.elapsed + "ms")));
         }
         if (ei.threadName != null) {
             lines.add(Line.from(
-                    Span.styled(" Thread:   ", Theme.label().bold()),
+                    Span.styled(" Thread:   ", Theme.muted()),
                     Span.raw(ei.threadName)));
         }
         Style handledStyle = ei.handled ? Theme.success() : Theme.error().bold();
         lines.add(Line.from(
-                Span.styled(" Handled:  ", Theme.label().bold()),
+                Span.styled(" Handled:  ", Theme.muted()),
                 Span.styled(ei.handled ? "true" : "false", handledStyle)));
 
         if (ei.exceptionType != null) {
@@ -640,7 +640,7 @@ class ErrorsTab extends AbstractTableTab {
         if (showBody && ei.body != null) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled(" Body", Theme.success().bold()),
+                    Span.styled(" Body", Theme.muted()),
                     ei.bodyType != null ? Span.styled(" (" + ei.bodyType + ")", Style.EMPTY.dim()) : Span.raw("")));
             for (String line : ei.body.split("\n")) {
                 lines.add(Line.from(Span.raw(" " + line)));
@@ -649,19 +649,19 @@ class ErrorsTab extends AbstractTableTab {
 
         if (showHeaders && !ei.headers.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Headers", Theme.success().bold())));
+            lines.add(Line.from(Span.styled(" Headers", Theme.muted())));
             addKvLines(lines, ei.headers);
         }
 
         if (showProperties && !ei.properties.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Properties", Theme.success().bold())));
+            lines.add(Line.from(Span.styled(" Properties", Theme.muted())));
             addKvLines(lines, ei.properties);
         }
 
         if (showVariables && !ei.variables.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Variables", Theme.success().bold())));
+            lines.add(Line.from(Span.styled(" Variables", Theme.muted())));
             addKvLines(lines, ei.variables);
         }
 
@@ -678,7 +678,7 @@ class ErrorsTab extends AbstractTableTab {
         for (var entry : map.entrySet()) {
             String val = entry.getValue() != null ? entry.getValue().toString() : "null";
             lines.add(Line.from(
-                    Span.styled(" " + entry.getKey(), Style.EMPTY.fg(Theme.accent())),
+                    Span.styled(" " + entry.getKey(), Theme.muted()),
                     Span.raw(" = " + val)));
         }
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -335,7 +335,7 @@ class ErrorsTab extends AbstractTableTab {
                     ? org.apache.camel.util.TimeUtils.printSince(ei.timestamp) : "";
             String handledStr = ei.handled ? "true" : "false";
             Style handledStyle = ei.handled
-                    ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY.fg(Color.LIGHT_RED);
+                    ? Theme.success() : Theme.error();
             String shortException = shortExceptionType(ei.exceptionType);
 
             rows.add(Row.from(
@@ -624,14 +624,14 @@ class ErrorsTab extends AbstractTableTab {
                     Span.styled(" Thread:   ", Theme.label().bold()),
                     Span.raw(ei.threadName)));
         }
-        Style handledStyle = ei.handled ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY.fg(Color.LIGHT_RED).bold();
+        Style handledStyle = ei.handled ? Theme.success() : Theme.error().bold();
         lines.add(Line.from(
                 Span.styled(" Handled:  ", Theme.label().bold()),
                 Span.styled(ei.handled ? "true" : "false", handledStyle)));
 
         if (ei.exceptionType != null) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Exception", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+            lines.add(Line.from(Span.styled(" Exception", Theme.error().bold())));
             lines.add(Line.from(Span.raw(" " + ei.exceptionType)));
             if (ei.exceptionMessage != null) {
                 lines.add(Line.from(Span.raw(" " + ei.exceptionMessage)));
@@ -641,7 +641,7 @@ class ErrorsTab extends AbstractTableTab {
         if (showBody && ei.body != null) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled(" Body", Style.EMPTY.fg(Color.GREEN).bold()),
+                    Span.styled(" Body", Theme.success().bold()),
                     ei.bodyType != null ? Span.styled(" (" + ei.bodyType + ")", Style.EMPTY.dim()) : Span.raw("")));
             for (String line : ei.body.split("\n")) {
                 lines.add(Line.from(Span.raw(" " + line)));
@@ -650,19 +650,19 @@ class ErrorsTab extends AbstractTableTab {
 
         if (showHeaders && !ei.headers.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Headers", Style.EMPTY.fg(Color.GREEN).bold())));
+            lines.add(Line.from(Span.styled(" Headers", Theme.success().bold())));
             addKvLines(lines, ei.headers);
         }
 
         if (showProperties && !ei.properties.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Properties", Style.EMPTY.fg(Color.GREEN).bold())));
+            lines.add(Line.from(Span.styled(" Properties", Theme.success().bold())));
             addKvLines(lines, ei.properties);
         }
 
         if (showVariables && !ei.variables.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Variables", Style.EMPTY.fg(Color.GREEN).bold())));
+            lines.add(Line.from(Span.styled(" Variables", Theme.success().bold())));
             addKvLines(lines, ei.variables);
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -341,7 +340,7 @@ class ErrorsTab extends AbstractTableTab {
             rows.add(Row.from(
                     Cell.from(ei.exchangeId != null ? ei.exchangeId : ""),
                     Cell.from(ago),
-                    Cell.from(Span.styled(ei.routeId != null ? ei.routeId : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(ei.routeId != null ? ei.routeId : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(ei.nodeId != null ? ei.nodeId : ""),
                     Cell.from(Span.styled(handledStr, handledStyle)),
                     Cell.from(shortException),
@@ -480,7 +479,7 @@ class ErrorsTab extends AbstractTableTab {
 
         // message history
         if (ei.messageHistory != null && ei.messageHistory.length > 0) {
-            lines.add(Line.from(Span.styled(" Message History:", Style.EMPTY.fg(Color.MAGENTA).bold())));
+            lines.add(Line.from(Span.styled(" Message History:", Theme.notice().bold())));
             for (String step : ei.messageHistory) {
                 lines.add(Line.from(Span.raw("   " + TuiHelper.fixControlChars(step))));
             }
@@ -576,7 +575,7 @@ class ErrorsTab extends AbstractTableTab {
         } else {
             for (var it = stack.descendingIterator(); it.hasNext();) {
                 spans.add(Span.styled(it.next(), nameStyle));
-                spans.add(Span.styled(" → ", Style.EMPTY.fg(Color.GRAY)));
+                spans.add(Span.styled(" → ", Theme.muted()));
             }
             spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
         }
@@ -610,7 +609,7 @@ class ErrorsTab extends AbstractTableTab {
                 Span.raw(ei.exchangeId != null ? ei.exchangeId : "")));
         lines.add(Line.from(
                 Span.styled(" Route:    ", Theme.label().bold()),
-                Span.styled(ei.routeId != null ? ei.routeId : "", Style.EMPTY.fg(Color.CYAN))));
+                Span.styled(ei.routeId != null ? ei.routeId : "", Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
                 Span.styled(" Node:     ", Theme.label().bold()),
                 Span.raw(ei.nodeId != null ? ei.nodeId : "")));
@@ -679,7 +678,7 @@ class ErrorsTab extends AbstractTableTab {
         for (var entry : map.entrySet()) {
             String val = entry.getValue() != null ? entry.getValue().toString() : "null";
             lines.add(Line.from(
-                    Span.styled(" " + entry.getKey(), Style.EMPTY.fg(Color.CYAN)),
+                    Span.styled(" " + entry.getKey(), Style.EMPTY.fg(Theme.accent())),
                     Span.raw(" = " + val)));
         }
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTab.java
@@ -313,7 +313,7 @@ class ErrorsTab extends AbstractTableTab {
                     Line title = Line.from(Span.styled(
                             String.format(" Error Topology — step %d/%d ",
                                     diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
-                            Style.EMPTY.fg(Color.WHITE)));
+                            Style.EMPTY.fg(Theme.baseFg())));
                     diagram.renderHistoryTopologyDiagram(frame, diagramArea, title);
                 } else {
                     String routeId = diagram.getHistoryDrillDownRouteId();
@@ -569,7 +569,7 @@ class ErrorsTab extends AbstractTableTab {
     private Line buildErrorBreadcrumbTitle() {
         Style nameStyle = Theme.label().bold();
         List<Span> spans = new ArrayList<>();
-        spans.add(Span.styled(" Error [", Style.EMPTY.fg(Color.WHITE)));
+        spans.add(Span.styled(" Error [", Style.EMPTY.fg(Theme.baseFg())));
         var stack = diagram.getHistoryNavigationStack();
         if (stack.isEmpty()) {
             spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
@@ -582,7 +582,7 @@ class ErrorsTab extends AbstractTableTab {
         }
         spans.add(Span.styled(String.format("] — step %d/%d ",
                 diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
-                Style.EMPTY.fg(Color.WHITE)));
+                Style.EMPTY.fg(Theme.baseFg())));
         return Line.from(spans);
     }
 
@@ -687,10 +687,10 @@ class ErrorsTab extends AbstractTableTab {
     private static void hintShowBhpv(List<Span> spans, boolean body, boolean headers, boolean props, boolean vars) {
         spans.add(Span.styled(" show", Theme.hintKey()));
         spans.add(Span.raw(" "));
-        spans.add(Span.styled(body ? "B" : "b", body ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
-        spans.add(Span.styled(headers ? "H" : "h", headers ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
-        spans.add(Span.styled(props ? "P" : "p", props ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
-        spans.add(Span.styled(vars ? "V" : "v", vars ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(body ? "B" : "b", body ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(headers ? "H" : "h", headers ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(props ? "P" : "p", props ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(vars ? "V" : "v", vars ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
         spans.add(Span.raw("  "));
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FilesBrowser.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FilesBrowser.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.CharWidth;
@@ -263,7 +262,7 @@ class FilesBrowser {
             if (entry.directory()) {
                 String label = String.format("  %s %-" + nameWidth + "s", entry.emoji(), entry.name());
                 boolean dimDir = entry.name().startsWith(".") || "target".equals(entry.name());
-                Style dirStyle = dimDir ? Style.EMPTY.fg(Color.CYAN).dim() : Style.EMPTY.fg(Color.CYAN);
+                Style dirStyle = dimDir ? Style.EMPTY.fg(Theme.accent()).dim() : Style.EMPTY.fg(Theme.accent());
                 items[i] = ListItem.from(Line.from(Span.styled(label, dirStyle)));
             } else {
                 String sizeStr = formatFileSize(entry.size());

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FilesBrowser.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FilesBrowser.java
@@ -284,7 +284,7 @@ class FilesBrowser {
                 .block(Block.builder()
                         .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(Line
-                                .from(Span.styled(popupTitle, Style.EMPTY.fg(Color.YELLOW).bold()))))
+                                .from(Span.styled(popupTitle, Theme.label().bold()))))
                         .build())
                 .build();
         frame.renderStatefulWidget(list, popup, listState);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FolderBrowser.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FolderBrowser.java
@@ -354,7 +354,7 @@ class FolderBrowser {
                 .block(Block.builder()
                         .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(Line
-                                .from(Span.styled(popupTitle, Style.EMPTY.fg(Color.YELLOW).bold()))))
+                                .from(Span.styled(popupTitle, Theme.label().bold()))))
                         .build())
                 .build();
         frame.renderStatefulWidget(list, popup, listState);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FolderBrowser.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FolderBrowser.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -342,7 +341,7 @@ class FolderBrowser {
         for (int i = 0; i < entries.size(); i++) {
             DirEntry entry = entries.get(i);
             String label = "  " + entry.emoji() + " " + entry.name();
-            Style style = entry.directory() ? Style.EMPTY.fg(Color.CYAN) : Style.EMPTY;
+            Style style = entry.directory() ? Style.EMPTY.fg(Theme.accent()) : Style.EMPTY;
             items[i] = ListItem.from(Line.from(Span.styled(label, style)));
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/GotoTabPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/GotoTabPopup.java
@@ -192,7 +192,7 @@ class GotoTabPopup {
             String sc = entry.shortcut();
             spans.add(Span.raw(" "));
             spans.add(Span.styled(sc, Theme.mnemonic()));
-            spans.add(Span.raw(" ".repeat(Math.max(1, 3 - sc.length()))));
+            spans.add(Span.raw(" " + entry.icon() + " "));
             String name = entry.name();
             if (name.length() > nameColWidth) {
                 name = name.substring(0, nameColWidth);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/GotoTabPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/GotoTabPopup.java
@@ -189,8 +189,10 @@ class GotoTabPopup {
         Style dimStyle = Style.EMPTY.dim();
         for (TabRegistry.TabEntry entry : filteredEntries) {
             List<Span> spans = new ArrayList<>();
-            String key = String.format(" %-2s ", entry.shortcut());
-            spans.add(Span.styled(key, dimStyle));
+            String sc = entry.shortcut();
+            spans.add(Span.raw(" "));
+            spans.add(Span.styled(sc, Theme.mnemonic()));
+            spans.add(Span.raw(" ".repeat(Math.max(1, 3 - sc.length()))));
             String name = entry.name();
             if (name.length() > nameColWidth) {
                 name = name.substring(0, nameColWidth);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/GotoTabPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/GotoTabPopup.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -186,7 +185,7 @@ class GotoTabPopup {
         items.add(ListItem.from(Line.from(Span.styled(sep, Style.EMPTY.dim()))));
 
         Style normalStyle = Style.EMPTY;
-        Style matchStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style matchStyle = Theme.label().bold();
         Style dimStyle = Style.EMPTY.dim();
         for (TabRegistry.TabEntry entry : filteredEntries) {
             List<Span> spans = new ArrayList<>();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
@@ -97,10 +97,10 @@ class HealthTab extends AbstractTableTab {
             Style stateStyle;
             String icon;
             if ("UP".equals(hc.state)) {
-                stateStyle = Style.EMPTY.fg(Color.GREEN);
+                stateStyle = Theme.success();
                 icon = TuiIcons.HEALTH_UP + " ";
             } else if ("DOWN".equals(hc.state)) {
-                stateStyle = Style.EMPTY.fg(Color.LIGHT_RED);
+                stateStyle = Theme.error();
                 icon = TuiIcons.HEALTH_DOWN + " ";
             } else {
                 stateStyle = Theme.warning();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
@@ -103,7 +103,7 @@ class HealthTab extends AbstractTableTab {
                 stateStyle = Style.EMPTY.fg(Color.LIGHT_RED);
                 icon = TuiIcons.HEALTH_DOWN + " ";
             } else {
-                stateStyle = Style.EMPTY.fg(Color.YELLOW);
+                stateStyle = Theme.warning();
                 icon = TuiIcons.HEALTH_WARN + " ";
             }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTab.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Span;
@@ -117,7 +116,7 @@ class HealthTab extends AbstractTableTab {
 
             rows.add(Row.from(
                     Cell.from(Span.styled(" " + (hc.group != null ? hc.group : ""), Style.EMPTY.dim())),
-                    Cell.from(Span.styled(hc.name != null ? hc.name : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(hc.name != null ? hc.name : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(icon + hc.state, stateStyle)),
                     Cell.from(kind),
                     Cell.from(hc.message != null ? hc.message : "")));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -132,7 +131,7 @@ class HeapHistogramTab extends AbstractTableTab {
         for (HeapEntry e : visible) {
             rows.add(Row.from(
                     rightCell(String.valueOf(e.num), 6),
-                    Cell.from(Span.styled(e.className != null ? e.className : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(e.className != null ? e.className : "", Style.EMPTY.fg(Theme.accent()))),
                     rightCell(formatNumber(e.instances), 14),
                     rightCell(formatBytes(e.bytes), 14)));
         }
@@ -194,7 +193,7 @@ class HeapHistogramTab extends AbstractTableTab {
         // Class info
         lines.add(Line.from(
                 Span.styled("  Class:      ", Theme.label().bold()),
-                Span.styled(className, Style.EMPTY.fg(Color.CYAN))));
+                Span.styled(className, Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
                 Span.styled("  Package:    ", Theme.label().bold()),
                 Span.styled(pkg.isEmpty() ? "(none)" : pkg,

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
@@ -192,16 +192,16 @@ class HeapHistogramTab extends AbstractTableTab {
 
         // Class info
         lines.add(Line.from(
-                Span.styled("  Class:      ", Theme.label().bold()),
+                Span.styled("  Class:      ", Theme.muted()),
                 Span.styled(className, Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
-                Span.styled("  Package:    ", Theme.label().bold()),
+                Span.styled("  Package:    ", Theme.muted()),
                 Span.styled(pkg.isEmpty() ? "(none)" : pkg,
                         pkg.isEmpty() ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
-                Span.styled("  Instances:  ", Theme.label().bold()),
+                Span.styled("  Instances:  ", Theme.muted()),
                 Span.styled(formatNumber(entry.instances), Style.EMPTY.fg(Theme.baseFg())),
-                Span.styled("          Bytes: ", Theme.label().bold()),
+                Span.styled("          Bytes: ", Theme.muted()),
                 Span.styled(formatBytes(entry.bytes), Style.EMPTY.fg(Theme.baseFg()))));
 
         // Package summary
@@ -218,14 +218,14 @@ class HeapHistogramTab extends AbstractTableTab {
             }
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Package Summary ", Theme.label().bold()),
+                    Span.styled("  Package Summary ", Theme.muted()),
                     Span.styled("(" + pkg + ")", Style.EMPTY.dim())));
             lines.add(Line.from(
-                    Span.styled("    Classes: ", Theme.label()),
+                    Span.styled("    Classes: ", Theme.muted()),
                     Span.styled(formatNumber(pkgClasses), Style.EMPTY.fg(Theme.baseFg())),
-                    Span.styled("     Instances: ", Theme.label()),
+                    Span.styled("     Instances: ", Theme.muted()),
                     Span.styled(formatNumber(pkgInstances), Style.EMPTY.fg(Theme.baseFg())),
-                    Span.styled("     Bytes: ", Theme.label()),
+                    Span.styled("     Bytes: ", Theme.muted()),
                     Span.styled(formatBytes(pkgBytes), Style.EMPTY.fg(Theme.baseFg()))));
         }
 
@@ -235,12 +235,12 @@ class HeapHistogramTab extends AbstractTableTab {
             lines.add(Line.from(Span.raw("")));
             if (jar.groupId() != null) {
                 lines.add(Line.from(
-                        Span.styled("  JAR:        ", Theme.label().bold()),
+                        Span.styled("  JAR:        ", Theme.muted()),
                         Span.styled(jar.groupId() + ":" + jar.artifactId() + ":" + jar.version(),
                                 Theme.success())));
             } else {
                 lines.add(Line.from(
-                        Span.styled("  JAR:        ", Theme.label().bold()),
+                        Span.styled("  JAR:        ", Theme.muted()),
                         Span.styled(jar.display(), Theme.success())));
             }
             if (jar.fullPath() != null) {
@@ -256,7 +256,7 @@ class HeapHistogramTab extends AbstractTableTab {
         } else if (isBuiltinClass(className)) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  JAR:        ", Theme.label().bold()),
+                    Span.styled("  JAR:        ", Theme.muted()),
                     Span.styled("JDK (built-in)", Theme.success())));
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
@@ -238,11 +238,11 @@ class HeapHistogramTab extends AbstractTableTab {
                 lines.add(Line.from(
                         Span.styled("  JAR:        ", Theme.label().bold()),
                         Span.styled(jar.groupId() + ":" + jar.artifactId() + ":" + jar.version(),
-                                Style.EMPTY.fg(Color.GREEN))));
+                                Theme.success())));
             } else {
                 lines.add(Line.from(
                         Span.styled("  JAR:        ", Theme.label().bold()),
-                        Span.styled(jar.display(), Style.EMPTY.fg(Color.GREEN))));
+                        Span.styled(jar.display(), Theme.success())));
             }
             if (jar.fullPath() != null) {
                 String path = jar.fullPath();
@@ -258,7 +258,7 @@ class HeapHistogramTab extends AbstractTableTab {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
                     Span.styled("  JAR:        ", Theme.label().bold()),
-                    Span.styled("JDK (built-in)", Style.EMPTY.fg(Color.GREEN))));
+                    Span.styled("JDK (built-in)", Theme.success())));
         }
 
         String title = " Detail: " + TuiHelper.truncate(className, area.width() - 14) + " ";

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
@@ -197,12 +197,13 @@ class HeapHistogramTab extends AbstractTableTab {
                 Span.styled(className, Style.EMPTY.fg(Color.CYAN))));
         lines.add(Line.from(
                 Span.styled("  Package:    ", Theme.label().bold()),
-                Span.styled(pkg.isEmpty() ? "(none)" : pkg, pkg.isEmpty() ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(pkg.isEmpty() ? "(none)" : pkg,
+                        pkg.isEmpty() ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
                 Span.styled("  Instances:  ", Theme.label().bold()),
-                Span.styled(formatNumber(entry.instances), Style.EMPTY.fg(Color.WHITE)),
+                Span.styled(formatNumber(entry.instances), Style.EMPTY.fg(Theme.baseFg())),
                 Span.styled("          Bytes: ", Theme.label().bold()),
-                Span.styled(formatBytes(entry.bytes), Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(formatBytes(entry.bytes), Style.EMPTY.fg(Theme.baseFg()))));
 
         // Package summary
         if (!pkg.isEmpty()) {
@@ -222,11 +223,11 @@ class HeapHistogramTab extends AbstractTableTab {
                     Span.styled("(" + pkg + ")", Style.EMPTY.dim())));
             lines.add(Line.from(
                     Span.styled("    Classes: ", Theme.label()),
-                    Span.styled(formatNumber(pkgClasses), Style.EMPTY.fg(Color.WHITE)),
+                    Span.styled(formatNumber(pkgClasses), Style.EMPTY.fg(Theme.baseFg())),
                     Span.styled("     Instances: ", Theme.label()),
-                    Span.styled(formatNumber(pkgInstances), Style.EMPTY.fg(Color.WHITE)),
+                    Span.styled(formatNumber(pkgInstances), Style.EMPTY.fg(Theme.baseFg())),
                     Span.styled("     Bytes: ", Theme.label()),
-                    Span.styled(formatBytes(pkgBytes), Style.EMPTY.fg(Color.WHITE))));
+                    Span.styled(formatBytes(pkgBytes), Style.EMPTY.fg(Theme.baseFg()))));
         }
 
         // JAR info

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HeapHistogramTab.java
@@ -193,15 +193,15 @@ class HeapHistogramTab extends AbstractTableTab {
 
         // Class info
         lines.add(Line.from(
-                Span.styled("  Class:      ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Class:      ", Theme.label().bold()),
                 Span.styled(className, Style.EMPTY.fg(Color.CYAN))));
         lines.add(Line.from(
-                Span.styled("  Package:    ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Package:    ", Theme.label().bold()),
                 Span.styled(pkg.isEmpty() ? "(none)" : pkg, pkg.isEmpty() ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE))));
         lines.add(Line.from(
-                Span.styled("  Instances:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Instances:  ", Theme.label().bold()),
                 Span.styled(formatNumber(entry.instances), Style.EMPTY.fg(Color.WHITE)),
-                Span.styled("          Bytes: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("          Bytes: ", Theme.label().bold()),
                 Span.styled(formatBytes(entry.bytes), Style.EMPTY.fg(Color.WHITE))));
 
         // Package summary
@@ -218,14 +218,14 @@ class HeapHistogramTab extends AbstractTableTab {
             }
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Package Summary ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("  Package Summary ", Theme.label().bold()),
                     Span.styled("(" + pkg + ")", Style.EMPTY.dim())));
             lines.add(Line.from(
-                    Span.styled("    Classes: ", Style.EMPTY.fg(Color.YELLOW)),
+                    Span.styled("    Classes: ", Theme.label()),
                     Span.styled(formatNumber(pkgClasses), Style.EMPTY.fg(Color.WHITE)),
-                    Span.styled("     Instances: ", Style.EMPTY.fg(Color.YELLOW)),
+                    Span.styled("     Instances: ", Theme.label()),
                     Span.styled(formatNumber(pkgInstances), Style.EMPTY.fg(Color.WHITE)),
-                    Span.styled("     Bytes: ", Style.EMPTY.fg(Color.YELLOW)),
+                    Span.styled("     Bytes: ", Theme.label()),
                     Span.styled(formatBytes(pkgBytes), Style.EMPTY.fg(Color.WHITE))));
         }
 
@@ -235,12 +235,12 @@ class HeapHistogramTab extends AbstractTableTab {
             lines.add(Line.from(Span.raw("")));
             if (jar.groupId() != null) {
                 lines.add(Line.from(
-                        Span.styled("  JAR:        ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                        Span.styled("  JAR:        ", Theme.label().bold()),
                         Span.styled(jar.groupId() + ":" + jar.artifactId() + ":" + jar.version(),
                                 Style.EMPTY.fg(Color.GREEN))));
             } else {
                 lines.add(Line.from(
-                        Span.styled("  JAR:        ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                        Span.styled("  JAR:        ", Theme.label().bold()),
                         Span.styled(jar.display(), Style.EMPTY.fg(Color.GREEN))));
             }
             if (jar.fullPath() != null) {
@@ -256,7 +256,7 @@ class HeapHistogramTab extends AbstractTableTab {
         } else if (isBuiltinClass(className)) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  JAR:        ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("  JAR:        ", Theme.label().bold()),
                     Span.styled("JDK (built-in)", Style.EMPTY.fg(Color.GREEN))));
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HelpOverlay.java
@@ -103,6 +103,7 @@ class HelpOverlay {
                 .source(markdown)
                 .scroll(scroll)
                 .block(block)
+                .styles(Theme.markdownStyles())
                 .build();
         frame.renderWidget(view, popup);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -810,7 +810,7 @@ class HistoryTab extends AbstractTab {
     }
 
     private Line buildHistoryBreadcrumbTitle() {
-        Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style nameStyle = Theme.label().bold();
         List<Span> spans = new ArrayList<>();
         spans.add(Span.styled(" History [", Style.EMPTY.fg(Color.WHITE)));
         var stack = diagram.getHistoryNavigationStack();
@@ -911,7 +911,7 @@ class HistoryTab extends AbstractTab {
         }
 
         List<Span> stepSpans = new ArrayList<>();
-        stepSpans.add(Span.styled(" Step:     ", Style.EMPTY.fg(Color.YELLOW).bold()));
+        stepSpans.add(Span.styled(" Step:     ", Theme.label().bold()));
         stepSpans.add(Span.raw(String.format("%d/%d", stepIdx + 1, diagram.getHistoryStepCount())));
         if (direction != null && !direction.isBlank()) {
             Style dirStyle = failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
@@ -920,37 +920,37 @@ class HistoryTab extends AbstractTab {
         }
         lines.add(Line.from(stepSpans));
         lines.add(Line.from(
-                Span.styled(" Exchange: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Exchange: ", Theme.label().bold()),
                 Span.raw(exchangeId)));
         lines.add(Line.from(
-                Span.styled(" Route:    ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Route:    ", Theme.label().bold()),
                 Span.styled(routeId != null ? routeId : "", Style.EMPTY.fg(Color.CYAN))));
         lines.add(Line.from(
-                Span.styled(" Node:     ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Node:     ", Theme.label().bold()),
                 Span.raw(nodeId != null ? nodeId : "")));
         if (processor != null) {
             lines.add(Line.from(
-                    Span.styled(" Proc:     ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Proc:     ", Theme.label().bold()),
                     Span.raw(processor.strip())));
         }
         if (elapsed >= 0) {
             lines.add(Line.from(
-                    Span.styled(" Elapsed:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Elapsed:  ", Theme.label().bold()),
                     Span.raw(elapsed + "ms")));
         }
         if (timestamp != null) {
             lines.add(Line.from(
-                    Span.styled(" Time:     ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Time:     ", Theme.label().bold()),
                     Span.raw(timestamp)));
         }
         if (threadName != null) {
             lines.add(Line.from(
-                    Span.styled(" Thread:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Thread:   ", Theme.label().bold()),
                     Span.raw(threadName)));
         }
         if (failed) {
             lines.add(Line.from(
-                    Span.styled(" Status:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Status:   ", Theme.label().bold()),
                     Span.styled("Failed", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
         }
 
@@ -967,7 +967,7 @@ class HistoryTab extends AbstractTab {
         boolean varsChanged = changes.length() > 3 && changes.charAt(3) == 'V';
 
         List<Span> changeSpans = new ArrayList<>();
-        changeSpans.add(Span.styled(" Changed:  ", Style.EMPTY.fg(Color.YELLOW).bold()));
+        changeSpans.add(Span.styled(" Changed:  ", Theme.label().bold()));
         if (!changes.isBlank()) {
             changeSpans.addAll(buildChangeSpans(changes));
         }
@@ -986,7 +986,7 @@ class HistoryTab extends AbstractTab {
         }
 
         if (showBody && body != null) {
-            Style headerStyle = bodyChanged ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style headerStyle = bodyChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
                     Span.styled(" Body", headerStyle),
@@ -997,21 +997,21 @@ class HistoryTab extends AbstractTab {
         }
 
         if (showHeaders && headers != null && !headers.isEmpty()) {
-            Style sectionStyle = headersChanged ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style sectionStyle = headersChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Headers", sectionStyle)));
             addInfoKvLines(lines, headers, headersChanged, prevHeaders);
         }
 
         if (showProps && properties != null && !properties.isEmpty()) {
-            Style sectionStyle = propsChanged ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style sectionStyle = propsChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Properties", sectionStyle)));
             addInfoKvLines(lines, properties, propsChanged, prevProperties);
         }
 
         if (showVars && variables != null && !variables.isEmpty()) {
-            Style sectionStyle = varsChanged ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style sectionStyle = varsChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Variables", sectionStyle)));
             addInfoKvLines(lines, variables, varsChanged, prevVariables);
@@ -1035,8 +1035,8 @@ class HistoryTab extends AbstractTab {
             boolean keyChanged = sectionChanged && prevMap != null
                     && (!prevMap.containsKey(entry.getKey())
                             || !Objects.equals(prevMap.get(entry.getKey()), entry.getValue()));
-            Style keyStyle = keyChanged ? Style.EMPTY.fg(Color.YELLOW) : Style.EMPTY.fg(Color.CYAN);
-            Style valStyle = keyChanged ? Style.EMPTY.fg(Color.YELLOW) : Style.EMPTY;
+            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Color.CYAN);
+            Style valStyle = keyChanged ? Theme.change() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled(" " + entry.getKey(), keyStyle),
                     Span.raw(" = "),
@@ -1196,7 +1196,7 @@ class HistoryTab extends AbstractTab {
             Style statusStyle = switch (s.status) {
                 case "Done" -> Style.EMPTY.fg(Color.GREEN);
                 case "Failed" -> Style.EMPTY.fg(Color.LIGHT_RED);
-                case "Processing" -> Style.EMPTY.fg(Color.YELLOW);
+                case "Processing" -> Theme.warning();
                 default -> Style.EMPTY;
             };
             rows.add(Row.from(
@@ -1499,7 +1499,7 @@ class HistoryTab extends AbstractTab {
         Style labelStyle = selected ? Style.EMPTY.fg(Color.CYAN).bold() : Style.EMPTY.fg(Color.CYAN);
 
         return Line.from(
-                Span.styled(indicator, Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(indicator, Theme.label().bold()),
                 Span.styled(label, labelStyle),
                 Span.styled(bar, bandStyle),
                 Span.raw(" ".repeat(pad)),
@@ -1934,7 +1934,7 @@ class HistoryTab extends AbstractTab {
             if (c == ' ') {
                 spans.add(Span.styled(String.valueOf(c), Style.EMPTY.dim()));
             } else {
-                spans.add(Span.styled(String.valueOf(c), Style.EMPTY.fg(Color.YELLOW)));
+                spans.add(Span.styled(String.valueOf(c), Theme.change()));
             }
         }
         return spans;
@@ -2031,25 +2031,25 @@ class HistoryTab extends AbstractTab {
             List<Line> lines, String exchangeId, String routeId,
             String nodeId, String nodeLabel, String location, long elapsed, String threadName, boolean failed) {
         lines.add(Line.from(
-                Span.styled(" Exchange: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Exchange: ", Theme.label().bold()),
                 Span.raw(exchangeId != null ? exchangeId : "")));
         lines.add(Line.from(
-                Span.styled(" Route:    ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Route:    ", Theme.label().bold()),
                 Span.raw(String.format("%-25s", routeId != null ? routeId : "")),
-                Span.styled("  Node: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Node: ", Theme.label().bold()),
                 Span.raw(nodeId != null ? nodeId : ""),
                 Span.raw(nodeLabel != null ? " (" + nodeLabel + ")" : "")));
         lines.add(Line.from(
-                Span.styled(" Location: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Location: ", Theme.label().bold()),
                 Span.raw(location != null ? location : "")));
         lines.add(Line.from(
-                Span.styled(" Elapsed:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(" Elapsed:  ", Theme.label().bold()),
                 Span.raw(elapsed >= 0 ? elapsed + "ms" : ""),
-                Span.styled("  Thread: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Thread: ", Theme.label().bold()),
                 Span.raw(threadName != null ? threadName : "")));
         if (failed) {
             lines.add(Line.from(
-                    Span.styled(" Status:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Status:   ", Theme.label().bold()),
                     Span.styled("Failed", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
         }
         lines.add(Line.from(Span.raw("")));
@@ -2062,7 +2062,7 @@ class HistoryTab extends AbstractTab {
         if (map == null || map.isEmpty()) {
             return;
         }
-        Style headerStyle = changed ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY.fg(Color.GREEN).bold();
+        Style headerStyle = changed ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
         lines.add(Line.from(Span.styled(section, headerStyle)));
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String type = types != null ? types.get(entry.getKey()) : null;
@@ -2084,8 +2084,8 @@ class HistoryTab extends AbstractTab {
             boolean keyChanged = changed && prevMap != null
                     && (!prevMap.containsKey(entry.getKey())
                             || !Objects.equals(prevMap.get(entry.getKey()), entry.getValue()));
-            Style keyStyle = keyChanged ? Style.EMPTY.fg(Color.YELLOW) : Style.EMPTY.fg(Color.CYAN);
-            Style valStyle = keyChanged ? Style.EMPTY.fg(Color.YELLOW) : Style.EMPTY;
+            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Color.CYAN);
+            Style valStyle = keyChanged ? Theme.change() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled("   " + typeLabel, Style.EMPTY.dim()),
                     Span.styled(entry.getKey(), keyStyle),
@@ -2096,7 +2096,7 @@ class HistoryTab extends AbstractTab {
     }
 
     static void addBodyLines(List<Line> lines, String body, String bodyType, boolean changed) {
-        Style headerStyle = changed ? Style.EMPTY.fg(Color.YELLOW).bold() : Style.EMPTY.fg(Color.GREEN).bold();
+        Style headerStyle = changed ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
         if (body != null) {
             if (bodyType != null) {
                 lines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -910,7 +910,7 @@ class HistoryTab extends AbstractTab {
         }
 
         List<Span> stepSpans = new ArrayList<>();
-        stepSpans.add(Span.styled(" Step:     ", Theme.label().bold()));
+        stepSpans.add(Span.styled(" Step:     ", Theme.muted()));
         stepSpans.add(Span.raw(String.format("%d/%d", stepIdx + 1, diagram.getHistoryStepCount())));
         if (direction != null && !direction.isBlank()) {
             Style dirStyle = failed ? Theme.error() : Theme.success();
@@ -919,37 +919,37 @@ class HistoryTab extends AbstractTab {
         }
         lines.add(Line.from(stepSpans));
         lines.add(Line.from(
-                Span.styled(" Exchange: ", Theme.label().bold()),
+                Span.styled(" Exchange: ", Theme.muted()),
                 Span.raw(exchangeId)));
         lines.add(Line.from(
-                Span.styled(" Route:    ", Theme.label().bold()),
+                Span.styled(" Route:    ", Theme.muted()),
                 Span.styled(routeId != null ? routeId : "", Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
-                Span.styled(" Node:     ", Theme.label().bold()),
+                Span.styled(" Node:     ", Theme.muted()),
                 Span.raw(nodeId != null ? nodeId : "")));
         if (processor != null) {
             lines.add(Line.from(
-                    Span.styled(" Proc:     ", Theme.label().bold()),
+                    Span.styled(" Proc:     ", Theme.muted()),
                     Span.raw(processor.strip())));
         }
         if (elapsed >= 0) {
             lines.add(Line.from(
-                    Span.styled(" Elapsed:  ", Theme.label().bold()),
+                    Span.styled(" Elapsed:  ", Theme.muted()),
                     Span.raw(elapsed + "ms")));
         }
         if (timestamp != null) {
             lines.add(Line.from(
-                    Span.styled(" Time:     ", Theme.label().bold()),
+                    Span.styled(" Time:     ", Theme.muted()),
                     Span.raw(timestamp)));
         }
         if (threadName != null) {
             lines.add(Line.from(
-                    Span.styled(" Thread:   ", Theme.label().bold()),
+                    Span.styled(" Thread:   ", Theme.muted()),
                     Span.raw(threadName)));
         }
         if (failed) {
             lines.add(Line.from(
-                    Span.styled(" Status:   ", Theme.label().bold()),
+                    Span.styled(" Status:   ", Theme.muted()),
                     Span.styled("Failed", Theme.error().bold())));
         }
 
@@ -966,7 +966,7 @@ class HistoryTab extends AbstractTab {
         boolean varsChanged = changes.length() > 3 && changes.charAt(3) == 'V';
 
         List<Span> changeSpans = new ArrayList<>();
-        changeSpans.add(Span.styled(" Changed:  ", Theme.label().bold()));
+        changeSpans.add(Span.styled(" Changed:  ", Theme.muted()));
         if (!changes.isBlank()) {
             changeSpans.addAll(buildChangeSpans(changes));
         }
@@ -985,7 +985,7 @@ class HistoryTab extends AbstractTab {
         }
 
         if (showBody && body != null) {
-            Style headerStyle = bodyChanged ? Theme.change().bold() : Theme.success().bold();
+            Style headerStyle = bodyChanged ? Theme.change().bold() : Theme.muted();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
                     Span.styled(" Body", headerStyle),
@@ -996,21 +996,21 @@ class HistoryTab extends AbstractTab {
         }
 
         if (showHeaders && headers != null && !headers.isEmpty()) {
-            Style sectionStyle = headersChanged ? Theme.change().bold() : Theme.success().bold();
+            Style sectionStyle = headersChanged ? Theme.change().bold() : Theme.muted();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Headers", sectionStyle)));
             addInfoKvLines(lines, headers, headersChanged, prevHeaders);
         }
 
         if (showProps && properties != null && !properties.isEmpty()) {
-            Style sectionStyle = propsChanged ? Theme.change().bold() : Theme.success().bold();
+            Style sectionStyle = propsChanged ? Theme.change().bold() : Theme.muted();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Properties", sectionStyle)));
             addInfoKvLines(lines, properties, propsChanged, prevProperties);
         }
 
         if (showVars && variables != null && !variables.isEmpty()) {
-            Style sectionStyle = varsChanged ? Theme.change().bold() : Theme.success().bold();
+            Style sectionStyle = varsChanged ? Theme.change().bold() : Theme.muted();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Variables", sectionStyle)));
             addInfoKvLines(lines, variables, varsChanged, prevVariables);
@@ -1034,7 +1034,7 @@ class HistoryTab extends AbstractTab {
             boolean keyChanged = sectionChanged && prevMap != null
                     && (!prevMap.containsKey(entry.getKey())
                             || !Objects.equals(prevMap.get(entry.getKey()), entry.getValue()));
-            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Theme.accent());
+            Style keyStyle = keyChanged ? Theme.change() : Theme.muted();
             Style valStyle = keyChanged ? Theme.change() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled(" " + entry.getKey(), keyStyle),
@@ -2030,25 +2030,25 @@ class HistoryTab extends AbstractTab {
             List<Line> lines, String exchangeId, String routeId,
             String nodeId, String nodeLabel, String location, long elapsed, String threadName, boolean failed) {
         lines.add(Line.from(
-                Span.styled(" Exchange: ", Theme.label().bold()),
+                Span.styled(" Exchange: ", Theme.muted()),
                 Span.raw(exchangeId != null ? exchangeId : "")));
         lines.add(Line.from(
-                Span.styled(" Route:    ", Theme.label().bold()),
+                Span.styled(" Route:    ", Theme.muted()),
                 Span.raw(String.format("%-25s", routeId != null ? routeId : "")),
-                Span.styled("  Node: ", Theme.label().bold()),
+                Span.styled("  Node: ", Theme.muted()),
                 Span.raw(nodeId != null ? nodeId : ""),
                 Span.raw(nodeLabel != null ? " (" + nodeLabel + ")" : "")));
         lines.add(Line.from(
-                Span.styled(" Location: ", Theme.label().bold()),
+                Span.styled(" Location: ", Theme.muted()),
                 Span.raw(location != null ? location : "")));
         lines.add(Line.from(
-                Span.styled(" Elapsed:  ", Theme.label().bold()),
+                Span.styled(" Elapsed:  ", Theme.muted()),
                 Span.raw(elapsed >= 0 ? elapsed + "ms" : ""),
-                Span.styled("  Thread: ", Theme.label().bold()),
+                Span.styled("  Thread: ", Theme.muted()),
                 Span.raw(threadName != null ? threadName : "")));
         if (failed) {
             lines.add(Line.from(
-                    Span.styled(" Status:   ", Theme.label().bold()),
+                    Span.styled(" Status:   ", Theme.muted()),
                     Span.styled("Failed", Theme.error().bold())));
         }
         lines.add(Line.from(Span.raw("")));
@@ -2061,7 +2061,7 @@ class HistoryTab extends AbstractTab {
         if (map == null || map.isEmpty()) {
             return;
         }
-        Style headerStyle = changed ? Theme.change().bold() : Theme.success().bold();
+        Style headerStyle = changed ? Theme.change().bold() : Theme.muted();
         lines.add(Line.from(Span.styled(section, headerStyle)));
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String type = types != null ? types.get(entry.getKey()) : null;
@@ -2083,7 +2083,7 @@ class HistoryTab extends AbstractTab {
             boolean keyChanged = changed && prevMap != null
                     && (!prevMap.containsKey(entry.getKey())
                             || !Objects.equals(prevMap.get(entry.getKey()), entry.getValue()));
-            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Theme.accent());
+            Style keyStyle = keyChanged ? Theme.change() : Theme.muted();
             Style valStyle = keyChanged ? Theme.change() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled("   " + typeLabel, Style.EMPTY.dim()),
@@ -2095,7 +2095,7 @@ class HistoryTab extends AbstractTab {
     }
 
     static void addBodyLines(List<Line> lines, String body, String bodyType, boolean changed) {
-        Style headerStyle = changed ? Theme.change().bold() : Theme.success().bold();
+        Style headerStyle = changed ? Theme.change().bold() : Theme.muted();
         if (body != null) {
             if (bodyType != null) {
                 lines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -694,7 +694,7 @@ class HistoryTab extends AbstractTab {
                     Line title = Line.from(Span.styled(
                             String.format(" History Topology — step %d/%d ",
                                     diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
-                            Style.EMPTY.fg(Color.WHITE)));
+                            Style.EMPTY.fg(Theme.baseFg())));
                     diagram.renderHistoryTopologyDiagram(frame, diagramArea, title);
                 } else {
                     String routeId = diagram.getHistoryDrillDownRouteId();
@@ -812,7 +812,7 @@ class HistoryTab extends AbstractTab {
     private Line buildHistoryBreadcrumbTitle() {
         Style nameStyle = Theme.label().bold();
         List<Span> spans = new ArrayList<>();
-        spans.add(Span.styled(" History [", Style.EMPTY.fg(Color.WHITE)));
+        spans.add(Span.styled(" History [", Style.EMPTY.fg(Theme.baseFg())));
         var stack = diagram.getHistoryNavigationStack();
         if (stack.isEmpty()) {
             spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
@@ -825,7 +825,7 @@ class HistoryTab extends AbstractTab {
         }
         spans.add(Span.styled(String.format("] — step %d/%d ",
                 diagram.getHistoryStepIndex() + 1, diagram.getHistoryStepCount()),
-                Style.EMPTY.fg(Color.WHITE)));
+                Style.EMPTY.fg(Theme.baseFg())));
         return Line.from(spans);
     }
 
@@ -1503,7 +1503,7 @@ class HistoryTab extends AbstractTab {
                 Span.styled(label, labelStyle),
                 Span.styled(bar, bandStyle),
                 Span.raw(" ".repeat(pad)),
-                Span.styled(durationStr, isRoute ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE).bold()));
+                Span.styled(durationStr, isRoute ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg()).bold()));
     }
 
     private static boolean nodeIdEquals(String a, String b) {
@@ -1883,10 +1883,10 @@ class HistoryTab extends AbstractTab {
     private static void hintShowBhpv(List<Span> spans, boolean body, boolean headers, boolean props, boolean vars) {
         spans.add(Span.styled(" show", Theme.hintKey()));
         spans.add(Span.raw(" "));
-        spans.add(Span.styled(body ? "B" : "b", body ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
-        spans.add(Span.styled(headers ? "H" : "h", headers ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
-        spans.add(Span.styled(props ? "P" : "p", props ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
-        spans.add(Span.styled(vars ? "V" : "v", vars ? Style.EMPTY.fg(Color.WHITE).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(body ? "B" : "b", body ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(headers ? "H" : "h", headers ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(props ? "P" : "p", props ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
+        spans.add(Span.styled(vars ? "V" : "v", vars ? Style.EMPTY.fg(Theme.baseFg()).bold() : Style.EMPTY.dim()));
         spans.add(Span.raw("  "));
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -914,7 +914,7 @@ class HistoryTab extends AbstractTab {
         stepSpans.add(Span.styled(" Step:     ", Theme.label().bold()));
         stepSpans.add(Span.raw(String.format("%d/%d", stepIdx + 1, diagram.getHistoryStepCount())));
         if (direction != null && !direction.isBlank()) {
-            Style dirStyle = failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
+            Style dirStyle = failed ? Theme.error() : Theme.success();
             stepSpans.add(Span.raw(" "));
             stepSpans.add(Span.styled(direction, dirStyle));
         }
@@ -951,7 +951,7 @@ class HistoryTab extends AbstractTab {
         if (failed) {
             lines.add(Line.from(
                     Span.styled(" Status:   ", Theme.label().bold()),
-                    Span.styled("Failed", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+                    Span.styled("Failed", Theme.error().bold())));
         }
 
         // Compute BHPV change indicators
@@ -981,12 +981,12 @@ class HistoryTab extends AbstractTab {
 
         if (exception != null && !exception.isBlank()) {
             lines.add(Line.from(Span.raw("")));
-            lines.add(Line.from(Span.styled(" Exception", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+            lines.add(Line.from(Span.styled(" Exception", Theme.error().bold())));
             lines.add(Line.from(Span.raw(" " + exception)));
         }
 
         if (showBody && body != null) {
-            Style headerStyle = bodyChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style headerStyle = bodyChanged ? Theme.change().bold() : Theme.success().bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
                     Span.styled(" Body", headerStyle),
@@ -997,21 +997,21 @@ class HistoryTab extends AbstractTab {
         }
 
         if (showHeaders && headers != null && !headers.isEmpty()) {
-            Style sectionStyle = headersChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style sectionStyle = headersChanged ? Theme.change().bold() : Theme.success().bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Headers", sectionStyle)));
             addInfoKvLines(lines, headers, headersChanged, prevHeaders);
         }
 
         if (showProps && properties != null && !properties.isEmpty()) {
-            Style sectionStyle = propsChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style sectionStyle = propsChanged ? Theme.change().bold() : Theme.success().bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Properties", sectionStyle)));
             addInfoKvLines(lines, properties, propsChanged, prevProperties);
         }
 
         if (showVars && variables != null && !variables.isEmpty()) {
-            Style sectionStyle = varsChanged ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
+            Style sectionStyle = varsChanged ? Theme.change().bold() : Theme.success().bold();
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(Span.styled(" Variables", sectionStyle)));
             addInfoKvLines(lines, variables, varsChanged, prevVariables);
@@ -1194,8 +1194,8 @@ class HistoryTab extends AbstractTab {
         List<Row> rows = new ArrayList<>();
         for (ExchangeSummary s : summaries) {
             Style statusStyle = switch (s.status) {
-                case "Done" -> Style.EMPTY.fg(Color.GREEN);
-                case "Failed" -> Style.EMPTY.fg(Color.LIGHT_RED);
+                case "Done" -> Theme.success();
+                case "Failed" -> Theme.error();
                 case "Processing" -> Theme.warning();
                 default -> Style.EMPTY;
             };
@@ -1905,9 +1905,9 @@ class HistoryTab extends AbstractTab {
             String description, long elapsed, String changes) {
         Style dirStyle;
         if (first || last || !direction.isBlank()) {
-            dirStyle = failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
+            dirStyle = failed ? Theme.error() : Theme.success();
         } else {
-            dirStyle = failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY;
+            dirStyle = failed ? Theme.error() : Style.EMPTY;
         }
         String elapsedStr = elapsed >= 0 ? elapsed + "ms" : "";
         String display = description != null ? description : (processor != null ? processor : "");
@@ -2015,7 +2015,7 @@ class HistoryTab extends AbstractTab {
         spans.add(Span.raw(" History of last completed — " + entries.size() + " steps ("));
         boolean failed = last.failed;
         spans.add(Span.styled("status:" + (failed ? "failed" : "success"),
-                failed ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY.fg(Color.GREEN).bold()));
+                failed ? Theme.error().bold() : Theme.success().bold()));
         if (last.elapsed >= 0) {
             spans.add(Span.raw(" elapsed:" + TimeUtils.printDuration(last.elapsed, true)));
         }
@@ -2050,7 +2050,7 @@ class HistoryTab extends AbstractTab {
         if (failed) {
             lines.add(Line.from(
                     Span.styled(" Status:   ", Theme.label().bold()),
-                    Span.styled("Failed", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+                    Span.styled("Failed", Theme.error().bold())));
         }
         lines.add(Line.from(Span.raw("")));
     }
@@ -2062,7 +2062,7 @@ class HistoryTab extends AbstractTab {
         if (map == null || map.isEmpty()) {
             return;
         }
-        Style headerStyle = changed ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
+        Style headerStyle = changed ? Theme.change().bold() : Theme.success().bold();
         lines.add(Line.from(Span.styled(section, headerStyle)));
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String type = types != null ? types.get(entry.getKey()) : null;
@@ -2096,7 +2096,7 @@ class HistoryTab extends AbstractTab {
     }
 
     static void addBodyLines(List<Line> lines, String body, String bodyType, boolean changed) {
-        Style headerStyle = changed ? Theme.change().bold() : Style.EMPTY.fg(Color.GREEN).bold();
+        Style headerStyle = changed ? Theme.change().bold() : Theme.success().bold();
         if (body != null) {
             if (bodyType != null) {
                 lines.add(Line.from(
@@ -2153,7 +2153,7 @@ class HistoryTab extends AbstractTab {
         if (exception == null) {
             return;
         }
-        lines.add(Line.from(Span.styled(" Exception:", Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+        lines.add(Line.from(Span.styled(" Exception:", Theme.error().bold())));
         for (String l : exception.split("\n", -1)) {
             lines.add(Line.from(Span.raw("   " + TuiHelper.fixControlChars(l))));
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTab.java
@@ -33,7 +33,6 @@ import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -819,7 +818,7 @@ class HistoryTab extends AbstractTab {
         } else {
             for (var it = stack.descendingIterator(); it.hasNext();) {
                 spans.add(Span.styled(it.next(), nameStyle));
-                spans.add(Span.styled(" → ", Style.EMPTY.fg(Color.GRAY)));
+                spans.add(Span.styled(" → ", Theme.muted()));
             }
             spans.add(Span.styled(diagram.getHistoryDrillDownRouteId(), nameStyle));
         }
@@ -924,7 +923,7 @@ class HistoryTab extends AbstractTab {
                 Span.raw(exchangeId)));
         lines.add(Line.from(
                 Span.styled(" Route:    ", Theme.label().bold()),
-                Span.styled(routeId != null ? routeId : "", Style.EMPTY.fg(Color.CYAN))));
+                Span.styled(routeId != null ? routeId : "", Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
                 Span.styled(" Node:     ", Theme.label().bold()),
                 Span.raw(nodeId != null ? nodeId : "")));
@@ -1035,7 +1034,7 @@ class HistoryTab extends AbstractTab {
             boolean keyChanged = sectionChanged && prevMap != null
                     && (!prevMap.containsKey(entry.getKey())
                             || !Objects.equals(prevMap.get(entry.getKey()), entry.getValue()));
-            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Color.CYAN);
+            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Theme.accent());
             Style valStyle = keyChanged ? Theme.change() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled(" " + entry.getKey(), keyStyle),
@@ -1203,7 +1202,7 @@ class HistoryTab extends AbstractTab {
                     Cell.from(s.timestamp != null ? TuiHelper.truncate(s.timestamp, 12) : ""),
                     Cell.from(Span.styled(
                             s.routeId != null ? TuiHelper.truncate(s.routeId, 25) : "",
-                            Style.EMPTY.fg(Color.CYAN))),
+                            Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(s.status, statusStyle)),
                     rightCell(s.elapsed + "ms", 10),
                     rightCell(String.valueOf(s.steps), 6),
@@ -1496,7 +1495,7 @@ class HistoryTab extends AbstractTab {
         String durationStr = entry.elapsed + "ms";
         int pad = Math.max(1, 8 - durationStr.length());
 
-        Style labelStyle = selected ? Style.EMPTY.fg(Color.CYAN).bold() : Style.EMPTY.fg(Color.CYAN);
+        Style labelStyle = selected ? Style.EMPTY.fg(Theme.accent()).bold() : Style.EMPTY.fg(Theme.accent());
 
         return Line.from(
                 Span.styled(indicator, Theme.label().bold()),
@@ -1917,7 +1916,7 @@ class HistoryTab extends AbstractTab {
                 rightCell(String.valueOf(stepNumber), 3),
                 Cell.from(Span.styled(direction, dirStyle)),
                 Cell.from(timestamp != null ? TuiHelper.truncate(timestamp, 12) : ""),
-                Cell.from(Span.styled(routeId != null ? TuiHelper.truncate(routeId, 25) : "", Style.EMPTY.fg(Color.CYAN))),
+                Cell.from(Span.styled(routeId != null ? TuiHelper.truncate(routeId, 25) : "", Style.EMPTY.fg(Theme.accent()))),
                 Cell.from(indent + (nodeId != null ? TuiHelper.truncate(nodeId, 25) : "")),
                 Cell.from(indent + display),
                 Cell.from(Line.from(changeSpans)),
@@ -2084,7 +2083,7 @@ class HistoryTab extends AbstractTab {
             boolean keyChanged = changed && prevMap != null
                     && (!prevMap.containsKey(entry.getKey())
                             || !Objects.equals(prevMap.get(entry.getKey()), entry.getValue()));
-            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Color.CYAN);
+            Style keyStyle = keyChanged ? Theme.change() : Style.EMPTY.fg(Theme.accent());
             Style valStyle = keyChanged ? Theme.change() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled("   " + typeLabel, Style.EMPTY.dim()),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
@@ -1031,7 +1031,7 @@ class HttpTab extends AbstractTableTab {
             titleStyle = Style.EMPTY.fg(Color.LIGHT_RED).bold();
         } else if ("Sending...".equals(probeResponseStatus)) {
             titleStr = " Sending... ";
-            titleStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+            titleStyle = Theme.warning().bold();
         } else {
             titleStr = " Response " + probeResponseStatus;
             if (probeResponseElapsed > 0) {
@@ -1074,7 +1074,7 @@ class HttpTab extends AbstractTableTab {
                 // Header line
                 int colon = line.indexOf(": ");
                 lines.add(Line.from(
-                        Span.styled(line.substring(0, colon + 1), Style.EMPTY.fg(Color.YELLOW)),
+                        Span.styled(line.substring(0, colon + 1), Theme.label()),
                         Span.raw(line.substring(colon + 1))));
             } else {
                 lines.add(Line.from(Span.raw(line)));
@@ -1158,7 +1158,7 @@ class HttpTab extends AbstractTableTab {
                 return Style.EMPTY.fg(Color.CYAN).bold();
             }
             if (code >= 400 && code < 500) {
-                return Style.EMPTY.fg(Color.YELLOW).bold();
+                return Theme.warning().bold();
             }
             if (code >= 500) {
                 return Style.EMPTY.fg(Color.LIGHT_RED).bold();
@@ -1214,7 +1214,7 @@ class HttpTab extends AbstractTableTab {
         String m = method.split(",")[0].trim().toUpperCase(Locale.ENGLISH);
         return switch (m) {
             case "GET" -> Style.EMPTY.fg(Color.GREEN);
-            case "POST" -> Style.EMPTY.fg(Color.YELLOW);
+            case "POST" -> Theme.label();
             case "PUT" -> Style.EMPTY.fg(Color.CYAN);
             case "DELETE" -> Style.EMPTY.fg(Color.LIGHT_RED);
             case "PATCH" -> Style.EMPTY.fg(Color.rgb(0xFF, 0x80, 0x00));
@@ -1227,7 +1227,7 @@ class HttpTab extends AbstractTableTab {
         spans.add(Span.raw(" HTTP Services [" + visible.size() + "]"));
         if (info.httpServer != null) {
             spans.add(Span.raw("  "));
-            spans.add(Span.styled("Server: ", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled("Server: ", Theme.label().bold()));
             spans.add(Span.styled(info.httpServer, Style.EMPTY.fg(Color.CYAN)));
         }
         long restCount = info.httpEndpoints.stream().filter(e -> e.fromRest && !e.specification).count();
@@ -1251,7 +1251,7 @@ class HttpTab extends AbstractTableTab {
         }
         if (mgmtCount > 0) {
             spans.add(Span.raw("  "));
-            spans.add(Span.styled("Mgmt: ", Style.EMPTY.fg(Color.YELLOW).dim()));
+            spans.add(Span.styled("Mgmt: ", Theme.label().dim()));
             spans.add(Span.raw(mgmtCount + ""));
         }
         spans.add(Span.raw(" "));
@@ -1400,7 +1400,7 @@ class HttpTab extends AbstractTableTab {
             return;
         }
         lines.add(Line.from(
-                Span.styled(String.format("  %-10s ", label + ":"), Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(String.format("  %-10s ", label + ":"), Theme.label().bold()),
                 Span.raw(value)));
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -1217,7 +1216,7 @@ class HttpTab extends AbstractTableTab {
             case "POST" -> Theme.label();
             case "PUT" -> Style.EMPTY.fg(Theme.accent());
             case "DELETE" -> Theme.error();
-            case "PATCH" -> Style.EMPTY.fg(Color.rgb(0xFF, 0x80, 0x00));
+            case "PATCH" -> Theme.warning();
             default -> Style.EMPTY.dim();
         };
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
@@ -1226,7 +1226,7 @@ class HttpTab extends AbstractTableTab {
         spans.add(Span.raw(" HTTP Services [" + visible.size() + "]"));
         if (info.httpServer != null) {
             spans.add(Span.raw("  "));
-            spans.add(Span.styled("Server: ", Theme.label().bold()));
+            spans.add(Span.styled("Server: ", Theme.muted()));
             spans.add(Span.styled(info.httpServer, Style.EMPTY.fg(Theme.accent())));
         }
         long restCount = info.httpEndpoints.stream().filter(e -> e.fromRest && !e.specification).count();
@@ -1399,7 +1399,7 @@ class HttpTab extends AbstractTableTab {
             return;
         }
         lines.add(Line.from(
-                Span.styled(String.format("  %-10s ", label + ":"), Theme.label().bold()),
+                Span.styled(String.format("  %-10s ", label + ":"), Theme.muted()),
                 Span.raw(value)));
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
@@ -1028,7 +1028,7 @@ class HttpTab extends AbstractTableTab {
             titleStr = " Response ";
         } else if (probeResponseError) {
             titleStr = " Response " + probeResponseStatus + " ";
-            titleStyle = Style.EMPTY.fg(Color.LIGHT_RED).bold();
+            titleStyle = Theme.error().bold();
         } else if ("Sending...".equals(probeResponseStatus)) {
             titleStr = " Sending... ";
             titleStyle = Theme.warning().bold();
@@ -1152,7 +1152,7 @@ class HttpTab extends AbstractTableTab {
         try {
             int code = Integer.parseInt(status);
             if (code >= 200 && code < 300) {
-                return Style.EMPTY.fg(Color.GREEN).bold();
+                return Theme.success().bold();
             }
             if (code >= 300 && code < 400) {
                 return Style.EMPTY.fg(Color.CYAN).bold();
@@ -1161,12 +1161,12 @@ class HttpTab extends AbstractTableTab {
                 return Theme.warning().bold();
             }
             if (code >= 500) {
-                return Style.EMPTY.fg(Color.LIGHT_RED).bold();
+                return Theme.error().bold();
             }
         } catch (NumberFormatException e) {
             // not a number — treat as error
         }
-        return Style.EMPTY.fg(Color.LIGHT_RED).bold();
+        return Theme.error().bold();
     }
 
     // ---- Existing table/spec methods ----
@@ -1213,10 +1213,10 @@ class HttpTab extends AbstractTableTab {
         }
         String m = method.split(",")[0].trim().toUpperCase(Locale.ENGLISH);
         return switch (m) {
-            case "GET" -> Style.EMPTY.fg(Color.GREEN);
+            case "GET" -> Theme.success();
             case "POST" -> Theme.label();
             case "PUT" -> Style.EMPTY.fg(Color.CYAN);
-            case "DELETE" -> Style.EMPTY.fg(Color.LIGHT_RED);
+            case "DELETE" -> Theme.error();
             case "PATCH" -> Style.EMPTY.fg(Color.rgb(0xFF, 0x80, 0x00));
             default -> Style.EMPTY.dim();
         };
@@ -1236,7 +1236,7 @@ class HttpTab extends AbstractTableTab {
         long mgmtCount = info.httpEndpoints.stream().filter(e -> e.management).count();
         if (restCount > 0) {
             spans.add(Span.raw("  "));
-            spans.add(Span.styled("REST: ", Style.EMPTY.fg(Color.GREEN)));
+            spans.add(Span.styled("REST: ", Theme.success()));
             spans.add(Span.raw(restCount + ""));
         }
         if (specCount > 0) {
@@ -1285,10 +1285,10 @@ class HttpTab extends AbstractTableTab {
                     Cell.from(produces),
                     Cell.from(Span.styled(source,
                             ep.specification ? Style.EMPTY.fg(Color.MAGENTA)
-                                    : ep.fromRest ? Style.EMPTY.fg(Color.GREEN)
+                                    : ep.fromRest ? Theme.success()
                                     : Style.EMPTY.fg(Color.CYAN))),
                     Cell.from(Span.styled(state,
-                            "Stopped".equals(state) ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY))));
+                            "Stopped".equals(state) ? Theme.error() : Style.EMPTY))));
         }
 
         Title title = buildTableTitle(info, visible);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTab.java
@@ -1155,7 +1155,7 @@ class HttpTab extends AbstractTableTab {
                 return Theme.success().bold();
             }
             if (code >= 300 && code < 400) {
-                return Style.EMPTY.fg(Color.CYAN).bold();
+                return Style.EMPTY.fg(Theme.accent()).bold();
             }
             if (code >= 400 && code < 500) {
                 return Theme.warning().bold();
@@ -1215,7 +1215,7 @@ class HttpTab extends AbstractTableTab {
         return switch (m) {
             case "GET" -> Theme.success();
             case "POST" -> Theme.label();
-            case "PUT" -> Style.EMPTY.fg(Color.CYAN);
+            case "PUT" -> Style.EMPTY.fg(Theme.accent());
             case "DELETE" -> Theme.error();
             case "PATCH" -> Style.EMPTY.fg(Color.rgb(0xFF, 0x80, 0x00));
             default -> Style.EMPTY.dim();
@@ -1228,7 +1228,7 @@ class HttpTab extends AbstractTableTab {
         if (info.httpServer != null) {
             spans.add(Span.raw("  "));
             spans.add(Span.styled("Server: ", Theme.label().bold()));
-            spans.add(Span.styled(info.httpServer, Style.EMPTY.fg(Color.CYAN)));
+            spans.add(Span.styled(info.httpServer, Style.EMPTY.fg(Theme.accent())));
         }
         long restCount = info.httpEndpoints.stream().filter(e -> e.fromRest && !e.specification).count();
         long specCount = info.httpEndpoints.stream().filter(e -> e.specification).count();
@@ -1241,12 +1241,12 @@ class HttpTab extends AbstractTableTab {
         }
         if (specCount > 0) {
             spans.add(Span.raw("  "));
-            spans.add(Span.styled("Spec: ", Style.EMPTY.fg(Color.MAGENTA)));
+            spans.add(Span.styled("Spec: ", Theme.notice()));
             spans.add(Span.raw(specCount + ""));
         }
         if (httpCount > 0) {
             spans.add(Span.raw("  "));
-            spans.add(Span.styled("HTTP: ", Style.EMPTY.fg(Color.CYAN)));
+            spans.add(Span.styled("HTTP: ", Style.EMPTY.fg(Theme.accent())));
             spans.add(Span.raw(httpCount + ""));
         }
         if (mgmtCount > 0) {
@@ -1284,9 +1284,9 @@ class HttpTab extends AbstractTableTab {
                     Cell.from(consumes),
                     Cell.from(produces),
                     Cell.from(Span.styled(source,
-                            ep.specification ? Style.EMPTY.fg(Color.MAGENTA)
+                            ep.specification ? Theme.notice()
                                     : ep.fromRest ? Theme.success()
-                                    : Style.EMPTY.fg(Color.CYAN))),
+                                    : Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(state,
                             "Stopped".equals(state) ? Theme.error() : Style.EMPTY))));
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -117,7 +116,7 @@ class InflightTab extends AbstractTableTab {
 
             rows.add(Row.from(
                     Cell.from(Span.styled(" " + status, statusStyle)),
-                    Cell.from(Span.styled(ii.exchangeId != null ? ii.exchangeId : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(ii.exchangeId != null ? ii.exchangeId : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(routeNode),
                     rightCell(duration, 14, durationStyle),
                     Cell.from(barSpan)));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
@@ -168,7 +168,7 @@ class InflightTab extends AbstractTableTab {
         if (durationMs >= THRESHOLD_RED) {
             return Style.EMPTY.fg(Color.LIGHT_RED).bold();
         } else if (durationMs >= THRESHOLD_YELLOW) {
-            return Style.EMPTY.fg(Color.YELLOW);
+            return Theme.warning();
         }
         return Style.EMPTY.fg(Color.GREEN);
     }
@@ -191,16 +191,16 @@ class InflightTab extends AbstractTableTab {
             sb.append(BAR_CHARS[partial]);
         }
 
-        Color color;
+        Style barStyle;
         if (duration >= THRESHOLD_RED) {
-            color = Color.LIGHT_RED;
+            barStyle = Style.EMPTY.fg(Color.LIGHT_RED);
         } else if (duration >= THRESHOLD_YELLOW) {
-            color = Color.YELLOW;
+            barStyle = Theme.warning();
         } else {
-            color = Color.GREEN;
+            barStyle = Style.EMPTY.fg(Color.GREEN);
         }
 
-        return Span.styled(sb.toString(), Style.EMPTY.fg(color));
+        return Span.styled(sb.toString(), barStyle);
     }
 
     private int sortExchange(InflightInfo a, InflightInfo b) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTab.java
@@ -103,8 +103,8 @@ class InflightTab extends AbstractTableTab {
         for (InflightInfo ii : sorted) {
             String status = ii.blocked ? "blocked" : "inflight";
             Style statusStyle = ii.blocked
-                    ? Style.EMPTY.fg(Color.LIGHT_RED).bold()
-                    : Style.EMPTY.fg(Color.GREEN);
+                    ? Theme.error().bold()
+                    : Theme.success();
 
             String duration = TimeUtils.printDuration(ii.duration, true);
             Style durationStyle = durationColor(ii.duration);
@@ -166,11 +166,11 @@ class InflightTab extends AbstractTableTab {
 
     private Style durationColor(long durationMs) {
         if (durationMs >= THRESHOLD_RED) {
-            return Style.EMPTY.fg(Color.LIGHT_RED).bold();
+            return Theme.error().bold();
         } else if (durationMs >= THRESHOLD_YELLOW) {
             return Theme.warning();
         }
-        return Style.EMPTY.fg(Color.GREEN);
+        return Theme.success();
     }
 
     private Span buildDurationBar(long duration, long maxDuration, int barWidth) {
@@ -193,11 +193,11 @@ class InflightTab extends AbstractTableTab {
 
         Style barStyle;
         if (duration >= THRESHOLD_RED) {
-            barStyle = Style.EMPTY.fg(Color.LIGHT_RED);
+            barStyle = Theme.error();
         } else if (duration >= THRESHOLD_YELLOW) {
             barStyle = Theme.warning();
         } else {
-            barStyle = Style.EMPTY.fg(Color.GREEN);
+            barStyle = Theme.success();
         }
 
         return Span.styled(sb.toString(), barStyle);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InfraBrowserPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InfraBrowserPopup.java
@@ -411,7 +411,7 @@ class InfraBrowserPopup {
         if (hasMultiImpl) {
             row++;
             Rect labelArea = new Rect(ix, row, labelW, 1);
-            frame.renderWidget(Paragraph.from(Line.from(Span.styled("Impl:", Style.EMPTY.bold()))), labelArea);
+            frame.renderWidget(Paragraph.from(Line.from(Span.styled("Impl:", Theme.muted()))), labelArea);
             String impl = selectedService.implementations().get(implIndex);
             Rect implArea = new Rect(ix + labelW, row, fieldW, 1);
             frame.renderWidget(Paragraph.from(Line.from(
@@ -423,7 +423,7 @@ class InfraBrowserPopup {
 
         row++;
         Rect labelArea = new Rect(ix, row, labelW, 1);
-        frame.renderWidget(Paragraph.from(Line.from(Span.styled("Port:", Style.EMPTY.bold()))), labelArea);
+        frame.renderWidget(Paragraph.from(Line.from(Span.styled("Port:", Theme.muted()))), labelArea);
         Rect portArea = new Rect(ix + labelW, row, fieldW, 1);
         TextInput textInput = TextInput.builder()
                 .cursorStyle(Style.EMPTY.reversed())

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InputHistory.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InputHistory.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
-import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -145,7 +143,7 @@ class InputHistory {
                 .highlightSymbol("")
                 .block(Block.builder()
                         .borderType(BorderType.ROUNDED)
-                        .title(Title.from(Line.from(Span.styled(" " + title + " ", Style.EMPTY.fg(Color.YELLOW).bold()))))
+                        .title(Title.from(Line.from(Span.styled(" " + title + " ", Theme.label().bold()))))
                         .build())
                 .build();
         frame.renderStatefulWidget(list, popup, listState);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
@@ -302,7 +302,7 @@ class LogTab extends AbstractTab {
         if (hasNew) {
             titleLine = Line.from(
                     Span.raw(logLabel + " "),
-                    Span.styled("(*)", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("(*)", Theme.label()),
                     Span.raw(" "));
         } else {
             titleLine = Line.from(Span.raw(logLabel + " "));
@@ -439,7 +439,7 @@ class LogTab extends AbstractTab {
         ListWidget list = ListWidget.builder()
                 .items(
                         ListItem.from("  ERROR  ").style(Style.EMPTY.fg(Color.LIGHT_RED)),
-                        ListItem.from("  WARN   ").style(Style.EMPTY.fg(Color.YELLOW)),
+                        ListItem.from("  WARN   ").style(Theme.warning()),
                         ListItem.from("  INFO   ").style(Style.EMPTY),
                         ListItem.from("  DEBUG  ").style(Style.EMPTY.fg(Color.CYAN)),
                         ListItem.from("  TRACE  ").style(Style.EMPTY.dim()))
@@ -644,7 +644,7 @@ class LogTab extends AbstractTab {
         String message = m.group(7);
         Style levelStyle = switch (level) {
             case "ERROR", "FATAL" -> Style.EMPTY.fg(Color.RED);
-            case "WARN" -> Style.EMPTY.fg(Color.YELLOW);
+            case "WARN" -> Theme.warning();
             case "INFO" -> Style.EMPTY.fg(Color.GREEN);
             case "DEBUG" -> Style.EMPTY.fg(Color.CYAN);
             case "TRACE" -> Style.EMPTY.dim();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
@@ -438,7 +438,7 @@ class LogTab extends AbstractTab {
 
         ListWidget list = ListWidget.builder()
                 .items(
-                        ListItem.from("  ERROR  ").style(Style.EMPTY.fg(Color.LIGHT_RED)),
+                        ListItem.from("  ERROR  ").style(Theme.error()),
                         ListItem.from("  WARN   ").style(Theme.warning()),
                         ListItem.from("  INFO   ").style(Style.EMPTY),
                         ListItem.from("  DEBUG  ").style(Style.EMPTY.fg(Color.CYAN)),
@@ -645,7 +645,7 @@ class LogTab extends AbstractTab {
         Style levelStyle = switch (level) {
             case "ERROR", "FATAL" -> Style.EMPTY.fg(Color.RED);
             case "WARN" -> Theme.warning();
-            case "INFO" -> Style.EMPTY.fg(Color.GREEN);
+            case "INFO" -> Theme.success();
             case "DEBUG" -> Style.EMPTY.fg(Color.CYAN);
             case "TRACE" -> Style.EMPTY.dim();
             default -> Style.EMPTY;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LogTab.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -441,7 +440,7 @@ class LogTab extends AbstractTab {
                         ListItem.from("  ERROR  ").style(Theme.error()),
                         ListItem.from("  WARN   ").style(Theme.warning()),
                         ListItem.from("  INFO   ").style(Style.EMPTY),
-                        ListItem.from("  DEBUG  ").style(Style.EMPTY.fg(Color.CYAN)),
+                        ListItem.from("  DEBUG  ").style(Style.EMPTY.fg(Theme.accent())),
                         ListItem.from("  TRACE  ").style(Style.EMPTY.dim()))
                 .highlightStyle(Theme.selectionBg())
                 .highlightSymbol("")
@@ -620,8 +619,8 @@ class LogTab extends AbstractTab {
     }
 
     private static final Style DIM = Style.EMPTY.dim();
-    private static final Style CYAN = Style.EMPTY.fg(Color.CYAN);
-    private static final Style MAGENTA = Style.EMPTY.fg(Color.MAGENTA);
+    private static final Style CYAN = Style.EMPTY.fg(Theme.accent());
+    private static final Style MAGENTA = Theme.notice();
 
     private static final Pattern PID_PATTERN = Pattern.compile(
             "^(\\d{4}-\\d{2}-\\d{2})[T ](\\d{2}:\\d{2}:\\d{2}\\.\\d+)\\S*\\s+"
@@ -643,10 +642,10 @@ class LogTab extends AbstractTab {
         String logger = m.group(6);
         String message = m.group(7);
         Style levelStyle = switch (level) {
-            case "ERROR", "FATAL" -> Style.EMPTY.fg(Color.RED);
+            case "ERROR", "FATAL" -> Theme.error();
             case "WARN" -> Theme.warning();
             case "INFO" -> Theme.success();
-            case "DEBUG" -> Style.EMPTY.fg(Color.CYAN);
+            case "DEBUG" -> Style.EMPTY.fg(Theme.accent());
             case "TRACE" -> Style.EMPTY.dim();
             default -> Style.EMPTY;
         };

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MavenDependenciesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MavenDependenciesTab.java
@@ -301,7 +301,7 @@ class MavenDependenciesTab extends AbstractTableTab {
     @Override
     public void renderFooter(List<Span> spans) {
         if (filterInputActive) {
-            spans.add(Span.styled(" /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled(" /", Theme.label().bold()));
             spans.add(Span.raw(filterInputState.text() + "█  "));
             hint(spans, "Enter", "filter");
             hintLast(spans, "Esc", "cancel");
@@ -316,7 +316,7 @@ class MavenDependenciesTab extends AbstractTableTab {
             hint(spans, "t", transitiveMode ? "direct" : "transitive");
         }
         if (filterTerm != null) {
-            spans.add(Span.styled("  /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled("  /", Theme.label().bold()));
             spans.add(Span.raw("\"" + filterTerm + "\"  "));
         } else {
             hint(spans, "/", "filter");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MavenDependenciesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MavenDependenciesTab.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -202,7 +201,7 @@ class MavenDependenciesTab extends AbstractTableTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(
-                                    Span.styled("  " + errorMessage, Style.EMPTY.fg(Color.LIGHT_RED)))))
+                                    Span.styled("  " + errorMessage, Theme.error()))))
                             .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Maven Dependencies ").build())
                             .build(),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
@@ -136,10 +136,10 @@ class McpLogPopup {
         List<ListItem> items = new ArrayList<>();
         for (TuiMcpServer.LogEntry entry : entries) {
             Style levelStyle = switch (entry.level()) {
-                case CONNECT -> Style.EMPTY.fg(Color.GREEN);
+                case CONNECT -> Theme.success();
                 case TOOL -> Style.EMPTY.fg(Color.CYAN);
-                case ERROR -> Style.EMPTY.fg(Color.LIGHT_RED);
-                default -> Style.EMPTY.fg(Color.GREEN);
+                case ERROR -> Theme.error();
+                default -> Theme.success();
             };
             String levelTag = switch (entry.level()) {
                 case CONNECT -> " CONNECT ";
@@ -187,7 +187,7 @@ class McpLogPopup {
             lines.add(Line.from(Span.raw("")));
         }
         if (entry.responseBody() != null) {
-            lines.add(Line.from(Span.styled(TuiIcons.ARROW_LEFT + " Response", Style.EMPTY.fg(Color.GREEN).bold())));
+            lines.add(Line.from(Span.styled(TuiIcons.ARROW_LEFT + " Response", Theme.success().bold())));
             addJsonLines(lines, entry.responseBody());
         }
         if (entry.requestBody() == null && entry.responseBody() == null) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
@@ -182,7 +182,7 @@ class McpLogPopup {
         TuiMcpServer.LogEntry entry = entries.get(selected);
         List<Line> lines = new ArrayList<>();
         if (entry.requestBody() != null) {
-            lines.add(Line.from(Span.styled(TuiIcons.ARROW_RIGHT + " Request", Style.EMPTY.fg(Color.YELLOW).bold())));
+            lines.add(Line.from(Span.styled(TuiIcons.ARROW_RIGHT + " Request", Theme.label().bold())));
             addJsonLines(lines, entry.requestBody());
             lines.add(Line.from(Span.raw("")));
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpLogPopup.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -137,7 +136,7 @@ class McpLogPopup {
         for (TuiMcpServer.LogEntry entry : entries) {
             Style levelStyle = switch (entry.level()) {
                 case CONNECT -> Theme.success();
-                case TOOL -> Style.EMPTY.fg(Color.CYAN);
+                case TOOL -> Style.EMPTY.fg(Theme.accent());
                 case ERROR -> Theme.error();
                 default -> Theme.success();
             };

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
@@ -245,7 +245,7 @@ class MemoryLeakTab extends AbstractTab {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
                     Span.styled("  Duration: ", Theme.label().bold()),
-                    Span.styled(duration + "s", Style.EMPTY.fg(Color.WHITE)),
+                    Span.styled(duration + "s", Style.EMPTY.fg(Theme.baseFg())),
                     Span.styled("  (use ", Style.EMPTY.dim()),
                     Span.styled("+", Theme.label().bold()),
                     Span.styled("/", Style.EMPTY.dim()),
@@ -254,7 +254,7 @@ class MemoryLeakTab extends AbstractTab {
             String modeLabel = recordingMode == RecordingMode.DUAL ? "dual" : "single";
             lines.add(Line.from(
                     Span.styled("  Mode:     ", Theme.label().bold()),
-                    Span.styled("[" + modeLabel + "]", Style.EMPTY.fg(Color.WHITE)),
+                    Span.styled("[" + modeLabel + "]", Style.EMPTY.fg(Theme.baseFg())),
                     Span.styled("  (press ", Style.EMPTY.dim()),
                     Span.styled("d", Theme.label().bold()),
                     Span.styled(" to toggle)", Style.EMPTY.dim())));
@@ -267,11 +267,11 @@ class MemoryLeakTab extends AbstractTab {
                         Span.styled("  Runs two sequential JFR recordings:", Style.EMPTY.dim())));
                 lines.add(Line.from(
                         Span.styled("    Run 1: ", Style.EMPTY.fg(Color.CYAN)),
-                        Span.styled(duration + "s", Style.EMPTY.fg(Color.WHITE)),
+                        Span.styled(duration + "s", Style.EMPTY.fg(Theme.baseFg())),
                         Span.styled(" baseline recording", Style.EMPTY.dim())));
                 lines.add(Line.from(
                         Span.styled("    Run 2: ", Style.EMPTY.fg(Color.CYAN)),
-                        Span.styled((duration * 2) + "s", Style.EMPTY.fg(Color.WHITE)),
+                        Span.styled((duration * 2) + "s", Style.EMPTY.fg(Theme.baseFg())),
                         Span.styled(" comparison recording (2x duration)", Style.EMPTY.dim())));
                 lines.add(Line.from(
                         Span.styled("  Compares trends to detect leaks: classes growing faster", Style.EMPTY.dim())));
@@ -320,13 +320,13 @@ class MemoryLeakTab extends AbstractTab {
         lines.add(Line.from(Span.raw("")));
         lines.add(Line.from(
                 Span.styled("  Elapsed:    ", Theme.label().bold()),
-                Span.styled(elapsedSec + "s", Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(elapsedSec + "s", Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
                 Span.styled("  Remaining:  ", Theme.label().bold()),
-                Span.styled(remainingSec + "s", Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(remainingSec + "s", Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
                 Span.styled("  Duration:   ", Theme.label().bold()),
-                Span.styled(currentRecordingDuration + "s", Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(currentRecordingDuration + "s", Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(Span.raw("")));
         lines.add(Line.from(
                 Span.styled("  Press ", Style.EMPTY.dim()),
@@ -437,7 +437,7 @@ class MemoryLeakTab extends AbstractTab {
                         Constraint.length(8),
                         Constraint.length(12),
                         Constraint.length(13))
-                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
+                .highlightStyle(Style.EMPTY.fg(Theme.baseFg()).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
                 .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
@@ -471,19 +471,19 @@ class MemoryLeakTab extends AbstractTab {
         List<Span> infoSpans = new ArrayList<>();
         if (entry.count > 1) {
             infoSpans.add(Span.styled("  Count:  ", Theme.label().bold()));
-            infoSpans.add(Span.styled(String.valueOf(entry.count), Style.EMPTY.fg(Color.WHITE)));
+            infoSpans.add(Span.styled(String.valueOf(entry.count), Style.EMPTY.fg(Theme.baseFg())));
         }
         if (entry.sampledSize > 0) {
             infoSpans.add(Span.styled(infoSpans.isEmpty() ? "  Sampled:  " : "    Sampled: ",
                     Theme.label().bold()));
-            infoSpans.add(Span.styled(formatBytes(entry.sampledSize), Style.EMPTY.fg(Color.WHITE)));
+            infoSpans.add(Span.styled(formatBytes(entry.sampledSize), Style.EMPTY.fg(Theme.baseFg())));
         }
         if (!infoSpans.isEmpty()) {
             lines.add(Line.from(infoSpans));
         }
         lines.add(Line.from(
                 Span.styled("  Age:    ", Theme.label().bold()),
-                Span.styled(formatDuration(entry.objectAge), Style.EMPTY.fg(Color.WHITE))));
+                Span.styled(formatDuration(entry.objectAge), Style.EMPTY.fg(Theme.baseFg()))));
 
         // Reference chain
         if (entry.referenceChain != null && !entry.referenceChain.isEmpty()) {
@@ -513,7 +513,7 @@ class MemoryLeakTab extends AbstractTab {
                     Span.styled("  Allocation Stack Trace:", Theme.label().bold())));
 
             for (StackEntry frame2 : entry.stackTrace) {
-                Style methodStyle = isJdkFrame(frame2.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE);
+                Style methodStyle = isJdkFrame(frame2.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg());
                 lines.add(Line.from(
                         Span.styled("    at ", Style.EMPTY.dim()),
                         Span.styled(frame2.method, methodStyle),
@@ -592,7 +592,7 @@ class MemoryLeakTab extends AbstractTab {
                         Constraint.length(10),
                         Constraint.length(9),
                         Constraint.length(13))
-                .highlightStyle(Style.EMPTY.fg(Color.WHITE).bold().onBlue())
+                .highlightStyle(Style.EMPTY.fg(Theme.baseFg()).bold().onBlue())
                 .highlightSpacing(Table.HighlightSpacing.ALWAYS)
                 .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL).title(title).build())
                 .build();
@@ -626,11 +626,11 @@ class MemoryLeakTab extends AbstractTab {
         lines.add(Line.from(
                 Span.styled("  Run 1:   ", Theme.label().bold()),
                 Span.styled(formatBytes(entry.baselineSampledSize) + " (" + entry.baselineCount + " samples)",
-                        Style.EMPTY.fg(Color.WHITE))));
+                        Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
                 Span.styled("  Run 2:   ", Theme.label().bold()),
                 Span.styled(formatBytes(entry.currentSampledSize) + " (" + entry.currentCount + " samples)",
-                        Style.EMPTY.fg(Color.WHITE))));
+                        Style.EMPTY.fg(Theme.baseFg()))));
         if (entry.growthRatio > 0) {
             String growthLabel = entry.lowConfidence
                     ? "~" + formatGrowthPercent(entry.growthRatio)
@@ -638,7 +638,7 @@ class MemoryLeakTab extends AbstractTab {
             lines.add(Line.from(
                     Span.styled("  Growth:  ", Theme.label().bold()),
                     Span.styled(growthLabel,
-                            entry.growthRatio > 1.3 ? Style.EMPTY.fg(Color.RED).bold() : Style.EMPTY.fg(Color.WHITE))));
+                            entry.growthRatio > 1.3 ? Style.EMPTY.fg(Color.RED).bold() : Style.EMPTY.fg(Theme.baseFg()))));
         }
         if (entry.lowConfidence) {
             lines.add(Line.from(
@@ -675,7 +675,7 @@ class MemoryLeakTab extends AbstractTab {
             lines.add(Line.from(
                     Span.styled("  Allocation Stack Trace:", Theme.label().bold())));
             for (StackEntry se : entry.stackTrace) {
-                Style methodStyle = isJdkFrame(se.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE);
+                Style methodStyle = isJdkFrame(se.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg());
                 lines.add(Line.from(
                         Span.styled("    at ", Style.EMPTY.dim()),
                         Span.styled(se.method, methodStyle),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -266,11 +265,11 @@ class MemoryLeakTab extends AbstractTab {
                 lines.add(Line.from(
                         Span.styled("  Runs two sequential JFR recordings:", Style.EMPTY.dim())));
                 lines.add(Line.from(
-                        Span.styled("    Run 1: ", Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled("    Run 1: ", Style.EMPTY.fg(Theme.accent())),
                         Span.styled(duration + "s", Style.EMPTY.fg(Theme.baseFg())),
                         Span.styled(" baseline recording", Style.EMPTY.dim())));
                 lines.add(Line.from(
-                        Span.styled("    Run 2: ", Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled("    Run 2: ", Style.EMPTY.fg(Theme.accent())),
                         Span.styled((duration * 2) + "s", Style.EMPTY.fg(Theme.baseFg())),
                         Span.styled(" comparison recording (2x duration)", Style.EMPTY.dim())));
                 lines.add(Line.from(
@@ -393,7 +392,7 @@ class MemoryLeakTab extends AbstractTab {
             String totalStr = e.sampledSize > 0 ? formatBytes(e.sampledSize) : "-";
             rows.add(Row.from(
                     rightCell(String.valueOf(e.num), 6),
-                    Cell.from(Span.styled(e.className != null ? e.className : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(e.className != null ? e.className : "", Style.EMPTY.fg(Theme.accent()))),
                     rightCell(String.valueOf(e.count), 8),
                     rightCell(totalStr, 12),
                     rightCell(formatDuration(e.objectAge), 12)));
@@ -466,7 +465,7 @@ class MemoryLeakTab extends AbstractTab {
         // Sample info
         lines.add(Line.from(
                 Span.styled("  Class:  ", Theme.label().bold()),
-                Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Color.CYAN))));
+                Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Theme.accent()))));
 
         List<Span> infoSpans = new ArrayList<>();
         if (entry.count > 1) {
@@ -499,8 +498,8 @@ class MemoryLeakTab extends AbstractTab {
                 String descInfo = link.description != null ? " [" + link.description + "]" : "";
 
                 lines.add(Line.from(
-                        Span.styled(prefix, Style.EMPTY.fg(Color.BLUE)),
-                        Span.styled(typeName, Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled(prefix, Style.EMPTY.fg(Theme.accent())),
+                        Span.styled(typeName, Style.EMPTY.fg(Theme.accent())),
                         Span.styled(fieldInfo, Theme.success()),
                         Span.styled(descInfo, Style.EMPTY.dim())));
             }
@@ -555,7 +554,7 @@ class MemoryLeakTab extends AbstractTab {
 
             rows.add(Row.from(
                     rightCell(String.valueOf(i + 1), 4),
-                    Cell.from(Span.styled(e.className != null ? e.className : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(e.className != null ? e.className : "", Style.EMPTY.fg(Theme.accent()))),
                     rightCell(run1, 10),
                     rightCell(run2, 10),
                     rightCell(growth, 8),
@@ -619,7 +618,7 @@ class MemoryLeakTab extends AbstractTab {
 
         lines.add(Line.from(
                 Span.styled("  Class:   ", Theme.label().bold()),
-                Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Color.CYAN))));
+                Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
                 Span.styled("  Trend:   ", Theme.label().bold()),
                 trendSpan(entry.trend)));
@@ -638,7 +637,7 @@ class MemoryLeakTab extends AbstractTab {
             lines.add(Line.from(
                     Span.styled("  Growth:  ", Theme.label().bold()),
                     Span.styled(growthLabel,
-                            entry.growthRatio > 1.3 ? Style.EMPTY.fg(Color.RED).bold() : Style.EMPTY.fg(Theme.baseFg()))));
+                            entry.growthRatio > 1.3 ? Theme.error().bold() : Style.EMPTY.fg(Theme.baseFg()))));
         }
         if (entry.lowConfidence) {
             lines.add(Line.from(
@@ -662,8 +661,8 @@ class MemoryLeakTab extends AbstractTab {
                 String fieldInfo = link.field != null ? " (field: " + link.field + ")" : "";
                 String descInfo = link.description != null ? " [" + link.description + "]" : "";
                 lines.add(Line.from(
-                        Span.styled(prefix, Style.EMPTY.fg(Color.BLUE)),
-                        Span.styled(typeName, Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled(prefix, Style.EMPTY.fg(Theme.accent())),
+                        Span.styled(typeName, Style.EMPTY.fg(Theme.accent())),
                         Span.styled(fieldInfo, Theme.success()),
                         Span.styled(descInfo, Style.EMPTY.dim())));
             }
@@ -707,7 +706,7 @@ class MemoryLeakTab extends AbstractTab {
             return Span.styled("-", Style.EMPTY.dim());
         }
         return switch (trend) {
-            case "growing" -> Span.styled(TuiIcons.ARROW_UP + " leak!", Style.EMPTY.fg(Color.RED).bold());
+            case "growing" -> Span.styled(TuiIcons.ARROW_UP + " leak!", Theme.error().bold());
             case "suspicious" -> Span.styled(TuiIcons.ARROW_UP + " leak?", Theme.warning());
             case "stable" -> Span.styled(TuiIcons.ARROW_STABLE + " stable", Theme.success());
             case "shrinking" -> Span.styled(TuiIcons.ARROW_DOWN, Style.EMPTY.dim());

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
@@ -262,7 +262,7 @@ class MemoryLeakTab extends AbstractTab {
             if (recordingMode == RecordingMode.DUAL) {
                 lines.add(Line.from(
                         Span.styled("  Dual mode ", Style.EMPTY.dim()),
-                        Span.styled("(recommended)", Style.EMPTY.fg(Color.GREEN))));
+                        Span.styled("(recommended)", Theme.success())));
                 lines.add(Line.from(
                         Span.styled("  Runs two sequential JFR recordings:", Style.EMPTY.dim())));
                 lines.add(Line.from(
@@ -311,10 +311,10 @@ class MemoryLeakTab extends AbstractTab {
                     ? "Recording 2 of 2 (" + currentRecordingDuration + "s)..."
                     : "Recording 1 of 2 (" + currentRecordingDuration + "s)...";
             lines.add(Line.from(
-                    Span.styled("  " + recLabel, Style.EMPTY.fg(Color.GREEN).bold())));
+                    Span.styled("  " + recLabel, Theme.success().bold())));
         } else {
             lines.add(Line.from(
-                    Span.styled("  Memory leak recording in progress...", Style.EMPTY.fg(Color.GREEN).bold())));
+                    Span.styled("  Memory leak recording in progress...", Theme.success().bold())));
         }
 
         lines.add(Line.from(Span.raw("")));
@@ -344,7 +344,7 @@ class MemoryLeakTab extends AbstractTab {
             bar.append(i < filled ? '█' : '░');
         }
         lines.add(Line.from(Span.raw("")));
-        lines.add(Line.from(Span.styled(bar.toString(), Style.EMPTY.fg(Color.GREEN))));
+        lines.add(Line.from(Span.styled(bar.toString(), Theme.success())));
 
         String title = recordingMode == RecordingMode.DUAL
                 ? " Memory Leak Recording [dual] "
@@ -501,7 +501,7 @@ class MemoryLeakTab extends AbstractTab {
                 lines.add(Line.from(
                         Span.styled(prefix, Style.EMPTY.fg(Color.BLUE)),
                         Span.styled(typeName, Style.EMPTY.fg(Color.CYAN)),
-                        Span.styled(fieldInfo, Style.EMPTY.fg(Color.GREEN)),
+                        Span.styled(fieldInfo, Theme.success()),
                         Span.styled(descInfo, Style.EMPTY.dim())));
             }
         }
@@ -664,7 +664,7 @@ class MemoryLeakTab extends AbstractTab {
                 lines.add(Line.from(
                         Span.styled(prefix, Style.EMPTY.fg(Color.BLUE)),
                         Span.styled(typeName, Style.EMPTY.fg(Color.CYAN)),
-                        Span.styled(fieldInfo, Style.EMPTY.fg(Color.GREEN)),
+                        Span.styled(fieldInfo, Theme.success()),
                         Span.styled(descInfo, Style.EMPTY.dim())));
             }
         }
@@ -709,7 +709,7 @@ class MemoryLeakTab extends AbstractTab {
         return switch (trend) {
             case "growing" -> Span.styled(TuiIcons.ARROW_UP + " leak!", Style.EMPTY.fg(Color.RED).bold());
             case "suspicious" -> Span.styled(TuiIcons.ARROW_UP + " leak?", Theme.warning());
-            case "stable" -> Span.styled(TuiIcons.ARROW_STABLE + " stable", Style.EMPTY.fg(Color.GREEN));
+            case "stable" -> Span.styled(TuiIcons.ARROW_STABLE + " stable", Theme.success());
             case "shrinking" -> Span.styled(TuiIcons.ARROW_DOWN, Style.EMPTY.dim());
             case "new" -> Span.styled("new", Theme.warning());
             case "gone" -> Span.styled("gone", Style.EMPTY.dim());

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
@@ -240,23 +240,23 @@ class MemoryLeakTab extends AbstractTab {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
                     Span.styled("  Press ", Style.EMPTY.dim()),
-                    Span.styled("R", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("R", Theme.label().bold()),
                     Span.styled(" to start a recording.", Style.EMPTY.dim())));
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Duration: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("  Duration: ", Theme.label().bold()),
                     Span.styled(duration + "s", Style.EMPTY.fg(Color.WHITE)),
                     Span.styled("  (use ", Style.EMPTY.dim()),
-                    Span.styled("+", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("+", Theme.label().bold()),
                     Span.styled("/", Style.EMPTY.dim()),
-                    Span.styled("-", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("-", Theme.label().bold()),
                     Span.styled(" to adjust)", Style.EMPTY.dim())));
             String modeLabel = recordingMode == RecordingMode.DUAL ? "dual" : "single";
             lines.add(Line.from(
-                    Span.styled("  Mode:     ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("  Mode:     ", Theme.label().bold()),
                     Span.styled("[" + modeLabel + "]", Style.EMPTY.fg(Color.WHITE)),
                     Span.styled("  (press ", Style.EMPTY.dim()),
-                    Span.styled("d", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("d", Theme.label().bold()),
                     Span.styled(" to toggle)", Style.EMPTY.dim())));
             lines.add(Line.from(Span.raw("")));
             if (recordingMode == RecordingMode.DUAL) {
@@ -319,18 +319,18 @@ class MemoryLeakTab extends AbstractTab {
 
         lines.add(Line.from(Span.raw("")));
         lines.add(Line.from(
-                Span.styled("  Elapsed:    ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Elapsed:    ", Theme.label().bold()),
                 Span.styled(elapsedSec + "s", Style.EMPTY.fg(Color.WHITE))));
         lines.add(Line.from(
-                Span.styled("  Remaining:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Remaining:  ", Theme.label().bold()),
                 Span.styled(remainingSec + "s", Style.EMPTY.fg(Color.WHITE))));
         lines.add(Line.from(
-                Span.styled("  Duration:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Duration:   ", Theme.label().bold()),
                 Span.styled(currentRecordingDuration + "s", Style.EMPTY.fg(Color.WHITE))));
         lines.add(Line.from(Span.raw("")));
         lines.add(Line.from(
                 Span.styled("  Press ", Style.EMPTY.dim()),
-                Span.styled("X", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("X", Theme.label().bold()),
                 Span.styled(" to stop recording early and view results.", Style.EMPTY.dim())));
 
         // progress bar
@@ -465,31 +465,31 @@ class MemoryLeakTab extends AbstractTab {
 
         // Sample info
         lines.add(Line.from(
-                Span.styled("  Class:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Class:  ", Theme.label().bold()),
                 Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Color.CYAN))));
 
         List<Span> infoSpans = new ArrayList<>();
         if (entry.count > 1) {
-            infoSpans.add(Span.styled("  Count:  ", Style.EMPTY.fg(Color.YELLOW).bold()));
+            infoSpans.add(Span.styled("  Count:  ", Theme.label().bold()));
             infoSpans.add(Span.styled(String.valueOf(entry.count), Style.EMPTY.fg(Color.WHITE)));
         }
         if (entry.sampledSize > 0) {
             infoSpans.add(Span.styled(infoSpans.isEmpty() ? "  Sampled:  " : "    Sampled: ",
-                    Style.EMPTY.fg(Color.YELLOW).bold()));
+                    Theme.label().bold()));
             infoSpans.add(Span.styled(formatBytes(entry.sampledSize), Style.EMPTY.fg(Color.WHITE)));
         }
         if (!infoSpans.isEmpty()) {
             lines.add(Line.from(infoSpans));
         }
         lines.add(Line.from(
-                Span.styled("  Age:    ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Age:    ", Theme.label().bold()),
                 Span.styled(formatDuration(entry.objectAge), Style.EMPTY.fg(Color.WHITE))));
 
         // Reference chain
         if (entry.referenceChain != null && !entry.referenceChain.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Reference Chain (Object → GC Root):", Style.EMPTY.fg(Color.YELLOW).bold())));
+                    Span.styled("  Reference Chain (Object → GC Root):", Theme.label().bold())));
 
             for (int i = 0; i < entry.referenceChain.size(); i++) {
                 ChainLink link = entry.referenceChain.get(i);
@@ -510,7 +510,7 @@ class MemoryLeakTab extends AbstractTab {
         if (entry.stackTrace != null && !entry.stackTrace.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Allocation Stack Trace:", Style.EMPTY.fg(Color.YELLOW).bold())));
+                    Span.styled("  Allocation Stack Trace:", Theme.label().bold())));
 
             for (StackEntry frame2 : entry.stackTrace) {
                 Style methodStyle = isJdkFrame(frame2.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE);
@@ -559,7 +559,7 @@ class MemoryLeakTab extends AbstractTab {
                     rightCell(run1, 10),
                     rightCell(run2, 10),
                     rightCell(growth, 8),
-                    Cell.from(Line.from(trendSpan, Span.styled(warn, Style.EMPTY.fg(Color.YELLOW))))));
+                    Cell.from(Line.from(trendSpan, Span.styled(warn, Theme.warning())))));
         }
 
         if (rows.isEmpty()) {
@@ -618,17 +618,17 @@ class MemoryLeakTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
 
         lines.add(Line.from(
-                Span.styled("  Class:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Class:   ", Theme.label().bold()),
                 Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Color.CYAN))));
         lines.add(Line.from(
-                Span.styled("  Trend:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Trend:   ", Theme.label().bold()),
                 trendSpan(entry.trend)));
         lines.add(Line.from(
-                Span.styled("  Run 1:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Run 1:   ", Theme.label().bold()),
                 Span.styled(formatBytes(entry.baselineSampledSize) + " (" + entry.baselineCount + " samples)",
                         Style.EMPTY.fg(Color.WHITE))));
         lines.add(Line.from(
-                Span.styled("  Run 2:   ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled("  Run 2:   ", Theme.label().bold()),
                 Span.styled(formatBytes(entry.currentSampledSize) + " (" + entry.currentCount + " samples)",
                         Style.EMPTY.fg(Color.WHITE))));
         if (entry.growthRatio > 0) {
@@ -636,13 +636,13 @@ class MemoryLeakTab extends AbstractTab {
                     ? "~" + formatGrowthPercent(entry.growthRatio)
                     : formatGrowthPercent(entry.growthRatio);
             lines.add(Line.from(
-                    Span.styled("  Growth:  ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled("  Growth:  ", Theme.label().bold()),
                     Span.styled(growthLabel,
                             entry.growthRatio > 1.3 ? Style.EMPTY.fg(Color.RED).bold() : Style.EMPTY.fg(Color.WHITE))));
         }
         if (entry.lowConfidence) {
             lines.add(Line.from(
-                    Span.styled("  " + TuiIcons.HEALTH_WARN + " Low confidence: ", Style.EMPTY.fg(Color.YELLOW)),
+                    Span.styled("  " + TuiIcons.HEALTH_WARN + " Low confidence: ", Theme.warning()),
                     Span.styled("sample counts are too low or diverge significantly", Style.EMPTY.dim())));
             lines.add(Line.from(
                     Span.styled("    between runs. The growth percentage may not be reliable.", Style.EMPTY.dim())));
@@ -654,7 +654,7 @@ class MemoryLeakTab extends AbstractTab {
         if (entry.referenceChain != null && !entry.referenceChain.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Reference Chain (Object -> GC Root):", Style.EMPTY.fg(Color.YELLOW).bold())));
+                    Span.styled("  Reference Chain (Object -> GC Root):", Theme.label().bold())));
             for (int i = 0; i < entry.referenceChain.size(); i++) {
                 ChainLink link = entry.referenceChain.get(i);
                 String prefix = i == entry.referenceChain.size() - 1 ? "  └─ " : "  ├─ ";
@@ -673,7 +673,7 @@ class MemoryLeakTab extends AbstractTab {
         if (entry.stackTrace != null && !entry.stackTrace.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Allocation Stack Trace:", Style.EMPTY.fg(Color.YELLOW).bold())));
+                    Span.styled("  Allocation Stack Trace:", Theme.label().bold())));
             for (StackEntry se : entry.stackTrace) {
                 Style methodStyle = isJdkFrame(se.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Color.WHITE);
                 lines.add(Line.from(
@@ -708,10 +708,10 @@ class MemoryLeakTab extends AbstractTab {
         }
         return switch (trend) {
             case "growing" -> Span.styled(TuiIcons.ARROW_UP + " leak!", Style.EMPTY.fg(Color.RED).bold());
-            case "suspicious" -> Span.styled(TuiIcons.ARROW_UP + " leak?", Style.EMPTY.fg(Color.YELLOW).bold());
+            case "suspicious" -> Span.styled(TuiIcons.ARROW_UP + " leak?", Theme.warning());
             case "stable" -> Span.styled(TuiIcons.ARROW_STABLE + " stable", Style.EMPTY.fg(Color.GREEN));
             case "shrinking" -> Span.styled(TuiIcons.ARROW_DOWN, Style.EMPTY.dim());
-            case "new" -> Span.styled("new", Style.EMPTY.fg(Color.YELLOW));
+            case "new" -> Span.styled("new", Theme.warning());
             case "gone" -> Span.styled("gone", Style.EMPTY.dim());
             default -> Span.styled(trend, Style.EMPTY.dim());
         };

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryLeakTab.java
@@ -243,7 +243,7 @@ class MemoryLeakTab extends AbstractTab {
                     Span.styled(" to start a recording.", Style.EMPTY.dim())));
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Duration: ", Theme.label().bold()),
+                    Span.styled("  Duration: ", Theme.muted()),
                     Span.styled(duration + "s", Style.EMPTY.fg(Theme.baseFg())),
                     Span.styled("  (use ", Style.EMPTY.dim()),
                     Span.styled("+", Theme.label().bold()),
@@ -252,7 +252,7 @@ class MemoryLeakTab extends AbstractTab {
                     Span.styled(" to adjust)", Style.EMPTY.dim())));
             String modeLabel = recordingMode == RecordingMode.DUAL ? "dual" : "single";
             lines.add(Line.from(
-                    Span.styled("  Mode:     ", Theme.label().bold()),
+                    Span.styled("  Mode:     ", Theme.muted()),
                     Span.styled("[" + modeLabel + "]", Style.EMPTY.fg(Theme.baseFg())),
                     Span.styled("  (press ", Style.EMPTY.dim()),
                     Span.styled("d", Theme.label().bold()),
@@ -265,11 +265,11 @@ class MemoryLeakTab extends AbstractTab {
                 lines.add(Line.from(
                         Span.styled("  Runs two sequential JFR recordings:", Style.EMPTY.dim())));
                 lines.add(Line.from(
-                        Span.styled("    Run 1: ", Style.EMPTY.fg(Theme.accent())),
+                        Span.styled("    Run 1: ", Theme.muted()),
                         Span.styled(duration + "s", Style.EMPTY.fg(Theme.baseFg())),
                         Span.styled(" baseline recording", Style.EMPTY.dim())));
                 lines.add(Line.from(
-                        Span.styled("    Run 2: ", Style.EMPTY.fg(Theme.accent())),
+                        Span.styled("    Run 2: ", Theme.muted()),
                         Span.styled((duration * 2) + "s", Style.EMPTY.fg(Theme.baseFg())),
                         Span.styled(" comparison recording (2x duration)", Style.EMPTY.dim())));
                 lines.add(Line.from(
@@ -318,13 +318,13 @@ class MemoryLeakTab extends AbstractTab {
 
         lines.add(Line.from(Span.raw("")));
         lines.add(Line.from(
-                Span.styled("  Elapsed:    ", Theme.label().bold()),
+                Span.styled("  Elapsed:    ", Theme.muted()),
                 Span.styled(elapsedSec + "s", Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
-                Span.styled("  Remaining:  ", Theme.label().bold()),
+                Span.styled("  Remaining:  ", Theme.muted()),
                 Span.styled(remainingSec + "s", Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
-                Span.styled("  Duration:   ", Theme.label().bold()),
+                Span.styled("  Duration:   ", Theme.muted()),
                 Span.styled(currentRecordingDuration + "s", Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(Span.raw("")));
         lines.add(Line.from(
@@ -464,31 +464,31 @@ class MemoryLeakTab extends AbstractTab {
 
         // Sample info
         lines.add(Line.from(
-                Span.styled("  Class:  ", Theme.label().bold()),
+                Span.styled("  Class:  ", Theme.muted()),
                 Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Theme.accent()))));
 
         List<Span> infoSpans = new ArrayList<>();
         if (entry.count > 1) {
-            infoSpans.add(Span.styled("  Count:  ", Theme.label().bold()));
+            infoSpans.add(Span.styled("  Count:  ", Theme.muted()));
             infoSpans.add(Span.styled(String.valueOf(entry.count), Style.EMPTY.fg(Theme.baseFg())));
         }
         if (entry.sampledSize > 0) {
             infoSpans.add(Span.styled(infoSpans.isEmpty() ? "  Sampled:  " : "    Sampled: ",
-                    Theme.label().bold()));
+                    Theme.muted()));
             infoSpans.add(Span.styled(formatBytes(entry.sampledSize), Style.EMPTY.fg(Theme.baseFg())));
         }
         if (!infoSpans.isEmpty()) {
             lines.add(Line.from(infoSpans));
         }
         lines.add(Line.from(
-                Span.styled("  Age:    ", Theme.label().bold()),
+                Span.styled("  Age:    ", Theme.muted()),
                 Span.styled(formatDuration(entry.objectAge), Style.EMPTY.fg(Theme.baseFg()))));
 
         // Reference chain
         if (entry.referenceChain != null && !entry.referenceChain.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Reference Chain (Object → GC Root):", Theme.label().bold())));
+                    Span.styled("  Reference Chain (Object → GC Root):", Theme.muted())));
 
             for (int i = 0; i < entry.referenceChain.size(); i++) {
                 ChainLink link = entry.referenceChain.get(i);
@@ -509,7 +509,7 @@ class MemoryLeakTab extends AbstractTab {
         if (entry.stackTrace != null && !entry.stackTrace.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Allocation Stack Trace:", Theme.label().bold())));
+                    Span.styled("  Allocation Stack Trace:", Theme.muted())));
 
             for (StackEntry frame2 : entry.stackTrace) {
                 Style methodStyle = isJdkFrame(frame2.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg());
@@ -617,17 +617,17 @@ class MemoryLeakTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
 
         lines.add(Line.from(
-                Span.styled("  Class:   ", Theme.label().bold()),
+                Span.styled("  Class:   ", Theme.muted()),
                 Span.styled(entry.className != null ? entry.className : "unknown", Style.EMPTY.fg(Theme.accent()))));
         lines.add(Line.from(
-                Span.styled("  Trend:   ", Theme.label().bold()),
+                Span.styled("  Trend:   ", Theme.muted()),
                 trendSpan(entry.trend)));
         lines.add(Line.from(
-                Span.styled("  Run 1:   ", Theme.label().bold()),
+                Span.styled("  Run 1:   ", Theme.muted()),
                 Span.styled(formatBytes(entry.baselineSampledSize) + " (" + entry.baselineCount + " samples)",
                         Style.EMPTY.fg(Theme.baseFg()))));
         lines.add(Line.from(
-                Span.styled("  Run 2:   ", Theme.label().bold()),
+                Span.styled("  Run 2:   ", Theme.muted()),
                 Span.styled(formatBytes(entry.currentSampledSize) + " (" + entry.currentCount + " samples)",
                         Style.EMPTY.fg(Theme.baseFg()))));
         if (entry.growthRatio > 0) {
@@ -635,7 +635,7 @@ class MemoryLeakTab extends AbstractTab {
                     ? "~" + formatGrowthPercent(entry.growthRatio)
                     : formatGrowthPercent(entry.growthRatio);
             lines.add(Line.from(
-                    Span.styled("  Growth:  ", Theme.label().bold()),
+                    Span.styled("  Growth:  ", Theme.muted()),
                     Span.styled(growthLabel,
                             entry.growthRatio > 1.3 ? Theme.error().bold() : Style.EMPTY.fg(Theme.baseFg()))));
         }
@@ -653,7 +653,7 @@ class MemoryLeakTab extends AbstractTab {
         if (entry.referenceChain != null && !entry.referenceChain.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Reference Chain (Object -> GC Root):", Theme.label().bold())));
+                    Span.styled("  Reference Chain (Object -> GC Root):", Theme.muted())));
             for (int i = 0; i < entry.referenceChain.size(); i++) {
                 ChainLink link = entry.referenceChain.get(i);
                 String prefix = i == entry.referenceChain.size() - 1 ? "  └─ " : "  ├─ ";
@@ -672,7 +672,7 @@ class MemoryLeakTab extends AbstractTab {
         if (entry.stackTrace != null && !entry.stackTrace.isEmpty()) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Allocation Stack Trace:", Theme.label().bold())));
+                    Span.styled("  Allocation Stack Trace:", Theme.muted())));
             for (StackEntry se : entry.stackTrace) {
                 Style methodStyle = isJdkFrame(se.method) ? Style.EMPTY.dim() : Style.EMPTY.fg(Theme.baseFg());
                 lines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -135,7 +135,7 @@ class MemoryTab extends AbstractTab {
 
             lines.add(Line.from(
                     Span.styled("  used:      ", Style.EMPTY.dim()),
-                    Span.styled(formatBytes(info.heapMemUsed), Style.EMPTY.fg(Color.WHITE).bold())));
+                    Span.styled(formatBytes(info.heapMemUsed), Style.EMPTY.fg(Theme.baseFg()).bold())));
 
             if (info.heapMemCommitted > 0) {
                 long pctComm = info.heapMemUsed * 100 / info.heapMemCommitted;
@@ -180,7 +180,7 @@ class MemoryTab extends AbstractTab {
 
             lines.add(Line.from(
                     Span.styled("  Old Gen:   ", Style.EMPTY.dim()),
-                    Span.styled(String.format("%-10s", formatBytes(info.oldGenUsed)), Style.EMPTY.fg(Color.WHITE).bold()),
+                    Span.styled(String.format("%-10s", formatBytes(info.oldGenUsed)), Style.EMPTY.fg(Theme.baseFg()).bold()),
                     Span.styled(oldGauge, oldColor),
                     Span.styled(String.format("  %d%%", oldPct), oldColor.bold())));
             lines.add(Line.from(
@@ -197,14 +197,15 @@ class MemoryTab extends AbstractTab {
                     Span.styled("  Non-Heap Memory", Style.EMPTY.fg(Color.CYAN).bold())));
             lines.add(Line.from(
                     Span.styled("  used:      ", Style.EMPTY.dim()),
-                    Span.styled(String.format("%-10s", formatBytes(info.nonHeapMemUsed)), Style.EMPTY.fg(Color.WHITE).bold()),
+                    Span.styled(String.format("%-10s", formatBytes(info.nonHeapMemUsed)),
+                            Style.EMPTY.fg(Theme.baseFg()).bold()),
                     Span.styled("  committed: ", Style.EMPTY.dim()),
                     Span.raw(formatBytes(info.nonHeapMemCommitted))));
         }
         if (info.metaspaceUsed > 0) {
             lines.add(Line.from(
                     Span.styled("  Metaspace: ", Style.EMPTY.dim()),
-                    Span.styled(String.format("%-10s", formatBytes(info.metaspaceUsed)), Style.EMPTY.fg(Color.WHITE).bold()),
+                    Span.styled(String.format("%-10s", formatBytes(info.metaspaceUsed)), Style.EMPTY.fg(Theme.baseFg()).bold()),
                     Span.styled("  committed: ", Style.EMPTY.dim()),
                     Span.raw(formatBytes(info.metaspaceCommitted)),
                     info.metaspaceMax > 0
@@ -218,7 +219,7 @@ class MemoryTab extends AbstractTab {
             List<Span> threadSpans = new ArrayList<>();
             threadSpans.add(Span.styled("  Threads", Style.EMPTY.fg(Color.CYAN).bold()));
             threadSpans.add(Span.styled("  current: ", Style.EMPTY.dim()));
-            threadSpans.add(Span.styled(String.valueOf(info.threadCount), Style.EMPTY.fg(Color.WHITE).bold()));
+            threadSpans.add(Span.styled(String.valueOf(info.threadCount), Style.EMPTY.fg(Theme.baseFg()).bold()));
             threadSpans.add(Span.styled("  peak: ", Style.EMPTY.dim()));
             threadSpans.add(Span.raw(String.valueOf(info.peakThreadCount)));
             lines.add(Line.from(threadSpans));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -126,14 +126,14 @@ class MemoryTab extends AbstractTab {
         // Heap memory with two gauge bars (used/committed and used/max)
         if (info.heapMemUsed > 0) {
             lines.add(Line.from(
-                    Span.styled("  Heap Memory", Style.EMPTY.fg(Theme.accent()).bold())));
+                    Span.styled("  Heap Memory", Theme.label().bold())));
 
             // Compute heap trend from history
             LinkedList<Long> hist = heapMemHistory.get(info.pid);
             Span trendSpan = computeTrendSpan(hist, info.heapMemCommitted);
 
             lines.add(Line.from(
-                    Span.styled("  used:      ", Style.EMPTY.dim()),
+                    Span.styled("  used:      ", Theme.muted()),
                     Span.styled(formatBytes(info.heapMemUsed), Style.EMPTY.fg(Theme.baseFg()).bold())));
 
             if (info.heapMemCommitted > 0) {
@@ -142,7 +142,7 @@ class MemoryTab extends AbstractTab {
                 Style colorComm = pctComm >= 80 ? Theme.error() : pctComm >= 60 ? Theme.warning()
                         : Theme.success();
                 List<Span> commSpans = new ArrayList<>();
-                commSpans.add(Span.styled("  committed: ", Style.EMPTY.dim()));
+                commSpans.add(Span.styled("  committed: ", Theme.muted()));
                 commSpans.add(Span.styled(String.format("%-10s", formatBytes(info.heapMemCommitted)), Style.EMPTY));
                 commSpans.add(Span.styled(gaugeComm, colorComm));
                 commSpans.add(Span.styled(String.format("  %d%%", pctComm), colorComm.bold()));
@@ -158,7 +158,7 @@ class MemoryTab extends AbstractTab {
                 Style colorMax = pctMax >= 80 ? Theme.error() : pctMax >= 60 ? Theme.warning()
                         : Theme.success();
                 List<Span> maxSpans = new ArrayList<>();
-                maxSpans.add(Span.styled("  max:       ", Style.EMPTY.dim()));
+                maxSpans.add(Span.styled("  max:       ", Theme.muted()));
                 maxSpans.add(Span.styled(String.format("%-10s", formatBytes(info.heapMemMax)), Style.EMPTY));
                 maxSpans.add(Span.styled(gaugeMax, colorMax));
                 maxSpans.add(Span.styled(String.format("  %d%%", pctMax), colorMax.bold()));
@@ -178,14 +178,14 @@ class MemoryTab extends AbstractTab {
                     : Theme.success();
 
             lines.add(Line.from(
-                    Span.styled("  Old Gen:   ", Style.EMPTY.dim()),
+                    Span.styled("  Old Gen:   ", Theme.muted()),
                     Span.styled(String.format("%-10s", formatBytes(info.oldGenUsed)), Style.EMPTY.fg(Theme.baseFg()).bold()),
                     Span.styled(oldGauge, oldColor),
                     Span.styled(String.format("  %d%%", oldPct), oldColor.bold())));
             lines.add(Line.from(
-                    Span.styled("  committed: ", Style.EMPTY.dim()),
+                    Span.styled("  committed: ", Theme.muted()),
                     Span.raw(formatBytes(info.oldGenCommitted)),
-                    Span.styled("    max: ", Style.EMPTY.dim()),
+                    Span.styled("    max: ", Theme.muted()),
                     Span.raw(formatBytes(info.oldGenMax))));
         }
 
@@ -193,22 +193,22 @@ class MemoryTab extends AbstractTab {
         if (info.nonHeapMemUsed > 0) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Non-Heap Memory", Style.EMPTY.fg(Theme.accent()).bold())));
+                    Span.styled("  Non-Heap Memory", Theme.label().bold())));
             lines.add(Line.from(
-                    Span.styled("  used:      ", Style.EMPTY.dim()),
+                    Span.styled("  used:      ", Theme.muted()),
                     Span.styled(String.format("%-10s", formatBytes(info.nonHeapMemUsed)),
                             Style.EMPTY.fg(Theme.baseFg()).bold()),
-                    Span.styled("  committed: ", Style.EMPTY.dim()),
+                    Span.styled("  committed: ", Theme.muted()),
                     Span.raw(formatBytes(info.nonHeapMemCommitted))));
         }
         if (info.metaspaceUsed > 0) {
             lines.add(Line.from(
-                    Span.styled("  Metaspace: ", Style.EMPTY.dim()),
+                    Span.styled("  Metaspace: ", Theme.muted()),
                     Span.styled(String.format("%-10s", formatBytes(info.metaspaceUsed)), Style.EMPTY.fg(Theme.baseFg()).bold()),
-                    Span.styled("  committed: ", Style.EMPTY.dim()),
+                    Span.styled("  committed: ", Theme.muted()),
                     Span.raw(formatBytes(info.metaspaceCommitted)),
                     info.metaspaceMax > 0
-                            ? Span.styled("  max: " + formatBytes(info.metaspaceMax), Style.EMPTY.dim())
+                            ? Span.styled("  max: " + formatBytes(info.metaspaceMax), Theme.muted())
                             : Span.raw("")));
         }
 
@@ -216,24 +216,24 @@ class MemoryTab extends AbstractTab {
         if (info.threadCount > 0) {
             lines.add(Line.from(Span.raw("")));
             List<Span> threadSpans = new ArrayList<>();
-            threadSpans.add(Span.styled("  Threads", Style.EMPTY.fg(Theme.accent()).bold()));
-            threadSpans.add(Span.styled("  current: ", Style.EMPTY.dim()));
+            threadSpans.add(Span.styled("  Threads", Theme.label().bold()));
+            threadSpans.add(Span.styled("  current: ", Theme.muted()));
             threadSpans.add(Span.styled(String.valueOf(info.threadCount), Style.EMPTY.fg(Theme.baseFg()).bold()));
-            threadSpans.add(Span.styled("  peak: ", Style.EMPTY.dim()));
+            threadSpans.add(Span.styled("  peak: ", Theme.muted()));
             threadSpans.add(Span.raw(String.valueOf(info.peakThreadCount)));
             lines.add(Line.from(threadSpans));
         }
 
         // GC and class loading on the same line
         List<Span> gcSpans = new ArrayList<>();
-        gcSpans.add(Span.styled("  GC: ", Style.EMPTY.dim()));
+        gcSpans.add(Span.styled("  GC: ", Theme.muted()));
         gcSpans.add(Span.raw(info.gcCollectionCount + " collections"));
         if (info.gcCollectionTime > 0) {
-            gcSpans.add(Span.styled("  time: ", Style.EMPTY.dim()));
+            gcSpans.add(Span.styled("  time: ", Theme.muted()));
             gcSpans.add(Span.raw(TimeUtils.printDuration(info.gcCollectionTime, true)));
         }
         if (info.loadedClassCount > 0) {
-            gcSpans.add(Span.styled("    Classes: ", Style.EMPTY.dim()));
+            gcSpans.add(Span.styled("    Classes: ", Theme.muted()));
             gcSpans.add(Span.raw(String.valueOf(info.loadedClassCount)));
         }
         lines.add(Line.from(Span.raw("")));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -26,7 +26,6 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -127,7 +126,7 @@ class MemoryTab extends AbstractTab {
         // Heap memory with two gauge bars (used/committed and used/max)
         if (info.heapMemUsed > 0) {
             lines.add(Line.from(
-                    Span.styled("  Heap Memory", Style.EMPTY.fg(Color.CYAN).bold())));
+                    Span.styled("  Heap Memory", Style.EMPTY.fg(Theme.accent()).bold())));
 
             // Compute heap trend from history
             LinkedList<Long> hist = heapMemHistory.get(info.pid);
@@ -194,7 +193,7 @@ class MemoryTab extends AbstractTab {
         if (info.nonHeapMemUsed > 0) {
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled("  Non-Heap Memory", Style.EMPTY.fg(Color.CYAN).bold())));
+                    Span.styled("  Non-Heap Memory", Style.EMPTY.fg(Theme.accent()).bold())));
             lines.add(Line.from(
                     Span.styled("  used:      ", Style.EMPTY.dim()),
                     Span.styled(String.format("%-10s", formatBytes(info.nonHeapMemUsed)),
@@ -217,7 +216,7 @@ class MemoryTab extends AbstractTab {
         if (info.threadCount > 0) {
             lines.add(Line.from(Span.raw("")));
             List<Span> threadSpans = new ArrayList<>();
-            threadSpans.add(Span.styled("  Threads", Style.EMPTY.fg(Color.CYAN).bold()));
+            threadSpans.add(Span.styled("  Threads", Style.EMPTY.fg(Theme.accent()).bold()));
             threadSpans.add(Span.styled("  current: ", Style.EMPTY.dim()));
             threadSpans.add(Span.styled(String.valueOf(info.threadCount), Style.EMPTY.fg(Theme.baseFg()).bold()));
             threadSpans.add(Span.styled("  peak: ", Style.EMPTY.dim()));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -140,12 +140,13 @@ class MemoryTab extends AbstractTab {
             if (info.heapMemCommitted > 0) {
                 long pctComm = info.heapMemUsed * 100 / info.heapMemCommitted;
                 String gaugeComm = buildGaugeBar(pctComm, 30);
-                Color colorComm = pctComm >= 80 ? Color.LIGHT_RED : pctComm >= 60 ? Color.YELLOW : Color.GREEN;
+                Style colorComm = pctComm >= 80 ? Style.EMPTY.fg(Color.LIGHT_RED) : pctComm >= 60 ? Theme.warning()
+                        : Style.EMPTY.fg(Color.GREEN);
                 List<Span> commSpans = new ArrayList<>();
                 commSpans.add(Span.styled("  committed: ", Style.EMPTY.dim()));
                 commSpans.add(Span.styled(String.format("%-10s", formatBytes(info.heapMemCommitted)), Style.EMPTY));
-                commSpans.add(Span.styled(gaugeComm, Style.EMPTY.fg(colorComm)));
-                commSpans.add(Span.styled(String.format("  %d%%", pctComm), Style.EMPTY.fg(colorComm).bold()));
+                commSpans.add(Span.styled(gaugeComm, colorComm));
+                commSpans.add(Span.styled(String.format("  %d%%", pctComm), colorComm.bold()));
                 if (info.heapMemMax <= 0 && trendSpan != null) {
                     commSpans.add(Span.raw("    "));
                     commSpans.add(trendSpan);
@@ -155,12 +156,13 @@ class MemoryTab extends AbstractTab {
             if (info.heapMemMax > 0) {
                 long pctMax = info.heapMemUsed * 100 / info.heapMemMax;
                 String gaugeMax = buildGaugeBar(pctMax, 30);
-                Color colorMax = pctMax >= 80 ? Color.LIGHT_RED : pctMax >= 60 ? Color.YELLOW : Color.GREEN;
+                Style colorMax = pctMax >= 80 ? Style.EMPTY.fg(Color.LIGHT_RED) : pctMax >= 60 ? Theme.warning()
+                        : Style.EMPTY.fg(Color.GREEN);
                 List<Span> maxSpans = new ArrayList<>();
                 maxSpans.add(Span.styled("  max:       ", Style.EMPTY.dim()));
                 maxSpans.add(Span.styled(String.format("%-10s", formatBytes(info.heapMemMax)), Style.EMPTY));
-                maxSpans.add(Span.styled(gaugeMax, Style.EMPTY.fg(colorMax)));
-                maxSpans.add(Span.styled(String.format("  %d%%", pctMax), Style.EMPTY.fg(colorMax).bold()));
+                maxSpans.add(Span.styled(gaugeMax, colorMax));
+                maxSpans.add(Span.styled(String.format("  %d%%", pctMax), colorMax.bold()));
                 if (trendSpan != null) {
                     maxSpans.add(Span.raw("    "));
                     maxSpans.add(trendSpan);
@@ -173,13 +175,14 @@ class MemoryTab extends AbstractTab {
         if (info.oldGenUsed > 0) {
             long oldPct = info.oldGenMax > 0 ? info.oldGenUsed * 100 / info.oldGenMax : 0;
             String oldGauge = buildGaugeBar(oldPct, 30);
-            Color oldColor = oldPct >= 80 ? Color.LIGHT_RED : oldPct >= 60 ? Color.YELLOW : Color.GREEN;
+            Style oldColor = oldPct >= 80 ? Style.EMPTY.fg(Color.LIGHT_RED) : oldPct >= 60 ? Theme.warning()
+                    : Style.EMPTY.fg(Color.GREEN);
 
             lines.add(Line.from(
                     Span.styled("  Old Gen:   ", Style.EMPTY.dim()),
                     Span.styled(String.format("%-10s", formatBytes(info.oldGenUsed)), Style.EMPTY.fg(Color.WHITE).bold()),
-                    Span.styled(oldGauge, Style.EMPTY.fg(oldColor)),
-                    Span.styled(String.format("  %d%%", oldPct), Style.EMPTY.fg(oldColor).bold())));
+                    Span.styled(oldGauge, oldColor),
+                    Span.styled(String.format("  %d%%", oldPct), oldColor.bold())));
             lines.add(Line.from(
                     Span.styled("  committed: ", Style.EMPTY.dim()),
                     Span.raw(formatBytes(info.oldGenCommitted)),
@@ -294,7 +297,7 @@ class MemoryTab extends AbstractTab {
         int greenEighths = (int) Math.round(0.6 * chartH * 8.0);
         int yellowEighths = (int) Math.round(0.8 * chartH * 8.0);
         Style greenStyle = Style.EMPTY.fg(Color.GREEN);
-        Style yellowStyle = Style.EMPTY.fg(Color.YELLOW);
+        Style yellowStyle = Theme.warning();
         Style redStyle = Style.EMPTY.fg(Color.LIGHT_RED);
 
         for (int col = 0; col < chartW; col++) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MemoryTab.java
@@ -140,8 +140,8 @@ class MemoryTab extends AbstractTab {
             if (info.heapMemCommitted > 0) {
                 long pctComm = info.heapMemUsed * 100 / info.heapMemCommitted;
                 String gaugeComm = buildGaugeBar(pctComm, 30);
-                Style colorComm = pctComm >= 80 ? Style.EMPTY.fg(Color.LIGHT_RED) : pctComm >= 60 ? Theme.warning()
-                        : Style.EMPTY.fg(Color.GREEN);
+                Style colorComm = pctComm >= 80 ? Theme.error() : pctComm >= 60 ? Theme.warning()
+                        : Theme.success();
                 List<Span> commSpans = new ArrayList<>();
                 commSpans.add(Span.styled("  committed: ", Style.EMPTY.dim()));
                 commSpans.add(Span.styled(String.format("%-10s", formatBytes(info.heapMemCommitted)), Style.EMPTY));
@@ -156,8 +156,8 @@ class MemoryTab extends AbstractTab {
             if (info.heapMemMax > 0) {
                 long pctMax = info.heapMemUsed * 100 / info.heapMemMax;
                 String gaugeMax = buildGaugeBar(pctMax, 30);
-                Style colorMax = pctMax >= 80 ? Style.EMPTY.fg(Color.LIGHT_RED) : pctMax >= 60 ? Theme.warning()
-                        : Style.EMPTY.fg(Color.GREEN);
+                Style colorMax = pctMax >= 80 ? Theme.error() : pctMax >= 60 ? Theme.warning()
+                        : Theme.success();
                 List<Span> maxSpans = new ArrayList<>();
                 maxSpans.add(Span.styled("  max:       ", Style.EMPTY.dim()));
                 maxSpans.add(Span.styled(String.format("%-10s", formatBytes(info.heapMemMax)), Style.EMPTY));
@@ -175,8 +175,8 @@ class MemoryTab extends AbstractTab {
         if (info.oldGenUsed > 0) {
             long oldPct = info.oldGenMax > 0 ? info.oldGenUsed * 100 / info.oldGenMax : 0;
             String oldGauge = buildGaugeBar(oldPct, 30);
-            Style oldColor = oldPct >= 80 ? Style.EMPTY.fg(Color.LIGHT_RED) : oldPct >= 60 ? Theme.warning()
-                    : Style.EMPTY.fg(Color.GREEN);
+            Style oldColor = oldPct >= 80 ? Theme.error() : oldPct >= 60 ? Theme.warning()
+                    : Theme.success();
 
             lines.add(Line.from(
                     Span.styled("  Old Gen:   ", Style.EMPTY.dim()),
@@ -297,9 +297,9 @@ class MemoryTab extends AbstractTab {
         // Precompute eighths thresholds for the color bands
         int greenEighths = (int) Math.round(0.6 * chartH * 8.0);
         int yellowEighths = (int) Math.round(0.8 * chartH * 8.0);
-        Style greenStyle = Style.EMPTY.fg(Color.GREEN);
+        Style greenStyle = Theme.success();
         Style yellowStyle = Theme.warning();
-        Style redStyle = Style.EMPTY.fg(Color.LIGHT_RED);
+        Style redStyle = Theme.error();
 
         for (int col = 0; col < chartW; col++) {
             double ratio = (double) data[col] / ceiling;
@@ -417,20 +417,20 @@ class MemoryTab extends AbstractTab {
         // ignore small fluctuations relative to heap capacity (at least 5M or 1% of ceiling)
         long threshold = Math.max(5 * 1024 * 1024, (long) (heapCeiling * 0.01));
         if (Math.abs(diff) < threshold) {
-            return Span.styled("  → stable over last " + period, Style.EMPTY.fg(Color.GREEN));
+            return Span.styled("  → stable over last " + period, Theme.success());
         }
 
         if (change > 0.05) {
             return Span.styled(
                     String.format("  %s growing by %d%% (%s) over last %s", TuiIcons.ARROW_UP, pct, formatBytes(diff), period),
-                    Style.EMPTY.fg(Color.LIGHT_RED).bold());
+                    Theme.error().bold());
         } else if (change < -0.05) {
             return Span.styled(
                     String.format("  %s shrinking by %d%% (%s) over last %s", TuiIcons.ARROW_DOWN,
                             Math.abs(pct), formatBytes(Math.abs(diff)), period),
-                    Style.EMPTY.fg(Color.GREEN));
+                    Theme.success());
         } else {
-            return Span.styled("  " + TuiIcons.ARROW_STABLE + " stable over last " + period, Style.EMPTY.fg(Color.GREEN));
+            return Span.styled("  " + TuiIcons.ARROW_STABLE + " stable over last " + period, Theme.success());
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -62,7 +62,6 @@ class MetricsTab extends AbstractTableTab {
 
     private static final Style LABEL = Style.EMPTY.dim();
     private static final Style VALUE = Style.EMPTY.fg(Color.WHITE).bold();
-    private static final Style HEADER = Style.EMPTY.fg(Color.YELLOW).bold();
     private static final Style GOOD = Style.EMPTY.fg(Color.GREEN);
     private static final Style BAD = Style.EMPTY.fg(Color.LIGHT_RED);
 
@@ -276,7 +275,7 @@ class MetricsTab extends AbstractTableTab {
         List<Line> lines = new ArrayList<>();
 
         // Exchanges section
-        lines.add(Line.from(Span.styled("  Exchanges", HEADER)));
+        lines.add(Line.from(Span.styled("  Exchanges", Theme.label().bold())));
         lines.add(Line.empty());
 
         long total = counterValue(meters, "camel.exchanges.total");
@@ -305,7 +304,7 @@ class MetricsTab extends AbstractTableTab {
         // Route timers
         List<MicrometerMeterInfo> routeTimers = findMeters(meters, "camel.route.policy");
         if (!routeTimers.isEmpty()) {
-            lines.add(Line.from(Span.styled("  Route Timers", HEADER),
+            lines.add(Line.from(Span.styled("  Route Timers", Theme.label().bold()),
                     Span.styled("                     mean / max", LABEL)));
             lines.add(Line.empty());
             for (MicrometerMeterInfo rt : routeTimers) {
@@ -331,7 +330,7 @@ class MetricsTab extends AbstractTableTab {
         List<MicrometerMeterInfo> eventTimers = findMeters(meters, "camel.exchange.event.notifier");
         if (!eventTimers.isEmpty()) {
             lines.add(Line.empty());
-            lines.add(Line.from(Span.styled("  Event Notifiers", HEADER),
+            lines.add(Line.from(Span.styled("  Event Notifiers", Theme.label().bold()),
                     Span.styled("                  mean / max", LABEL)));
             lines.add(Line.empty());
             for (MicrometerMeterInfo et : eventTimers) {
@@ -359,7 +358,7 @@ class MetricsTab extends AbstractTableTab {
         List<Line> lines = new ArrayList<>();
 
         // Memory section
-        lines.add(Line.from(Span.styled("  Memory", HEADER)));
+        lines.add(Line.from(Span.styled("  Memory", Theme.label().bold())));
         lines.add(Line.empty());
 
         double heapUsed = gaugeValue(meters, "jvm.memory.used", "area", "heap");
@@ -390,7 +389,7 @@ class MetricsTab extends AbstractTableTab {
         lines.add(Line.empty());
 
         // Runtime section
-        lines.add(Line.from(Span.styled("  Runtime", HEADER)));
+        lines.add(Line.from(Span.styled("  Runtime", Theme.label().bold())));
         lines.add(Line.empty());
 
         double cpuProcess = gaugeValue(meters, "process.cpu.usage");
@@ -431,7 +430,7 @@ class MetricsTab extends AbstractTableTab {
         List<MicrometerMeterInfo> gcTimers = findMeters(meters, "jvm.gc.pause");
         if (!gcTimers.isEmpty()) {
             lines.add(Line.empty());
-            lines.add(Line.from(Span.styled("  Garbage Collection", HEADER)));
+            lines.add(Line.from(Span.styled("  Garbage Collection", Theme.label().bold())));
             lines.add(Line.empty());
             for (MicrometerMeterInfo gc : gcTimers) {
                 String cause = tagValue(gc, "cause");
@@ -645,7 +644,6 @@ class MetricsTab extends AbstractTableTab {
     private static final Style PROM_COMMENT = Style.EMPTY.dim();
     private static final Style PROM_NAME = Style.EMPTY.fg(Color.CYAN);
     private static final Style PROM_VALUE = Style.EMPTY.fg(Color.WHITE).bold();
-    private static final Style PROM_TAGS = Style.EMPTY.fg(Color.YELLOW);
 
     private static Line colorPrometheusLine(String line) {
         if (line.startsWith("#")) {
@@ -660,7 +658,7 @@ class MetricsTab extends AbstractTableTab {
             String rest = line.substring(braceEnd + 1).trim();
             return Line.from(
                     Span.styled(name, PROM_NAME),
-                    Span.styled(tags, PROM_TAGS),
+                    Span.styled(tags, Theme.label()),
                     Span.styled(" " + rest, PROM_VALUE));
         }
         // name value (no tags)

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -62,8 +62,8 @@ class MetricsTab extends AbstractTableTab {
 
     private static final Style LABEL = Style.EMPTY.dim();
     private static final Style VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
-    private static final Style GOOD = Style.EMPTY.fg(Color.GREEN);
-    private static final Style BAD = Style.EMPTY.fg(Color.LIGHT_RED);
+    private static final Style GOOD = Theme.success();
+    private static final Style BAD = Theme.error();
 
     private final ScrollbarState scrollbarState = new ScrollbarState();
     private final ScrollbarState rawScrollbarState = new ScrollbarState();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -256,7 +255,7 @@ class MetricsTab extends AbstractTableTab {
                     .split(area);
             frame.renderWidget(Paragraph.from(Line.from(
                     Span.styled("  Endpoint: ", LABEL),
-                    Span.styled(metricsUrl, Style.EMPTY.fg(Color.CYAN)))), vParts.get(0));
+                    Span.styled(metricsUrl, Style.EMPTY.fg(Theme.accent())))), vParts.get(0));
             panelArea = vParts.get(1);
         }
 
@@ -320,7 +319,7 @@ class MetricsTab extends AbstractTableTab {
                         rt.max != null ? rt.max : 0);
                 int pad = Math.max(1, 30 - routeId.length());
                 lines.add(Line.from(
-                        Span.styled("    " + routeId, Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled("    " + routeId, Style.EMPTY.fg(Theme.accent())),
                         Span.styled(" ".repeat(pad), Style.EMPTY),
                         Span.styled(timing, VALUE)));
             }
@@ -341,7 +340,7 @@ class MetricsTab extends AbstractTableTab {
                         et.max != null ? et.max : 0);
                 int pad = Math.max(1, 30 - shortName.length());
                 lines.add(Line.from(
-                        Span.styled("    " + shortName, Style.EMPTY.fg(Color.CYAN)),
+                        Span.styled("    " + shortName, Style.EMPTY.fg(Theme.accent())),
                         Span.styled(" ".repeat(pad), Style.EMPTY),
                         Span.styled(timing, VALUE)));
             }
@@ -474,7 +473,7 @@ class MetricsTab extends AbstractTableTab {
 
             rows.add(Row.from(
                     Cell.from(Span.styled(typeLabel, typeStyle)),
-                    Cell.from(Span.styled(m.name != null ? m.name : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(m.name != null ? m.name : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(value),
                     Cell.from(Span.styled(tags, Style.EMPTY.dim()))));
         }
@@ -642,7 +641,7 @@ class MetricsTab extends AbstractTableTab {
     // ---- Prometheus syntax coloring ----
 
     private static final Style PROM_COMMENT = Style.EMPTY.dim();
-    private static final Style PROM_NAME = Style.EMPTY.fg(Color.CYAN);
+    private static final Style PROM_NAME = Style.EMPTY.fg(Theme.accent());
     private static final Style PROM_VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
 
     private static Line colorPrometheusLine(String line) {
@@ -833,11 +832,11 @@ class MetricsTab extends AbstractTableTab {
             return Style.EMPTY;
         }
         return switch (type) {
-            case "counter" -> Style.EMPTY.fg(Color.LIGHT_BLUE);
-            case "gauge" -> Style.EMPTY.fg(Color.LIGHT_GREEN);
-            case "timer" -> Style.EMPTY.fg(Color.LIGHT_YELLOW);
-            case "longTaskTimer" -> Style.EMPTY.fg(Color.LIGHT_MAGENTA);
-            case "distribution" -> Style.EMPTY.fg(Color.LIGHT_CYAN);
+            case "counter" -> Style.EMPTY.fg(Theme.accent());
+            case "gauge" -> Theme.success();
+            case "timer" -> Theme.warning();
+            case "longTaskTimer" -> Theme.notice();
+            case "distribution" -> Theme.info();
             default -> Style.EMPTY;
         };
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -227,9 +227,15 @@ class MetricsTab extends AbstractTableTab {
     @Override
     protected void renderContent(Frame frame, Rect area, IntegrationInfo info) {
         if (info.meters.isEmpty()) {
-            Paragraph p = Paragraph.from(Line.from(
-                    Span.styled("No metrics available. Run with --observe to enable micrometer.", LABEL)));
-            frame.renderWidget(p, area);
+            frame.renderWidget(
+                    Paragraph.builder()
+                            .text(Text.from(Line.from(
+                                    Span.styled("  No metrics available. Run with --observe to enable micrometer.",
+                                            LABEL))))
+                            .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
+                                    .title(" Metrics ").build())
+                            .build(),
+                    area);
             return;
         }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -61,7 +61,7 @@ class MetricsTab extends AbstractTableTab {
     private static final int MOUSE_SCROLL_LINES = 3;
 
     private static final Style LABEL = Style.EMPTY.dim();
-    private static final Style VALUE = Style.EMPTY.fg(Color.WHITE).bold();
+    private static final Style VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
     private static final Style GOOD = Style.EMPTY.fg(Color.GREEN);
     private static final Style BAD = Style.EMPTY.fg(Color.LIGHT_RED);
 
@@ -643,7 +643,7 @@ class MetricsTab extends AbstractTableTab {
 
     private static final Style PROM_COMMENT = Style.EMPTY.dim();
     private static final Style PROM_NAME = Style.EMPTY.fg(Color.CYAN);
-    private static final Style PROM_VALUE = Style.EMPTY.fg(Color.WHITE).bold();
+    private static final Style PROM_VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
 
     private static Line colorPrometheusLine(String line) {
         if (line.startsWith("#")) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTab.java
@@ -59,7 +59,7 @@ class MetricsTab extends AbstractTableTab {
 
     private static final int MOUSE_SCROLL_LINES = 3;
 
-    private static final Style LABEL = Style.EMPTY.dim();
+    private static final Style LABEL = Theme.muted();
     private static final Style VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
     private static final Style GOOD = Theme.success();
     private static final Style BAD = Theme.error();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -633,7 +633,7 @@ class OverviewTab extends AbstractTab {
         frame.renderWidget(infoBlock, area);
         Rect inner = infoBlock.inner(area);
         List<Line> lines = new ArrayList<>();
-        Style dim = Style.EMPTY.dim();
+        Style dim = Theme.muted();
         int jvmDetailStart = -1;
         int jvmDetailCount = 0;
         if (sel != null) {
@@ -749,7 +749,7 @@ class OverviewTab extends AbstractTab {
         frame.renderWidget(infoBlock, area);
         Rect inner = infoBlock.inner(area);
         List<Line> lines = new ArrayList<>();
-        Style dim = Style.EMPTY.dim();
+        Style dim = Theme.muted();
         lines.add(Line.from(
                 Span.styled("Service: ", dim),
                 Span.styled(infra.alias, Theme.notice())));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -525,14 +524,14 @@ class OverviewTab extends AbstractTab {
                         Span.raw(" ["),
                         Span.styled(chartName, Theme.label().bold()),
                         Span.raw(String.format("] Throughput: %s msg/s  ", curTpFmt)),
-                        Span.styled("■", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
+                        Span.styled("■", Style.EMPTY.fg(Color.GREEN)),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.RED)),
                         Span.raw(String.format(" fail:%s ", curFailFmt)));
             } else {
                 titleLine = Line.from(
                         Span.raw(String.format(" [All] Throughput: %s msg/s  ", curTpFmt)),
-                        Span.styled("■", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
+                        Span.styled("■", Style.EMPTY.fg(Color.GREEN)),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.RED)),
                         Span.raw(String.format(" fail:%s ", curFailFmt)));
@@ -547,7 +546,7 @@ class OverviewTab extends AbstractTab {
                 long failed = Math.min(mergedFailed[i], mergedTotal[i]);
                 long ok = Math.max(0, mergedTotal[i] - failed);
                 groups.add(BarGroup.of(
-                        Bar.builder().value(ok).textValue("").style(Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN)))
+                        Bar.builder().value(ok).textValue("").style(Style.EMPTY.fg(Color.GREEN))
                                 .build(),
                         Bar.builder().value(failed).textValue("").style(Style.EMPTY.fg(Color.RED)).build()));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -293,7 +293,7 @@ class OverviewTab extends AbstractTab {
                         Cell.from(Span.styled(vanishName, dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
-                        Cell.from(Span.styled(TuiIcons.STOPPED + " Stopped", Style.EMPTY.fg(Color.LIGHT_RED).dim())),
+                        Cell.from(Span.styled(TuiIcons.STOPPED + " Stopped", Theme.error().dim())),
                         Cell.from(Span.styled(info.ago != null ? info.ago : "", dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
@@ -400,7 +400,7 @@ class OverviewTab extends AbstractTab {
                         Cell.from(Span.styled(vanishAlias, dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
-                        Cell.from(Span.styled(TuiIcons.STOPPED + " Stopped", Style.EMPTY.fg(Color.LIGHT_RED).dim())),
+                        Cell.from(Span.styled(TuiIcons.STOPPED + " Stopped", Theme.error().dim())),
                         Cell.from(Span.styled("", dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
                         Cell.from(Span.styled("", dimStyle)),
@@ -524,14 +524,14 @@ class OverviewTab extends AbstractTab {
                         Span.raw(" ["),
                         Span.styled(chartName, Theme.label().bold()),
                         Span.raw(String.format("] Throughput: %s msg/s  ", curTpFmt)),
-                        Span.styled("■", Style.EMPTY.fg(Color.GREEN)),
+                        Span.styled("■", Theme.success()),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.RED)),
                         Span.raw(String.format(" fail:%s ", curFailFmt)));
             } else {
                 titleLine = Line.from(
                         Span.raw(String.format(" [All] Throughput: %s msg/s  ", curTpFmt)),
-                        Span.styled("■", Style.EMPTY.fg(Color.GREEN)),
+                        Span.styled("■", Theme.success()),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.RED)),
                         Span.raw(String.format(" fail:%s ", curFailFmt)));
@@ -546,7 +546,7 @@ class OverviewTab extends AbstractTab {
                 long failed = Math.min(mergedFailed[i], mergedTotal[i]);
                 long ok = Math.max(0, mergedTotal[i] - failed);
                 groups.add(BarGroup.of(
-                        Bar.builder().value(ok).textValue("").style(Style.EMPTY.fg(Color.GREEN))
+                        Bar.builder().value(ok).textValue("").style(Theme.success())
                                 .build(),
                         Bar.builder().value(failed).textValue("").style(Style.EMPTY.fg(Color.RED)).build()));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -330,7 +330,7 @@ class OverviewTab extends AbstractTab {
                 List<Span> nameSpans = new ArrayList<>();
                 nameSpans.add(Span.styled(nameText, Theme.info()));
                 if (info.devMode) {
-                    nameSpans.add(Span.styled(" [dev]", Style.EMPTY.fg(Color.YELLOW).dim()));
+                    nameSpans.add(Span.styled(" [dev]", Theme.label()));
                 }
                 if (hasDoc) {
                     nameSpans.add(Span.styled(" " + TuiIcons.README, Style.EMPTY));
@@ -523,7 +523,7 @@ class OverviewTab extends AbstractTab {
                         : ctx.selectedPid != null ? ctx.selectedPid : "?";
                 titleLine = Line.from(
                         Span.raw(" ["),
-                        Span.styled(chartName, Style.EMPTY.fg(Color.YELLOW)),
+                        Span.styled(chartName, Theme.label().bold()),
                         Span.raw(String.format("] Throughput: %s msg/s  ", curTpFmt)),
                         Span.styled("■", Style.EMPTY.fg(Color.ansi(AnsiColor.BRIGHT_GREEN))),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/OverviewTab.java
@@ -414,7 +414,7 @@ class OverviewTab extends AbstractTab {
                 String version = info.serviceVersion != null ? info.serviceVersion : "";
                 rows.add(Row.from(
                         Cell.from(info.pid),
-                        Cell.from(Span.styled(infraAlias, Style.EMPTY.fg(Color.MAGENTA))),
+                        Cell.from(Span.styled(infraAlias, Theme.notice())),
                         Cell.from(version),
                         Cell.from(""),
                         Cell.from(Span.styled(statusText, statusStyle)),
@@ -526,14 +526,14 @@ class OverviewTab extends AbstractTab {
                         Span.raw(String.format("] Throughput: %s msg/s  ", curTpFmt)),
                         Span.styled("■", Theme.success()),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),
-                        Span.styled("■", Style.EMPTY.fg(Color.RED)),
+                        Span.styled("■", Theme.error()),
                         Span.raw(String.format(" fail:%s ", curFailFmt)));
             } else {
                 titleLine = Line.from(
                         Span.raw(String.format(" [All] Throughput: %s msg/s  ", curTpFmt)),
                         Span.styled("■", Theme.success()),
                         Span.raw(String.format(" ok:%s  ", curOkFmt)),
-                        Span.styled("■", Style.EMPTY.fg(Color.RED)),
+                        Span.styled("■", Theme.error()),
                         Span.raw(String.format(" fail:%s ", curFailFmt)));
             }
 
@@ -548,7 +548,7 @@ class OverviewTab extends AbstractTab {
                 groups.add(BarGroup.of(
                         Bar.builder().value(ok).textValue("").style(Theme.success())
                                 .build(),
-                        Bar.builder().value(failed).textValue("").style(Style.EMPTY.fg(Color.RED)).build()));
+                        Bar.builder().value(failed).textValue("").style(Theme.error()).build()));
             }
 
             BarChart barChart = BarChart.builder()
@@ -752,7 +752,7 @@ class OverviewTab extends AbstractTab {
         Style dim = Style.EMPTY.dim();
         lines.add(Line.from(
                 Span.styled("Service: ", dim),
-                Span.styled(infra.alias, Style.EMPTY.fg(Color.MAGENTA))));
+                Span.styled(infra.alias, Theme.notice())));
         lines.add(Line.from(Span.raw("")));
         for (Map.Entry<String, Object> e : infra.properties.entrySet()) {
             String key = e.getKey();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
@@ -409,7 +409,7 @@ class PopupManager {
 
         frame.renderWidget(Clear.INSTANCE, popup);
 
-        Style keyStyle = Theme.hintKey();
+        Style keyStyle = Theme.mnemonic();
         ListItem[] items = morePopupItems(keyStyle);
         ListWidget list = ListWidget.builder()
                 .items(items)

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.CharWidth;
@@ -478,7 +477,7 @@ class PopupManager {
             String label = String.format("  %s %s (pid:%s)%s", TuiIcons.CAMEL, name, info.pid,
                     current ? " " + TuiIcons.SELECTED : "");
             if (current) {
-                items[i] = ListItem.from(Line.from(Span.styled(label, Style.EMPTY.fg(Color.CYAN))));
+                items[i] = ListItem.from(Line.from(Span.styled(label, Style.EMPTY.fg(Theme.accent()))));
             } else {
                 items[i] = ListItem.from(label);
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
@@ -409,7 +409,7 @@ class PopupManager {
 
         frame.renderWidget(Clear.INSTANCE, popup);
 
-        Style keyStyle = Theme.label().bold();
+        Style keyStyle = Theme.hintKey();
         ListItem[] items = morePopupItems(keyStyle);
         ListWidget list = ListWidget.builder()
                 .items(items)

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
@@ -410,7 +410,7 @@ class PopupManager {
 
         frame.renderWidget(Clear.INSTANCE, popup);
 
-        Style keyStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style keyStyle = Theme.label().bold();
         ListItem[] items = morePopupItems(keyStyle);
         ListWidget list = ListWidget.builder()
                 .items(items)
@@ -421,7 +421,7 @@ class PopupManager {
                         .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(Line.from(Span.styled(
                                 " " + TuiIcons.TAB_MORE + " More Tabs ",
-                                Style.EMPTY.fg(Color.YELLOW).bold()))))
+                                Theme.label().bold()))))
                         .build())
                 .build();
         frame.renderStatefulWidget(list, popup, morePopupState);
@@ -492,7 +492,7 @@ class PopupManager {
                 .block(Block.builder()
                         .borderType(BorderType.ROUNDED).borders(Borders.ALL)
                         .title(Title.from(
-                                Line.from(Span.styled(" Switch Integration ", Style.EMPTY.fg(Color.YELLOW).bold()))))
+                                Line.from(Span.styled(" Switch Integration ", Theme.label().bold()))))
                         .build())
                 .build();
         frame.renderStatefulWidget(listWidget, popup, switchPopupState);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/PopupManager.java
@@ -510,7 +510,7 @@ class PopupManager {
         frame.renderWidget(Clear.INSTANCE, popup);
         Block block = Block.builder()
                 .borderType(BorderType.ROUNDED).borders(Borders.ALL)
-                .borderStyle(Style.EMPTY.fg(Color.LIGHT_RED))
+                .borderStyle(Theme.error())
                 .title(" Confirm Kill ")
                 .build();
         frame.renderWidget(block, popup);
@@ -519,7 +519,7 @@ class PopupManager {
                 Paragraph.builder()
                         .text(Text.from(
                                 Line.from(Span.raw("")),
-                                Line.from(Span.styled(msg, Style.EMPTY.fg(Color.LIGHT_RED).bold())),
+                                Line.from(Span.styled(msg, Theme.error().bold())),
                                 Line.from(Span.raw("")),
                                 Line.from(
                                         Span.raw("  "),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
@@ -142,7 +142,7 @@ class ProcessTab extends AbstractTab {
         String cmdLine = getCommandLine(info.pid);
         if (cmdLine != null) {
             lines.add(Line.from(
-                    Span.styled("  Command Line", Style.EMPTY.fg(Theme.accent()).bold())));
+                    Span.styled("  Command Line", Theme.label().bold())));
             lines.add(Line.from(Span.raw("")));
             if (wrap) {
                 lines.add(Line.from(Span.raw("  " + cmdLine)));
@@ -241,7 +241,7 @@ class ProcessTab extends AbstractTab {
         }
         String padded = String.format("  %-12s", label + ":");
         lines.add(Line.from(
-                Span.styled(padded, Style.EMPTY.dim()),
+                Span.styled(padded, Theme.muted()),
                 Span.styled(value, Style.EMPTY.fg(Theme.baseFg()).bold())));
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
@@ -243,7 +243,7 @@ class ProcessTab extends AbstractTab {
         String padded = String.format("  %-12s", label + ":");
         lines.add(Line.from(
                 Span.styled(padded, Style.EMPTY.dim()),
-                Span.styled(value, Style.EMPTY.fg(Color.WHITE).bold())));
+                Span.styled(value, Style.EMPTY.fg(Theme.baseFg()).bold())));
     }
 
     private static String getProcessUser(String pid) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ProcessTab.java
@@ -22,7 +22,6 @@ import java.util.List;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -143,7 +142,7 @@ class ProcessTab extends AbstractTab {
         String cmdLine = getCommandLine(info.pid);
         if (cmdLine != null) {
             lines.add(Line.from(
-                    Span.styled("  Command Line", Style.EMPTY.fg(Color.CYAN).bold())));
+                    Span.styled("  Command Line", Style.EMPTY.fg(Theme.accent()).bold())));
             lines.add(Line.from(Span.raw("")));
             if (wrap) {
                 lines.add(Line.from(Span.raw("  " + cmdLine)));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -113,7 +112,7 @@ class RouteTreePreview {
         if ("from".equals(type)) {
             style = Theme.label();
         } else if (STRUCTURAL_TYPES.contains(type)) {
-            style = Style.EMPTY.fg(Color.CYAN);
+            style = Style.EMPTY.fg(Theme.accent());
         } else {
             style = Style.EMPTY;
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RouteTreePreview.java
@@ -102,7 +102,7 @@ class RouteTreePreview {
         boolean selected = (node == selectedNode);
 
         List<Span> spans = new ArrayList<>();
-        spans.add(Span.styled(prefix, Style.EMPTY.fg(Color.DARK_GRAY)));
+        spans.add(Span.styled(prefix, Theme.muted()));
         spans.add(styledLabel(node.info.type, truncate(label, maxWidth - prefix.length()), selected));
         result.add(Line.from(spans));
         lineNodes.add(node);
@@ -111,14 +111,14 @@ class RouteTreePreview {
     private static Span styledLabel(String type, String text, boolean selected) {
         Style style;
         if ("from".equals(type)) {
-            style = Style.EMPTY.fg(Color.YELLOW);
+            style = Theme.label();
         } else if (STRUCTURAL_TYPES.contains(type)) {
             style = Style.EMPTY.fg(Color.CYAN);
         } else {
             style = Style.EMPTY;
         }
         if (selected) {
-            style = Style.EMPTY.fg(Color.YELLOW).bold().bg(Color.DARK_GRAY);
+            style = Theme.selectionBg();
         }
         return Span.styled(text, style);
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -836,69 +836,69 @@ class RoutesTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
         if (route != null) {
             lines.add(Line.from(
-                    Span.styled(" Route: ", Theme.label().bold()),
+                    Span.styled(" Route: ", Theme.muted()),
                     Span.styled(route.routeId, Style.EMPTY.fg(Theme.baseFg()).bold())));
             lines.add(Line.from(
-                    Span.styled(" From:  ", Style.EMPTY.dim()),
+                    Span.styled(" From:  ", Theme.muted()),
                     Span.raw(route.from != null ? route.from : "")));
             String stateLabel = route.state != null ? route.state : "";
             Style stateStyle = "Started".equals(route.state) ? Theme.success() : Theme.error();
             lines.add(Line.from(
-                    Span.styled(" State: ", Style.EMPTY.dim()),
+                    Span.styled(" State: ", Theme.muted()),
                     Span.styled(stateLabel, stateStyle)));
 
             lines.add(Line.from(Span.raw("")));
             lines.add(Line.from(
-                    Span.styled(" Uptime:     ", Style.EMPTY.dim()),
+                    Span.styled(" Uptime:     ", Theme.muted()),
                     Span.raw(route.uptime != null ? route.uptime : "")));
             lines.add(Line.from(
-                    Span.styled(" Throughput: ", Style.EMPTY.dim()),
+                    Span.styled(" Throughput: ", Theme.muted()),
                     Span.raw(route.throughput != null ? route.throughput : "")));
             if (route.coverage != null) {
                 lines.add(Line.from(
-                        Span.styled(" Coverage:   ", Style.EMPTY.dim()),
+                        Span.styled(" Coverage:   ", Theme.muted()),
                         Span.raw(route.coverage)));
             }
 
             lines.add(Line.from(Span.raw("")));
             int w = numWidth(route.total, route.failed, route.inflight);
             lines.add(Line.from(
-                    Span.styled(" Total:    ", Style.EMPTY.dim()),
+                    Span.styled(" Total:    ", Theme.muted()),
                     Span.raw(String.format("%" + w + "d", route.total))));
             Style failStyle = route.failed > 0 ? Theme.error().bold() : Style.EMPTY;
             lines.add(Line.from(
-                    Span.styled(" Failed:   ", Style.EMPTY.dim()),
+                    Span.styled(" Failed:   ", Theme.muted()),
                     Span.styled(String.format("%" + w + "d", route.failed), failStyle)));
             lines.add(Line.from(
-                    Span.styled(" Inflight: ", Style.EMPTY.dim()),
+                    Span.styled(" Inflight: ", Theme.muted()),
                     Span.raw(String.format("%" + w + "d", route.inflight))));
 
             lines.add(Line.from(Span.raw("")));
             if (route.total > 0) {
                 int tw = numWidth(route.meanTime, route.maxTime, route.minTime);
                 lines.add(Line.from(
-                        Span.styled(" Mean: ", Style.EMPTY.dim()),
+                        Span.styled(" Mean: ", Theme.muted()),
                         Span.raw(String.format("%" + tw + "d ms", route.meanTime))));
                 lines.add(Line.from(
-                        Span.styled(" Max:  ", Style.EMPTY.dim()),
+                        Span.styled(" Max:  ", Theme.muted()),
                         Span.raw(String.format("%" + tw + "d ms", route.maxTime))));
                 lines.add(Line.from(
-                        Span.styled(" Min:  ", Style.EMPTY.dim()),
+                        Span.styled(" Min:  ", Theme.muted()),
                         Span.raw(String.format("%" + tw + "d ms", route.minTime))));
             }
 
             if (route.sinceLastCompleted != null || route.sinceLastFailed != null) {
                 lines.add(Line.from(Span.raw("")));
                 lines.add(Line.from(
-                        Span.styled(" Since last:", Style.EMPTY.dim())));
+                        Span.styled(" Since last:", Theme.muted())));
                 if (route.sinceLastCompleted != null) {
                     lines.add(Line.from(
-                            Span.styled("   success: ", Style.EMPTY.dim()),
+                            Span.styled("   success: ", Theme.muted()),
                             Span.raw(route.sinceLastCompleted)));
                 }
                 if (route.sinceLastFailed != null) {
                     lines.add(Line.from(
-                            Span.styled("   fail:    ", Style.EMPTY.dim()),
+                            Span.styled("   fail:    ", Theme.muted()),
                             Span.styled(route.sinceLastFailed,
                                     Theme.error())));
                 }
@@ -913,28 +913,28 @@ class RoutesTab extends AbstractTab {
                                 Style.EMPTY.fg(Theme.accent()).bold())));
                 lines.add(Line.from(Span.raw("")));
                 lines.add(Line.from(
-                        Span.styled(" URI: ", Style.EMPTY.dim()),
+                        Span.styled(" URI: ", Theme.muted()),
                         Span.raw(topoNode.from != null ? topoNode.from : "")));
                 if (topoNode.description != null && !topoNode.description.isBlank()) {
                     lines.add(Line.from(
-                            Span.styled(" Path: ", Style.EMPTY.dim()),
+                            Span.styled(" Path: ", Theme.muted()),
                             Span.raw(topoNode.description)));
                 }
                 String connectedRoute = diagram.getConnectedRouteId(routeId);
                 if (connectedRoute != null) {
                     lines.add(Line.from(Span.raw("")));
                     lines.add(Line.from(
-                            Span.styled(isInbound ? " To route: " : " From route: ", Style.EMPTY.dim()),
+                            Span.styled(isInbound ? " To route: " : " From route: ", Theme.muted()),
                             Span.styled(connectedRoute, Style.EMPTY.fg(Theme.baseFg()))));
                 }
                 if (topoNode.exchangesTotal > 0 || topoNode.exchangesFailed > 0) {
                     lines.add(Line.from(Span.raw("")));
                     lines.add(Line.from(
-                            Span.styled(" Total:  ", Style.EMPTY.dim()),
+                            Span.styled(" Total:  ", Theme.muted()),
                             Span.raw(String.valueOf(topoNode.exchangesTotal))));
                     if (topoNode.exchangesFailed > 0) {
                         lines.add(Line.from(
-                                Span.styled(" Failed: ", Style.EMPTY.dim()),
+                                Span.styled(" Failed: ", Theme.muted()),
                                 Span.styled(String.valueOf(topoNode.exchangesFailed),
                                         Theme.error().bold())));
                     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -569,7 +569,7 @@ class RoutesTab extends AbstractTab {
                         : Style.EMPTY;
 
                 routeRows.add(Row.from(
-                        Cell.from(Span.styled(route.routeId != null ? route.routeId : "", Style.EMPTY.fg(Color.CYAN))),
+                        Cell.from(Span.styled(route.routeId != null ? route.routeId : "", Style.EMPTY.fg(Theme.accent()))),
                         Cell.from(routeFromLabel(route)),
                         rightCell(route.total > 0 ? String.valueOf(route.meanTime) : "", 6, topTimeStyle(route.meanTime)),
                         rightCell(route.total > 0 ? String.valueOf(route.maxTime) : "", 6, topTimeStyle(route.maxTime)),
@@ -631,7 +631,7 @@ class RoutesTab extends AbstractTab {
                 String sinceLastRoute = formatSinceLastRoute(route);
 
                 routeRows.add(Row.from(
-                        Cell.from(Span.styled(route.routeId != null ? route.routeId : "", Style.EMPTY.fg(Color.CYAN))),
+                        Cell.from(Span.styled(route.routeId != null ? route.routeId : "", Style.EMPTY.fg(Theme.accent()))),
                         Cell.from(routeFromLabel(route)),
                         Cell.from(Span.styled(route.state != null ? route.state : "", stateStyle)),
                         Cell.from(route.uptime != null ? route.uptime : ""),
@@ -910,7 +910,7 @@ class RoutesTab extends AbstractTab {
                 boolean isInbound = "external-in".equals(topoNode.nodeType);
                 lines.add(Line.from(
                         Span.styled(isInbound ? " Inbound" : " Outbound",
-                                Style.EMPTY.fg(Color.CYAN).bold())));
+                                Style.EMPTY.fg(Theme.accent()).bold())));
                 lines.add(Line.from(Span.raw("")));
                 lines.add(Line.from(
                         Span.styled(" URI: ", Style.EMPTY.dim()),
@@ -941,7 +941,7 @@ class RoutesTab extends AbstractTab {
                 }
             } else {
                 lines.add(Line.from(
-                        Span.styled(" " + routeId, Style.EMPTY.fg(Color.CYAN).bold())));
+                        Span.styled(" " + routeId, Style.EMPTY.fg(Theme.accent()).bold())));
                 lines.add(Line.from(
                         Span.styled(" (external endpoint)", Style.EMPTY.dim())));
             }
@@ -1093,7 +1093,7 @@ class RoutesTab extends AbstractTab {
             }
 
             for (ProcessorInfo proc : sorted) {
-                Style nameStyle = proc.failed > 0 ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
+                Style nameStyle = proc.failed > 0 ? Theme.error() : Style.EMPTY.fg(Theme.accent());
                 long chartVal = procChartValue(proc);
                 String bar;
                 if (chartVal > 0) {
@@ -1105,7 +1105,7 @@ class RoutesTab extends AbstractTab {
                 }
                 Style barStyle = topTimeStyle(chartVal);
                 if (barStyle == Style.EMPTY) {
-                    barStyle = Style.EMPTY.fg(Color.CYAN);
+                    barStyle = Style.EMPTY.fg(Theme.accent());
                 }
 
                 rows.add(Row.from(
@@ -1157,7 +1157,7 @@ class RoutesTab extends AbstractTab {
             List<Row> rows = new ArrayList<>();
 
             // Synthetic top row representing the route itself
-            Style routeStyle = route.failed > 0 ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
+            Style routeStyle = route.failed > 0 ? Theme.error() : Style.EMPTY.fg(Theme.accent());
             rows.add(Row.from(
                     Cell.from("   route"),
                     Cell.from(Span.styled(route.from != null ? route.from : route.routeId, routeStyle)),
@@ -1173,7 +1173,7 @@ class RoutesTab extends AbstractTab {
 
             for (ProcessorInfo proc : route.processors) {
                 String indent = "  ".repeat(proc.level);
-                Style nameStyle = proc.failed > 0 ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
+                Style nameStyle = proc.failed > 0 ? Theme.error() : Style.EMPTY.fg(Theme.accent());
 
                 rows.add(Row.from(
                         Cell.from("   " + (proc.processor != null ? proc.processor : "")),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -496,7 +496,7 @@ class RoutesTab extends AbstractTab {
                 if (info.name != null) {
                     title = Line.from(
                             Span.raw(" Topology ["),
-                            Span.styled(info.name, Style.EMPTY.fg(Color.YELLOW).bold()),
+                            Span.styled(info.name, Theme.label().bold()),
                             Span.raw("] "));
                 } else {
                     title = Line.from(Span.raw(" Topology "));
@@ -836,7 +836,7 @@ class RoutesTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
         if (route != null) {
             lines.add(Line.from(
-                    Span.styled(" Route: ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                    Span.styled(" Route: ", Theme.label().bold()),
                     Span.styled(route.routeId, Style.EMPTY.fg(Color.WHITE).bold())));
             lines.add(Line.from(
                     Span.styled(" From:  ", Style.EMPTY.dim()),
@@ -983,7 +983,7 @@ class RoutesTab extends AbstractTab {
             String linkedRoute = diagram.findLinkedRouteId(drillDownRouteId);
             if (linkedRoute != null && diagram.getRouteLayout(linkedRoute) != null) {
                 lines.add(Line.from(
-                        Span.styled(" ↵ ", Style.EMPTY.fg(Color.YELLOW).bold()),
+                        Span.styled(" ↵ ", Theme.label().bold()),
                         Span.styled(linkedRoute, Style.EMPTY.fg(Color.WHITE))));
             } else if (ln.treeNode != null && ln.treeNode.info.remote) {
                 String arrow = "from".equals(ln.type) ? " external → " : " → external";
@@ -1060,7 +1060,7 @@ class RoutesTab extends AbstractTab {
     }
 
     private Line buildBreadcrumbTitle() {
-        Style nameStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style nameStyle = Theme.label().bold();
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" Route ["));
         if (routeNavigationStack.isEmpty()) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -837,7 +837,7 @@ class RoutesTab extends AbstractTab {
         if (route != null) {
             lines.add(Line.from(
                     Span.styled(" Route: ", Theme.label().bold()),
-                    Span.styled(route.routeId, Style.EMPTY.fg(Color.WHITE).bold())));
+                    Span.styled(route.routeId, Style.EMPTY.fg(Theme.baseFg()).bold())));
             lines.add(Line.from(
                     Span.styled(" From:  ", Style.EMPTY.dim()),
                     Span.raw(route.from != null ? route.from : "")));
@@ -925,7 +925,7 @@ class RoutesTab extends AbstractTab {
                     lines.add(Line.from(Span.raw("")));
                     lines.add(Line.from(
                             Span.styled(isInbound ? " To route: " : " From route: ", Style.EMPTY.dim()),
-                            Span.styled(connectedRoute, Style.EMPTY.fg(Color.WHITE))));
+                            Span.styled(connectedRoute, Style.EMPTY.fg(Theme.baseFg()))));
                 }
                 if (topoNode.exchangesTotal > 0 || topoNode.exchangesFailed > 0) {
                     lines.add(Line.from(Span.raw("")));
@@ -984,7 +984,7 @@ class RoutesTab extends AbstractTab {
             if (linkedRoute != null && diagram.getRouteLayout(linkedRoute) != null) {
                 lines.add(Line.from(
                         Span.styled(" ↵ ", Theme.label().bold()),
-                        Span.styled(linkedRoute, Style.EMPTY.fg(Color.WHITE))));
+                        Span.styled(linkedRoute, Style.EMPTY.fg(Theme.baseFg()))));
             } else if (ln.treeNode != null && ln.treeNode.info.remote) {
                 String arrow = "from".equals(ln.type) ? " external → " : " → external";
                 lines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -565,7 +565,7 @@ class RoutesTab extends AbstractTab {
             List<Row> routeRows = new ArrayList<>();
             for (RouteInfo route : sortedRoutes) {
                 Style failStyle = route.failed > 0
-                        ? Style.EMPTY.fg(Color.LIGHT_RED).bold()
+                        ? Theme.error().bold()
                         : Style.EMPTY;
 
                 routeRows.add(Row.from(
@@ -621,11 +621,11 @@ class RoutesTab extends AbstractTab {
             List<Row> routeRows = new ArrayList<>();
             for (RouteInfo route : sortedRoutes) {
                 Style stateStyle = "Started".equals(route.state)
-                        ? Style.EMPTY.fg(Color.GREEN)
-                        : Style.EMPTY.fg(Color.LIGHT_RED);
+                        ? Theme.success()
+                        : Theme.error();
 
                 Style failStyle = route.failed > 0
-                        ? Style.EMPTY.fg(Color.LIGHT_RED).bold()
+                        ? Theme.error().bold()
                         : Style.EMPTY;
 
                 String sinceLastRoute = formatSinceLastRoute(route);
@@ -842,7 +842,7 @@ class RoutesTab extends AbstractTab {
                     Span.styled(" From:  ", Style.EMPTY.dim()),
                     Span.raw(route.from != null ? route.from : "")));
             String stateLabel = route.state != null ? route.state : "";
-            Style stateStyle = "Started".equals(route.state) ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY.fg(Color.LIGHT_RED);
+            Style stateStyle = "Started".equals(route.state) ? Theme.success() : Theme.error();
             lines.add(Line.from(
                     Span.styled(" State: ", Style.EMPTY.dim()),
                     Span.styled(stateLabel, stateStyle)));
@@ -865,7 +865,7 @@ class RoutesTab extends AbstractTab {
             lines.add(Line.from(
                     Span.styled(" Total:    ", Style.EMPTY.dim()),
                     Span.raw(String.format("%" + w + "d", route.total))));
-            Style failStyle = route.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY;
+            Style failStyle = route.failed > 0 ? Theme.error().bold() : Style.EMPTY;
             lines.add(Line.from(
                     Span.styled(" Failed:   ", Style.EMPTY.dim()),
                     Span.styled(String.format("%" + w + "d", route.failed), failStyle)));
@@ -900,7 +900,7 @@ class RoutesTab extends AbstractTab {
                     lines.add(Line.from(
                             Span.styled("   fail:    ", Style.EMPTY.dim()),
                             Span.styled(route.sinceLastFailed,
-                                    Style.EMPTY.fg(Color.LIGHT_RED))));
+                                    Theme.error())));
                 }
             }
 
@@ -936,7 +936,7 @@ class RoutesTab extends AbstractTab {
                         lines.add(Line.from(
                                 Span.styled(" Failed: ", Style.EMPTY.dim()),
                                 Span.styled(String.valueOf(topoNode.exchangesFailed),
-                                        Style.EMPTY.fg(Color.LIGHT_RED).bold())));
+                                        Theme.error().bold())));
                     }
                 }
             } else {
@@ -1001,7 +1001,7 @@ class RoutesTab extends AbstractTab {
                         Span.styled(" Total:    ", Style.EMPTY.dim()),
                         Span.raw(String.format("%" + w + "d", stat.exchangesTotal))));
                 Style failStyle = stat.exchangesFailed > 0
-                        ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY;
+                        ? Theme.error().bold() : Style.EMPTY;
                 lines.add(Line.from(
                         Span.styled(" Failed:   ", Style.EMPTY.dim()),
                         Span.styled(String.format("%" + w + "d", stat.exchangesFailed), failStyle)));
@@ -1042,7 +1042,7 @@ class RoutesTab extends AbstractTab {
                             lines.add(Line.from(
                                     Span.styled("   fail:    ", Style.EMPTY.dim()),
                                     Span.styled(TimeUtils.printDuration(ago, false),
-                                            Style.EMPTY.fg(Color.LIGHT_RED))));
+                                            Theme.error())));
                         }
                     }
                 }
@@ -1093,7 +1093,7 @@ class RoutesTab extends AbstractTab {
             }
 
             for (ProcessorInfo proc : sorted) {
-                Style nameStyle = proc.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.CYAN);
+                Style nameStyle = proc.failed > 0 ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
                 long chartVal = procChartValue(proc);
                 String bar;
                 if (chartVal > 0) {
@@ -1120,7 +1120,7 @@ class RoutesTab extends AbstractTab {
                                 topDeltaStyle(proc.deltaTime)),
                         rightCell(String.valueOf(proc.total), 8),
                         rightCell(String.valueOf(proc.failed), 6,
-                                proc.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY),
+                                proc.failed > 0 ? Theme.error() : Style.EMPTY),
                         rightCell(String.valueOf(proc.inflight), 8)));
             }
 
@@ -1157,14 +1157,14 @@ class RoutesTab extends AbstractTab {
             List<Row> rows = new ArrayList<>();
 
             // Synthetic top row representing the route itself
-            Style routeStyle = route.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.CYAN);
+            Style routeStyle = route.failed > 0 ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
             rows.add(Row.from(
                     Cell.from("   route"),
                     Cell.from(Span.styled(route.from != null ? route.from : route.routeId, routeStyle)),
                     Cell.from(""), Cell.from(""), Cell.from(""), Cell.from(""),
                     rightCell(String.valueOf(route.total), 8),
                     rightCell(String.valueOf(route.failed), 6,
-                            route.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY),
+                            route.failed > 0 ? Theme.error() : Style.EMPTY),
                     rightCell(String.valueOf(route.inflight), 8),
                     rightCell(route.total > 0
                             ? route.minTime + "/" + route.maxTime + "/" + route.meanTime
@@ -1173,7 +1173,7 @@ class RoutesTab extends AbstractTab {
 
             for (ProcessorInfo proc : route.processors) {
                 String indent = "  ".repeat(proc.level);
-                Style nameStyle = proc.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.CYAN);
+                Style nameStyle = proc.failed > 0 ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
 
                 rows.add(Row.from(
                         Cell.from("   " + (proc.processor != null ? proc.processor : "")),
@@ -1181,7 +1181,7 @@ class RoutesTab extends AbstractTab {
                         Cell.from(""), Cell.from(""), Cell.from(""), Cell.from(""),
                         rightCell(String.valueOf(proc.total), 8),
                         rightCell(String.valueOf(proc.failed), 6,
-                                proc.failed > 0 ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY),
+                                proc.failed > 0 ? Theme.error() : Style.EMPTY),
                         rightCell(String.valueOf(proc.inflight), 8),
                         rightCell(proc.total > 0
                                 ? proc.minTime + "/" + proc.maxTime + "/" + proc.meanTime

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTab.java
@@ -988,7 +988,7 @@ class RoutesTab extends AbstractTab {
             } else if (ln.treeNode != null && ln.treeNode.info.remote) {
                 String arrow = "from".equals(ln.type) ? " external → " : " → external";
                 lines.add(Line.from(
-                        Span.styled(arrow, Style.EMPTY.fg(Color.DARK_GRAY))));
+                        Span.styled(arrow, Theme.muted())));
             } else {
                 lines.add(Line.from(Span.raw("")));
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SearchHighlighter.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SearchHighlighter.java
@@ -39,8 +39,6 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.TuiHelper.hintLast;
  */
 class SearchHighlighter {
 
-    static final Style HIGHLIGHT_STYLE = Style.EMPTY.fg(Color.BLACK).bg(Color.YELLOW);
-    static final Style FIND_MATCH_STYLE = Style.EMPTY.fg(Color.BLACK).bg(Color.YELLOW);
     static final Style FIND_CURRENT_STYLE = Style.EMPTY.fg(Color.BLACK).bg(Color.LIGHT_GREEN);
 
     private boolean findInputActive;
@@ -202,7 +200,7 @@ class SearchHighlighter {
             Matcher m = highlightPattern.matcher(fullText);
             while (m.find()) {
                 ranges.add(new int[] { m.start(), m.end() });
-                rangeStyles.add(HIGHLIGHT_STYLE);
+                rangeStyles.add(Theme.searchMatch());
             }
         }
         if (findPattern != null) {
@@ -210,7 +208,7 @@ class SearchHighlighter {
             Matcher m = findPattern.matcher(fullText);
             while (m.find()) {
                 ranges.add(new int[] { m.start(), m.end() });
-                rangeStyles.add(isCurrentLine ? FIND_CURRENT_STYLE : FIND_MATCH_STYLE);
+                rangeStyles.add(isCurrentLine ? FIND_CURRENT_STYLE : Theme.searchMatch());
             }
         }
         if (ranges.isEmpty()) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SearchHighlighter.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SearchHighlighter.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -39,7 +38,7 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.TuiHelper.hintLast;
  */
 class SearchHighlighter {
 
-    static final Style FIND_CURRENT_STYLE = Style.EMPTY.fg(Color.BLACK).bg(Color.LIGHT_GREEN);
+    static final Style FIND_CURRENT_STYLE = Theme.searchMatch();
 
     private boolean findInputActive;
     private boolean highlightInputActive;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SendMessagePopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SendMessagePopup.java
@@ -696,7 +696,7 @@ class SendMessagePopup {
 
         Block block = Block.builder()
                 .borderType(BorderType.ROUNDED).borders(Borders.ALL)
-                .title(Title.from(Line.from(Span.styled(title, Style.EMPTY.fg(Color.YELLOW).bold()))))
+                .title(Title.from(Line.from(Span.styled(title, Theme.label().bold()))))
                 .build();
         frame.renderWidget(block, area);
         Rect inner = block.inner(area);
@@ -821,7 +821,7 @@ class SendMessagePopup {
             titleStr = " Response ";
         } else if (sending) {
             titleStr = " Sending... ";
-            titleStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+            titleStyle = Theme.warning();
         } else if (responseError) {
             titleStr = " Response — Error ";
             if (responseElapsed > 0) {
@@ -869,7 +869,7 @@ class SendMessagePopup {
                     && !line.startsWith("[") && !line.startsWith("\"")) {
                 int colon = line.indexOf(": ");
                 lines.add(Line.from(
-                        Span.styled(line.substring(0, colon + 1), Style.EMPTY.fg(Color.YELLOW)),
+                        Span.styled(line.substring(0, colon + 1), Theme.label()),
                         Span.raw(line.substring(colon + 1))));
             } else {
                 lines.add(Line.from(Span.raw(line)));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SendMessagePopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SendMessagePopup.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -827,14 +826,14 @@ class SendMessagePopup {
             if (responseElapsed > 0) {
                 titleStr = " Response — Error (" + responseElapsed + "ms) ";
             }
-            titleStyle = Style.EMPTY.fg(Color.LIGHT_RED).bold();
+            titleStyle = Theme.error().bold();
         } else {
             titleStr = " Response — " + (inOut ? "InOut" : "InOnly");
             if (responseElapsed > 0) {
                 titleStr += " (" + responseElapsed + "ms)";
             }
             titleStr += " ";
-            titleStyle = Style.EMPTY.fg(Color.GREEN).bold();
+            titleStyle = Theme.success().bold();
         }
 
         Title title = Title.from(Line.from(Span.styled(titleStr, titleStyle)));
@@ -923,7 +922,7 @@ class SendMessagePopup {
                     : "";
 
             Style lineStyle = selected ? Style.EMPTY.bold() : Style.EMPTY;
-            Style statusStyle = entry.error ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
+            Style statusStyle = entry.error ? Theme.error() : Theme.success();
             if (!selected) {
                 statusStyle = statusStyle.dim();
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -28,7 +28,6 @@ import java.util.function.IntConsumer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -777,7 +776,7 @@ class SourceViewer {
         Line highlighted = SyntaxHighlighter.highlightLine(code, language);
 
         List<Span> spans = new ArrayList<>();
-        Style selBg = Style.EMPTY.bg(Color.rgb(30, 45, 70));
+        Style selBg = Theme.selectionBg();
         if (isSelected) {
             spans.add(Span.styled(">> ", Theme.label().bold()));
             if (!prefix.isEmpty()) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceViewer.java
@@ -779,9 +779,9 @@ class SourceViewer {
         List<Span> spans = new ArrayList<>();
         Style selBg = Style.EMPTY.bg(Color.rgb(30, 45, 70));
         if (isSelected) {
-            spans.add(Span.styled(">> ", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled(">> ", Theme.label().bold()));
             if (!prefix.isEmpty()) {
-                spans.add(Span.styled(prefix, Style.EMPTY.fg(Color.YELLOW).bold().patch(selBg)));
+                spans.add(Span.styled(prefix, Theme.label().bold().patch(selBg)));
             }
             for (Span s : highlighted.spans()) {
                 spans.add(Span.styled(s.content(), s.style().patch(selBg)));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
@@ -399,10 +399,10 @@ class SpansTab extends AbstractTab {
                         Cell.from(Span.styled(sortLabel("FROM", "from"), sortStyle("from"))),
                         Cell.from(Span.styled(sortLabel("SPANS", "spans"), sortStyle("spans"))),
                         Cell.from(Span.styled(sortLabel("ROUTES", "routes"), sortStyle("routes"))),
-                        Cell.from(Span.styled("REMOTE", Style.EMPTY.fg(Color.YELLOW).bold())),
+                        Cell.from(Span.styled("REMOTE", Theme.label().bold())),
                         Cell.from(Span.styled(sortLabel("STATUS", "status"), sortStyle("status"))),
                         Cell.from(Span.styled(sortLabel("DURATION", "duration"), sortStyle("duration"))),
-                        Cell.from(Span.styled("DEPTH", Style.EMPTY.fg(Color.YELLOW).bold()))))
+                        Cell.from(Span.styled("DEPTH", Theme.label().bold()))))
                 .widths(
                         Constraint.length(10),
                         Constraint.length(20),
@@ -564,7 +564,7 @@ class SpansTab extends AbstractTab {
         String errorTag = error ? " ERR" : "";
 
         return Line.from(
-                Span.styled(indicator, Style.EMPTY.fg(Color.YELLOW).bold()),
+                Span.styled(indicator, Theme.label().bold()),
                 Span.styled(label, labelStyle),
                 Span.raw(gap),
                 Span.styled(bar, bandStyle),
@@ -605,11 +605,11 @@ class SpansTab extends AbstractTab {
             List<Span> ctx = new ArrayList<>();
             if (span.routeId() != null) {
                 ctx.add(Span.styled(" Route:  ", Style.EMPTY.dim()));
-                ctx.add(Span.styled(span.routeId(), Style.EMPTY.fg(Color.YELLOW)));
+                ctx.add(Span.styled(span.routeId(), Theme.label()));
             }
             if (span.processorId() != null) {
                 ctx.add(Span.styled("  Processor: ", Style.EMPTY.dim()));
-                ctx.add(Span.styled(span.processorId(), Style.EMPTY.fg(Color.YELLOW)));
+                ctx.add(Span.styled(span.processorId(), Theme.label()));
             }
             if (!span.isCamelSpan()) {
                 ctx.add(Span.styled("  Source: ", Style.EMPTY.dim()));
@@ -650,7 +650,7 @@ class SpansTab extends AbstractTab {
             hint(spans, TuiIcons.HINT_SCROLL, "navigate");
             hintLast(spans, "PgUp/Dn", "page");
         } else if (filterInputActive) {
-            spans.add(Span.styled(" /", Style.EMPTY.fg(Color.YELLOW).bold()));
+            spans.add(Span.styled(" /", Theme.label().bold()));
             spans.add(Span.raw(filterInputState.text() + "█  "));
             hint(spans, "Enter", "filter");
             hintLast(spans, "Esc", "cancel");
@@ -659,7 +659,7 @@ class SpansTab extends AbstractTab {
             hint(spans, "F5", "refresh");
             hint(spans, "Enter", "waterfall");
             if (filterTerm != null) {
-                spans.add(Span.styled("  /", Style.EMPTY.fg(Color.YELLOW).bold()));
+                spans.add(Span.styled("  /", Theme.label().bold()));
                 spans.add(Span.raw("\"" + filterTerm + "\"  "));
             } else {
                 hint(spans, "/", "filter");
@@ -955,7 +955,7 @@ class SpansTab extends AbstractTab {
     }
 
     private Style sortStyle(String column) {
-        return Style.EMPTY.fg(Color.YELLOW).bold();
+        return Theme.label().bold();
     }
 
     private static int computeMaxDepth(List<SpanEntry> traceSpans) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
@@ -367,9 +367,9 @@ class SpansTab extends AbstractTab {
         for (TraceSummary ts : summaries) {
             Style statusStyle;
             if (ts.hasError) {
-                statusStyle = Style.EMPTY.fg(Color.LIGHT_RED);
+                statusStyle = Theme.error();
             } else {
-                statusStyle = Style.EMPTY.fg(Color.GREEN);
+                statusStyle = Theme.success();
             }
 
             rows.add(Row.from(
@@ -551,8 +551,8 @@ class SpansTab extends AbstractTab {
         Style labelStyle;
         Style bandStyle;
         if (error) {
-            labelStyle = selected ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY.fg(Color.LIGHT_RED);
-            bandStyle = Style.EMPTY.fg(Color.LIGHT_RED);
+            labelStyle = selected ? Theme.error().bold() : Theme.error();
+            bandStyle = Theme.error();
         } else if (!camelSpan) {
             labelStyle = selected ? Style.EMPTY.fg(Color.LIGHT_MAGENTA).bold() : Style.EMPTY.fg(Color.LIGHT_MAGENTA);
             bandStyle = Style.EMPTY.fg(Color.LIGHT_MAGENTA);
@@ -568,10 +568,10 @@ class SpansTab extends AbstractTab {
                 Span.styled(label, labelStyle),
                 Span.raw(gap),
                 Span.styled(bar, bandStyle),
-                Span.styled(errorTag, Style.EMPTY.fg(Color.LIGHT_RED).bold()),
+                Span.styled(errorTag, Theme.error().bold()),
                 Span.raw(" ".repeat(pad)),
                 Span.styled(durationStr, error
-                        ? Style.EMPTY.fg(Color.LIGHT_RED).bold()
+                        ? Theme.error().bold()
                         : Style.EMPTY.fg(Theme.baseFg()).bold()));
     }
 
@@ -584,7 +584,7 @@ class SpansTab extends AbstractTab {
         List<Line> lines = new ArrayList<>();
 
         // Row 1: span identity
-        Style statusStyle = span.isError() ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY.fg(Color.GREEN);
+        Style statusStyle = span.isError() ? Theme.error().bold() : Theme.success();
         lines.add(Line.from(
                 Span.styled(" Span:   ", Style.EMPTY.dim()),
                 Span.styled(span.spanId(), Style.EMPTY.fg(Theme.baseFg()).bold()),
@@ -628,7 +628,7 @@ class SpansTab extends AbstractTab {
             }
         }
 
-        Style titleStyle = span.isError() ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.CYAN);
+        Style titleStyle = span.isError() ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -554,10 +553,10 @@ class SpansTab extends AbstractTab {
             labelStyle = selected ? Theme.error().bold() : Theme.error();
             bandStyle = Theme.error();
         } else if (!camelSpan) {
-            labelStyle = selected ? Style.EMPTY.fg(Color.LIGHT_MAGENTA).bold() : Style.EMPTY.fg(Color.LIGHT_MAGENTA);
-            bandStyle = Style.EMPTY.fg(Color.LIGHT_MAGENTA);
+            labelStyle = selected ? Theme.notice().bold() : Theme.notice();
+            bandStyle = Theme.notice();
         } else {
-            labelStyle = selected ? Style.EMPTY.fg(Color.CYAN).bold() : Style.EMPTY.fg(Color.CYAN);
+            labelStyle = selected ? Style.EMPTY.fg(Theme.accent()).bold() : Style.EMPTY.fg(Theme.accent());
             bandStyle = TuiHelper.colorForDuration(node.span.durationMs(), minDuration, maxDuration);
         }
 
@@ -613,7 +612,7 @@ class SpansTab extends AbstractTab {
             }
             if (!span.isCamelSpan()) {
                 ctx.add(Span.styled("  Source: ", Style.EMPTY.dim()));
-                ctx.add(Span.styled(span.scopeName(), Style.EMPTY.fg(Color.LIGHT_MAGENTA)));
+                ctx.add(Span.styled(span.scopeName(), Theme.notice()));
             }
             lines.add(Line.from(ctx));
         }
@@ -628,7 +627,7 @@ class SpansTab extends AbstractTab {
             }
         }
 
-        Style titleStyle = span.isError() ? Theme.error() : Style.EMPTY.fg(Color.CYAN);
+        Style titleStyle = span.isError() ? Theme.error() : Style.EMPTY.fg(Theme.accent());
         frame.renderWidget(
                 Paragraph.builder()
                         .text(Text.from(lines))

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
@@ -585,33 +585,33 @@ class SpansTab extends AbstractTab {
         // Row 1: span identity
         Style statusStyle = span.isError() ? Theme.error().bold() : Theme.success();
         lines.add(Line.from(
-                Span.styled(" Span:   ", Style.EMPTY.dim()),
+                Span.styled(" Span:   ", Theme.muted()),
                 Span.styled(span.spanId(), Style.EMPTY.fg(Theme.baseFg()).bold()),
-                Span.styled("  Parent: ", Style.EMPTY.dim()),
+                Span.styled("  Parent: ", Theme.muted()),
                 Span.raw(span.parentSpanId() != null ? span.parentSpanId() : "-"),
-                Span.styled("  Kind: ", Style.EMPTY.dim()),
+                Span.styled("  Kind: ", Theme.muted()),
                 Span.raw(span.kind() != null ? span.kind() : "")));
 
         // Row 2: status and duration
         lines.add(Line.from(
-                Span.styled(" Status: ", Style.EMPTY.dim()),
+                Span.styled(" Status: ", Theme.muted()),
                 Span.styled(span.isError() ? "ERROR" : "OK", statusStyle),
-                Span.styled("  Duration: ", Style.EMPTY.dim()),
+                Span.styled("  Duration: ", Theme.muted()),
                 Span.raw(span.durationMs() + "ms")));
 
         // Row 3: route, processor context, and scope (for 3rd-party spans)
         if (span.routeId() != null || span.processorId() != null || !span.isCamelSpan()) {
             List<Span> ctx = new ArrayList<>();
             if (span.routeId() != null) {
-                ctx.add(Span.styled(" Route:  ", Style.EMPTY.dim()));
+                ctx.add(Span.styled(" Route:  ", Theme.muted()));
                 ctx.add(Span.styled(span.routeId(), Theme.label()));
             }
             if (span.processorId() != null) {
-                ctx.add(Span.styled("  Processor: ", Style.EMPTY.dim()));
+                ctx.add(Span.styled("  Processor: ", Theme.muted()));
                 ctx.add(Span.styled(span.processorId(), Theme.label()));
             }
             if (!span.isCamelSpan()) {
-                ctx.add(Span.styled("  Source: ", Style.EMPTY.dim()));
+                ctx.add(Span.styled("  Source: ", Theme.muted()));
                 ctx.add(Span.styled(span.scopeName(), Theme.notice()));
             }
             lines.add(Line.from(ctx));
@@ -622,7 +622,7 @@ class SpansTab extends AbstractTab {
             lines.add(Line.from(Span.raw("")));
             for (Map.Entry<String, Object> entry : span.attributes().entrySet()) {
                 lines.add(Line.from(
-                        Span.styled(" " + entry.getKey() + ": ", Style.EMPTY.dim()),
+                        Span.styled(" " + entry.getKey() + ": ", Theme.muted()),
                         Span.raw(String.valueOf(entry.getValue()))));
             }
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTab.java
@@ -572,7 +572,7 @@ class SpansTab extends AbstractTab {
                 Span.raw(" ".repeat(pad)),
                 Span.styled(durationStr, error
                         ? Style.EMPTY.fg(Color.LIGHT_RED).bold()
-                        : Style.EMPTY.fg(Color.WHITE).bold()));
+                        : Style.EMPTY.fg(Theme.baseFg()).bold()));
     }
 
     private void renderSpanDetail(Frame frame, Rect area, List<WaterfallNode> nodes) {
@@ -587,7 +587,7 @@ class SpansTab extends AbstractTab {
         Style statusStyle = span.isError() ? Style.EMPTY.fg(Color.LIGHT_RED).bold() : Style.EMPTY.fg(Color.GREEN);
         lines.add(Line.from(
                 Span.styled(" Span:   ", Style.EMPTY.dim()),
-                Span.styled(span.spanId(), Style.EMPTY.fg(Color.WHITE).bold()),
+                Span.styled(span.spanId(), Style.EMPTY.fg(Theme.baseFg()).bold()),
                 Span.styled("  Parent: ", Style.EMPTY.dim()),
                 Span.raw(span.parentSpanId() != null ? span.parentSpanId() : "-"),
                 Span.styled("  Kind: ", Style.EMPTY.dim()),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -378,7 +378,7 @@ class SqlQueryTab extends AbstractTab {
                     sb.append("  ");
                 }
             }
-            Style style = focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Theme.muted();
+            Style style = focusOnInput ? Style.EMPTY.fg(Theme.accent()) : Theme.muted();
             Paragraph dsLabel = Paragraph.builder()
                     .text(Text.from(Line.from(Span.styled(sb.toString(), style))))
                     .build();
@@ -399,7 +399,7 @@ class SqlQueryTab extends AbstractTab {
         } else {
             title = " SQL Query (F5 to execute) ";
         }
-        Style borderStyle = focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Theme.muted();
+        Style borderStyle = focusOnInput ? Style.EMPTY.fg(Theme.accent()) : Theme.muted();
         Block inputBlock = Block.builder()
                 .title(Title.from(title))
                 .borders(Borders.ALL)
@@ -426,12 +426,12 @@ class SqlQueryTab extends AbstractTab {
                     .title(Title.from(" Error "))
                     .borders(Borders.ALL)
                     .borderType(BorderType.ROUNDED)
-                    .borderStyle(Style.EMPTY.fg(Color.RED))
+                    .borderStyle(Theme.error())
                     .build();
             Rect inner = errBlock.inner(area);
             frame.renderWidget(errBlock, area);
             Paragraph errText = Paragraph.builder()
-                    .text(Text.from(Line.from(Span.styled(errorMessage, Style.EMPTY.fg(Color.RED)))))
+                    .text(Text.from(Line.from(Span.styled(errorMessage, Theme.error()))))
                     .build();
             frame.renderWidget(errText, inner);
             return;
@@ -477,7 +477,7 @@ class SqlQueryTab extends AbstractTab {
         // build result table
         String resultTitle = String.format(" %d row(s)%s  %dms ",
                 rowCount, truncated ? " (truncated)" : "", elapsed);
-        Style tableBorderStyle = !focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Theme.muted();
+        Style tableBorderStyle = !focusOnInput ? Style.EMPTY.fg(Theme.accent()) : Theme.muted();
         Block tableBlock = Block.builder()
                 .title(Title.from(resultTitle))
                 .borders(Borders.ALL)
@@ -772,7 +772,7 @@ class SqlQueryTab extends AbstractTab {
             if (isPk) {
                 labelStyle = Theme.muted();
             } else if (isFocused) {
-                labelStyle = Style.EMPTY.fg(Color.CYAN).bold();
+                labelStyle = Style.EMPTY.fg(Theme.accent()).bold();
             } else {
                 labelStyle = Style.EMPTY;
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -442,13 +442,13 @@ class SqlQueryTab extends AbstractTab {
                     .title(Title.from(" Result "))
                     .borders(Borders.ALL)
                     .borderType(BorderType.ROUNDED)
-                    .borderStyle(Style.EMPTY.fg(Color.GREEN))
+                    .borderStyle(Theme.success())
                     .build();
             Rect inner = ucBlock.inner(area);
             frame.renderWidget(ucBlock, area);
             String msg = String.format("Update count: %d  (%dms)", updateCount, elapsed);
             Paragraph ucText = Paragraph.builder()
-                    .text(Text.from(Line.from(Span.styled(msg, Style.EMPTY.fg(Color.GREEN)))))
+                    .text(Text.from(Line.from(Span.styled(msg, Theme.success()))))
                     .build();
             frame.renderWidget(ucText, inner);
             return;
@@ -788,7 +788,9 @@ class SqlQueryTab extends AbstractTab {
                         Span.styled(val.isEmpty() ? "null" : val, Style.EMPTY.fg(Color.DARK_GRAY)))), valArea);
             } else if (isFocused) {
                 boolean changed = !editInputs[i].text().equals(editOriginalValues[i]);
-                Style cursorStyle = changed ? Style.EMPTY.reversed().fg(Color.GREEN) : Style.EMPTY.reversed();
+                Style cursorStyle = changed
+                        ? Style.EMPTY.reversed().fg(Theme.success().fg().orElse(Color.GREEN))
+                        : Style.EMPTY.reversed();
                 TextInput input = TextInput.builder()
                         .cursorStyle(cursorStyle)
                         .build();
@@ -796,7 +798,7 @@ class SqlQueryTab extends AbstractTab {
             } else {
                 String val = editInputs[i].text();
                 boolean changed = !val.equals(editOriginalValues[i]);
-                Style valStyle = changed ? Style.EMPTY.fg(Color.GREEN) : Style.EMPTY;
+                Style valStyle = changed ? Theme.success() : Style.EMPTY;
                 frame.renderWidget(Paragraph.from(Line.from(
                         Span.styled(val.isEmpty() ? "null" : val, valStyle))), valArea);
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -378,7 +378,7 @@ class SqlQueryTab extends AbstractTab {
                     sb.append("  ");
                 }
             }
-            Style style = focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Style.EMPTY.fg(Color.DARK_GRAY);
+            Style style = focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Theme.muted();
             Paragraph dsLabel = Paragraph.builder()
                     .text(Text.from(Line.from(Span.styled(sb.toString(), style))))
                     .build();
@@ -399,7 +399,7 @@ class SqlQueryTab extends AbstractTab {
         } else {
             title = " SQL Query (F5 to execute) ";
         }
-        Style borderStyle = focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Style.EMPTY.fg(Color.DARK_GRAY);
+        Style borderStyle = focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Theme.muted();
         Block inputBlock = Block.builder()
                 .title(Title.from(title))
                 .borders(Borders.ALL)
@@ -459,7 +459,7 @@ class SqlQueryTab extends AbstractTab {
                     .title(Title.from(" Results "))
                     .borders(Borders.ALL)
                     .borderType(BorderType.ROUNDED)
-                    .borderStyle(Style.EMPTY.fg(Color.DARK_GRAY))
+                    .borderStyle(Theme.muted())
                     .build();
             Rect inner = emptyBlock.inner(area);
             frame.renderWidget(emptyBlock, area);
@@ -468,7 +468,7 @@ class SqlQueryTab extends AbstractTab {
                     ? "No DataSource available"
                     : "Type a SQL query and press F5 to execute";
             Paragraph hintText = Paragraph.builder()
-                    .text(Text.from(Line.from(Span.styled(hint, Style.EMPTY.fg(Color.DARK_GRAY)))))
+                    .text(Text.from(Line.from(Span.styled(hint, Theme.muted()))))
                     .build();
             frame.renderWidget(hintText, inner);
             return;
@@ -477,7 +477,7 @@ class SqlQueryTab extends AbstractTab {
         // build result table
         String resultTitle = String.format(" %d row(s)%s  %dms ",
                 rowCount, truncated ? " (truncated)" : "", elapsed);
-        Style tableBorderStyle = !focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Style.EMPTY.fg(Color.DARK_GRAY);
+        Style tableBorderStyle = !focusOnInput ? Style.EMPTY.fg(Color.CYAN) : Theme.muted();
         Block tableBlock = Block.builder()
                 .title(Title.from(resultTitle))
                 .borders(Borders.ALL)
@@ -496,7 +496,7 @@ class SqlQueryTab extends AbstractTab {
             for (String col : columnNames) {
                 Object val = row.get(col);
                 String s = val != null ? String.valueOf(val) : "null";
-                Style style = val == null ? Style.EMPTY.fg(Color.DARK_GRAY) : Style.EMPTY.fg(Theme.baseFg());
+                Style style = val == null ? Theme.muted() : Style.EMPTY.fg(Theme.baseFg());
                 cells.add(Cell.from(Span.styled(s, style)));
             }
             dataRows.add(Row.from(cells));
@@ -513,7 +513,7 @@ class SqlQueryTab extends AbstractTab {
                 .rows(dataRows)
                 .widths(colConstraints)
                 .block(tableBlock)
-                .highlightStyle(Style.EMPTY.bg(Color.DARK_GRAY))
+                .highlightStyle(Theme.selectionBg())
                 .build();
         lastTableArea = area;
         frame.renderStatefulWidget(table, area, tableState);
@@ -770,7 +770,7 @@ class SqlQueryTab extends AbstractTab {
             String label = columnNames[i] + (isPk ? " *" : "  ");
             Style labelStyle;
             if (isPk) {
-                labelStyle = Style.EMPTY.fg(Color.DARK_GRAY);
+                labelStyle = Theme.muted();
             } else if (isFocused) {
                 labelStyle = Style.EMPTY.fg(Color.CYAN).bold();
             } else {
@@ -785,7 +785,7 @@ class SqlQueryTab extends AbstractTab {
             if (isPk) {
                 String val = editOriginalValues[i];
                 frame.renderWidget(Paragraph.from(Line.from(
-                        Span.styled(val.isEmpty() ? "null" : val, Style.EMPTY.fg(Color.DARK_GRAY)))), valArea);
+                        Span.styled(val.isEmpty() ? "null" : val, Theme.muted()))), valArea);
             } else if (isFocused) {
                 boolean changed = !editInputs[i].text().equals(editOriginalValues[i]);
                 Style cursorStyle = changed
@@ -810,11 +810,11 @@ class SqlQueryTab extends AbstractTab {
             Rect footerArea = new Rect(inner.left(), footerY, inner.width(), 1);
             frame.renderWidget(Paragraph.from(Line.from(
                     Span.styled(" F5", Theme.label().bold()),
-                    Span.styled("=Save  ", Style.EMPTY.fg(Color.DARK_GRAY)),
+                    Span.styled("=Save  ", Theme.muted()),
                     Span.styled("Esc", Theme.label().bold()),
-                    Span.styled("=Cancel  ", Style.EMPTY.fg(Color.DARK_GRAY)),
-                    Span.styled("*", Style.EMPTY.fg(Color.DARK_GRAY)),
-                    Span.styled("=Primary Key", Style.EMPTY.fg(Color.DARK_GRAY)))), footerArea);
+                    Span.styled("=Cancel  ", Theme.muted()),
+                    Span.styled("*", Theme.muted()),
+                    Span.styled("=Primary Key", Theme.muted()))), footerArea);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -796,7 +795,7 @@ class SqlQueryTab extends AbstractTab {
             } else if (isFocused) {
                 boolean changed = !editInputs[i].text().equals(editOriginalValues[i]);
                 Style cursorStyle = changed
-                        ? Style.EMPTY.reversed().fg(Theme.success().fg().orElse(Color.GREEN))
+                        ? Style.EMPTY.reversed().fg(Theme.success().fg().orElseThrow())
                         : Style.EMPTY.reversed();
                 TextInput input = TextInput.builder()
                         .cursorStyle(cursorStyle)

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -103,7 +103,7 @@ class SqlQueryTab extends AbstractTab {
     }
 
     boolean isInputActive() {
-        return editMode || focusOnInput;
+        return !dsNames.isEmpty() && (editMode || focusOnInput);
     }
 
     void handlePaste(String text) {
@@ -139,8 +139,8 @@ class SqlQueryTab extends AbstractTab {
 
     @Override
     public boolean handleKeyEvent(KeyEvent ke) {
-        if (executing.get()) {
-            return true;
+        if (dsNames.isEmpty() || executing.get()) {
+            return dsNames.isEmpty() ? false : true;
         }
 
         // edit mode takes priority
@@ -396,10 +396,13 @@ class SqlQueryTab extends AbstractTab {
             title = String.format(" SQL Query (%d updated, %dms) ", updateCount, elapsed);
         } else if (resultRows != null) {
             title = String.format(" SQL Query (%d row(s), %dms) ", rowCount, elapsed);
+        } else if (dsNames.isEmpty()) {
+            title = " SQL Query ";
         } else {
             title = " SQL Query (F5 to execute) ";
         }
-        Style borderStyle = focusOnInput ? Style.EMPTY.fg(Theme.accent()) : Theme.muted();
+        Style borderStyle = dsNames.isEmpty() ? Theme.muted()
+                : focusOnInput ? Style.EMPTY.fg(Theme.accent()) : Theme.muted();
         Block inputBlock = Block.builder()
                 .title(Title.from(title))
                 .borders(Borders.ALL)
@@ -411,9 +414,13 @@ class SqlQueryTab extends AbstractTab {
 
         TextArea textArea = TextArea.builder()
                 .cursorStyle(Style.EMPTY.reversed())
-                .placeholder("Type SQL query or file:query.sql ...")
+                .placeholder(dsNames.isEmpty()
+                        ? "No DataSource available"
+                        : "Type SQL query or file:query.sql ...")
                 .build();
-        if (focusOnInput) {
+        if (dsNames.isEmpty()) {
+            textArea.render(inner, frame.buffer(), sqlInput);
+        } else if (focusOnInput) {
             textArea.renderWithCursor(inner, frame.buffer(), sqlInput, frame);
         } else {
             textArea.render(inner, frame.buffer(), sqlInput);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -496,7 +496,7 @@ class SqlQueryTab extends AbstractTab {
             for (String col : columnNames) {
                 Object val = row.get(col);
                 String s = val != null ? String.valueOf(val) : "null";
-                Style style = val == null ? Style.EMPTY.fg(Color.DARK_GRAY) : Style.EMPTY.fg(Color.WHITE);
+                Style style = val == null ? Style.EMPTY.fg(Color.DARK_GRAY) : Style.EMPTY.fg(Theme.baseFg());
                 cells.add(Cell.from(Span.styled(s, style)));
             }
             dataRows.add(Row.from(cells));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlQueryTab.java
@@ -488,7 +488,7 @@ class SqlQueryTab extends AbstractTab {
         int[] widths = computeColumnWidths(area.width() - 2);
 
         Row header = Row.from(buildHeaderCells());
-        header.style(Style.EMPTY.fg(Color.YELLOW));
+        header.style(Theme.label());
 
         List<Row> dataRows = new ArrayList<>();
         for (JsonObject row : resultRows) {
@@ -544,7 +544,7 @@ class SqlQueryTab extends AbstractTab {
             if (columnIsPk != null && columnIsPk[i]) {
                 label = label + " " + TuiIcons.KEY;
             }
-            cells[i] = Cell.from(Span.styled(label, Style.EMPTY.fg(Color.YELLOW)));
+            cells[i] = Cell.from(Span.styled(label, Theme.label().bold()));
         }
         return cells;
     }
@@ -747,7 +747,7 @@ class SqlQueryTab extends AbstractTab {
 
         Block block = Block.builder()
                 .borderType(BorderType.ROUNDED)
-                .title(Title.from(Line.from(Span.styled(title, Style.EMPTY.fg(Color.YELLOW).bold()))))
+                .title(Title.from(Line.from(Span.styled(title, Theme.label().bold()))))
                 .build();
         Rect inner = block.inner(popup);
         frame.renderWidget(block, popup);
@@ -807,9 +807,9 @@ class SqlQueryTab extends AbstractTab {
         if (footerY < popup.bottom() - 1) {
             Rect footerArea = new Rect(inner.left(), footerY, inner.width(), 1);
             frame.renderWidget(Paragraph.from(Line.from(
-                    Span.styled(" F5", Style.EMPTY.fg(Color.YELLOW)),
+                    Span.styled(" F5", Theme.label().bold()),
                     Span.styled("=Save  ", Style.EMPTY.fg(Color.DARK_GRAY)),
-                    Span.styled("Esc", Style.EMPTY.fg(Color.YELLOW)),
+                    Span.styled("Esc", Theme.label().bold()),
                     Span.styled("=Cancel  ", Style.EMPTY.fg(Color.DARK_GRAY)),
                     Span.styled("*", Style.EMPTY.fg(Color.DARK_GRAY)),
                     Span.styled("=Primary Key", Style.EMPTY.fg(Color.DARK_GRAY)))), footerArea);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
@@ -146,7 +146,7 @@ class SqlTraceTab extends AbstractTableTab {
     private void renderKpiStrip(Frame frame, Rect area, IntegrationInfo info) {
         Style labelStyle = Style.EMPTY.dim();
         Style valueStyle = Style.EMPTY.fg(Color.CYAN).bold();
-        Style warnStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+        Style warnStyle = Theme.warning().bold();
         Style errorStyle = Style.EMPTY.fg(Color.LIGHT_RED).bold();
 
         List<Span> spans = new ArrayList<>();
@@ -233,7 +233,7 @@ class SqlTraceTab extends AbstractTableTab {
     private void renderTable(Frame frame, Rect area, List<SqlTraceInfo> sorted) {
         List<Row> rows = new ArrayList<>();
         for (SqlTraceInfo si : sorted) {
-            Style durStyle = si.duration >= 100 ? Style.EMPTY.fg(Color.YELLOW) : Style.EMPTY;
+            Style durStyle = si.duration >= 100 ? Theme.warning() : Style.EMPTY;
             Style statusStyle = si.failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
             String status = si.failed ? "FAIL" : "OK";
 
@@ -339,7 +339,7 @@ class SqlTraceTab extends AbstractTableTab {
             time = LocalDateTime.ofInstant(Instant.ofEpochMilli(si.timestamp), ZoneId.systemDefault())
                     .format(TIME_FMT);
         }
-        Style durStyle = si.duration >= 100 ? Style.EMPTY.fg(Color.YELLOW) : Style.EMPTY;
+        Style durStyle = si.duration >= 100 ? Theme.warning() : Style.EMPTY;
         Style statusStyle = si.failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
         lines.add(Line.from(
                 Span.styled(" Time: ", labelStyle),
@@ -378,7 +378,7 @@ class SqlTraceTab extends AbstractTableTab {
         return switch (category) {
             case "SELECT" -> Style.EMPTY.fg(Color.CYAN);
             case "INSERT" -> Style.EMPTY.fg(Color.GREEN);
-            case "UPDATE" -> Style.EMPTY.fg(Color.YELLOW);
+            case "UPDATE" -> Theme.label();
             case "DELETE" -> Style.EMPTY.fg(Color.LIGHT_RED);
             default -> Style.EMPTY;
         };

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
@@ -27,7 +27,6 @@ import java.util.function.Consumer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -145,7 +144,7 @@ class SqlTraceTab extends AbstractTableTab {
 
     private void renderKpiStrip(Frame frame, Rect area, IntegrationInfo info) {
         Style labelStyle = Style.EMPTY.dim();
-        Style valueStyle = Style.EMPTY.fg(Color.CYAN).bold();
+        Style valueStyle = Style.EMPTY.fg(Theme.accent()).bold();
         Style warnStyle = Theme.warning().bold();
         Style errorStyle = Theme.error().bold();
 
@@ -254,7 +253,7 @@ class SqlTraceTab extends AbstractTableTab {
                     Cell.from(Span.styled(time, Style.EMPTY.dim())),
                     Cell.from(Span.styled(si.category != null ? si.category : "", categoryStyle(si.category))),
                     Cell.from(si.query != null ? si.query : ""),
-                    Cell.from(Span.styled(si.routeId != null ? si.routeId : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(si.routeId != null ? si.routeId : "", Style.EMPTY.fg(Theme.accent()))),
                     rightCell(String.valueOf(si.duration), 10, durStyle),
                     rightCell(rowsStr, 8),
                     Cell.from(Span.styled(status, statusStyle))));
@@ -311,7 +310,7 @@ class SqlTraceTab extends AbstractTableTab {
 
     private void renderDetail(Frame frame, Rect area, SqlTraceInfo si) {
         List<Line> lines = new ArrayList<>();
-        Style labelStyle = Style.EMPTY.fg(Color.CYAN).bold();
+        Style labelStyle = Style.EMPTY.fg(Theme.accent()).bold();
         Style valueStyle = Style.EMPTY;
 
         lines.add(Line.from(
@@ -376,7 +375,7 @@ class SqlTraceTab extends AbstractTableTab {
             return Style.EMPTY;
         }
         return switch (category) {
-            case "SELECT" -> Style.EMPTY.fg(Color.CYAN);
+            case "SELECT" -> Style.EMPTY.fg(Theme.accent());
             case "INSERT" -> Theme.success();
             case "UPDATE" -> Theme.label();
             case "DELETE" -> Theme.error();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
@@ -143,7 +143,7 @@ class SqlTraceTab extends AbstractTableTab {
     }
 
     private void renderKpiStrip(Frame frame, Rect area, IntegrationInfo info) {
-        Style labelStyle = Style.EMPTY.dim();
+        Style labelStyle = Theme.muted();
         Style valueStyle = Style.EMPTY.fg(Theme.accent()).bold();
         Style warnStyle = Theme.warning().bold();
         Style errorStyle = Theme.error().bold();
@@ -310,7 +310,7 @@ class SqlTraceTab extends AbstractTableTab {
 
     private void renderDetail(Frame frame, Rect area, SqlTraceInfo si) {
         List<Line> lines = new ArrayList<>();
-        Style labelStyle = Style.EMPTY.fg(Theme.accent()).bold();
+        Style labelStyle = Theme.muted();
         Style valueStyle = Style.EMPTY;
 
         lines.add(Line.from(

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTab.java
@@ -147,7 +147,7 @@ class SqlTraceTab extends AbstractTableTab {
         Style labelStyle = Style.EMPTY.dim();
         Style valueStyle = Style.EMPTY.fg(Color.CYAN).bold();
         Style warnStyle = Theme.warning().bold();
-        Style errorStyle = Style.EMPTY.fg(Color.LIGHT_RED).bold();
+        Style errorStyle = Theme.error().bold();
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.styled("  Total: ", labelStyle));
@@ -234,7 +234,7 @@ class SqlTraceTab extends AbstractTableTab {
         List<Row> rows = new ArrayList<>();
         for (SqlTraceInfo si : sorted) {
             Style durStyle = si.duration >= 100 ? Theme.warning() : Style.EMPTY;
-            Style statusStyle = si.failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
+            Style statusStyle = si.failed ? Theme.error() : Theme.success();
             String status = si.failed ? "FAIL" : "OK";
 
             String time = "";
@@ -340,7 +340,7 @@ class SqlTraceTab extends AbstractTableTab {
                     .format(TIME_FMT);
         }
         Style durStyle = si.duration >= 100 ? Theme.warning() : Style.EMPTY;
-        Style statusStyle = si.failed ? Style.EMPTY.fg(Color.LIGHT_RED) : Style.EMPTY.fg(Color.GREEN);
+        Style statusStyle = si.failed ? Theme.error() : Theme.success();
         lines.add(Line.from(
                 Span.styled(" Time: ", labelStyle),
                 Span.styled(time, valueStyle),
@@ -377,9 +377,9 @@ class SqlTraceTab extends AbstractTableTab {
         }
         return switch (category) {
             case "SELECT" -> Style.EMPTY.fg(Color.CYAN);
-            case "INSERT" -> Style.EMPTY.fg(Color.GREEN);
+            case "INSERT" -> Theme.success();
             case "UPDATE" -> Theme.label();
-            case "DELETE" -> Style.EMPTY.fg(Color.LIGHT_RED);
+            case "DELETE" -> Theme.error();
             default -> Style.EMPTY;
         };
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
@@ -52,7 +52,6 @@ class StartupTab extends AbstractTab {
     private static final int MOUSE_SCROLL_LINES = 3;
     private static final Style LABEL = Style.EMPTY.dim();
     private static final Style VALUE = Style.EMPTY.fg(Color.WHITE).bold();
-    private static final Style HEADER = Style.EMPTY.fg(Color.YELLOW).bold();
 
     private final ScrollbarState scrollbarState = new ScrollbarState();
     private final AtomicBoolean loading = new AtomicBoolean(false);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -159,7 +158,7 @@ class StartupTab extends AbstractTab {
             frame.renderWidget(
                     Paragraph.builder()
                             .text(Text.from(Line.from(
-                                    Span.styled("  " + errorMessage, Style.EMPTY.fg(Color.LIGHT_RED)))))
+                                    Span.styled("  " + errorMessage, Theme.error()))))
                             .block(Block.builder().borderType(BorderType.ROUNDED).borders(Borders.ALL)
                                     .title(" Startup Timeline ").build())
                             .build(),

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
@@ -49,7 +49,7 @@ import static org.apache.camel.dsl.jbang.core.commands.tui.TuiHelper.*;
 class StartupTab extends AbstractTab {
 
     private static final int MOUSE_SCROLL_LINES = 3;
-    private static final Style LABEL = Style.EMPTY.dim();
+    private static final Style LABEL = Theme.muted();
     private static final Style VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
 
     private final ScrollbarState scrollbarState = new ScrollbarState();

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/StartupTab.java
@@ -51,7 +51,7 @@ class StartupTab extends AbstractTab {
 
     private static final int MOUSE_SCROLL_LINES = 3;
     private static final Style LABEL = Style.EMPTY.dim();
-    private static final Style VALUE = Style.EMPTY.fg(Color.WHITE).bold();
+    private static final Style VALUE = Style.EMPTY.fg(Theme.baseFg()).bold();
 
     private final ScrollbarState scrollbarState = new ScrollbarState();
     private final AtomicBoolean loading = new AtomicBoolean(false);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
@@ -19,8 +19,10 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -84,6 +86,15 @@ public final class Theme {
     private static final Color FALLBACK_DIAGRAM_ACTION = Color.rgb(0xC5, 0x86, 0xC0);
     private static final Color FALLBACK_DIAGRAM_EIP = Color.rgb(0x89, 0x57, 0xE5);
     private static final Color FALLBACK_DIAGRAM_DEFAULT = Color.rgb(0x80, 0x80, 0x80);
+
+    private static final String[] REQUIRED_TOKENS = {
+            "accent", "accent-bg", "hint-key", "border", "border-focused", "title",
+            "success", "warning", "error", "muted", "selection", "info", "notice",
+            "row-alt", "base-bg", "base-fg",
+            "label", "change", "search-match",
+            "diagram-border", "diagram-id", "diagram-from", "diagram-to",
+            "diagram-choice", "diagram-action", "diagram-eip", "diagram-default"
+    };
 
     private static final Map<String, Style> CACHE = new HashMap<>();
 
@@ -414,6 +425,7 @@ public final class Theme {
             String cssContent = loadCssResource(mode.stylesheetResource());
             e.addStylesheet(stylesheet, cssContent);
             e.setActiveStylesheet(stylesheet);
+            validateTokens(e, stylesheet);
             engine = e;
         } catch (Exception ex) {
             engine = null;
@@ -501,6 +513,24 @@ public final class Theme {
             persistedWriteFallbackLogged = true;
             LOG.warn("Camel TUI theme preference could not be saved; the selected theme may not persist across restarts",
                     t);
+        }
+    }
+
+    private static void validateTokens(StyleEngine e, String stylesheet) {
+        List<String> missing = new ArrayList<>();
+        for (String token : REQUIRED_TOKENS) {
+            try {
+                Style resolved = e.resolve(new Token(token)).toStyle();
+                if (resolved.equals(Style.EMPTY)) {
+                    missing.add(token);
+                }
+            } catch (RuntimeException ex) {
+                missing.add(token);
+            }
+        }
+        if (!missing.isEmpty()) {
+            throw new IllegalStateException(
+                    "Theme stylesheet '" + stylesheet + "' is missing required CSS tokens: " + missing);
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
@@ -244,6 +244,19 @@ public final class Theme {
         return style("search-match", FALLBACK_SEARCH_MATCH);
     }
 
+    /** Theme-aware markdown styles for MarkdownView headings and other elements. */
+    public static dev.tamboui.markdown.MarkdownStyles markdownStyles() {
+        return dev.tamboui.markdown.MarkdownStyles.builder()
+                .heading(1, label().bold())
+                .heading(2, label().bold())
+                .heading(3, label().bold())
+                .inlineCode(Style.EMPTY.fg(accent()))
+                .codeBlock(muted())
+                .listMarker(Style.EMPTY.fg(accent()))
+                .link(Style.EMPTY.fg(accent()).underlined())
+                .build();
+    }
+
     /** Diagram box-drawing border color. */
     public static synchronized Color diagramBorder() {
         return color("diagram-border", FALLBACK_DIAGRAM_BORDER);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  * plain white/black foregrounds. Fallbacks mirror {@code dark.tcss}. If a stylesheet is missing or malformed, the
  * facade falls back to the built-in palette below and logs once, so a cosmetic failure never crashes the TUI.
  */
-final class Theme {
+public final class Theme {
 
     /** Camel brand orange. */
     static final Color ACCENT = Color.rgb(0xF6, 0x91, 0x23);
@@ -73,6 +73,21 @@ final class Theme {
     private static final Color FALLBACK_BASE_BG = Color.rgb(0x1E, 0x1E, 0x1E);
     private static final Color FALLBACK_BASE_FG = Color.rgb(0xD4, 0xD4, 0xD4);
 
+    // Content token fallbacks (dark-theme defaults).
+    private static final Style FALLBACK_LABEL = Style.EMPTY.fg(Color.rgb(0xDC, 0xDC, 0xAA));
+    private static final Style FALLBACK_CHANGE = Style.EMPTY.fg(Color.rgb(0xDC, 0xDC, 0xAA));
+    private static final Style FALLBACK_SEARCH_MATCH = Style.EMPTY.fg(Color.BLACK).bg(Color.rgb(0xDC, 0xDC, 0xAA));
+
+    // Diagram token fallbacks (dark-theme defaults).
+    private static final Color FALLBACK_DIAGRAM_BORDER = Color.rgb(0x80, 0x80, 0x80);
+    private static final Color FALLBACK_DIAGRAM_ID = FALLBACK_BASE_FG;
+    private static final Color FALLBACK_DIAGRAM_FROM = Color.rgb(0x4E, 0xC9, 0xB0);
+    private static final Color FALLBACK_DIAGRAM_TO = Color.rgb(0x56, 0xB6, 0xC2);
+    private static final Color FALLBACK_DIAGRAM_CHOICE = Color.rgb(0xDC, 0xDC, 0xAA);
+    private static final Color FALLBACK_DIAGRAM_ACTION = Color.rgb(0xC5, 0x86, 0xC0);
+    private static final Color FALLBACK_DIAGRAM_EIP = Color.rgb(0x89, 0x57, 0xE5);
+    private static final Color FALLBACK_DIAGRAM_DEFAULT = Color.rgb(0x80, 0x80, 0x80);
+
     private static final Map<String, Style> CACHE = new HashMap<>();
 
     private static boolean initialized;
@@ -88,7 +103,7 @@ final class Theme {
     private Theme() {
     }
 
-    static synchronized Color accent() {
+    public static synchronized Color accent() {
         StyleEngine e = engine();
         if (e == null) {
             return ACCENT;
@@ -105,7 +120,7 @@ final class Theme {
      * Subtle alternating-row background for zebra striping. Theme-aware (dark gray on dark, light gray on light) so
      * stripes stay readable on both terminals. Applied at the row level so it never overrides the selection highlight.
      */
-    static synchronized Color zebra() {
+    public static synchronized Color zebra() {
         StyleEngine e = engine();
         if (e == null) {
             return FALLBACK_ZEBRA;
@@ -121,7 +136,7 @@ final class Theme {
     /**
      * Base background color for the main content area. Theme-aware (dark on dark mode, white on light mode).
      */
-    static Color baseBg() {
+    public static Color baseBg() {
         StyleEngine e = engine();
         if (e == null) {
             return FALLBACK_BASE_BG;
@@ -137,7 +152,7 @@ final class Theme {
     /**
      * Base foreground color for normal text. Theme-aware (light gray on dark mode, dark gray on light mode).
      */
-    static Color baseFg() {
+    public static Color baseFg() {
         StyleEngine e = engine();
         if (e == null) {
             return FALLBACK_BASE_FG;
@@ -151,90 +166,145 @@ final class Theme {
     }
 
     /** White-on-orange: active tab highlight. */
-    static Style accentBg() {
+    public static Style accentBg() {
         return style("accent-bg", FALLBACK_ACCENT_BG);
     }
 
     /** Black-on-orange chip: key hints in footers and prompts. */
-    static Style hintKey() {
+    public static Style hintKey() {
         return style("hint-key", FALLBACK_HINT_KEY);
     }
 
     /** Dim border for unfocused panels. */
-    static Style border() {
+    public static Style border() {
         return style("border", FALLBACK_BORDER);
     }
 
     /** Orange border for the focused panel. */
-    static Style borderFocused() {
+    public static Style borderFocused() {
         return style("border-focused", FALLBACK_BORDER_FOCUSED);
     }
 
     /** Panel and border titles. */
-    static Style title() {
+    public static Style title() {
         return style("title", FALLBACK_TITLE);
     }
 
-    static Style success() {
+    public static Style success() {
         return style("success", FALLBACK_SUCCESS);
     }
 
-    static Style warning() {
+    public static Style warning() {
         return style("warning", FALLBACK_WARNING);
     }
 
-    static Style error() {
+    public static Style error() {
         return style("error", FALLBACK_ERROR);
     }
 
-    static Style muted() {
+    public static Style muted() {
         return style("muted", FALLBACK_MUTED);
     }
 
     /** Row/selection highlight (matches the existing list highlight). */
-    static Style selectionBg() {
+    public static Style selectionBg() {
         return style("selection", FALLBACK_SELECTION);
     }
 
     /** Informational accent (header integration count, integration name text, popup prompts). */
-    static Style info() {
+    public static Style info() {
         return style("info", FALLBACK_INFO);
     }
 
     /** Secondary accent (header infra / selected). */
-    static Style notice() {
+    public static Style notice() {
         return style("notice", FALLBACK_NOTICE);
     }
 
     /** MCP indicator: connected with recent activity. */
-    static Style mcpActive() {
+    public static Style mcpActive() {
         return style("mcp-active", FALLBACK_MCP_ACTIVE);
     }
 
     /** MCP indicator: connected but idle. */
-    static Style mcpIdle() {
+    public static Style mcpIdle() {
         return style("mcp-idle", FALLBACK_MCP_IDLE);
     }
 
     /** MCP indicator: not connected. */
-    static Style mcpDown() {
+    public static Style mcpDown() {
         return style("mcp-down", FALLBACK_MCP_DOWN);
     }
 
+    /** Secondary accent for field labels, section headers, key hints, and popup titles. */
+    public static Style label() {
+        return style("label", FALLBACK_LABEL);
+    }
+
+    /** Changed-value indicator in trace diffs. */
+    public static Style change() {
+        return style("change", FALLBACK_CHANGE);
+    }
+
+    /** Search/find match highlight (foreground + background). */
+    public static Style searchMatch() {
+        return style("search-match", FALLBACK_SEARCH_MATCH);
+    }
+
+    /** Diagram box-drawing border color. */
+    public static synchronized Color diagramBorder() {
+        return color("diagram-border", FALLBACK_DIAGRAM_BORDER);
+    }
+
+    /** Route ID text color in diagrams. */
+    public static synchronized Color diagramId() {
+        return color("diagram-id", FALLBACK_DIAGRAM_ID);
+    }
+
+    /** Diagram color for "from" EIP nodes. */
+    public static synchronized Color diagramFrom() {
+        return color("diagram-from", FALLBACK_DIAGRAM_FROM);
+    }
+
+    /** Diagram color for "to", "enrich", marshal, and transform EIP nodes. */
+    public static synchronized Color diagramTo() {
+        return color("diagram-to", FALLBACK_DIAGRAM_TO);
+    }
+
+    /** Diagram color for "choice"/"when"/"otherwise" EIP nodes. */
+    public static synchronized Color diagramChoice() {
+        return color("diagram-choice", FALLBACK_DIAGRAM_CHOICE);
+    }
+
+    /** Diagram color for "bean"/"process"/"log"/"script" EIP nodes. */
+    public static synchronized Color diagramAction() {
+        return color("diagram-action", FALLBACK_DIAGRAM_ACTION);
+    }
+
+    /** Diagram color for routing EIPs (split, aggregate, multicast, etc.). */
+    public static synchronized Color diagramEip() {
+        return color("diagram-eip", FALLBACK_DIAGRAM_EIP);
+    }
+
+    /** Diagram fallback color for unknown EIP types. */
+    public static synchronized Color diagramDefault() {
+        return color("diagram-default", FALLBACK_DIAGRAM_DEFAULT);
+    }
+
     /** The active theme mode: {@code "dark"} or {@code "light"}. */
-    static String mode() {
+    public static String mode() {
         engine();
         return mode.id();
     }
 
     /** True if the active mode is dark. */
-    static boolean isDark() {
+    public static boolean isDark() {
         engine();
         return mode == ThemeMode.DARK;
     }
 
     /** Flip the active theme mode, persist it (outside test mode), and activate it, returning the new mode. */
-    static synchronized String toggle() {
+    public static synchronized String toggle() {
         ThemeMode next = mode.toggle();
         if (!testMode) {
             persist(next);
@@ -250,7 +320,7 @@ final class Theme {
      * loaded, so outside test mode a later {@link #engine()} re-initialization can still overwrite the mode with
      * whatever is on disk.
      */
-    static synchronized void setMode(String newMode) {
+    public static synchronized void setMode(String newMode) {
         activate(ThemeMode.parseOrDefault(newMode), false);
     }
 
@@ -261,19 +331,19 @@ final class Theme {
      * @throws IllegalArgumentException if {@code newMode} is not a known theme mode; callers should normally validate
      *                                  with {@link #isValidMode(String)} first to report a friendlier CLI error.
      */
-    static synchronized void applyStartupMode(String newMode) {
+    public static synchronized void applyStartupMode(String newMode) {
         ThemeMode parsed = ThemeMode.parse(newMode)
                 .orElseThrow(() -> new IllegalArgumentException("Unknown Camel TUI theme mode: " + newMode));
         activate(parsed, true);
     }
 
     /** Whether {@code value} parses to a known theme mode. */
-    static boolean isValidMode(String value) {
+    public static boolean isValidMode(String value) {
         return ThemeMode.parse(value).isPresent();
     }
 
     /** Test hook: enable in-memory-only mode so tests never touch user config files. */
-    static synchronized void resetForTesting() {
+    public static synchronized void resetForTesting() {
         resetForTesting(true);
     }
 
@@ -281,7 +351,7 @@ final class Theme {
      * Test hook like {@link #resetForTesting()}, but lets the caller keep {@code testMode} disabled so a test can
      * exercise the real persistence path (disk read/write) against an isolated home directory.
      */
-    static synchronized void resetForTesting(boolean testModeValue) {
+    public static synchronized void resetForTesting(boolean testModeValue) {
         testMode = testModeValue;
         stylesheetFallbackLogged = false;
         tokenFallbackLogged = false;
@@ -303,6 +373,19 @@ final class Theme {
         engine = null;
         initialized = false;
         engine();
+    }
+
+    private static synchronized Color color(String id, Color fallback) {
+        StyleEngine e = engine();
+        if (e == null) {
+            return fallback;
+        }
+        try {
+            return e.resolve(new Token(id)).foreground().orElse(fallback);
+        } catch (RuntimeException ex) {
+            logTokenFallbackOnce(ex);
+            return fallback;
+        }
     }
 
     private static synchronized Style style(String id, Style fallback) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
@@ -66,9 +66,6 @@ public final class Theme {
     private static final Style FALLBACK_SELECTION = Style.EMPTY.fg(Color.WHITE).bg(Color.rgb(0x26, 0x4F, 0x78)).bold();
     private static final Style FALLBACK_INFO = Style.EMPTY.fg(Color.rgb(0x9C, 0xDC, 0xFE));
     private static final Style FALLBACK_NOTICE = Style.EMPTY.fg(Color.rgb(0xC5, 0x86, 0xC0));
-    private static final Style FALLBACK_MCP_ACTIVE = Style.EMPTY.fg(Color.rgb(0x4E, 0xC9, 0xB0));
-    private static final Style FALLBACK_MCP_IDLE = Style.EMPTY.fg(Color.rgb(0x60, 0x60, 0x60));
-    private static final Style FALLBACK_MCP_DOWN = Style.EMPTY.fg(Color.rgb(0xF4, 0x87, 0x71));
     private static final Color FALLBACK_ZEBRA = Color.rgb(0x25, 0x25, 0x25);
     private static final Color FALLBACK_BASE_BG = Color.rgb(0x1E, 0x1E, 0x1E);
     private static final Color FALLBACK_BASE_FG = Color.rgb(0xD4, 0xD4, 0xD4);
@@ -219,21 +216,6 @@ public final class Theme {
     /** Secondary accent (header infra / selected). */
     public static Style notice() {
         return style("notice", FALLBACK_NOTICE);
-    }
-
-    /** MCP indicator: connected with recent activity. */
-    public static Style mcpActive() {
-        return style("mcp-active", FALLBACK_MCP_ACTIVE);
-    }
-
-    /** MCP indicator: connected but idle. */
-    public static Style mcpIdle() {
-        return style("mcp-idle", FALLBACK_MCP_IDLE);
-    }
-
-    /** MCP indicator: not connected. */
-    public static Style mcpDown() {
-        return style("mcp-down", FALLBACK_MCP_DOWN);
     }
 
     /** Secondary accent for field labels, section headers, key hints, and popup titles. */

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/Theme.java
@@ -76,6 +76,7 @@ public final class Theme {
     private static final Style FALLBACK_LABEL = Style.EMPTY.fg(Color.rgb(0xDC, 0xDC, 0xAA));
     private static final Style FALLBACK_CHANGE = Style.EMPTY.fg(Color.rgb(0xDC, 0xDC, 0xAA));
     private static final Style FALLBACK_SEARCH_MATCH = Style.EMPTY.fg(Color.BLACK).bg(Color.rgb(0xDC, 0xDC, 0xAA));
+    private static final Style FALLBACK_MNEMONIC = Style.EMPTY.fg(Color.rgb(0xDC, 0xDC, 0xAA)).bold().underlined();
 
     // Diagram token fallbacks (dark-theme defaults).
     private static final Color FALLBACK_DIAGRAM_BORDER = Color.rgb(0x80, 0x80, 0x80);
@@ -91,7 +92,7 @@ public final class Theme {
             "accent", "accent-bg", "hint-key", "border", "border-focused", "title",
             "success", "warning", "error", "muted", "selection", "info", "notice",
             "row-alt", "base-bg", "base-fg",
-            "label", "change", "search-match",
+            "label", "change", "search-match", "mnemonic",
             "diagram-border", "diagram-id", "diagram-from", "diagram-to",
             "diagram-choice", "diagram-action", "diagram-eip", "diagram-default"
     };
@@ -242,6 +243,11 @@ public final class Theme {
     /** Search/find match highlight (foreground + background). */
     public static Style searchMatch() {
         return style("search-match", FALLBACK_SEARCH_MATCH);
+    }
+
+    /** Keyboard shortcut mnemonic in tab headers and menus (bold + underlined). */
+    public static Style mnemonic() {
+        return style("mnemonic", FALLBACK_MNEMONIC);
     }
 
     /** Theme-aware markdown styles for MarkdownView headings and other elements. */

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
@@ -316,8 +316,8 @@ class ThreadsTab extends AbstractTableTab {
             return Style.EMPTY;
         }
         return switch (state) {
-            case "RUNNABLE" -> Style.EMPTY.fg(Color.GREEN);
-            case "BLOCKED" -> Style.EMPTY.fg(Color.LIGHT_RED);
+            case "RUNNABLE" -> Theme.success();
+            case "BLOCKED" -> Theme.error();
             case "WAITING" -> Theme.warning();
             case "TIMED_WAITING" -> Style.EMPTY.fg(Color.CYAN);
             default -> Style.EMPTY;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
@@ -251,7 +251,7 @@ class ThreadsTab extends AbstractTableTab {
             String frame2 = thread.stackTrace.get(i);
             Style style = Style.EMPTY;
             if (frame2 != null && frame2.contains("org.apache.camel")) {
-                style = Style.EMPTY.fg(Color.YELLOW);
+                style = Theme.label();
             }
             lines.add(Line.from(Span.styled("  " + (frame2 != null ? frame2 : ""), style)));
         }
@@ -318,7 +318,7 @@ class ThreadsTab extends AbstractTableTab {
         return switch (state) {
             case "RUNNABLE" -> Style.EMPTY.fg(Color.GREEN);
             case "BLOCKED" -> Style.EMPTY.fg(Color.LIGHT_RED);
-            case "WAITING" -> Style.EMPTY.fg(Color.YELLOW);
+            case "WAITING" -> Theme.warning();
             case "TIMED_WAITING" -> Style.EMPTY.fg(Color.CYAN);
             default -> Style.EMPTY;
         };

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ThreadsTab.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
@@ -174,7 +173,7 @@ class ThreadsTab extends AbstractTableTab {
 
             rows.add(Row.from(
                     rightCell(String.valueOf(t.id), 8),
-                    Cell.from(Span.styled(t.name != null ? t.name : "", Style.EMPTY.fg(Color.CYAN))),
+                    Cell.from(Span.styled(t.name != null ? t.name : "", Style.EMPTY.fg(Theme.accent()))),
                     Cell.from(Span.styled(state, stateStyle(state))),
                     rightCell(blocked, 14),
                     rightCell(waited, 14)));
@@ -319,7 +318,7 @@ class ThreadsTab extends AbstractTableTab {
             case "RUNNABLE" -> Theme.success();
             case "BLOCKED" -> Theme.error();
             case "WAITING" -> Theme.warning();
-            case "TIMED_WAITING" -> Style.EMPTY.fg(Color.CYAN);
+            case "TIMED_WAITING" -> Style.EMPTY.fg(Theme.accent());
             default -> Style.EMPTY;
         };
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiHelper.java
@@ -569,7 +569,7 @@ final class TuiHelper {
 
     static Style topTimeStyle(long ms) {
         if (ms >= 1000) {
-            return Style.EMPTY.fg(Color.LIGHT_RED).bold();
+            return Theme.error().bold();
         } else if (ms >= 100) {
             return Theme.warning();
         }
@@ -578,9 +578,9 @@ final class TuiHelper {
 
     static Style topDeltaStyle(long delta) {
         if (delta > 0) {
-            return Style.EMPTY.fg(Color.LIGHT_RED);
+            return Theme.error();
         } else if (delta < 0) {
-            return Style.EMPTY.fg(Color.GREEN);
+            return Theme.success();
         }
         return Style.EMPTY;
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiHelper.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiHelper.java
@@ -427,6 +427,10 @@ final class TuiHelper {
         double ratio = (Math.log1p(duration) - Math.log1p(minDuration))
                        / (Math.log1p(maxDuration) - Math.log1p(minDuration));
         int bandIndex = Math.max(0, Math.min((int) (ratio * 5), 4));
+        // band 2 uses the theme warning color instead of the static array entry
+        if (bandIndex == 2) {
+            return Theme.warning();
+        }
         return DURATION_BAND_STYLES[bandIndex];
     }
 
@@ -567,7 +571,7 @@ final class TuiHelper {
         if (ms >= 1000) {
             return Style.EMPTY.fg(Color.LIGHT_RED).bold();
         } else if (ms >= 100) {
-            return Style.EMPTY.fg(Color.YELLOW);
+            return Theme.warning();
         }
         return Style.EMPTY;
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiIcons.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiIcons.java
@@ -175,7 +175,7 @@ final class TuiIcons {
     static dev.tamboui.text.Span[] primaryTabHeader(String icon, String key, String name) {
         return new dev.tamboui.text.Span[] {
                 dev.tamboui.text.Span.raw(icon + "  "),
-                dev.tamboui.text.Span.styled(key, Theme.hintKey()),
+                dev.tamboui.text.Span.styled(key, Theme.mnemonic()),
                 dev.tamboui.text.Span.raw(" " + name)
         };
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiIcons.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiIcons.java
@@ -172,8 +172,12 @@ final class TuiIcons {
      * Primary tab bar label of the form {@code "<icon>  <key> <name>"} with two spaces between the emoji and the key
      * digit so the two do not visually collide. Rendered without outer padding (compact) for every tab.
      */
-    static String primaryTabHeader(String icon, String key, String name) {
-        return icon + "  " + key + " " + name;
+    static dev.tamboui.text.Span[] primaryTabHeader(String icon, String key, String name) {
+        return new dev.tamboui.text.Span[] {
+                dev.tamboui.text.Span.raw(icon + "  "),
+                dev.tamboui.text.Span.styled(key, Theme.hintKey()),
+                dev.tamboui.text.Span.raw(" " + name)
+        };
     }
 
     /** Removes the {@value #MNEMONIC_MARKER} mnemonic marker from a label for display. */

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/DiagramColors.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/DiagramColors.java
@@ -18,22 +18,9 @@ package org.apache.camel.dsl.jbang.core.commands.tui.diagram;
 
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
+import org.apache.camel.dsl.jbang.core.commands.tui.Theme;
 
 public final class DiagramColors {
-
-    static final Color OK_COLOR = Color.GREEN;
-    static final Color FAIL_COLOR = Color.LIGHT_RED;
-    static final Color EXTERNAL_COLOR = Color.CYAN;
-
-    static final Style BORDER_STYLE = Style.EMPTY.fg(Color.WHITE);
-    static final Style DASHED_BORDER_STYLE = Style.EMPTY.fg(Color.CYAN);
-    static final Style SELECTION_STYLE = Style.EMPTY.bg(Color.DARK_GRAY);
-    static final Style ROUTE_ID_STYLE = Style.EMPTY.fg(Color.WHITE).bold();
-    static final Style FROM_LABEL_STYLE = Style.EMPTY.fg(Color.GRAY);
-    static final Style METRICS_OK_STYLE = Style.EMPTY.fg(Color.GREEN);
-    static final Style METRICS_FAIL_STYLE = Style.EMPTY.fg(Color.LIGHT_RED).bold();
-    static final Color HIGHLIGHT_OK_COLOR = Color.GREEN;
-    static final Color HIGHLIGHT_FAIL_COLOR = Color.LIGHT_RED;
 
     // Unicode box-drawing characters
     static final char H = '─';
@@ -52,25 +39,73 @@ public final class DiagramColors {
     private DiagramColors() {
     }
 
+    static Style borderStyle() {
+        return Style.EMPTY.fg(Theme.diagramBorder());
+    }
+
+    static Style dashedBorderStyle() {
+        return Style.EMPTY.fg(Theme.diagramTo());
+    }
+
+    static Style selectionStyle() {
+        return Theme.selectionBg();
+    }
+
+    static Style routeIdStyle() {
+        return Style.EMPTY.fg(Theme.diagramId()).bold();
+    }
+
+    static Style fromLabelStyle() {
+        return Theme.muted();
+    }
+
+    static Style metricsOkStyle() {
+        return Theme.success();
+    }
+
+    static Style metricsFailStyle() {
+        return Theme.error().bold();
+    }
+
+    static Color okColor() {
+        return Theme.diagramFrom();
+    }
+
+    static Color failColor() {
+        return Theme.error().fg().orElse(Color.LIGHT_RED);
+    }
+
+    static Color externalColor() {
+        return Theme.diagramTo();
+    }
+
+    static Color highlightOkColor() {
+        return Theme.diagramFrom();
+    }
+
+    static Color highlightFailColor() {
+        return Theme.error().fg().orElse(Color.LIGHT_RED);
+    }
+
     public static Color getEipColor(String type) {
         if (type == null) {
-            return Color.GRAY;
+            return Theme.diagramDefault();
         }
         return switch (type) {
-            case "from" -> Color.GREEN;
-            case "to", "toD", "wireTap", "enrich", "pollEnrich" -> Color.CYAN;
-            case "choice", "when", "otherwise" -> Color.YELLOW;
+            case "from" -> Theme.diagramFrom();
+            case "to", "toD", "wireTap", "enrich", "pollEnrich" -> Theme.diagramTo();
+            case "choice", "when", "otherwise" -> Theme.diagramChoice();
             case "marshal", "unmarshal", "transform", "setBody", "setHeader", "setProperty",
                     "convertBodyTo", "removeHeader", "removeHeaders", "removeProperty", "removeProperties" ->
-                Color.CYAN;
-            case "bean", "process", "log", "script", "delay" -> Color.MAGENTA;
+                Theme.diagramTo();
+            case "bean", "process", "log", "script", "delay" -> Theme.diagramAction();
             case "filter", "split", "aggregate", "multicast", "recipientList",
                     "routingSlip", "dynamicRouter", "loadBalance",
                     "circuitBreaker", "saga", "doTry", "doCatch", "doFinally",
                     "onException", "onCompletion", "intercept",
                     "loop", "resequence", "throttle", "kamelet", "pipeline", "threads" ->
-                Color.rgb(0x89, 0x57, 0xE5);
-            default -> Color.GRAY;
+                Theme.diagramEip();
+            default -> Theme.diagramDefault();
         };
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
@@ -303,7 +303,7 @@ public class RouteDiagramWidget implements Widget {
         } else if (dashed) {
             edgeStyle = Theme.muted();
         } else {
-            edgeStyle = Style.EMPTY.fg(Color.GRAY);
+            edgeStyle = Theme.muted();
         }
 
         if (fromCx == toCx) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
@@ -33,6 +33,7 @@ import org.apache.camel.diagram.RouteDiagramLayoutEngine.LayoutNode;
 import org.apache.camel.diagram.RouteDiagramLayoutEngine.LayoutRoute;
 import org.apache.camel.diagram.RouteDiagramLayoutEngine.StatInfo;
 import org.apache.camel.diagram.RouteDiagramLayoutEngine.TreeNode;
+import org.apache.camel.dsl.jbang.core.commands.tui.Theme;
 
 import static org.apache.camel.diagram.RouteDiagramLayoutEngine.BRANCH_CHILD_TYPES;
 import static org.apache.camel.diagram.RouteDiagramLayoutEngine.PADDING;
@@ -187,13 +188,13 @@ public class RouteDiagramWidget implements Widget {
 
         Color eipColor;
         if (highlighted) {
-            eipColor = highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR;
+            eipColor = highlightFailed ? highlightFailColor() : highlightOkColor();
         } else {
             eipColor = getEipColor(node.type);
         }
         Style borderStyle = Style.EMPTY.fg(eipColor);
         if (selected) {
-            borderStyle = borderStyle.patch(SELECTION_STYLE);
+            borderStyle = borderStyle.patch(selectionStyle());
         }
 
         char hChar = external ? DASH_H : H;
@@ -220,7 +221,7 @@ public class RouteDiagramWidget implements Widget {
             setChar(buffer, area, r, col, vChar, borderStyle);
             setChar(buffer, area, r, col + boxWidth - 1, vChar, borderStyle);
 
-            Style bgStyle = selected ? SELECTION_STYLE : Style.EMPTY;
+            Style bgStyle = selected ? selectionStyle() : Style.EMPTY;
             for (int c = col + 1; c < col + boxWidth - 1; c++) {
                 setChar(buffer, area, r, c, ' ', bgStyle);
             }
@@ -235,14 +236,14 @@ public class RouteDiagramWidget implements Widget {
             if (i == 0) {
                 writeText(buffer, area, r, textCol, text, style(Style.EMPTY.fg(eipColor).bold(), selected));
             } else {
-                writeText(buffer, area, r, textCol, text, style(FROM_LABEL_STYLE, selected));
+                writeText(buffer, area, r, textCol, text, style(fromLabelStyle(), selected));
             }
         }
 
         // Link indicator for nodes that connect to other routes
         String linkedRouteId = findLinkedRouteId(node);
         if (linkedRouteId != null) {
-            Style linkStyle = Style.EMPTY.fg(Color.YELLOW).bold();
+            Style linkStyle = Theme.label().bold();
             writeText(buffer, area, bottom, col + boxWidth, " ↵ " + linkedRouteId, linkStyle);
         }
 
@@ -296,9 +297,9 @@ public class RouteDiagramWidget implements Widget {
         char hChar = dashed ? DASH_H : H;
         Style edgeStyle;
         if (highlighted) {
-            edgeStyle = Style.EMPTY.fg(highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR);
+            edgeStyle = Style.EMPTY.fg(highlightFailed ? highlightFailColor() : highlightOkColor());
         } else if (external) {
-            edgeStyle = Style.EMPTY.fg(EXTERNAL_COLOR);
+            edgeStyle = Style.EMPTY.fg(externalColor());
         } else if (dashed) {
             edgeStyle = Style.EMPTY.fg(Color.DARK_GRAY);
         } else {
@@ -342,12 +343,12 @@ public class RouteDiagramWidget implements Widget {
         long ok = total - failed;
         if (ok > 0) {
             String okStr = String.valueOf(ok);
-            writeText(buffer, area, toTop - 1, toCx + 2, okStr, METRICS_OK_STYLE);
+            writeText(buffer, area, toTop - 1, toCx + 2, okStr, metricsOkStyle());
         }
         if (failed > 0) {
             String failStr = String.valueOf(failed);
             int col = toCx - 1 - failStr.length();
-            writeText(buffer, area, toTop - 1, col, failStr, METRICS_FAIL_STYLE);
+            writeText(buffer, area, toTop - 1, col, failStr, metricsFailStyle());
         }
     }
 
@@ -488,7 +489,7 @@ public class RouteDiagramWidget implements Widget {
     }
 
     private Style style(Style base, boolean selected) {
-        return selected ? base.patch(SELECTION_STYLE) : base;
+        return selected ? base.patch(selectionStyle()) : base;
     }
 
     private int toCol(int pixelX) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/RouteDiagramWidget.java
@@ -301,7 +301,7 @@ public class RouteDiagramWidget implements Widget {
         } else if (external) {
             edgeStyle = Style.EMPTY.fg(externalColor());
         } else if (dashed) {
-            edgeStyle = Style.EMPTY.fg(Color.DARK_GRAY);
+            edgeStyle = Theme.muted();
         } else {
             edgeStyle = Style.EMPTY.fg(Color.GRAY);
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyDiagramWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyDiagramWidget.java
@@ -29,6 +29,7 @@ import dev.tamboui.widget.Widget;
 import org.apache.camel.diagram.TopologyLayoutEngine.TopologyLayoutEdge;
 import org.apache.camel.diagram.TopologyLayoutEngine.TopologyLayoutNode;
 import org.apache.camel.diagram.TopologyLayoutEngine.TopologyLayoutResult;
+import org.apache.camel.dsl.jbang.core.commands.tui.Theme;
 
 import static org.apache.camel.dsl.jbang.core.commands.tui.diagram.DiagramColors.*;
 
@@ -171,13 +172,13 @@ public class TopologyDiagramWidget implements Widget {
         char vChar = ext ? DASH_V : V;
         Style borderStyle;
         if (highlighted) {
-            Color hlColor = highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR;
+            Color hlColor = highlightFailed ? highlightFailColor() : highlightOkColor();
             borderStyle = Style.EMPTY.fg(hlColor).bold();
         } else {
-            borderStyle = ext ? DASHED_BORDER_STYLE : BORDER_STYLE;
+            borderStyle = ext ? dashedBorderStyle() : borderStyle();
         }
         if (selected) {
-            borderStyle = borderStyle.patch(SELECTION_STYLE);
+            borderStyle = borderStyle.patch(selectionStyle());
         }
 
         // Top border
@@ -203,7 +204,7 @@ public class TopologyDiagramWidget implements Widget {
             setChar(buffer, area, r, col + boxWidth - 1, vChar, borderStyle);
 
             // Clear interior
-            Style bgStyle = selected ? SELECTION_STYLE : Style.EMPTY;
+            Style bgStyle = selected ? selectionStyle() : Style.EMPTY;
             for (int c = col + 1; c < col + boxWidth - 1; c++) {
                 setChar(buffer, area, r, c, ' ', bgStyle);
             }
@@ -216,16 +217,16 @@ public class TopologyDiagramWidget implements Widget {
 
             // Choose style based on content type
             if (ext && i == 0) {
-                writeText(buffer, area, r, textCol, text, style(DASHED_BORDER_STYLE, selected));
+                writeText(buffer, area, r, textCol, text, style(dashedBorderStyle(), selected));
             } else if (showMetrics && i == lines.size() - 1 && node.exchangesTotal > 0) {
                 drawMetricsLine(buffer, area, r, textCol, text, node, selected);
             } else if (i == 0 && !ext) {
                 Style idStyle = highlighted
-                        ? Style.EMPTY.fg(highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR).bold()
-                        : ROUTE_ID_STYLE;
+                        ? Style.EMPTY.fg(highlightFailed ? highlightFailColor() : highlightOkColor()).bold()
+                        : routeIdStyle();
                 writeText(buffer, area, r, textCol, text, style(idStyle, selected));
             } else {
-                writeText(buffer, area, r, textCol, text, style(FROM_LABEL_STYLE, selected));
+                writeText(buffer, area, r, textCol, text, style(fromLabelStyle(), selected));
             }
         }
 
@@ -239,14 +240,14 @@ public class TopologyDiagramWidget implements Widget {
         if (ok > 0 && node.exchangesFailed > 0) {
             String okStr = String.valueOf(ok);
             String failStr = String.valueOf(node.exchangesFailed);
-            writeText(buffer, area, row, col, okStr, style(METRICS_OK_STYLE, selected));
+            writeText(buffer, area, row, col, okStr, style(metricsOkStyle(), selected));
             int slashCol = col + okStr.length();
-            writeText(buffer, area, row, slashCol, "/", style(Style.EMPTY.fg(Color.GRAY), selected));
-            writeText(buffer, area, row, slashCol + 1, failStr, style(METRICS_FAIL_STYLE, selected));
+            writeText(buffer, area, row, slashCol, "/", style(Style.EMPTY.fg(Theme.diagramBorder()), selected));
+            writeText(buffer, area, row, slashCol + 1, failStr, style(metricsFailStyle(), selected));
         } else if (ok > 0) {
-            writeText(buffer, area, row, col, text, style(METRICS_OK_STYLE, selected));
+            writeText(buffer, area, row, col, text, style(metricsOkStyle(), selected));
         } else if (node.exchangesFailed > 0) {
-            writeText(buffer, area, row, col, text, style(METRICS_FAIL_STYLE, selected));
+            writeText(buffer, area, row, col, text, style(metricsFailStyle(), selected));
         }
     }
 
@@ -268,9 +269,9 @@ public class TopologyDiagramWidget implements Widget {
                 && edge.to.routeId != null && highlightRouteIds.contains(edge.to.routeId);
         Style edgeStyle;
         if (edgeHighlighted) {
-            edgeStyle = Style.EMPTY.fg(highlightFailed ? HIGHLIGHT_FAIL_COLOR : HIGHLIGHT_OK_COLOR);
+            edgeStyle = Style.EMPTY.fg(highlightFailed ? highlightFailColor() : highlightOkColor());
         } else {
-            edgeStyle = dashed ? DASHED_BORDER_STYLE : Style.EMPTY.fg(Color.GRAY);
+            edgeStyle = dashed ? dashedBorderStyle() : Style.EMPTY.fg(Theme.diagramBorder());
         }
 
         if (fromCx == toCx) {
@@ -306,7 +307,7 @@ public class TopologyDiagramWidget implements Widget {
         int topRow = toRow(edge.from.y) + 1;
         int botRow = topRow + 2;
 
-        Style s = Style.EMPTY.fg(Color.GRAY);
+        Style s = Style.EMPTY.fg(Theme.diagramBorder());
         for (int c = col; c < col + 3; c++) {
             setChar(buffer, area, topRow, c, H, s);
             setChar(buffer, area, botRow, c, H, s);
@@ -373,7 +374,7 @@ public class TopologyDiagramWidget implements Widget {
     }
 
     private Style style(Style base, boolean selected) {
-        return selected ? base.patch(SELECTION_STYLE) : base;
+        return selected ? base.patch(selectionStyle()) : base;
     }
 
     private int toCol(int pixelX) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyMinimapWidget.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/diagram/TopologyMinimapWidget.java
@@ -18,17 +18,13 @@ package org.apache.camel.dsl.jbang.core.commands.tui.diagram;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.widget.Widget;
 import org.apache.camel.diagram.TopologyLayoutEngine.TopologyLayoutNode;
 import org.apache.camel.diagram.TopologyLayoutEngine.TopologyLayoutResult;
+import org.apache.camel.dsl.jbang.core.commands.tui.Theme;
 
 public class TopologyMinimapWidget implements Widget {
-
-    private static final Style CURRENT_STYLE = Style.EMPTY.fg(Color.YELLOW).bold();
-    private static final Style OTHER_STYLE = Style.EMPTY.fg(Color.DARK_GRAY);
-    private static final Style EXTERNAL_STYLE = Style.EMPTY.fg(Color.CYAN).dim();
 
     private final TopologyLayoutResult layout;
     private final String currentRouteId;
@@ -69,7 +65,7 @@ public class TopologyMinimapWidget implements Widget {
             col = Math.max(0, col);
             row = Math.max(0, row);
 
-            Style style = isCurrent ? CURRENT_STYLE : OTHER_STYLE;
+            Style style = isCurrent ? Theme.label().bold() : Theme.muted();
 
             drawMiniBox(buffer, area, col, row, nodeW, nodeH, style, isCurrent);
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/dark.tcss
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/dark.tcss
@@ -34,9 +34,6 @@ $dark-fg: #D4D4D4;
 #info           { color: #9CDCFE; }
 #notice         { color: #C586C0; }
 #row-alt        { background: #252525; }
-#mcp-active     { color: #4EC9B0; }
-#mcp-idle       { color: #606060; }
-#mcp-down       { color: #F48771; }
 #base-bg        { background: $dark-bg; }
 #base-fg        { color: $dark-fg; }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/dark.tcss
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/dark.tcss
@@ -39,3 +39,18 @@ $dark-fg: #D4D4D4;
 #mcp-down       { color: #F48771; }
 #base-bg        { background: $dark-bg; }
 #base-fg        { color: $dark-fg; }
+
+/* Content tokens — labels, change indicators, search highlight */
+#label          { color: #DCDCAA; }
+#change         { color: #DCDCAA; }
+#search-match   { color: black; background: #DCDCAA; }
+
+/* Diagram tokens */
+#diagram-border  { color: #808080; }
+#diagram-id      { color: $dark-fg; }
+#diagram-from    { color: #4EC9B0; }
+#diagram-to      { color: #56B6C2; }
+#diagram-choice  { color: #DCDCAA; }
+#diagram-action  { color: #C586C0; }
+#diagram-eip     { color: #8957E5; }
+#diagram-default { color: #808080; }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/dark.tcss
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/dark.tcss
@@ -41,6 +41,7 @@ $dark-fg: #D4D4D4;
 #label          { color: #DCDCAA; }
 #change         { color: #DCDCAA; }
 #search-match   { color: black; background: #DCDCAA; }
+#mnemonic       { color: #DCDCAA; text-style: bold underline; }
 
 /* Diagram tokens */
 #diagram-border  { color: #808080; }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/light.tcss
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/light.tcss
@@ -41,6 +41,7 @@ $light-fg: #24292E;
 #label          { color: #735C00; }
 #change         { color: #B08800; }
 #search-match   { color: black; background: #FFD33D; }
+#mnemonic       { color: #735C00; text-style: bold underline; }
 
 /* Diagram tokens */
 #diagram-border  { color: #808080; }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/light.tcss
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/light.tcss
@@ -34,9 +34,6 @@ $light-fg: #24292E;
 #info           { color: #0366D6; }
 #notice         { color: #6F42C1; }
 #row-alt        { background: #F6F8FA; }
-#mcp-active     { color: #22863A; }
-#mcp-idle       { color: #959DA5; }
-#mcp-down       { color: #D73A49; }
 #base-bg        { background: $light-bg; }
 #base-fg        { color: $light-fg; }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/light.tcss
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/light.tcss
@@ -39,3 +39,18 @@ $light-fg: #24292E;
 #mcp-down       { color: #D73A49; }
 #base-bg        { background: $light-bg; }
 #base-fg        { color: $light-fg; }
+
+/* Content tokens — labels, change indicators, search highlight */
+#label          { color: #735C00; }
+#change         { color: #B08800; }
+#search-match   { color: black; background: #FFD33D; }
+
+/* Diagram tokens */
+#diagram-border  { color: #808080; }
+#diagram-id      { color: $light-fg; }
+#diagram-from    { color: #22863A; }
+#diagram-to      { color: #0366D6; }
+#diagram-choice  { color: #B08800; }
+#diagram-action  { color: #6F42C1; }
+#diagram-eip     { color: #5A32A3; }
+#diagram-default { color: #6A737D; }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/theme.md
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/resources/tui/themes/theme.md
@@ -1,0 +1,98 @@
+# Camel TUI Theme Reference
+
+This document describes the CSS token system used by the Camel TUI.
+Every `.tcss` theme file must define all 27 tokens listed below.
+Missing tokens cause a startup validation error.
+
+## File Format
+
+Theme files use the `.tcss` (TamboUI CSS) format with standard CSS syntax.
+Variables are declared with `$name: value;` and referenced as `$name`.
+
+```css
+$brand: #F69123;
+#accent { color: $brand; }
+#success { color: #4EC9B0; }
+#selection { color: white; background: #264F78; text-style: bold; }
+```
+
+### Supported properties
+
+| Property | Values |
+|----------|--------|
+| `color` | Hex (`#RRGGBB`), named (`white`, `black`), or variable (`$name`) |
+| `background` | Same as `color` |
+| `text-style` | `bold`, `dim`, `italic`, `underline`, `reversed` |
+
+## Token Reference
+
+### Brand & Chrome (10 tokens)
+
+| Token | Type | Purpose |
+|-------|------|---------|
+| `accent` | fg | Brand color for focused borders, links, and highlights |
+| `accent-bg` | fg+bg+bold | Inverted brand badge (e.g., active tab) |
+| `hint-key` | fg+bg+bold | Key-hint chips in footers and prompts |
+| `border` | fg | Unfocused panel borders |
+| `border-focused` | fg | Focused panel borders |
+| `title` | fg+bold | Panel and border titles |
+| `selection` | fg+bg+bold | Row/item selection highlight |
+| `row-alt` | bg | Zebra-stripe background for alternating rows |
+| `base-bg` | bg | Main content area background |
+| `base-fg` | fg | Default text foreground |
+
+### Semantic Status (6 tokens)
+
+| Token | Type | Purpose |
+|-------|------|---------|
+| `success` | fg | OK, running, passed, healthy |
+| `warning` | fg | Caution, WARN log level, thresholds |
+| `error` | fg | Failed, errors, stopped, ERROR log level |
+| `muted` | fg | Disabled, secondary, placeholder text |
+| `info` | fg | Informational accent (counts, prompts) |
+| `notice` | fg | Secondary accent, typically purple (e.g., TRACE log level) |
+
+### Content (3 tokens)
+
+| Token | Type | Purpose |
+|-------|------|---------|
+| `label` | fg | Field labels, section headers, key hints, table headers |
+| `change` | fg | Changed-value indicator in trace diffs |
+| `search-match` | fg+bg | Search/find match highlight |
+
+### Diagram (8 tokens)
+
+| Token | Type | Purpose |
+|-------|------|---------|
+| `diagram-border` | fg | Box-drawing borders in route diagrams |
+| `diagram-id` | fg | Route ID text |
+| `diagram-from` | fg | "from" EIP nodes |
+| `diagram-to` | fg | "to", "enrich", "marshal", "transform" nodes |
+| `diagram-choice` | fg | "choice", "when", "otherwise" nodes |
+| `diagram-action` | fg | "bean", "process", "log", "script" nodes |
+| `diagram-eip` | fg | Routing EIPs (split, aggregate, multicast, etc.) |
+| `diagram-default` | fg | Fallback for unknown EIP types |
+
+## Design Guidelines
+
+When creating a new theme:
+
+- **Contrast**: ensure all `fg` tokens are readable against `base-bg`.
+  Status colors (`success`, `error`, `warning`) must be distinguishable
+  from each other and from `muted`.
+- **Brand**: `accent` is Camel orange (`#F69123`) by convention but can
+  be changed. `accent-bg` and `hint-key` should use the same brand color
+  as background with a contrasting foreground (white or black).
+- **Selection**: `selection` needs high contrast since it overlays any
+  row content. Use a bold, distinct background.
+- **Diagram colors**: the 7 EIP colors should be visually distinct from
+  each other. They appear as foreground text on `base-bg`.
+- **Zebra striping**: `row-alt` background should be subtle, just enough
+  to distinguish alternating rows without clashing with `selection`.
+
+## Built-in Themes
+
+| Theme | File | Description |
+|-------|------|-------------|
+| `dark` | `dark.tcss` | VS Code-inspired dark palette (default) |
+| `light` | `light.tcss` | GitHub-inspired light palette |

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTabRenderTest.java
@@ -105,7 +105,7 @@ class CircuitBreakerTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundGreen = TuiTestHelper.findCellWithColor(buffer, "c", Color.GREEN);
+        boolean foundGreen = TuiTestHelper.findCellWithColor(buffer, "c", Theme.success().fg().orElse(Color.GREEN));
         assertTrue(foundGreen, "closed state should be rendered in GREEN");
     }
 
@@ -120,7 +120,7 @@ class CircuitBreakerTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "o", Color.LIGHT_RED);
+        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "o", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "open state should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTabRenderTest.java
@@ -135,8 +135,9 @@ class CircuitBreakerTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundYellow = TuiTestHelper.findCellWithColor(buffer, "h", Color.YELLOW);
-        assertTrue(foundYellow, "half_open state should be rendered in YELLOW");
+        Color warningColor = Theme.warning().fg().orElse(Color.YELLOW);
+        boolean foundWarning = TuiTestHelper.findCellWithColor(buffer, "h", warningColor);
+        assertTrue(foundWarning, "half_open state should be rendered in warning color");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/CircuitBreakerTabRenderTest.java
@@ -90,7 +90,7 @@ class CircuitBreakerTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "m", Color.CYAN);
+        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "m", Theme.accent());
         assertTrue(foundCyan, "Route ID should use CYAN color");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTabRenderTest.java
@@ -132,8 +132,8 @@ class ConfigurationTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "x", Color.DARK_GRAY),
-                "Secret value 'xxxxxx' should be rendered in DARK_GRAY");
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "x", Theme.muted().fg().orElse(Color.DARK_GRAY)),
+                "Secret value 'xxxxxx' should be rendered in muted color");
     }
 
     // ---- Helper methods ----

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConfigurationTabRenderTest.java
@@ -72,7 +72,7 @@ class ConfigurationTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "c", Color.CYAN),
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "c", Theme.accent()),
                 "Property key should be rendered in CYAN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
@@ -107,7 +107,7 @@ class ConsumersTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "S", Color.GREEN),
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "S", Theme.success().fg().orElse(Color.GREEN)),
                 "Started status should be rendered in GREEN");
     }
 
@@ -123,7 +123,7 @@ class ConsumersTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "S", Color.LIGHT_RED),
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "S", Theme.error().fg().orElse(Color.LIGHT_RED)),
                 "Stopped status should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
@@ -91,7 +91,7 @@ class ConsumersTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "m", Color.CYAN),
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "m", Theme.accent()),
                 "Route id should be rendered in CYAN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTabRenderTest.java
@@ -106,7 +106,7 @@ class DataSourceTabRenderTest {
         tab.render(frame, area);
 
         // active (10) >= maxPoolSize (10), so active column should be LIGHT_RED
-        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "1", Color.LIGHT_RED);
+        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "1", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "Exhausted pool active count should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/DataSourceTabRenderTest.java
@@ -90,7 +90,7 @@ class DataSourceTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "m", Color.CYAN);
+        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "m", Theme.accent());
         assertTrue(foundCyan, "DataSource name should be rendered in CYAN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTabRenderTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Span;
@@ -107,9 +106,9 @@ class EndpointsTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundBrightGreen
-                = TuiTestHelper.findCellWithColor(buffer, TuiIcons.KEY_RIGHT, Color.ansi(AnsiColor.BRIGHT_GREEN));
-        assertTrue(foundBrightGreen, "In-direction arrow should be rendered in BRIGHT_GREEN");
+        boolean foundGreen
+                = TuiTestHelper.findCellWithColor(buffer, TuiIcons.KEY_RIGHT, Color.GREEN);
+        assertTrue(foundGreen, "In-direction arrow should be rendered in GREEN");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTabRenderTest.java
@@ -91,7 +91,7 @@ class EndpointsTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "h", Color.CYAN);
+        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "h", Theme.accent());
         assertTrue(foundCyan, "Component name should be rendered in CYAN");
     }
 
@@ -122,7 +122,7 @@ class EndpointsTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyanArrow = TuiTestHelper.findCellWithColor(buffer, TuiIcons.KEY_LEFT, Color.CYAN);
+        boolean foundCyanArrow = TuiTestHelper.findCellWithColor(buffer, TuiIcons.KEY_LEFT, Theme.accent());
         assertTrue(foundCyanArrow, "Out-direction arrow should be rendered in CYAN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/EndpointsTabRenderTest.java
@@ -107,7 +107,7 @@ class EndpointsTabRenderTest {
         tab.render(frame, area);
 
         boolean foundGreen
-                = TuiTestHelper.findCellWithColor(buffer, TuiIcons.KEY_RIGHT, Color.GREEN);
+                = TuiTestHelper.findCellWithColor(buffer, TuiIcons.KEY_RIGHT, Theme.success().fg().orElse(Color.GREEN));
         assertTrue(foundGreen, "In-direction arrow should be rendered in GREEN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTabRenderTest.java
@@ -116,7 +116,7 @@ class ErrorsTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundGreen = findCellWithColor(buffer, "t", Color.GREEN);
+        boolean foundGreen = findCellWithColor(buffer, "t", Theme.success().fg().orElse(Color.GREEN));
         assertTrue(foundGreen, "handled=true should be rendered in GREEN");
     }
 
@@ -131,7 +131,7 @@ class ErrorsTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRed = findCellWithColor(buffer, "f", Color.LIGHT_RED);
+        boolean foundRed = findCellWithColor(buffer, "f", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "handled=false should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ErrorsTabRenderTest.java
@@ -101,7 +101,7 @@ class ErrorsTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyan = findCellWithColor(buffer, "m", Color.CYAN);
+        boolean foundCyan = findCellWithColor(buffer, "m", Theme.accent());
         assertTrue(foundCyan, "Route ID should use CYAN color");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HealthTabRenderTest.java
@@ -113,7 +113,7 @@ class HealthTabRenderTest {
                 var cell = buffer.get(x, y);
                 if (TuiIcons.HEALTH_DOWN.equals(cell.symbol()) || "D".equals(cell.symbol())) {
                     var fg = cell.style().fg().orElse(null);
-                    if (Color.LIGHT_RED.equals(fg)) {
+                    if (Theme.error().fg().orElse(Color.LIGHT_RED).equals(fg)) {
                         foundRedDown = true;
                         break;
                     }
@@ -150,7 +150,7 @@ class HealthTabRenderTest {
                 var cell = buffer.get(x, y);
                 if (TuiIcons.HEALTH_UP.equals(cell.symbol())) {
                     var fg = cell.style().fg().orElse(null);
-                    if (Color.GREEN.equals(fg)) {
+                    if (Theme.success().fg().orElse(Color.GREEN).equals(fg)) {
                         foundGreenUp = true;
                         break;
                     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTabRenderTest.java
@@ -133,7 +133,7 @@ class HistoryTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "m", Color.CYAN),
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "m", Theme.accent()),
                 "Route ID should contain a cell rendered in CYAN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HistoryTabRenderTest.java
@@ -100,8 +100,9 @@ class HistoryTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "D", Color.GREEN),
-                "Done status should contain a cell rendered in GREEN");
+        Color successColor = Theme.success().fg().orElse(Color.GREEN);
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "D", successColor),
+                "Done status should contain a cell rendered in success color");
     }
 
     @Test
@@ -116,7 +117,8 @@ class HistoryTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        assertTrue(TuiTestHelper.findCellWithColor(buffer, "F", Color.LIGHT_RED),
+        Color errorColor = Theme.error().fg().orElse(Color.LIGHT_RED);
+        assertTrue(TuiTestHelper.findCellWithColor(buffer, "F", errorColor),
                 "Failed status should contain a cell rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTabRenderTest.java
@@ -102,8 +102,9 @@ class HttpTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundYellow = TuiTestHelper.findCellWithColor(buffer, "P", Color.YELLOW);
-        assertTrue(foundYellow, "POST method should be rendered in YELLOW");
+        Color labelColor = Theme.label().fg().orElse(Color.YELLOW);
+        boolean foundLabel = TuiTestHelper.findCellWithColor(buffer, "P", labelColor);
+        assertTrue(foundLabel, "POST method should be rendered in label color");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/HttpTabRenderTest.java
@@ -87,7 +87,7 @@ class HttpTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundGreen = TuiTestHelper.findCellWithColor(buffer, "G", Color.GREEN);
+        boolean foundGreen = TuiTestHelper.findCellWithColor(buffer, "G", Theme.success().fg().orElse(Color.GREEN));
         assertTrue(foundGreen, "GET method should be rendered in GREEN");
     }
 
@@ -118,7 +118,7 @@ class HttpTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "D", Color.LIGHT_RED);
+        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "D", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "DELETE method should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTabRenderTest.java
@@ -89,7 +89,7 @@ class InflightTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundGreen = TuiTestHelper.findCellWithColor(buffer, "i", Color.GREEN);
+        boolean foundGreen = TuiTestHelper.findCellWithColor(buffer, "i", Theme.success().fg().orElse(Color.GREEN));
         assertTrue(foundGreen, "Inflight status should be rendered in GREEN");
     }
 
@@ -104,7 +104,7 @@ class InflightTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "b", Color.LIGHT_RED);
+        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "b", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "Blocked status should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/InflightTabRenderTest.java
@@ -119,7 +119,7 @@ class InflightTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "I", Color.CYAN);
+        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, "I", Theme.accent());
         assertTrue(foundCyan, "Exchange ID should use CYAN color");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MetricsTabRenderTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Span;
 import dev.tamboui.tui.event.KeyEvent;
@@ -118,7 +117,7 @@ class MetricsTabRenderTest {
 
         // Use "." which only appears in the metric name (e.g., "camel.exchanges.total"),
         // not in the type label "counter".
-        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, ".", Color.CYAN);
+        boolean foundCyan = TuiTestHelper.findCellWithColor(buffer, ".", Theme.accent());
         assertTrue(foundCyan, "Metric name should use CYAN color");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextRenderTest.java
@@ -24,6 +24,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Span;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,6 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Frame/Buffer rendering pipeline to verify that text and styles appear correctly.
  */
 class MonitorContextRenderTest {
+
+    @BeforeEach
+    void setUp() {
+        Theme.resetForTesting();
+    }
 
     @Test
     void renderNoSelectionShowsPromptText() {
@@ -173,7 +179,8 @@ class MonitorContextRenderTest {
     @Test
     void sortStyleActiveColumnIsYellowBold() {
         var style = AbstractTab.sortStyle("name", "name");
-        assertEquals(Color.YELLOW, style.fg().orElse(null), "Active sort column should be YELLOW");
+        Color labelColor = Theme.label().fg().orElse(Color.YELLOW);
+        assertEquals(labelColor, style.fg().orElse(null), "Active sort column should be label color");
         assertTrue(style.effectiveModifiers().contains(dev.tamboui.style.Modifier.BOLD),
                 "Active sort column should be BOLD");
     }
@@ -181,8 +188,9 @@ class MonitorContextRenderTest {
     @Test
     void sortStyleInactiveColumnIsBoldOnly() {
         var style = AbstractTab.sortStyle("name", "status");
-        assertTrue(style.fg().isEmpty() || !Color.YELLOW.equals(style.fg().get()),
-                "Inactive column should not be YELLOW");
+        Color labelColor = Theme.label().fg().orElse(Color.YELLOW);
+        assertTrue(style.fg().isEmpty() || !labelColor.equals(style.fg().get()),
+                "Inactive column should not be label color");
         assertTrue(style.effectiveModifiers().contains(dev.tamboui.style.Modifier.BOLD),
                 "Inactive column should still be BOLD");
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextRenderTest.java
@@ -146,7 +146,7 @@ class MonitorContextRenderTest {
 
     @Test
     void rightCellWithStyleAppliesStyle() {
-        var cell = AbstractTab.rightCell("5", 6, dev.tamboui.style.Style.EMPTY.fg(Color.LIGHT_RED));
+        var cell = AbstractTab.rightCell("5", 6, Theme.error());
         // The cell should have styled content
         String content = extractCellContent(cell);
         assertTrue(content.contains("5"), "Should contain the value");

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.dsl.jbang.core.commands.tui;
 
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
 import org.junit.jupiter.api.BeforeEach;
@@ -180,7 +179,7 @@ class MonitorContextTest {
     void topTimeStyleOver1000ms() {
         Style style = TuiHelper.topTimeStyle(1000);
         assertTrue(style.effectiveModifiers().contains(Modifier.BOLD));
-        assertEquals(Color.LIGHT_RED, style.fg().orElse(null));
+        assertEquals(Theme.error().fg().orElse(null), style.fg().orElse(null));
     }
 
     @Test
@@ -200,13 +199,13 @@ class MonitorContextTest {
     @Test
     void topDeltaStylePositive() {
         Style style = TuiHelper.topDeltaStyle(10);
-        assertEquals(Color.LIGHT_RED, style.fg().orElse(null));
+        assertEquals(Theme.error().fg().orElse(null), style.fg().orElse(null));
     }
 
     @Test
     void topDeltaStyleNegative() {
         Style style = TuiHelper.topDeltaStyle(-5);
-        assertEquals(Color.GREEN, style.fg().orElse(null));
+        assertEquals(Theme.success().fg().orElse(null), style.fg().orElse(null));
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/MonitorContextTest.java
@@ -19,12 +19,18 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MonitorContextTest {
+
+    @BeforeEach
+    void setUp() {
+        Theme.resetForTesting();
+    }
 
     // ---- formatSinceLast tests ----
 
@@ -180,7 +186,7 @@ class MonitorContextTest {
     @Test
     void topTimeStyleOver100ms() {
         Style style = TuiHelper.topTimeStyle(500);
-        assertEquals(Color.YELLOW, style.fg().orElse(null));
+        assertEquals(Theme.warning(), style);
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTabRenderTest.java
@@ -120,7 +120,7 @@ class RoutesTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundCyanRouteId = findCellWithColorContaining(buffer, "m", Color.CYAN);
+        boolean foundCyanRouteId = findCellWithColorContaining(buffer, "m", Theme.accent());
         assertTrue(foundCyanRouteId, "Route ID should be rendered in CYAN");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/RoutesTabRenderTest.java
@@ -90,7 +90,7 @@ class RoutesTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundGreenStarted = findCellWithColorContaining(buffer, "S", Color.GREEN);
+        boolean foundGreenStarted = findCellWithColorContaining(buffer, "S", Theme.success().fg().orElse(Color.GREEN));
         assertTrue(foundGreenStarted, "Started status should be rendered in GREEN");
     }
 
@@ -105,7 +105,7 @@ class RoutesTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRedStopped = findCellWithColorContaining(buffer, "S", Color.LIGHT_RED);
+        boolean foundRedStopped = findCellWithColorContaining(buffer, "S", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRedStopped, "Stopped status should be rendered in LIGHT_RED");
     }
 
@@ -151,7 +151,7 @@ class RoutesTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRedFailed = findCellWithColorContaining(buffer, "5", Color.LIGHT_RED);
+        boolean foundRedFailed = findCellWithColorContaining(buffer, "5", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRedFailed, "Failed count should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SearchHighlighterTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SearchHighlighterTest.java
@@ -25,6 +25,7 @@ import dev.tamboui.text.Span;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,6 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SearchHighlighterTest {
+
+    @BeforeEach
+    void setUp() {
+        Theme.resetForTesting();
+    }
 
     // ---- applyHighlights tests ----
 
@@ -76,7 +82,7 @@ class SearchHighlighterTest {
         boolean foundHighlight = false;
         for (Span span : result.spans()) {
             if (span.content().equals("err")) {
-                assertEquals(SearchHighlighter.HIGHLIGHT_STYLE, span.style());
+                assertEquals(Theme.searchMatch(), span.style());
                 foundHighlight = true;
             }
         }
@@ -127,7 +133,7 @@ class SearchHighlighterTest {
         boolean foundMatch = false;
         for (Span span : result.spans()) {
             if (span.content().equals("bar")) {
-                assertEquals(SearchHighlighter.FIND_MATCH_STYLE, span.style());
+                assertEquals(Theme.searchMatch(), span.style());
                 foundMatch = true;
             }
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SpansTabRenderTest.java
@@ -109,7 +109,7 @@ class SpansTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "E", Color.LIGHT_RED);
+        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "E", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "ERROR status should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTabRenderTest.java
@@ -120,7 +120,7 @@ class SqlTraceTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "F", Color.LIGHT_RED);
+        boolean foundRed = TuiTestHelper.findCellWithColor(buffer, "F", Theme.error().fg().orElse(Color.LIGHT_RED));
         assertTrue(foundRed, "Failed status should be rendered in LIGHT_RED");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SqlTraceTabRenderTest.java
@@ -104,8 +104,9 @@ class SqlTraceTabRenderTest {
         Frame frame = Frame.forTesting(buffer);
         tab.render(frame, area);
 
-        boolean foundYellow = TuiTestHelper.findCellWithColor(buffer, "1", Color.YELLOW);
-        assertTrue(foundYellow, "Slow query duration should be highlighted in YELLOW");
+        Color warningColor = Theme.warning().fg().orElse(Color.YELLOW);
+        boolean foundWarning = TuiTestHelper.findCellWithColor(buffer, "1", warningColor);
+        assertTrue(foundWarning, "Slow query duration should be highlighted in warning color");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TabBarRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TabBarRenderTest.java
@@ -35,7 +35,9 @@ class TabBarRenderTest {
     void primaryTabHeadersStartWithIconAndTwoSpaces() {
         String[] names = { "Overview", "Log", "Diagram", "Route", "Endpoint", "HTTP", "Health", "Inspect", "Errors" };
         for (int i = 0; i < names.length; i++) {
-            String header = TuiIcons.primaryTabHeader(TuiIcons.PRIMARY_TAB_ICONS.get(i), String.valueOf(i + 1), names[i]);
+            String header
+                    = Line.from(TuiIcons.primaryTabHeader(TuiIcons.PRIMARY_TAB_ICONS.get(i), String.valueOf(i + 1), names[i]))
+                            .rawContent();
             assertTrue(header.startsWith(TuiIcons.PRIMARY_TAB_ICONS.get(i) + "  " + (i + 1)),
                     "Tab header should be '<icon>  <key> <name>': " + header);
         }
@@ -43,7 +45,7 @@ class TabBarRenderTest {
 
     @Test
     void moreTabHeaderIncludesIconAndChevron() {
-        String header = TuiIcons.primaryTabHeader(TuiIcons.TAB_MORE, "0", TuiIcons.moreTabLabel());
+        String header = Line.from(TuiIcons.primaryTabHeader(TuiIcons.TAB_MORE, "0", TuiIcons.moreTabLabel())).rawContent();
         assertTrue(header.startsWith(TuiIcons.TAB_MORE));
         assertTrue(header.contains(TuiIcons.MORE_CHEVRON));
     }
@@ -51,8 +53,8 @@ class TabBarRenderTest {
     @Test
     void routeAndTopLabelsHaveEqualWidth() {
         // toggling Top mode must not shift the tab bar
-        int route = CharWidth.of(TuiIcons.primaryTabHeader(TuiIcons.TAB_ROUTES, "4", "Route"));
-        int top = CharWidth.of(TuiIcons.primaryTabHeader(TuiIcons.TAB_ROUTES, "4", " Top "));
+        int route = Line.from(TuiIcons.primaryTabHeader(TuiIcons.TAB_ROUTES, "4", "Route")).width();
+        int top = Line.from(TuiIcons.primaryTabHeader(TuiIcons.TAB_ROUTES, "4", " Top ")).width();
         assertEquals(route, top, "Route and Top tab cells must be the same width");
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ThemeTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ThemeTest.java
@@ -73,9 +73,6 @@ class ThemeTest {
         assertEquals(Style.EMPTY.fg(Color.WHITE).bg(Color.rgb(0x26, 0x4F, 0x78)).bold(), Theme.selectionBg());
         assertEquals(Style.EMPTY.fg(Color.rgb(0x9C, 0xDC, 0xFE)), Theme.info());
         assertEquals(Style.EMPTY.fg(Color.rgb(0xC5, 0x86, 0xC0)), Theme.notice());
-        assertEquals(Style.EMPTY.fg(Color.rgb(0x4E, 0xC9, 0xB0)), Theme.mcpActive());
-        assertEquals(Style.EMPTY.fg(Color.rgb(0x60, 0x60, 0x60)), Theme.mcpIdle());
-        assertEquals(Style.EMPTY.fg(Color.rgb(0xF4, 0x87, 0x71)), Theme.mcpDown());
         assertEquals(Color.rgb(0x25, 0x25, 0x25), Theme.zebra());
         assertEquals(Color.rgb(0x1E, 0x1E, 0x1E), Theme.baseBg());
         assertEquals(Color.rgb(0xD4, 0xD4, 0xD4), Theme.baseFg());
@@ -88,10 +85,6 @@ class ThemeTest {
         assertEquals(Color.rgb(0xF6, 0x91, 0x23), Theme.accent());
         assertEquals(Style.EMPTY.fg(Color.rgb(0x22, 0x86, 0x3A)), Theme.success());
         assertEquals(Style.EMPTY.fg(Color.rgb(0xC0, 0xC0, 0xC0)), Theme.border());
-        // MCP indicator hues track the light palette: idle gray and down red differ from the dark ANSI variants.
-        assertEquals(Style.EMPTY.fg(Color.rgb(0x22, 0x86, 0x3A)), Theme.mcpActive());
-        assertEquals(Style.EMPTY.fg(Color.rgb(0x95, 0x9D, 0xA5)), Theme.mcpIdle());
-        assertEquals(Style.EMPTY.fg(Color.rgb(0xD7, 0x3A, 0x49)), Theme.mcpDown());
         // Zebra background is theme-aware: light gray on light, unlike the dark gray used on dark.
         assertEquals(Color.rgb(0xF6, 0xF8, 0xFA), Theme.zebra());
         // Base colors differ significantly between themes: white background and dark text on light mode.
@@ -242,9 +235,6 @@ class ThemeTest {
         assertNotNull(Theme.selectionBg());
         assertNotNull(Theme.info());
         assertNotNull(Theme.notice());
-        assertNotNull(Theme.mcpActive());
-        assertNotNull(Theme.mcpIdle());
-        assertNotNull(Theme.mcpDown());
         assertNotNull(Theme.zebra());
         assertNotNull(Theme.baseBg());
         assertNotNull(Theme.baseFg());


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Route all hardcoded ANSI colors through CSS tokens so new themes can be added by writing a single `.tcss` file
- Add 12 new CSS tokens: `label`, `change`, `search-match`, `mnemonic`, and 8 `diagram-*` tokens for theme-aware diagram colors
- Standardize key-value label styling to `Theme.muted()` across all tabs
- Add `Theme.markdownStyles()` for theme-aware MarkdownView heading/code/link colors
- Add `#mnemonic` CSS token with bold+underline for tab bar and menu keyboard shortcuts
- Show tab icons in the Go To popup with mnemonic-styled shortcut keys
- Make `DiagramColors` theme-aware (borders, route IDs, EIP colors all resolve from CSS)
- Add theme token validation at startup with clear error messages for missing tokens
- Add `theme.md` reference documentation for all CSS tokens

## Test plan

- [x] All 569 TUI tests pass
- [x] Build succeeds with `mvn install -DskipTests`
- [ ] Visual check: verify all tabs readable on both dark and light theme (Ctrl+T to toggle)
- [ ] Visual check: diagram colors readable on light theme
- [ ] Visual check: Go To popup shows icons and underlined shortcut keys

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)