### PR TITLE
CAMEL-23971: fix ordered properties containsKey support

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/BaseOrderedProperties.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/BaseOrderedProperties.java
@@ -77,6 +77,36 @@ abstract class BaseOrderedProperties extends Properties {
     }
 
     @Override
+    public boolean containsKey(Object key) {
+        lock.lock();
+        try {
+            return map.containsKey(key);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        lock.lock();
+        try {
+            return map.containsValue(value);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean contains(Object value) {
+        lock.lock();
+        try {
+            return map.containsValue(value);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
     public boolean isEmpty() {
         lock.lock();
         try {

--- a/core/camel-util/src/main/java/org/apache/camel/util/CamelCaseOrderedProperties.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/CamelCaseOrderedProperties.java
@@ -44,6 +44,19 @@ public final class CamelCaseOrderedProperties extends BaseOrderedProperties {
     }
 
     @Override
+    public boolean containsKey(Object key) {
+        lock.lock();
+        try {
+            String k = key.toString();
+            return super.containsKey(k)
+                    || super.containsKey(StringHelper.dashToCamelCase(k))
+                    || super.containsKey(StringHelper.camelCaseToDash(k));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
     public String getProperty(String key) {
         String answer = super.getProperty(key);
         if (answer == null) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/CamelCaseOrderedProperties.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/CamelCaseOrderedProperties.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.util;
 
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -48,9 +49,10 @@ public final class CamelCaseOrderedProperties extends BaseOrderedProperties {
         lock.lock();
         try {
             String k = key.toString();
-            return super.containsKey(k)
-                    || super.containsKey(StringHelper.dashToCamelCase(k))
-                    || super.containsKey(StringHelper.camelCaseToDash(k));
+            Map<String, Object> m = asMap();
+            return m.containsKey(k)
+                    || m.containsKey(StringHelper.dashToCamelCase(k))
+                    || m.containsKey(StringHelper.camelCaseToDash(k));
         } finally {
             lock.unlock();
         }

--- a/core/camel-util/src/test/java/org/apache/camel/util/CamelCaseOrderedPropertiesTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/CamelCaseOrderedPropertiesTest.java
@@ -22,6 +22,8 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CamelCaseOrderedPropertiesTest {
 
@@ -75,6 +77,23 @@ public class CamelCaseOrderedPropertiesTest {
         assertEquals("500", prop.getProperty("camel.component.seda.queue-size", "MyDefault"));
         assertEquals("500", prop.getProperty("camel.component.seda.queueSize", "MyDefault"));
         assertEquals("1234", prop.getProperty("camel.component.direct.timeout", "MyDefault"));
+    }
+
+    @Test
+    public void testContainsKeyCamelCaseAndDashFallback() {
+        Properties prop = new CamelCaseOrderedProperties();
+        prop.setProperty("camel.main.stream-caching-enabled", "true");
+        prop.setProperty("camel.component.seda.queueSize", "500");
+
+        // stored as dash, looked up as dash or camelCase
+        assertTrue(prop.containsKey("camel.main.stream-caching-enabled"));
+        assertTrue(prop.containsKey("camel.main.streamCachingEnabled"));
+
+        // stored as camelCase, looked up as camelCase or dash
+        assertTrue(prop.containsKey("camel.component.seda.queueSize"));
+        assertTrue(prop.containsKey("camel.component.seda.queue-size"));
+
+        assertFalse(prop.containsKey("camel.main.unknown"));
     }
 
 }

--- a/core/camel-util/src/test/java/org/apache/camel/util/OrderedPropertiesTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/OrderedPropertiesTest.java
@@ -22,6 +22,8 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrderedPropertiesTest {
 
@@ -70,6 +72,45 @@ public class OrderedPropertiesTest {
         assertEquals("2", it.next());
         assertEquals("500", it.next());
         assertEquals("1234", it.next());
+    }
+
+    @Test
+    public void testContainsKey() {
+        Properties prop = new OrderedProperties();
+        prop.setProperty("foo", "bar");
+
+        assertTrue(prop.containsKey("foo"));
+        assertFalse(prop.containsKey("bar"));
+    }
+
+    @Test
+    public void testContainsValue() {
+        Properties prop = new OrderedProperties();
+        prop.setProperty("foo", "bar");
+
+        assertTrue(prop.containsValue("bar"));
+        assertFalse(prop.containsValue("foo"));
+    }
+
+    @Test
+    public void testContainsLegacy() {
+        Properties prop = new OrderedProperties();
+        prop.setProperty("foo", "bar");
+
+        assertTrue(prop.contains("bar"));
+        assertFalse(prop.contains("foo"));
+    }
+
+    @Test
+    public void testContainsKeyAfterRemove() {
+        Properties prop = new OrderedProperties();
+        prop.setProperty("foo", "bar");
+
+        assertTrue(prop.containsKey("foo"));
+
+        prop.remove("foo");
+
+        assertFalse(prop.containsKey("foo"));
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -287,13 +287,13 @@ class ExportCamelMain extends Export {
             Properties prop = new CamelCaseOrderedProperties();
             RuntimeUtil.loadProperties(prop, profile);
             // if metrics is defined then include camel-micrometer-prometheus for camel-main runtime
-            if (prop.getProperty("camel.metrics.enabled") != null
-                    || prop.getProperty("camel.management.metricsEnabled") != null
-                    || prop.getProperty("camel.server.metricsEnabled") != null) {
+            if (prop.containsKey("camel.metrics.enabled")
+                    || prop.containsKey("camel.management.metricsEnabled")
+                    || prop.containsKey("camel.server.metricsEnabled")) {
                 answer.add("mvn:org.apache.camel:camel-micrometer-prometheus");
             }
             // if health-check is defined then include camel-health for camel-main runtime
-            if (prop.getProperty("camel.management.healthCheckEnabled") != null) {
+            if (prop.containsKey("camel.management.healthCheckEnabled")) {
                 answer.add("mvn:org.apache.camel:camel-health");
             }
         }


### PR DESCRIPTION
# Description

Fixes `OrderedProperties` containment support by delegating `containsKey`, `containsValue`, and legacy `contains` to the backing `LinkedHashMap` in `BaseOrderedProperties`, and adds regression coverage for those semantics plus remove behavior.

`BaseOrderedProperties` moved storage into a backing map but never overrode the inherited `Hashtable` containment methods, so property presence checks could return false even when the ordered properties instance actually contained the key.

Additionally, `CamelCaseOrderedProperties` overrides `get`/`getProperty` to look up keys as-is, then `dashToCamelCase`, then `camelCaseToDash`, but left `containsKey` with the plain exact-match behavior. This override now makes `containsKey` apply the same camelCase/dash fallback so it stays consistent with `get`/`getProperty`. Only `containsKey` needs this; values are never transformed, so `containsValue`/`contains` remain the plain base-class delegation.

The Camel JBang export path in `ExportCamelMain` uses `containsKey(...)` for profile-based property presence checks, so explicitly configured keys are treated as present even when their value is empty. With the `CamelCaseOrderedProperties.containsKey` override, dash-style keys (e.g. `camel.management.metrics-enabled`) are still matched.

All `BaseOrderedProperties` descendants were reviewed: `OrderedProperties` (no read overrides) and `OrderedLocationProperties` (only `clear`/`remove` overrides, no key transformation on read) need no containment changes.

_AI-generated by Codex/Claude Code on behalf of ammachado._

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.