### PR TITLE
[backport camel-4.18.x] CAMEL-23875: camel-keycloak - add optional audience (aud) validation to token verification

### DIFF
--- a/components/camel-keycloak/src/main/docs/keycloak-component.adoc
+++ b/components/camel-keycloak/src/main/docs/keycloak-component.adoc
@@ -3419,7 +3419,62 @@ beans:
 NOTE: When an access token is present, it is always verified - signature, issuer and expiry for local JWT
 verification, or active state and issuer when token introspection is enabled - regardless of whether
 `requiredRoles` or `requiredPermissions` are configured. Role and permission checks are applied only after the
-token has been verified. A request without a token is rejected.
+token has been verified. A request without a token is rejected. Audience validation (see below) is optional and
+applied in addition to these checks when `expectedAudience` is configured.
+
+=== Audience Validation
+
+By default, the security policy does not check the token's `aud` (audience) claim. In a multi-client Keycloak
+realm this means a token issued for one client could be accepted by a route intended for another client. Setting
+`expectedAudience` closes this gap: tokens whose `aud` claim does not contain every one of the configured
+audiences are rejected, for both local JWT verification and token introspection. This matches the behavior of
+Keycloak's own `TokenVerifier.audience(String...)` check.
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy(
+    "http://localhost:8080", "my-realm", "my-client", "client-secret");
+
+// Reject tokens that do not have "my-client" in their "aud" claim
+policy.setExpectedAudience("my-client");
+
+from("direct:protected")
+    .policy(policy)
+    .to("mock:result");
+----
+
+YAML::
++
+[source,yaml]
+----
+- route:
+    from:
+      uri: direct:protected
+      steps:
+        - policy:
+            ref: audiencePolicy
+        - to:
+            uri: mock:result
+
+# Bean definition
+beans:
+  - name: audiencePolicy
+    type: org.apache.camel.component.keycloak.security.KeycloakSecurityPolicy
+    properties:
+      serverUrl: "http://localhost:8080"
+      realm: "my-realm"
+      clientId: "my-client"
+      clientSecret: "client-secret"
+      expectedAudience: "my-client"
+----
+====
+
+`expectedAudience` accepts a comma-separated list (e.g., `"my-client,my-other-client"`) when a token must carry
+several audiences at once. Disabled by default for backward compatibility.
 
 === Role-based Authorization
 

--- a/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelper.java
+++ b/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelper.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.security.PublicKey;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,6 +52,26 @@ public final class KeycloakSecurityHelper {
      */
     public static AccessToken parseAndVerifyAccessToken(String tokenString, PublicKey publicKey, String expectedIssuer)
             throws VerificationException {
+        return parseAndVerifyAccessToken(tokenString, publicKey, expectedIssuer, null);
+    }
+
+    /**
+     * Parses and fully verifies an access token including signature, issuer and, optionally, audience validation. This
+     * is the recommended method for secure token validation.
+     *
+     * @param  tokenString           the JWT token string
+     * @param  publicKey             the public key for signature verification
+     * @param  expectedIssuer        the expected issuer URL (e.g., "http://localhost:8080/realms/myrealm")
+     * @param  expectedAudiences     the expected audiences; when non-empty, the token's "aud" claim must contain every
+     *                               one of them (matching Keycloak's own {@link TokenVerifier#audience(String...)}
+     *                               check). Pass null or an empty list to skip audience validation.
+     * @return                       the verified access token
+     * @throws VerificationException if verification fails (invalid signature, wrong issuer, expired, missing/wrong
+     *                               audience, etc.)
+     */
+    public static AccessToken parseAndVerifyAccessToken(
+            String tokenString, PublicKey publicKey, String expectedIssuer, List<String> expectedAudiences)
+            throws VerificationException {
         if (publicKey == null) {
             throw new VerificationException("Public key is required for secure token verification");
         }
@@ -58,12 +79,18 @@ public final class KeycloakSecurityHelper {
             throw new VerificationException("Expected issuer is required for secure token verification");
         }
 
+        boolean checkAudience = expectedAudiences != null && !expectedAudiences.isEmpty();
+
         TokenVerifier<AccessToken> verifier = TokenVerifier.create(tokenString, AccessToken.class)
                 .publicKey(publicKey)
                 .withChecks(
                         TokenVerifier.SUBJECT_EXISTS_CHECK,
                         TokenVerifier.IS_ACTIVE,
                         new TokenVerifier.RealmUrlCheck(expectedIssuer));
+
+        if (checkAudience) {
+            verifier.audience(expectedAudiences.toArray(new String[0]));
+        }
 
         AccessToken token = verifier.verify().getToken();
 

--- a/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityPolicy.java
+++ b/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityPolicy.java
@@ -98,6 +98,13 @@ public class KeycloakSecurityPolicy implements AuthorizationPolicy {
      * {serverUrl}/realms/{realm}/protocol/openid-connect/certs. This ensures token signatures are properly verified.
      */
     private boolean autoFetchPublicKey = true;
+    /**
+     * Comma-separated list of expected audiences for token validation. When set, tokens whose "aud" claim does not
+     * contain every one of the configured audiences are rejected (matching Keycloak's own audience verification
+     * behavior). This prevents a token issued for one client from being accepted by routes intended for another client
+     * in multi-client Keycloak realms. Disabled by default for backward compatibility. Example: "my-client"
+     */
+    private String expectedAudience;
 
     public KeycloakSecurityPolicy() {
         this.requiredRoles = "";
@@ -428,5 +435,39 @@ public class KeycloakSecurityPolicy implements AuthorizationPolicy {
      */
     public String getExpectedIssuer() {
         return serverUrl + "/realms/" + realm;
+    }
+
+    /**
+     * Gets the expected audience(s) as a comma-separated string.
+     *
+     * @return comma-separated audiences (e.g., "my-client,my-other-client"), or null if not configured
+     */
+    public String getExpectedAudience() {
+        return expectedAudience;
+    }
+
+    /**
+     * Sets the expected audience(s) as a comma-separated string. When set, tokens whose "aud" claim does not contain
+     * every one of the configured audiences are rejected.
+     *
+     * @param expectedAudience comma-separated audiences (e.g., "my-client,my-other-client")
+     */
+    public void setExpectedAudience(String expectedAudience) {
+        this.expectedAudience = expectedAudience;
+    }
+
+    /**
+     * Gets the expected audiences as a list.
+     *
+     * @return list of expected audiences, or an empty list if not configured
+     */
+    public List<String> getExpectedAudienceAsList() {
+        if (ObjectHelper.isEmpty(expectedAudience)) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(expectedAudience.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
     }
 }

--- a/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessor.java
+++ b/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessor.java
@@ -22,6 +22,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.camel.CamelAuthorizationException;
@@ -106,6 +109,10 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
 
             if (policy.isValidateIssuer()) {
                 validateIssuerFromIntrospection(introspectionResult, exchange);
+            }
+
+            if (!policy.getExpectedAudienceAsList().isEmpty()) {
+                validateAudienceFromIntrospection(introspectionResult, exchange);
             }
         } else {
             parseAndVerifyToken(accessToken, exchange);
@@ -271,6 +278,11 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
                     validateIssuerFromIntrospection(introspectionResult, exchange);
                 }
 
+                // Validate audience from introspection result if configured
+                if (!policy.getExpectedAudienceAsList().isEmpty()) {
+                    validateAudienceFromIntrospection(introspectionResult, exchange);
+                }
+
                 userRoles = KeycloakSecurityHelper.extractRolesFromIntrospection(
                         introspectionResult, policy.getRealm(), policy.getClientId());
             } else {
@@ -321,10 +333,11 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
             publicKey = policy.getPublicKey();
         }
 
-        // Verify token with public key and issuer validation
+        // Verify token with public key, issuer and (optionally) audience validation
         if (publicKey != null) {
             try {
-                return KeycloakSecurityHelper.parseAndVerifyAccessToken(accessToken, publicKey, expectedIssuer);
+                return KeycloakSecurityHelper.parseAndVerifyAccessToken(
+                        accessToken, publicKey, expectedIssuer, policy.getExpectedAudienceAsList());
             } catch (VerificationException e) {
                 LOG.error("Token verification failed: {}", e.getMessage());
                 throw new CamelAuthorizationException("Token verification failed: " + e.getMessage(), exchange, e);
@@ -366,6 +379,40 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
         LOG.debug("Issuer validation from introspection successful: {}", expectedIssuer);
     }
 
+    /**
+     * Validates the audience from an introspection result. Unlike issuer validation, a token whose "aud" claim is
+     * missing is rejected: the whole point of this check is to reject tokens that were not issued for this policy's
+     * client(s).
+     */
+    private void validateAudienceFromIntrospection(
+            KeycloakTokenIntrospector.IntrospectionResult introspectionResult, Exchange exchange)
+            throws CamelAuthorizationException {
+        List<String> expectedAudiences = policy.getExpectedAudienceAsList();
+        Object audienceClaim = introspectionResult.getClaim("aud");
+
+        Set<String> actualAudiences = new HashSet<>();
+        if (audienceClaim instanceof Collection<?> audienceCollection) {
+            for (Object audience : audienceCollection) {
+                if (audience instanceof String s) {
+                    actualAudiences.add(s);
+                }
+            }
+        } else if (audienceClaim instanceof String s) {
+            actualAudiences.add(s);
+        }
+
+        if (!actualAudiences.containsAll(expectedAudiences)) {
+            LOG.error("SECURITY: Token audience mismatch from introspection - expected all of '{}' but got '{}'",
+                    expectedAudiences, actualAudiences);
+            throw new CamelAuthorizationException(
+                    String.format("Token audience mismatch: expected all of '%s' but got '%s'",
+                            expectedAudiences, actualAudiences),
+                    exchange);
+        }
+
+        LOG.debug("Audience validation from introspection successful: {}", expectedAudiences);
+    }
+
     private void validatePermissions(String accessToken, Exchange exchange) throws Exception {
         try {
             Set<String> userPermissions;
@@ -383,6 +430,11 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
                 // Validate issuer from introspection result if enabled
                 if (policy.isValidateIssuer()) {
                     validateIssuerFromIntrospection(introspectionResult, exchange);
+                }
+
+                // Validate audience from introspection result if configured
+                if (!policy.getExpectedAudienceAsList().isEmpty()) {
+                    validateAudienceFromIntrospection(introspectionResult, exchange);
                 }
 
                 userPermissions = KeycloakSecurityHelper.extractPermissionsFromIntrospection(introspectionResult);

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelperTest.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityHelperTest.java
@@ -19,6 +19,10 @@ package org.apache.camel.component.keycloak.security;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -41,7 +45,7 @@ public class KeycloakSecurityHelperTest {
         when(token.getRealmAccess()).thenReturn(realmAccess);
         when(realmAccess.getRoles()).thenReturn(Set.of("realm-admin", "user"));
 
-        when(token.getResourceAccess()).thenReturn(java.util.Map.of("test-client", clientAccess));
+        when(token.getResourceAccess()).thenReturn(Map.of("test-client", clientAccess));
         when(clientAccess.getRoles()).thenReturn(Set.of("client-admin"));
 
         Set<String> roles = KeycloakSecurityHelper.extractRoles(token, "test-realm", "test-client");
@@ -221,6 +225,127 @@ public class KeycloakSecurityHelperTest {
     }
 
     @Test
+    void testParseAndVerifyAccessTokenAcceptsMatchingAudience() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        token.audience("my-client");
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        AccessToken verified = KeycloakSecurityHelper.parseAndVerifyAccessToken(
+                signed, keyPair.getPublic(), expectedIssuer, List.of("my-client"));
+        assertEquals("user-123", verified.getSubject());
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenAcceptsTokenWithAllExpectedAudiences() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        token.audience("my-client", "my-other-client");
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        AccessToken verified = KeycloakSecurityHelper.parseAndVerifyAccessToken(
+                signed, keyPair.getPublic(), expectedIssuer, List.of("my-client", "my-other-client"));
+        assertEquals("user-123", verified.getSubject());
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenRejectsTokenMissingOneOfMultipleExpectedAudiences() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        // Token only has one of the two expected audiences
+        token.audience("my-client");
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        assertThrows(VerificationException.class,
+                () -> KeycloakSecurityHelper.parseAndVerifyAccessToken(
+                        signed, keyPair.getPublic(), expectedIssuer, List.of("my-client", "my-other-client")));
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenRejectsMissingAudience() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        // No audience set on the token
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        assertThrows(VerificationException.class,
+                () -> KeycloakSecurityHelper.parseAndVerifyAccessToken(
+                        signed, keyPair.getPublic(), expectedIssuer, List.of("my-client")));
+    }
+
+    @Test
+    void testParseAndVerifyAccessTokenRejectsNonMatchingAudience() throws Exception {
+        String expectedIssuer = "http://localhost:8080/realms/test";
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        AccessToken token = new AccessToken();
+        token.issuer(expectedIssuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        token.audience("some-other-client");
+
+        String signed = new JWSBuilder()
+                .type("JWT")
+                .jsonContent(token)
+                .rsa256(keyPair.getPrivate());
+
+        assertThrows(VerificationException.class,
+                () -> KeycloakSecurityHelper.parseAndVerifyAccessToken(
+                        signed, keyPair.getPublic(), expectedIssuer, List.of("my-client")));
+    }
+
+    @Test
     void testExtractPermissions() {
         AccessToken token = Mockito.mock(AccessToken.class);
 
@@ -229,12 +354,12 @@ public class KeycloakSecurityHelperTest {
         when(token.getAuthorization()).thenReturn(authorization);
 
         // Test permissions extraction from custom claims
-        java.util.Map<String, Object> otherClaims = new java.util.HashMap<>();
-        otherClaims.put("permissions", java.util.Arrays.asList("read:documents", "write:documents", "admin:users"));
+        Map<String, Object> otherClaims = new HashMap<>();
+        otherClaims.put("permissions", Arrays.asList("read:documents", "write:documents", "admin:users"));
 
         when(token.getOtherClaims()).thenReturn(otherClaims);
 
-        java.util.Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
+        Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
 
         assertEquals(3, permissions.size());
         assertTrue(permissions.contains("read:documents"));
@@ -247,13 +372,13 @@ public class KeycloakSecurityHelperTest {
         AccessToken token = Mockito.mock(AccessToken.class);
 
         // Mock other claims with permissions
-        java.util.Map<String, Object> otherClaims = new java.util.HashMap<>();
-        otherClaims.put("permissions", java.util.Arrays.asList("read:files", "write:files", "delete:files"));
+        Map<String, Object> otherClaims = new HashMap<>();
+        otherClaims.put("permissions", Arrays.asList("read:files", "write:files", "delete:files"));
 
         when(token.getOtherClaims()).thenReturn(otherClaims);
         when(token.getAuthorization()).thenReturn(null);
 
-        java.util.Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
+        Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
 
         assertEquals(3, permissions.size());
         assertTrue(permissions.contains("read:files"));
@@ -266,13 +391,13 @@ public class KeycloakSecurityHelperTest {
         AccessToken token = Mockito.mock(AccessToken.class);
 
         // Mock other claims with scope-based permissions
-        java.util.Map<String, Object> otherClaims = new java.util.HashMap<>();
+        Map<String, Object> otherClaims = new HashMap<>();
         otherClaims.put("scope", "read write admin");
 
         when(token.getOtherClaims()).thenReturn(otherClaims);
         when(token.getAuthorization()).thenReturn(null);
 
-        java.util.Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
+        Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
 
         assertEquals(3, permissions.size());
         assertTrue(permissions.contains("read"));
@@ -284,9 +409,9 @@ public class KeycloakSecurityHelperTest {
     void testExtractPermissionsEmpty() {
         AccessToken token = Mockito.mock(AccessToken.class);
         when(token.getAuthorization()).thenReturn(null);
-        when(token.getOtherClaims()).thenReturn(java.util.Map.of());
+        when(token.getOtherClaims()).thenReturn(Map.of());
 
-        java.util.Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
+        Set<String> permissions = KeycloakSecurityHelper.extractPermissions(token);
 
         assertTrue(permissions.isEmpty());
     }

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityPolicyTest.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityPolicyTest.java
@@ -100,6 +100,17 @@ public class KeycloakSecurityPolicyTest extends CamelTestSupport {
     }
 
     @Test
+    void testKeycloakSecurityPolicyWithExpectedAudience() {
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy();
+        assertTrue(policy.getExpectedAudienceAsList().isEmpty(), "Audience validation is disabled by default");
+
+        policy.setExpectedAudience("my-client,my-other-client");
+
+        assertEquals("my-client,my-other-client", policy.getExpectedAudience());
+        assertEquals(Arrays.asList("my-client", "my-other-client"), policy.getExpectedAudienceAsList());
+    }
+
+    @Test
     void testResourceOwnerPasswordCredentialsConfiguration() {
         KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy(
                 "http://localhost:8080", "test-realm", "test-client", "testuser", "testpass");

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessorTest.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessorTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.component.keycloak.security;
 
+import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -30,9 +32,12 @@ import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.representations.AccessToken;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies that {@link KeycloakSecurityProcessor} authenticates the access token even when the policy does not require
@@ -114,5 +119,257 @@ class KeycloakSecurityProcessorTest {
 
         assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer("x")));
         assertFalse(routeReached.get(), "Route body must not be reached for an inactive token");
+    }
+
+    @Test
+    void testTokenMissingExpectedAudienceRejectedLocalJwt() throws Exception {
+        String issuer = "http://localhost:8080/realms/test-realm";
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy();
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setAutoFetchPublicKey(false);
+        policy.setPublicKey(keyPair.getPublic());
+        policy.setExpectedAudience("expected-client");
+
+        AccessToken token = new AccessToken();
+        token.issuer(issuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        // No audience on the token
+
+        String signed = new JWSBuilder().type("JWT").jsonContent(token).rsa256(keyPair.getPrivate());
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer(signed)));
+        assertFalse(routeReached.get(), "Route body must not be reached for a token missing the expected audience");
+    }
+
+    @Test
+    void testTokenWithMatchingAudienceAcceptedLocalJwt() throws Exception {
+        String issuer = "http://localhost:8080/realms/test-realm";
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy();
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setAutoFetchPublicKey(false);
+        policy.setPublicKey(keyPair.getPublic());
+        policy.setExpectedAudience("expected-client");
+
+        AccessToken token = new AccessToken();
+        token.issuer(issuer);
+        token.subject("user-123");
+        token.exp(System.currentTimeMillis() / 1000 + 3600);
+        token.audience("expected-client");
+
+        String signed = new JWSBuilder().type("JWT").jsonContent(token).rsa256(keyPair.getPrivate());
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        processor.process(bearer(signed));
+        assertTrue(routeReached.get(), "Route body must be reached for a token with the expected audience");
+    }
+
+    @Test
+    void testTokenMissingExpectedAudienceRejectedIntrospection() throws Exception {
+        KeycloakTokenIntrospector introspector = new KeycloakTokenIntrospector(
+                "http://localhost:8080", "test-realm", "test-client", "test-secret", (TokenCache) null) {
+            @Override
+            public IntrospectionResult introspect(String token) {
+                // Active but no "aud" claim at all
+                return new IntrospectionResult(Map.<String, Object> of("active", true));
+            }
+        };
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy() {
+            @Override
+            public boolean isUseTokenIntrospection() {
+                return true;
+            }
+
+            @Override
+            public KeycloakTokenIntrospector getTokenIntrospector() {
+                return introspector;
+            }
+        };
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setValidateIssuer(false);
+        policy.setExpectedAudience("expected-client");
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer("x")));
+        assertFalse(routeReached.get(), "Route body must not be reached for a token missing the expected audience");
+    }
+
+    @Test
+    void testTokenWithMatchingAudienceAcceptedIntrospection() throws Exception {
+        KeycloakTokenIntrospector introspector = new KeycloakTokenIntrospector(
+                "http://localhost:8080", "test-realm", "test-client", "test-secret", (TokenCache) null) {
+            @Override
+            public IntrospectionResult introspect(String token) {
+                return new IntrospectionResult(
+                        Map.of("active", true, "aud", List.of("expected-client", "other-client")));
+            }
+        };
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy() {
+            @Override
+            public boolean isUseTokenIntrospection() {
+                return true;
+            }
+
+            @Override
+            public KeycloakTokenIntrospector getTokenIntrospector() {
+                return introspector;
+            }
+        };
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setValidateIssuer(false);
+        policy.setExpectedAudience("expected-client");
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        processor.process(bearer("x"));
+        assertTrue(routeReached.get(), "Route body must be reached for a token with the expected audience");
+    }
+
+    @Test
+    void testTokenMissingOneOfMultipleExpectedAudiencesRejectedIntrospection() throws Exception {
+        KeycloakTokenIntrospector introspector = new KeycloakTokenIntrospector(
+                "http://localhost:8080", "test-realm", "test-client", "test-secret", (TokenCache) null) {
+            @Override
+            public IntrospectionResult introspect(String token) {
+                // Token only has one of the two expected audiences
+                return new IntrospectionResult(Map.of("active", true, "aud", "expected-client"));
+            }
+        };
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy() {
+            @Override
+            public boolean isUseTokenIntrospection() {
+                return true;
+            }
+
+            @Override
+            public KeycloakTokenIntrospector getTokenIntrospector() {
+                return introspector;
+            }
+        };
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setValidateIssuer(false);
+        policy.setExpectedAudience("expected-client,other-required-client");
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer("x")));
+        assertFalse(routeReached.get(),
+                "Route body must not be reached when the token has only some of the expected audiences");
+    }
+
+    @Test
+    void testTokenMissingExpectedAudienceRejectedWithRequiredRolesIntrospection() throws Exception {
+        // Token would satisfy the required role, but is missing the expected audience: the audience check
+        // inside validateRoles() must still reject it before the role check ever runs.
+        KeycloakTokenIntrospector introspector = new KeycloakTokenIntrospector(
+                "http://localhost:8080", "test-realm", "test-client", "test-secret", (TokenCache) null) {
+            @Override
+            public IntrospectionResult introspect(String token) {
+                return new IntrospectionResult(
+                        Map.of("active", true, "realm_access", Map.of("roles", List.of("admin"))));
+            }
+        };
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy() {
+            @Override
+            public boolean isUseTokenIntrospection() {
+                return true;
+            }
+
+            @Override
+            public KeycloakTokenIntrospector getTokenIntrospector() {
+                return introspector;
+            }
+        };
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setValidateIssuer(false);
+        policy.setExpectedAudience("expected-client");
+        policy.setRequiredRoles("admin");
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer("x")));
+        assertFalse(routeReached.get(),
+                "Route body must not be reached when the token has the required role but not the expected audience");
+    }
+
+    @Test
+    void testTokenMissingExpectedAudienceRejectedWithRequiredPermissionsIntrospection() throws Exception {
+        // Token would satisfy the required permission, but is missing the expected audience: the audience check
+        // inside validatePermissions() must still reject it before the permission check ever runs.
+        KeycloakTokenIntrospector introspector = new KeycloakTokenIntrospector(
+                "http://localhost:8080", "test-realm", "test-client", "test-secret", (TokenCache) null) {
+            @Override
+            public IntrospectionResult introspect(String token) {
+                return new IntrospectionResult(Map.of("active", true, "scope", "read"));
+            }
+        };
+
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy() {
+            @Override
+            public boolean isUseTokenIntrospection() {
+                return true;
+            }
+
+            @Override
+            public KeycloakTokenIntrospector getTokenIntrospector() {
+                return introspector;
+            }
+        };
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        policy.setValidateIssuer(false);
+        policy.setExpectedAudience("expected-client");
+        policy.setRequiredPermissions("read");
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer("x")));
+        assertFalse(routeReached.get(),
+                "Route body must not be reached when the token has the required permission but not the expected audience");
     }
 }


### PR DESCRIPTION
## Backport of #24477

Cherry-pick of #24477 onto `camel-4.18.x`.

**Original PR:** #24477 - CAMEL-23875: camel-keycloak - add optional audience (aud) validation to token verification
**Original author:** @ammachado
**Target branch:** `camel-4.18.x`
**JIRA:** https://issues.apache.org/jira/browse/CAMEL-23875

### What this backports

Adds the opt-in `expectedAudience` option to `KeycloakSecurityPolicy`. When set, tokens whose `aud` claim does not contain every configured audience are rejected — enforced on both the local JWT verification path (via Keycloak's `TokenVerifier.audience(...)`) and the token-introspection path. **Disabled by default for backward compatibility.** This lets operators on the 4.18.x line close the multi-client token-confusion gap (a token issued for one client being accepted by a route intended for another client in the same realm).

### Backport notes

- The three core classes (`KeycloakSecurityHelper`, `KeycloakSecurityPolicy`, `KeycloakSecurityProcessor`) and the `KeycloakSecurityPolicyTest` / `KeycloakSecurityProcessorTest` cherry-picked cleanly.
- `KeycloakSecurityHelperTest` had a trivial import-block conflict; resolved to match the upstream file exactly (simple names, no FQCNs).
- **Documentation:** the upstream change edited `keycloak-security.adoc`, which does **not** exist on 4.18.x — that page was introduced on `main` by the later docs split (CAMEL-23806) which is intentionally not backported. The new *Audience Validation* section was therefore ported into `keycloak-component.adoc`, where the security-policy documentation lives on 4.18.x.

### Original description

> Add opt-in `expectedAudience` option to `KeycloakSecurityPolicy` so tokens whose `aud` claim does not contain every configured audience are rejected. This prevents a token issued for one client from being accepted by routes intended for another client in multi-client Keycloak realms. Enforced on both local JWT verification (via Keycloak's `TokenVerifier.audience`) and token introspection. Disabled by default for backward compatibility.

---

_Claude Code on behalf of Andrea Cosentino (@oscerd)_