### PR TITLE
Do not store workspace on jenkins in case of success

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,6 +210,15 @@ pipeline {
                             body: '${DEFAULT_CONTENT}',
                             recipientProviders: [[$class: 'DevelopersRecipientProvider']]
                         )
+                        cleanWs(
+                            cleanWhenNotBuilt: false,
+                            cleanWhenUnstable: false,
+                            cleanWhenFailure: false,
+                            cleanWhenAborted: false,
+                            cleanWhenSuccess: true,
+                            deleteDirs: true,
+                            disableDeferredWipeout: true,
+                            notFailBuild: true)
                     }
                 }
             }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -77,6 +77,15 @@ pipeline {
                 body: '${DEFAULT_CONTENT}',
                 recipientProviders: [[$class: 'DevelopersRecipientProvider']]
             )
+            cleanWs(
+                cleanWhenNotBuilt: false,
+                cleanWhenUnstable: false,
+                cleanWhenFailure: false,
+                cleanWhenAborted: false,
+                cleanWhenSuccess: true,
+                deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true)
         }
     }
 }

--- a/Jenkinsfile.jdk26
+++ b/Jenkinsfile.jdk26
@@ -139,6 +139,15 @@ pipeline {
                             body: '${DEFAULT_CONTENT}',
                             recipientProviders: [[$class: 'DevelopersRecipientProvider']]
                         )
+                        cleanWs(
+                            cleanWhenNotBuilt: false,
+                            cleanWhenUnstable: false,
+                            cleanWhenFailure: false,
+                            cleanWhenAborted: false,
+                            cleanWhenSuccess: true,
+                            deleteDirs: true,
+                            disableDeferredWipeout: true,
+                            notFailBuild: true)
                     }
                 }
             }


### PR DESCRIPTION
This should save around 3G per build (including matrixed builds) in the history, so potentially 6*5*3=90G across the various nodes. In practice, given the number of failures, I expect more around 50G

When the build is in success we usually do not need to look at the workspace content

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

