### PR TITLE
fix(jbang): update container image-check to match renamed CLI version output

### DIFF
--- a/dsl/camel-jbang/camel-jbang-container/Makefile
+++ b/dsl/camel-jbang/camel-jbang-container/Makefile
@@ -97,12 +97,12 @@ images-check-all:
 image-check:
 	@echo "####### Checking Camel JBang (CLI) $(IMAGE_CHECK) container image..."
 	@EXPECTED="$(CAMEL_VERSION)"; \
-	ACTUAL=$$(docker run --rm $(IMAGE_CHECK) version | sed -n 's/^Camel JBang version: //p'); \
+	ACTUAL=$$(docker run --rm $(IMAGE_CHECK) version | sed -n 's/^Camel CLI version: //p'); \
 	test "$$ACTUAL" = "$$EXPECTED"
 	@for arch in $(ARCH_VERSIONS); do \
 		echo "####### Checking $$arch"; \
 		EXPECTED="$(CAMEL_VERSION)"; \
 		ACTUAL=$$(docker run --rm --platform linux/$$arch $(IMAGE_CHECK) version | \
-			sed -n 's/^Camel JBang version: //p'); \
+			sed -n 's/^Camel CLI version: //p'); \
 		test "$$ACTUAL" = "$$EXPECTED" || exit 1; \
 	done


### PR DESCRIPTION
## Summary

- The Camel CLI `version` command output was renamed from `Camel JBang version:` to `Camel CLI version:`, but the container `image-check` Makefile target still used the old prefix in its `sed` pattern.
- Updated both the default check (line 100) and the per-arch check (line 106) to use the new `Camel CLI version:` prefix so the version extraction works correctly.

## Test plan

- [ ] Run `make CAMEL_VERSION=<version> image-check` and verify it passes
- [ ] Run `make CAMEL_VERSION=<version> images-check-all` and verify all JDK/arch variants pass

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>