### PR TITLE
CAMEL-23974: Pass OAuth credentials from ZeebeComponent to ZeebeService

### DIFF
--- a/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/ZeebeComponent.java
+++ b/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/ZeebeComponent.java
@@ -118,7 +118,7 @@ public class ZeebeComponent extends DefaultComponent {
         super.doStart();
 
         if (zeebeService == null) {
-            zeebeService = new ZeebeService(gatewayHost, gatewayPort);
+            zeebeService = new ZeebeService(gatewayHost, gatewayPort, clientId, clientSecret, oAuthAPI);
             zeebeService.doStart();
         }
     }

--- a/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/internal/ZeebeService.java
+++ b/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/internal/ZeebeService.java
@@ -62,8 +62,15 @@ public class ZeebeService {
     private String oAuthAPI;
 
     public ZeebeService(String gatewayHost, int gatewayPort) {
+        this(gatewayHost, gatewayPort, null, null, null);
+    }
+
+    public ZeebeService(String gatewayHost, int gatewayPort, String clientId, String clientSecret, String oAuthAPI) {
         this.gatewayHost = gatewayHost;
         this.gatewayPort = gatewayPort;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.oAuthAPI = oAuthAPI;
 
         objectMapper = new ObjectMapper();
     }


### PR DESCRIPTION
## Summary

- Fix silent OAuth authentication failure in camel-zeebe: `clientId`, `clientSecret`, and `oAuthAPI` configured on `ZeebeComponent` were never passed to `ZeebeService`, making the OAuth code path unreachable dead code
- Add a constructor overload to `ZeebeService` that accepts the three OAuth parameters, and update `ZeebeComponent.doStart()` to use it

## Test plan

- [x] Existing unit tests pass (20 tests, 0 failures)
- [ ] Manual verification with a Zeebe cluster using OAuth (requires Camunda Cloud credentials)

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>