### PR TITLE
[backport camel-4.18.x] CAMEL-23974: Pass OAuth credentials from ZeebeComponent to ZeebeService

### DIFF
--- a/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/ZeebeComponent.java
+++ b/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/ZeebeComponent.java
@@ -116,7 +116,7 @@ public class ZeebeComponent extends DefaultComponent {
         super.doStart();
 
         if (zeebeService == null) {
-            zeebeService = new ZeebeService(gatewayHost, gatewayPort);
+            zeebeService = new ZeebeService(gatewayHost, gatewayPort, clientId, clientSecret, oAuthAPI);
             zeebeService.doStart();
         }
     }

--- a/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/internal/ZeebeService.java
+++ b/components/camel-zeebe/src/main/java/org/apache/camel/component/zeebe/internal/ZeebeService.java
@@ -61,8 +61,15 @@ public class ZeebeService {
     private String oAuthAPI;
 
     public ZeebeService(String gatewayHost, int gatewayPort) {
+        this(gatewayHost, gatewayPort, null, null, null);
+    }
+
+    public ZeebeService(String gatewayHost, int gatewayPort, String clientId, String clientSecret, String oAuthAPI) {
         this.gatewayHost = gatewayHost;
         this.gatewayPort = gatewayPort;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.oAuthAPI = oAuthAPI;
 
         objectMapper = new ObjectMapper();
     }


### PR DESCRIPTION
## Backport of #24557

Cherry-pick of #24557 onto `camel-4.18.x`.

**Original PR:** #24557 - CAMEL-23974: Pass OAuth credentials from ZeebeComponent to ZeebeService
**Original author:** @davsclaus
**Target branch:** `camel-4.18.x`

### Original description

Fix silent OAuth authentication failure in camel-zeebe where clientId, clientSecret, and oAuthAPI configured on ZeebeComponent were never passed to ZeebeService, making the OAuth code path unreachable dead code.

_Claude Code on behalf of davsclaus_