### PR TITLE
CAMEL-23939: Fix Kamelet dependencies ignored in Camel CLI

### DIFF
--- a/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/utils/format/schema/DelegatingSchemaResolver.java
+++ b/components/camel-kamelet/src/main/java/org/apache/camel/component/kamelet/utils/format/schema/DelegatingSchemaResolver.java
@@ -17,6 +17,8 @@
 
 package org.apache.camel.component.kamelet.utils.format.schema;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.jackson.avro.transform.AvroSchemaResolver;
@@ -31,12 +33,29 @@ import org.apache.camel.util.ObjectHelper;
  * determine the schema resolver (Avro or Json). Delegates to schema resolver and sets proper content class and schema
  * properties on the delegate.
  */
-public class DelegatingSchemaResolver implements Processor {
+public class DelegatingSchemaResolver implements Processor, CamelContextAware {
+
+    private static final String AVRO_SCHEMA_RESOLVER = "org.apache.camel.component.jackson.avro.transform.AvroSchemaResolver";
+    private static final String PROTOBUF_SCHEMA_RESOLVER
+            = "org.apache.camel.component.jackson.protobuf.transform.ProtobufSchemaResolver";
+    private static final String JSON_SCHEMA_RESOLVER = "org.apache.camel.component.jackson.transform.JsonSchemaResolver";
+
+    private CamelContext camelContext;
     private String mimeType;
     private String targetMimeType;
 
     private String schema;
     private String contentClass;
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -65,25 +84,64 @@ public class DelegatingSchemaResolver implements Processor {
             case PROTOBUF:
             case PROTOBUF_BINARY:
             case PROTOBUF_STRUCT:
+                return createSchemaResolver(PROTOBUF_SCHEMA_RESOLVER);
+            case AVRO:
+            case AVRO_BINARY:
+            case AVRO_STRUCT:
+                return createSchemaResolver(AVRO_SCHEMA_RESOLVER);
+            case JSON:
+            case STRUCT:
+                return createSchemaResolver(JSON_SCHEMA_RESOLVER);
+            default:
+                return null;
+        }
+    }
+
+    private Processor createSchemaResolver(String className) {
+        try {
+            return doCreateSchemaResolver(className);
+        } catch (NoClassDefFoundError e) {
+            // fallback to dynamic class resolution (e.g. Camel CLI with downloaded dependencies)
+            return doCreateSchemaResolverReflection(className);
+        }
+    }
+
+    private Processor doCreateSchemaResolver(String className) {
+        switch (className) {
+            case PROTOBUF_SCHEMA_RESOLVER:
                 ProtobufSchemaResolver protobufSchemaResolver = new ProtobufSchemaResolver();
                 protobufSchemaResolver.setSchema(this.schema);
                 protobufSchemaResolver.setContentClass(this.contentClass);
                 return protobufSchemaResolver;
-            case AVRO:
-            case AVRO_BINARY:
-            case AVRO_STRUCT:
+            case AVRO_SCHEMA_RESOLVER:
                 AvroSchemaResolver avroSchemaResolver = new AvroSchemaResolver();
                 avroSchemaResolver.setSchema(this.schema);
                 avroSchemaResolver.setContentClass(this.contentClass);
                 return avroSchemaResolver;
-            case JSON:
-            case STRUCT:
+            case JSON_SCHEMA_RESOLVER:
                 JsonSchemaResolver jsonSchemaResolver = new JsonSchemaResolver();
                 jsonSchemaResolver.setSchema(this.schema);
                 jsonSchemaResolver.setContentClass(this.contentClass);
                 return jsonSchemaResolver;
             default:
                 return null;
+        }
+    }
+
+    private Processor doCreateSchemaResolverReflection(String className) {
+        try {
+            Class<?> clazz;
+            if (camelContext != null) {
+                clazz = camelContext.getClassResolver().resolveMandatoryClass(className);
+            } else {
+                clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
+            }
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+            clazz.getMethod("setSchema", String.class).invoke(instance, this.schema);
+            clazz.getMethod("setContentClass", String.class).invoke(instance, this.contentClass);
+            return (Processor) instance;
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot create schema resolver: " + className, e);
         }
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Fix `DelegatingSchemaResolver` failing with `NoClassDefFoundError` when running Kamelets via Camel CLI
- The class has hard imports to `AvroSchemaResolver`, `ProtobufSchemaResolver`, `JsonSchemaResolver` from `provided`-scope dependencies that are downloaded into a child classloader at runtime
- Add a try/catch fallback: direct `new` is tried first (works on flat classpaths like Spring Boot), and on `NoClassDefFoundError` the resolver is loaded reflectively via `CamelContext.getClassResolver()` which can see dynamically downloaded JARs
- Implement `CamelContextAware` to get access to the `ClassResolver`

## Root Cause

When `DelegatingSchemaResolver` was moved from `camel-kamelets` into `camel-kamelet` (CAMEL-21249), it ended up on the boot classpath while its `provided` dependencies (`camel-jackson-avro`, `camel-jackson-protobuf`, `camel-jackson`) are dynamically downloaded into a child `DependencyDownloaderClassLoader`. Parent-first delegation means the parent classloader (which loaded `DelegatingSchemaResolver`) cannot see the child's JARs.

## Test plan

- [x] Existing `camel-kamelet` tests pass (flat classpath path exercised)
- [ ] Manual verification with `camel run` using a Kamelet that declares `camel:jackson-avro` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>