### PR TITLE
CAMEL-23972: Skip IBM MQ JMS tests on aarch64

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
@@ -28,10 +28,12 @@ import org.apache.camel.test.infra.ibmmq.services.IbmMQService;
 import org.apache.camel.test.infra.ibmmq.services.IbmMQServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 
+@DisabledOnOs(architectures = { "aarch64", "aarch_64" }, disabledReason = "IBM MQ has no Linux ARM64 native image")
 public class JmsComponentIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
@@ -26,11 +26,13 @@ import org.apache.camel.test.infra.ibmmq.services.IbmMQService;
 import org.apache.camel.test.infra.ibmmq.services.IbmMQServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisabledOnOs(architectures = { "aarch64", "aarch_64" }, disabledReason = "IBM MQ has no Linux ARM64 native image")
 public class JmsReplyToIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension


### PR DESCRIPTION
# Description

This change updates the two IBM MQ JMS tests to skip on `aarch64` regardless of OS by using the existing `@DisabledOnOs(architectures = ...)` form for the following tests:
- `JmsComponentIbmMQTest`
- `JmsReplyToIbmMQTest`

AI-generated by Codex on behalf of ammachado.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.
