### PR TITLE
CAMEL-21438: Fix racy JpaPollingConsumerLockEntityTest and fact-check jpa-component.adoc

### DIFF
--- a/components/camel-jpa/src/main/docs/jpa-component.adoc
+++ b/components/camel-jpa/src/main/docs/jpa-component.adoc
@@ -37,7 +37,7 @@ jpa:entityClassName[?options]
 ----
 
 For sending to the endpoint, the _entityClassName_ is optional. If
-specified, it helps the http://camel.apache.org/type-converter.html[Type Converter] to
+specified, it helps the xref:manual::type-converter.adoc[Type Converter] to
 ensure the body is of the correct type.
 
 For consuming, the _entityClassName_ is mandatory.
@@ -56,7 +56,7 @@ include::partial$component-endpoint-headers.adoc[]
 You can store a Java entity bean in a database by sending it to a JPA
 producer endpoint. The body of the _In_ message is assumed to be an
 entity bean (that is a POJO with an
-https://jakarta.ee/specifications/persistence/2.2/apidocs/javax/persistence/entity[@Entity]
+https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/entity[@Entity]
 annotation on it) or a collection or array of entity beans.
 
 If the body is a List of entities, make sure to use
@@ -149,6 +149,45 @@ explicitly configure a JPA component that references the
    <property name="transactionStrategy" ref="myTransactionStrategy"/>
 </bean>
 ----
+
+=== Entity enhancement
+
+JPA providers such as OpenJPA need to enhance (byte-code weave) your `@Entity` classes so they
+can track field access and manage lazy loading. Without enhancement, you may see errors such as
+`ArgumentException: ... were not enhanced at build time or at class load time with a javaagent`
+when the entity is first used.
+
+OpenJPA supports enhancing entities either dynamically at runtime (for example through a
+`-javaagent`, or automatic class-loading hooks in a Jakarta EE/OSGi container) or at build time.
+https://openjpa.apache.org/entity-enhancement.html[Build-time enhancement] is recommended: it is
+faster and more reliable than dynamic enhancement, which OpenJPA's own documentation discourages
+for production use due to known performance and functional issues.
+
+To enable build-time enhancement with Maven, add the `openjpa-maven-plugin` to your `pom.xml`
+bound to the `process-classes` phase:
+
+[source,xml]
+----
+<plugin>
+    <groupId>org.apache.openjpa</groupId>
+    <artifactId>openjpa-maven-plugin</artifactId>
+    <!-- use the same version as your OpenJPA runtime dependency -->
+    <version>4.1.1</version>
+    <executions>
+        <execution>
+            <id>enhancer</id>
+            <phase>process-classes</phase>
+            <goals>
+                <goal>enhance</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+----
+
+See https://openjpa.apache.org/enhancement-with-maven.html[Entity Enhancement with Maven] for the
+full set of plugin options (such as scoping enhancement to specific packages with
+`includes`/`excludes`) and for the `maven-antrun-plugin` alternative.
 
 === Using a consumer with a named query
 
@@ -431,23 +470,40 @@ the message body.
 
 === Using the JPA-Based Idempotent Repository
 
-The Idempotent Consumer from the http://camel.apache.org/enterprise-integration-patterns.html[EIP patterns] is used to filter out duplicate messages. A JPA-based idempotent repository is provided.
+Camel supports the Idempotent Consumer EIP, which is used to filter out duplicate messages. A JPA-based idempotent repository is provided.
 
 To use the JPA based idempotent repository.
 
 .Procedure
 
 . Set up a `persistence-unit` in the persistence.xml file:
++
+[source,xml]
+----
+<persistence-unit name="idempotentDb" transaction-type="RESOURCE_LOCAL">
+    <class>org.apache.camel.processor.idempotent.jpa.MessageProcessed</class>
 
-. Set up a `org.springframework.orm.jpa.JpaTemplate`
-which is used by the
-`org.apache.camel.processor.idempotent.jpa.JpaMessageIdRepository`:
+    <properties>
+        <property name="openjpa.ConnectionURL" value="jdbc:h2:./target/idempotentTest;DB_CLOSE_DELAY=-1"/>
+        <property name="openjpa.ConnectionDriverName" value="org.h2.Driver"/>
+        <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
+    </properties>
+</persistence-unit>
+----
 
-. Configure the error formatting macro: snippet: java.lang.IndexOutOfBoundsException:
-Index: 20, Size: 20
-
-. Configure the idempotent repository:
-`org.apache.camel.processor.idempotent.jpa.JpaMessageIdRepository`:
+. Configure the `org.apache.camel.processor.idempotent.jpa.JpaMessageIdRepository` bean,
+referencing the `EntityManagerFactory` built from that persistence unit:
++
+[source,xml]
+----
+<bean id="jpaStore" class="org.apache.camel.processor.idempotent.jpa.JpaMessageIdRepository">
+    <!-- Here we refer to the entityManagerFactory -->
+    <constructor-arg index="0" ref="entityManagerFactory"/>
+    <!-- This 2nd parameter is the name (a category name).
+         You can have different repositories with different names -->
+    <constructor-arg index="1" value="myProcessorName"/>
+</bean>
+----
 
 . Create the JPA idempotent repository in the Spring XML file:
 
@@ -520,10 +576,10 @@ https://github.com/apache/camel/blob/main/components/camel-jpa/pom.xml[enhance
 the byte-code at build time]. To overcome this, you need to enable
 http://openjpa.apache.org/entity-enhancement.html#dynamic-enhancement[dynamic
 byte-code enhancement of OpenJPA]. For example, assuming the current
-OpenJPA version being used in Camel is 2.2.1, to run the
+OpenJPA version being used in Camel is 4.1.1, to run the
 tests inside your IDE, you would need to pass the following
 argument to the JVM:
 
 ----
--javaagent:<path_to_your_local_m2_cache>/org/apache/openjpa/openjpa/2.2.1/openjpa-2.2.1.jar
+-javaagent:<path_to_your_local_m2_cache>/org/apache/openjpa/openjpa/4.1.1/openjpa-4.1.1.jar
 ----

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaPollingConsumerLockEntityTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaPollingConsumerLockEntityTest.java
@@ -50,7 +50,10 @@ public class JpaPollingConsumerLockEntityTest extends AbstractJpaTest {
     public void testPollingConsumerWithLock() throws Exception {
 
         MockEndpoint mock = getMockEndpoint("mock:locked");
-        mock.expectedBodiesReceived(
+        // The two concurrent requests race for the optimistic lock, so whichever one wins the
+        // uncontended read (and thus produces "orders: 1") is not deterministic, and the winner's
+        // exchange is not guaranteed to reach the mock endpoint first under CI-level thread contention.
+        mock.expectedBodiesReceivedInAnyOrder(
                 "orders: 1",
                 "orders: 2");
 
@@ -104,8 +107,10 @@ public class JpaPollingConsumerLockEntityTest extends AbstractJpaTest {
 
                 from("direct:locked")
                         .onException(OptimisticLockException.class)
-                        .redeliveryDelay(60)
-                        .maximumRedeliveries(2)
+                        // Generous budget so the losing side of the optimistic-lock race has enough
+                        // room to succeed even under heavy CI host contention.
+                        .redeliveryDelay(100)
+                        .maximumRedeliveries(10)
                         .end()
                         .pollEnrich()
                         .simple("jpa://" + Customer.class.getName()

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -214,10 +214,3 @@ by the file-based consumers (see the `localWorkDirectory` note in the 4.21 upgra
 
 Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
 `IllegalArgumentException`.
-
-=== camel-jpa - entity enhancement now documented
-
-The xref:components::jpa-component.adoc[JPA component] docs now cover OpenJPA entity enhancement:
-build-time enhancement (via the `openjpa-maven-plugin`) is recommended over runtime/dynamic
-enhancement (`-javaagent`), which OpenJPA discourages for production use. This is a documentation
-addition only; no component behavior has changed.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -214,3 +214,10 @@ by the file-based consumers (see the `localWorkDirectory` note in the 4.21 upgra
 
 Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
 `IllegalArgumentException`.
+
+=== camel-jpa - entity enhancement now documented
+
+The xref:components::jpa-component.adoc[JPA component] docs now cover OpenJPA entity enhancement:
+build-time enhancement (via the `openjpa-maven-plugin`) is recommended over runtime/dynamic
+enhancement (`-javaagent`), which OpenJPA discourages for production use. This is a documentation
+addition only; no component behavior has changed.


### PR DESCRIPTION
# Description

Bundles two related fixes surfaced while investigating flaky CI on PR #24541:

**1. Fix racy `JpaPollingConsumerLockEntityTest.testPollingConsumerWithLock`**

The test fires two concurrent requests racing for an optimistic lock on the same entity, but asserted a fixed arrival order on the mock endpoint and gave the losing side of the race only 120ms (2 retries x 60ms) to resolve the conflict. Under CI host contention this produced two distinct, previously observed failures:
- wrong message order (`orders: 2` arriving before `orders: 1`)
- the losing side exhausting its retries and landing on `mock:error` instead of `mock:locked`

Switched the assertion to order-independent (`expectedBodiesReceivedInAnyOrder`) and widened the redelivery budget (`redeliveryDelay(100)` / `maximumRedeliveries(10)`) so contention has realistic room to resolve, still well within the existing 20s `assertIsSatisfied` timeout. Verified with 6 consecutive local runs (all green, ~0.7-0.8s each). Searched the rest of the `camel-jpa` test module for the same pattern (concurrent racing requests + order-sensitive assertion) — this was the only instance.

**2. Fact-check `jpa-component.adoc` against the actual source/pom.xml**

- OpenJPA version references were stale (`2.2.1`); corrected to `4.1.1`, matching `parent/pom.xml`'s `openjpa-version` property (verified against the actual `openjpa-maven-plugin` / `openjpa` dependency wiring in `camel-jpa/pom.xml`).
- Replaced external `camel.apache.org` links with `xref:manual::` per the project's doc convention, and updated the `@Entity` javadoc link from the old `javax.persistence`/Jakarta Persistence 2.2 spec to `jakarta.persistence`/3.2, matching the `jakarta-persistence-api-version` (3.2.0) actually used.
- The "Using the JPA-Based Idempotent Repository" procedure had an ~8-year-old broken doc-tooling artifact — a literal `IndexOutOfBoundsException` message left over from a failed Confluence "snippet" macro migration (traced via `git log -S`) — and incorrectly instructed readers to configure a `org.springframework.orm.jpa.JpaTemplate`, which `JpaMessageIdRepository` does not use (its constructor takes an `EntityManagerFactory` directly).
  Replaced both with real, source-verified `persistence-unit`/bean XML pulled from the actual test fixtures (`persistence.xml`'s `SNIPPET: e1` block and `fileConsumerJpaIdempotentTest-config.xml`'s `SNIPPET: jpaStore` block).
- Added a new "Entity enhancement" section documenting OpenJPA's recommendation to use build-time enhancement (via `openjpa-maven-plugin`) over runtime/dynamic enhancement, per https://openjpa.apache.org/entity-enhancement.html and https://openjpa.apache.org/enhancement-with-maven.html.

A small, explicitly-flagged documentation-only note was added to the 4.22 upgrade guide.

_AI-generated by Claude Code on behalf of ammachado._

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.