### PR TITLE
Avoid flakiness of CxfTimeoutTest

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
@@ -36,6 +36,7 @@ import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.hello_world_soap_http.Greeter;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated
 public class CxfTimeoutTest extends CamelSpringTestSupport {
 
     protected static final String GREET_ME_OPERATION = "greetMe";


### PR DESCRIPTION
as we can see here
https://develocity.apache.org/scans/tests?search.rootProjectNames=camel&search.timeZoneId=Europe%2FParis&tests.container=org.apache.camel.component.cxf.CxfTimeoutTest , this test is flaky.
it also sometimes cannot even be initialized with
```
jakarta.xml.ws.WebServiceException:
org.apache.cxf.endpoint.ListenerRegistrationException: Soap 1.1 endpoint
already registered on address
http://localhost:29753/CxfTimeoutTest/SoapContext/SoapPort
	at org.apache.cxf.jaxws.EndpointImpl.doPublish(EndpointImpl.java:373)
	at org.apache.cxf.jaxws.EndpointImpl.publish(EndpointImpl.java:255)
	at org.apache.cxf.jaxws.spi.ProviderImpl.createAndPublishEndpoint(ProviderImpl.java:130)
	at jakarta.xml.ws.Endpoint.publish(Endpoint.java:224)
	at org.apache.camel.component.cxf.CxfTimeoutTest.startService(CxfTimeoutTest.java:57)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: org.apache.cxf.endpoint.ListenerRegistrationException: Soap
1.1 endpoint already registered on address
http://localhost:29753/CxfTimeoutTest/SoapContext/SoapPort
	at org.apache.cxf.binding.soap.SoapBindingFactory.addListener(SoapBindingFactory.java:923)
	at org.apache.cxf.endpoint.ServerImpl.start(ServerImpl.java:130)
	at org.apache.cxf.jaxws.EndpointImpl.doPublish(EndpointImpl.java:364)
	... 6 more
```

Attempt to enforce this test to play in isolation to avoid side effect

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

