### PR TITLE
chore: Upgrade IBM WatsonX AI SDK from 0.21.0 to 0.22.0

### DIFF
--- a/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/handler/EmbeddingHandler.java
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/handler/EmbeddingHandler.java
@@ -67,7 +67,7 @@ public class EmbeddingHandler extends AbstractWatsonxAiHandler {
 
         // Call the service
         EmbeddingService service = endpoint.getEmbeddingService();
-        EmbeddingResponse response = service.embedding(inputs, paramsBuilder.build());
+        EmbeddingResponse response = service.embed(inputs, paramsBuilder.build());
 
         // Extract embedding vectors from response
         List<List<Float>> embeddings = response.results().stream()

--- a/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/handler/RerankHandler.java
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/handler/RerankHandler.java
@@ -75,10 +75,9 @@ public class RerankHandler extends AbstractWatsonxAiHandler {
         }
         if (topN != null) {
             paramsBuilder.topN(topN);
-            // TODO: remove the following with the next sdk release
-            paramsBuilder.inputs(config.getReturnDocuments() != null ? config.getReturnDocuments() : false);
+            paramsBuilder.returnInputs(config.getReturnDocuments() != null && config.getReturnDocuments());
         } else if (config.getReturnDocuments() != null) {
-            paramsBuilder.inputs(config.getReturnDocuments());
+            paramsBuilder.returnInputs(config.getReturnDocuments());
         }
 
         // Call the service

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -236,7 +236,7 @@
         <ibm-cos-sdk-version>2.15.1</ibm-cos-sdk-version>
         <ibm-secrets-manager-version>2.0.28</ibm-secrets-manager-version>
         <ibm-watson-sdk-version>16.2.0</ibm-watson-sdk-version>
-        <ibm-watsonx-ai-sdk-version>0.21.0</ibm-watsonx-ai-sdk-version>
+        <ibm-watsonx-ai-sdk-version>0.22.0</ibm-watsonx-ai-sdk-version>
         <ibm-watsonx-data-sdk-version>0.9.0</ibm-watsonx-data-sdk-version>
         <ical4j-version>4.3.0</ical4j-version>
         <icu4j-version>78.3</icu4j-version>


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Upgrade `ibm-watsonx-ai-sdk` from 0.21.0 to 0.22.0 and adapt to API changes:

- `EmbeddingService.embedding()` renamed to `embed()`
- `RerankParams.Builder.inputs()` renamed to `returnInputs()`
- Removed stale TODO comment in RerankHandler

Supersedes #24452.

## Test plan

- [x] `camel-ibm-watsonx-ai` compiles and all 8 unit tests pass
- [ ] Integration tests require IBM WatsonX access

🤖 Generated with [Claude Code](https://claude.com/claude-code)