### PR TITLE
CAMEL-23940 - fix JBang 0.138+ wrapper script -D property serialization

### DIFF
--- a/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
+++ b/test-infra/camel-test-infra-cli/src/test/java/org/apache/camel/test/infra/cli/services/CliLocalContainerService.java
@@ -17,6 +17,8 @@
 package org.apache.camel.test.infra.cli.services;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +78,7 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
         if (!container.isRunning()) {
             LOG.info("Trying to start the {} container", CONTAINER_NAME);
             container.start();
-
+            fixJBangAppScript();
             registerProperties();
             LOG.info("{} instance running", CONTAINER_NAME);
             if (ObjectHelper.isNotEmpty(forceToRunVersion)) {
@@ -94,6 +96,25 @@ public class CliLocalContainerService implements CliService, ContainerService<Cl
             LOG.debug("the container is already running");
         }
 
+    }
+
+    private void fixJBangAppScript() {
+        // JBang 0.138+ has a bug: "jbang app install -Dkey=value" generates wrapper scripts
+        // with "-D key=value" (space-separated), but "jbang run" rejects that format.
+        // Patch the wrapper script to use "-Dkey=value" (no space).
+        String cmd = getMainCommand();
+        Path script = Path.of(System.getProperty("user.home"), ".jbang", "bin", cmd);
+        try {
+            if (Files.exists(script)) {
+                String content = Files.readString(script);
+                if (content.contains(" -D ")) {
+                    Files.writeString(script, content.replace(" -D ", " -D"));
+                    LOG.info("Patched JBang app script to fix -D property serialization");
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to patch JBang app script: {}", e.getMessage());
+        }
     }
 
     @Override

--- a/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/test/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -64,6 +64,9 @@ RUN source ~/.bashrc \
     -Dcamel.jbang.version=$CAMEL_JBANG_VERSION \
     camel@$CAMEL_REPO/$CAMEL_REF ; fi
 
+# Fix JBang 0.138+ bug: wrapper scripts serialize -D with a space that breaks parsing - see https://github.com/jbangdev/jbang/issues/2555
+RUN if [ -f ~/.jbang/bin/camel ]; then sed -i 's/ -D / -D/g' ~/.jbang/bin/camel; fi
+
 LABEL "camel.ref"=$CAMEL_REF
 LABEL "keep.container.running"=$KEEP_RUNNING
 


### PR DESCRIPTION
bug

this is a backport from
https://github.com/apache/camel/commit/4ff8202ab22537fd1f6ca6e2d937c6aa1fc2c205 (cannot be cherry-picked directly)

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

