### PR TITLE
CAMEL-23317 - use separate mail user in tests to reduce flakiness

### DIFF
--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/AuthenticatorTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/AuthenticatorTest.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AuthenticatorTest extends CamelTestSupport {
-    private static final MailboxUser james3 = Mailbox.getOrCreateUser("james3", "secret");
-    private static final MailboxUser james4 = Mailbox.getOrCreateUser("james4", "secret");
+    private static final MailboxUser james3 = Mailbox.getOrCreateUser("authenticator-test-james3", "secret");
+    private static final MailboxUser james4 = Mailbox.getOrCreateUser("authenticator-test-james4", "secret");
 
     /**
      * Checks that the authenticator does dynamically return passwords for the smtp endpoint.
@@ -120,7 +120,7 @@ public class AuthenticatorTest extends CamelTestSupport {
                 from("pop3://localhost:" + Mailbox.getPort(Protocol.pop3)
                      + "?initialDelay=100&delay=100&authenticator=#authPop3").removeHeader("to")
                         .to("smtp://localhost:" + Mailbox.getPort(Protocol.smtp)
-                            + "?authenticator=#authSmtp&to=james4@localhost");
+                            + "?authenticator=#authSmtp&to=" + james4.getEmail());
                 from("imap://localhost:" + Mailbox.getPort(Protocol.imap)
                      + "?initialDelay=200&delay=100&authenticator=#authImap").convertBodyTo(String.class)
                         .to("mock:result");
@@ -148,7 +148,7 @@ public class AuthenticatorTest extends CamelTestSupport {
                 } else if (counter < 4) {
                     // return in the second call the wrongPassword which will throw an MessagingException, see MyMockTransport
                     counter++;
-                    return new PasswordAuthentication("james4", "wrongPassword");
+                    return new PasswordAuthentication(james4.getLogin(), "wrongPassword");
                 } else {
                     return auth(james4);
                 }

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/FromFileSendMailTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/FromFileSendMailTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FromFileSendMailTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("FromFileSendMailTest-james", "secret");
 
     @Test
     public void testSendFileAsMail() throws Exception {
@@ -57,7 +57,7 @@ public class FromFileSendMailTest extends CamelTestSupport {
             public void configure() {
                 from("file://target/mailtext?initialDelay=100&delay=100")
                         .setHeader("Subject", constant("Hello World"))
-                        .setHeader("To", constant("james@localhost"))
+                        .setHeader("To", constant(james.getEmail()))
                         .setHeader("From", constant("claus@localhost"))
                         .to(james.uriPrefix(Protocol.smtp)
                             + "&initialDelay=100&delay=100&useHeaderRecipients=true&useHeaderFrom=true&useHeaderSubject=true",

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentDuplicateNamesTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentDuplicateNamesTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for Camel attachments and Mail attachments.
  */
 public class MailAttachmentDuplicateNamesTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailAttachmentDuplicateNamesTest-james", "secret");
 
     @Test
     public void testSendAndReceiveMailWithAttachmentsWithDuplicateNames() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentNamesTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentNamesTest.java
@@ -48,9 +48,9 @@ public class MailAttachmentNamesTest extends CamelTestSupport {
 
     public static final String UUID_EXPRESSION = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
-    private static final MailboxUser default_ = Mailbox.getOrCreateUser("default", "secret");
-    private static final MailboxUser suffix = Mailbox.getOrCreateUser("suffix", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailAttachmentNamesTest-james", "secret");
+    private static final MailboxUser default_ = Mailbox.getOrCreateUser("MailAttachmentNamesTest-default", "secret");
+    private static final MailboxUser suffix = Mailbox.getOrCreateUser("MailAttachmentNamesTest-suffix", "secret");
 
     MockEndpoint resultEndpoint;
     MockEndpoint resultDefaultEndpoint;

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentPollEnrichTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentPollEnrichTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for Camel attachments and Mail attachments.
  */
 public class MailAttachmentPollEnrichTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailAttachmentPollEnrichTest-james", "secret");
 
     @Test
     public void testPollEnrichMailWithAttachments() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentRedeliveryTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentRedeliveryTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for Camel attachments and Mail attachments.
  */
 public class MailAttachmentRedeliveryTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailAttachmentRedeliveryTest-james", "secret");
 
     private final List<String> names = new ArrayList<>();
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for Camel attachments and Mail attachments.
  */
 public class MailAttachmentTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailAttachmentTest-james", "secret");
 
     @Test
     public void testSendAndReceiveMailWithAttachments() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentsUmlautIssueTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentsUmlautIssueTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Disabled("Fails on CI servers and some platforms - maybe due locale or something")
 public class MailAttachmentsUmlautIssueTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailAttachmentsUmlautIssueTest-james", "secret");
 
     @Test
     public void testSendAndReceiveMailWithAttachments() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailBatchConsumerTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailBatchConsumerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for batch consumer.
  */
 public class MailBatchConsumerTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailBatchConsumerTest-jones", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCollectionHeaderTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCollectionHeaderTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MailCollectionHeaderTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailCollectionHeaderTest-james", "secret");
 
     @Test
     public void testMailHeaderWithCollection() throws Exception {
@@ -60,7 +60,7 @@ public class MailCollectionHeaderTest extends CamelTestSupport {
                 from("direct:a").to(james.uriPrefix(Protocol.smtp));
 
                 from("pop3://localhost:" + Mailbox.getPort(Protocol.pop3)
-                     + "?username=james&password=secret&initialDelay=100&delay=100").to("mock:result");
+                     + "?username=" + james.getLogin() + "&password=secret&initialDelay=100&delay=100").to("mock:result");
             }
         };
     }

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailComponentRecipientSetTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailComponentRecipientSetTest.java
@@ -27,12 +27,12 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MailComponentRecipientSetTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
-    private static final MailboxUser admin = Mailbox.getOrCreateUser("admin", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailComponentRecipientSetTest-james", "secret");
+    private static final MailboxUser admin = Mailbox.getOrCreateUser("MailComponentRecipientSetTest-admin", "secret");
 
-    private static final MailboxUser a = Mailbox.getOrCreateUser("a", "secret");
-    private static final MailboxUser b = Mailbox.getOrCreateUser("b", "secret");
-    private static final MailboxUser c = Mailbox.getOrCreateUser("c", "secret");
+    private static final MailboxUser a = Mailbox.getOrCreateUser("MailComponentRecipientSetTest-a", "secret");
+    private static final MailboxUser b = Mailbox.getOrCreateUser("MailComponentRecipientSetTest-b", "secret");
+    private static final MailboxUser c = Mailbox.getOrCreateUser("MailComponentRecipientSetTest-c", "secret");
 
     @Test
     public void testMultipleEndpoints() throws Exception {
@@ -78,12 +78,15 @@ public class MailComponentRecipientSetTest extends CamelTestSupport {
                 MailComponent mail = context.getComponent("smtp", MailComponent.class);
                 mail.setConfiguration(config);
 
-                from("direct:a").to(james.uriPrefix(Protocol.smtp) + "&to=a@localhost&useHeaderSubject=true");
+                from("direct:a")
+                        .to(james.uriPrefix(Protocol.smtp) + "&to=" + a.getLogin() + "@localhost&useHeaderSubject=true");
 
-                from("direct:b").to(james.uriPrefix(Protocol.smtp) + "&to=b@localhost&from=you@you.com&useHeaderSubject=true");
+                from("direct:b").to(james.uriPrefix(Protocol.smtp) + "&to=" + b.getLogin()
+                                    + "@localhost&from=you@you.com&useHeaderSubject=true");
 
                 from("direct:c").to(
-                        admin.uriPrefix(Protocol.smtp) + "&to=c@localhost&cc=you@you.com,them@them.com&useHeaderSubject=true");
+                        admin.uriPrefix(Protocol.smtp) + "&to=" + c.getLogin()
+                                    + "@localhost&cc=you@you.com,them@them.com&useHeaderSubject=true");
             }
         };
     }

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerAuthenticatorTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerAuthenticatorTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
  * Test the dynamic behavior of the MailAuthenticator in the MailConsumer.
  */
 public class MailConsumerAuthenticatorTest {
-    private static final MailboxUser user1 = Mailbox.getOrCreateUser("user1", "correctPassword");
+    private static final MailboxUser user1 = Mailbox.getOrCreateUser("MailConsumerAuthenticatorTest-user1", "correctPassword");
 
     @Test
     public void dynamicPasswordPop3() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerIdleMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerIdleMessageTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * and a polling event yields no results.
  */
 public class MailConsumerIdleMessageTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailConsumerIdleMessageTest-james", "secret");
 
     @Test
     public void testConsumeIdleMessages() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerUnsupportedCharsetTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerUnsupportedCharsetTest.java
@@ -31,7 +31,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class MailConsumerUnsupportedCharsetTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailConsumerUnsupportedCharsetTest-jones", "secret");
 
     @Test
     public void testConsumeUnsupportedCharset() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailContentTypeResolverTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailContentTypeResolverTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for Camel attachments and Mail attachments.
  */
 public class MailContentTypeResolverTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailContentTypeResolverTest-james", "secret");
 
     @Test
     public void testCustomContentTypeResolver() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailContentTypeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailContentTypeTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for contentType option.
  */
 public class MailContentTypeTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailContentTypeTest-claus", "secret");
 
     @Test
     public void testSendHtmlMail() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConvertersTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConvertersTest.java
@@ -41,7 +41,7 @@ public class MailConvertersTest extends CamelTestSupport {
     @Override
     public void doPreSetup() {
         Mailbox.clearAll();
-        james = Mailbox.getOrCreateUser("james", "secret");
+        james = Mailbox.getOrCreateUser("MailConvertersTest-james", "secret");
     }
 
     @Test

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCopyToTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCopyToTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for copyTo.
  */
 public class MailCopyToTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailCopyToTest-jones", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCustomContentTypeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCustomContentTypeTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for contentType option.
  */
 public class MailCustomContentTypeTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailCustomContentTypeTest-claus", "secret");
 
     @Test
     public void testSendHtmlMail() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCustomMailSenderTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailCustomMailSenderTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MailCustomMailSenderTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailCustomMailSenderTest-claus", "secret");
 
     private static boolean sent;
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailDefaultDelayForMailConsumeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailDefaultDelayForMailConsumeTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for testing mail polling is happening according to the default poll interval.
  */
 public class MailDefaultDelayForMailConsumeTest extends CamelTestSupport {
-    private static final MailboxUser bond = Mailbox.getOrCreateUser("bond", "secret");
+    private static final MailboxUser bond = Mailbox.getOrCreateUser("MailDefaultDelayForMailConsumeTest-bond", "secret");
 
     @Test
     public void testConsuming() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailDisconnectTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailDisconnectTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
  * Unit test for batch consumer.
  */
 public class MailDisconnectTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailDisconnectTest-jones", "secret");
 
     private int expectedCount = 5;
     private CountDownLatch latch = new CountDownLatch(expectedCount);

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailDoNotDeleteIfProcessFailsTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailDoNotDeleteIfProcessFailsTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for rollback option.
  */
 public class MailDoNotDeleteIfProcessFailsTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailDoNotDeleteIfProcessFailsTest-claus", "secret");
 
     private static int counter;
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailFetchSizeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailFetchSizeTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for fetch size.
  */
 public class MailFetchSizeTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailFetchSizeTest-jones", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailFetchSizeZeroTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailFetchSizeZeroTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for a special corner case with fetchSize=0
  */
 public class MailFetchSizeZeroTest extends CamelTestSupport {
-    private static final MailboxUser bill = Mailbox.getOrCreateUser("bill", "secret");
+    private static final MailboxUser bill = Mailbox.getOrCreateUser("MailFetchSizeZeroTest-bill", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailHeaderOverrulePreConfigurationRecipientsTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailHeaderOverrulePreConfigurationRecipientsTest.java
@@ -31,8 +31,10 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify that message headers override pre configuration.
  */
 public class MailHeaderOverrulePreConfigurationRecipientsTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
-    private static final MailboxUser willem = Mailbox.getOrCreateUser("willem", "secret");
+    private static final MailboxUser claus
+            = Mailbox.getOrCreateUser("MailHeaderOverrulePreConfigurationRecipientsTest-claus", "secret");
+    private static final MailboxUser willem
+            = Mailbox.getOrCreateUser("MailHeaderOverrulePreConfigurationRecipientsTest-willem", "secret");
 
     @Test
     public void testSendWithRecipientsInHeaders() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailHtmlAttachmentTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailHtmlAttachmentTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for Camel html attachments and Mail attachments.
  */
 public class MailHtmlAttachmentTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailHtmlAttachmentTest-james", "secret");
 
     @Test
     public void testSendAndReceiveMailWithAttachments() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailIdempotentRepositoryDuplicateTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailIdempotentRepositoryDuplicateTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for idempotent repository.
  */
 public class MailIdempotentRepositoryDuplicateTest extends CamelTestSupport {
-    protected static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    protected static final MailboxUser jones = Mailbox.getOrCreateUser("MailIdempotentRepositoryDuplicateTest-jones", "secret");
 
     @BindToRegistry("myRepo")
     MemoryIdempotentRepository myRepo = new MemoryIdempotentRepository();

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailIdempotentRepositoryTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailIdempotentRepositoryTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for idempotent repository.
  */
 public class MailIdempotentRepositoryTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailIdempotentRepositoryTest-jones", "secret");
 
     @BindToRegistry("myRepo")
     private MemoryIdempotentRepository myRepo = new MemoryIdempotentRepository();

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMaxMessagesPerPollTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMaxMessagesPerPollTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
  * Unit test for batch consumer.
  */
 public class MailMaxMessagesPerPollTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailMaxMessagesPerPollTest-jones", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMimeDecodeHeadersTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMimeDecodeHeadersTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Test;
  * Unit test for Mail header decoding/unfolding support.
  */
 public class MailMimeDecodeHeadersTest extends CamelTestSupport {
-    private static final MailboxUser plain = Mailbox.getOrCreateUser("plain", "secret");
-    private static final MailboxUser decoded = Mailbox.getOrCreateUser("decoded", "secret");
+    private static final MailboxUser plain = Mailbox.getOrCreateUser("MailMimeDecodeHeadersTest-plain", "secret");
+    private static final MailboxUser decoded = Mailbox.getOrCreateUser("MailMimeDecodeHeadersTest-decoded", "secret");
     private String nonAsciiSubject = "\uD83D\uDC2A rocks!";
     private String encodedNonAsciiSubject = "=?UTF-8?Q?=F0=9F=90=AA_rocks!?=";
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMoveToTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMoveToTest.java
@@ -41,8 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for moveTo.
  */
 public class MailMoveToTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
-    private static final MailboxUser jones2 = Mailbox.getOrCreateUser("jones2", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailMoveToTest-jones", "secret");
+    private static final MailboxUser jones2 = Mailbox.getOrCreateUser("MailMoveToTest-jones2", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMultipleRecipientsTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMultipleRecipientsTest.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.Test;
  * Unit test to verify that we can have multiple recipients in To, CC and BCC
  */
 public class MailMultipleRecipientsTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
-    private static final MailboxUser willem = Mailbox.getOrCreateUser("willem", "secret");
-    private static final MailboxUser hadrian = Mailbox.getOrCreateUser("hadrian", "secret");
-    private static final MailboxUser tracy = Mailbox.getOrCreateUser("tracy", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailMultipleRecipientsTest-claus", "secret");
+    private static final MailboxUser willem = Mailbox.getOrCreateUser("MailMultipleRecipientsTest-willem", "secret");
+    private static final MailboxUser hadrian = Mailbox.getOrCreateUser("MailMultipleRecipientsTest-hadrian", "secret");
+    private static final MailboxUser tracy = Mailbox.getOrCreateUser("MailMultipleRecipientsTest-tracy", "secret");
 
     @Test
     public void testSendWithMultipleRecipientsInHeader() throws Exception {
@@ -42,7 +42,8 @@ public class MailMultipleRecipientsTest extends CamelTestSupport {
         // START SNIPPET: e1
         Map<String, Object> headers = new HashMap<>();
         // test with both comma and semi colon as Camel supports both kind of separators
-        headers.put("to", "claus@localhost, willem@localhost ; hadrian@localhost, \"Snell, Tracy\" <tracy@localhost>");
+        headers.put("to", claus.getEmail() + ", " + willem.getEmail() + " ; " + hadrian.getEmail() + ", \"Snell, Tracy\" <"
+                          + tracy.getEmail() + ">");
         headers.put("cc", "james@localhost");
 
         assertMailbox("claus");
@@ -66,7 +67,8 @@ public class MailMultipleRecipientsTest extends CamelTestSupport {
         // START SNIPPET: e2
         // here we have pre configured the to receivers to claus and willem. Notice we use comma to separate
         // the two recipients. Camel also support using colon as separator char
-        template.sendBody(claus.uriPrefix(Protocol.smtp) + "&to=claus@localhost,willem@localhost&cc=james@localhost",
+        template.sendBody(
+                claus.uriPrefix(Protocol.smtp) + "&to=" + claus.getEmail() + "," + willem.getEmail() + "&cc=james@localhost",
                 "Hello World");
         // END SNIPPET: e2
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMultipleRecipientsUsingHeadersTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailMultipleRecipientsUsingHeadersTest.java
@@ -33,8 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for Mail using camel headers to set recipeient subject.
  */
 public class MailMultipleRecipientsUsingHeadersTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
-    private static final MailboxUser jon = Mailbox.getOrCreateUser("jon", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailMultipleRecipientsUsingHeadersTest-claus", "secret");
+    private static final MailboxUser jon = Mailbox.getOrCreateUser("MailMultipleRecipientsUsingHeadersTest-jon", "secret");
 
     @Test
     public void testMailMultipleRecipientUsingHeaders() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailNameAndEmailInRecipientTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailNameAndEmailInRecipientTest.java
@@ -27,8 +27,8 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
 public class MailNameAndEmailInRecipientTest extends CamelTestSupport {
-    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("davsclaus", "secret");
-    private static final MailboxUser jstrachan = Mailbox.getOrCreateUser("jstrachan", "secret");
+    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("MailNameAndEmailInRecipientTest-davsclaus", "secret");
+    private static final MailboxUser jstrachan = Mailbox.getOrCreateUser("MailNameAndEmailInRecipientTest-jstrachan", "secret");
 
     @Test
     public void testSendWithNameAndEmailInRecipient() throws Exception {
@@ -36,8 +36,8 @@ public class MailNameAndEmailInRecipientTest extends CamelTestSupport {
 
         // START SNIPPET: e1
         Map<String, Object> headers = new HashMap<>();
-        headers.put("to", "Claus Ibsen <davsclaus@localhost>");
-        headers.put("cc", "James Strachan <jstrachan@localhost>");
+        headers.put("to", "Claus Ibsen <" + davsclaus.getEmail() + ">");
+        headers.put("cc", "James Strachan <" + jstrachan.getEmail() + ">");
 
         assertMailbox("davsclaus");
         assertMailbox("jstrachan");
@@ -52,8 +52,8 @@ public class MailNameAndEmailInRecipientTest extends CamelTestSupport {
     private void assertMailbox(String name) {
         MockEndpoint mock = getMockEndpoint("mock:" + name);
         mock.expectedBodiesReceived("Hello World\r\n");
-        mock.message(0).header("to").isEqualTo("Claus Ibsen <davsclaus@localhost>");
-        mock.message(0).header("cc").isEqualTo("James Strachan <jstrachan@localhost>");
+        mock.message(0).header("to").isEqualTo("Claus Ibsen <" + davsclaus.getEmail() + ">");
+        mock.message(0).header("cc").isEqualTo("James Strachan <" + jstrachan.getEmail() + ">");
     }
 
     @Override

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailPollEnrichNoMailTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailPollEnrichNoMailTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * Unit test with poll enrich
  */
 public class MailPollEnrichNoMailTest extends CamelTestSupport {
-    private static final MailboxUser bill = Mailbox.getOrCreateUser("bill", "secret");
+    private static final MailboxUser bill = Mailbox.getOrCreateUser("MailPollEnrichNoMailTest-bill", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailPollEnrichTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailPollEnrichTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test with poll enrich
  */
 public class MailPollEnrichTest extends CamelTestSupport {
-    private static final MailboxUser bill = Mailbox.getOrCreateUser("bill", "secret");
+    private static final MailboxUser bill = Mailbox.getOrCreateUser("MailPollEnrichTest-bill", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailPostProcessActionTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailPostProcessActionTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests if post process action is called if it is set
  */
 public class MailPostProcessActionTest extends CamelTestSupport {
-    private static final MailboxUser bill = Mailbox.getOrCreateUser("bill", "secret");
+    private static final MailboxUser bill = Mailbox.getOrCreateUser("MailPostProcessActionTest-bill", "secret");
     private static final Logger LOG = LoggerFactory.getLogger(MailPostProcessActionTest.class);
 
     @BindToRegistry("postProcessAction")

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProcessOnlyUnseenMessagesTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProcessOnlyUnseenMessagesTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
  * Unit test for unseen option.
  */
 public class MailProcessOnlyUnseenMessagesTest extends CamelTestSupport {
-    private static final MailboxUser claus = Mailbox.getOrCreateUser("claus", "secret");
+    private static final MailboxUser claus = Mailbox.getOrCreateUser("MailProcessOnlyUnseenMessagesTest-claus", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerConcurrentTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerConcurrentTest.java
@@ -40,8 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Mail producer concurrent test.
  */
 public class MailProducerConcurrentTest extends CamelTestSupport {
-    private static final MailboxUser camel = Mailbox.getOrCreateUser("camel", "secret");
-    private static final MailboxUser someone = Mailbox.getOrCreateUser("someone", "secret");
+    private static final MailboxUser camel = Mailbox.getOrCreateUser("MailProducerConcurrentTest-camel", "secret");
+    private static final MailboxUser someone = Mailbox.getOrCreateUser("MailProducerConcurrentTest-someone", "secret");
 
     @Test
     public void testNoConcurrentProducers() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerTest.java
@@ -34,16 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MailProducerTest extends CamelTestSupport {
-    private static final MailboxUser camel = Mailbox.getOrCreateUser("camel", "secret");
-    private static final MailboxUser someone = Mailbox.getOrCreateUser("someone", "secret");
-    private static final MailboxUser recipient2 = Mailbox.getOrCreateUser("recipient2", "secret");
+    private static final MailboxUser camel = Mailbox.getOrCreateUser("MailProducerTest-camel", "secret");
+    private static final MailboxUser someone = Mailbox.getOrCreateUser("MailProducerTest-someone", "secret");
+    private static final MailboxUser recipient2 = Mailbox.getOrCreateUser("MailProducerTest-recipient2", "secret");
 
     @Test
     public void testProducer() throws Exception {
         Mailbox.clearAll();
         getMockEndpoint("mock:result").expectedMessageCount(1);
 
-        template.sendBodyAndHeader("direct:start", "Message ", "To", "someone@localhost");
+        template.sendBodyAndHeader("direct:start", "Message ", "To", someone.getEmail());
         MockEndpoint.assertIsSatisfied(context);
         // need to check the message header
         Exchange exchange = getMockEndpoint("mock:result").getExchanges().get(0);
@@ -67,7 +67,7 @@ public class MailProducerTest extends CamelTestSupport {
         mimeMessage.setSubject("This is the subject.");
         mimeMessage.setText("This is the message");
 
-        template.sendBodyAndHeader("direct:start", mimeMessage, "To", "someone@localhost");
+        template.sendBodyAndHeader("direct:start", mimeMessage, "To", someone.getEmail());
         MockEndpoint.assertIsSatisfied(context);
         // need to check the message header
         Exchange exchange = getMockEndpoint("mock:result").getExchanges().get(0);

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerUnsupportedCharsetTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailProducerUnsupportedCharsetTest.java
@@ -27,12 +27,14 @@ import org.apache.camel.component.mail.Mailbox.Protocol;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.apache.camel.test.junit6.TestSupport.assertIsInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Isolated
 public class MailProducerUnsupportedCharsetTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailProducerUnsupportedCharsetTest-jones", "secret");
 
     @Override
     public boolean isUseRouteBuilder() {
@@ -57,12 +59,12 @@ public class MailProducerUnsupportedCharsetTest extends CamelTestSupport {
         mock.allMessages().header("Content-Type").isEqualTo("text/plain");
 
         Map<String, Object> headers = new HashMap<>();
-        headers.put("To", "jones@localhost");
+        headers.put("To", jones.getEmail());
         headers.put("Content-Type", "text/plain");
         template.sendBodyAndHeaders(jones.uriPrefix(Protocol.smtp) + "&ignoreUnsupportedCharset=true", "Hello World", headers);
 
         headers.clear();
-        headers.put("To", "jones@localhost");
+        headers.put("To", jones.getEmail());
         headers.put("Content-Type", "text/plain; charset=ansi_x3.110-1983");
         template.sendBodyAndHeaders(jones.uriPrefix(Protocol.smtp) + "&ignoreUnsupportedCharset=true", "Bye World", headers);
 
@@ -87,12 +89,12 @@ public class MailProducerUnsupportedCharsetTest extends CamelTestSupport {
         mock.allMessages().header("Content-Type").isEqualTo("text/plain");
 
         Map<String, Object> headers = new HashMap<>();
-        headers.put("To", "jones@localhost");
+        headers.put("To", jones.getEmail());
         headers.put("Content-Type", "text/plain");
         template.sendBodyAndHeaders(jones.uriPrefix(Protocol.smtp) + "&ignoreUnsupportedCharset=false", "Hello World", headers);
 
         headers.clear();
-        headers.put("To", "jones@localhost");
+        headers.put("To", jones.getEmail());
         headers.put("Content-Type", "text/plain; charset=XXX");
 
         RuntimeCamelException e = assertThrows(RuntimeCamelException.class,

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailRecipientsPipeIssueTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailRecipientsPipeIssueTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for recipients using | in email address
  */
 public class MailRecipientsPipeIssueTest extends CamelTestSupport {
-    private static final MailboxUser you = Mailbox.getOrCreateUser("you", "secret");
+    private static final MailboxUser you = Mailbox.getOrCreateUser("MailRecipientsPipeIssueTest-you", "secret");
     private static final MailboxUser camelPipes = Mailbox.getOrCreateUser("camel|pipes@riders.org", "camelPipes", "secret");
     private static final MailboxUser easyPipes = Mailbox.getOrCreateUser("easyPipes@riders.org", "easyPipes", "secret");
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailReplyToTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailReplyToTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for Mail replyTo support.
  */
 public class MailReplyToTest extends CamelTestSupport {
-    private static final MailboxUser christian = Mailbox.getOrCreateUser("christian", "secret");
+    private static final MailboxUser christian = Mailbox.getOrCreateUser("MailReplyToTest-christian", "secret");
 
     @Test
     public void testMailReplyTo() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailRouteTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailRouteTest.java
@@ -41,9 +41,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MailRouteTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
-    private static final MailboxUser result = Mailbox.getOrCreateUser("result", "secret");
-    private static final MailboxUser copy = Mailbox.getOrCreateUser("copy", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailRouteTest-james", "secret");
+    private static final MailboxUser result = Mailbox.getOrCreateUser("MailRouteTest-result", "secret");
+    private static final MailboxUser copy = Mailbox.getOrCreateUser("MailRouteTest-copy", "secret");
 
     @Test
     public void testSendAndReceiveMails() throws Exception {
@@ -130,7 +130,7 @@ public class MailRouteTest extends CamelTestSupport {
                 // plain string with semi colon
                 // to seperate the mail addresses
                 from("direct:a")
-                        .setHeader("to", constant("result@localhost; copy@localhost"))
+                        .setHeader("to", constant(result.getEmail() + "; " + copy.getEmail()))
                         .to(result.uriPrefix(Protocol.smtp)
                             + "&useHeaderRecipients=true&useHeaderReplyTo=true&useHeaderSubject=true");
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSearchTermTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSearchTermTest.java
@@ -35,7 +35,7 @@ import static org.apache.camel.component.mail.SearchTermBuilder.Op;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MailSearchTermTest extends CamelTestSupport {
-    protected static final MailboxUser bill = Mailbox.getOrCreateUser("bill", "secret");
+    protected static final MailboxUser bill = Mailbox.getOrCreateUser("MailSearchTermTest-bill", "secret");
 
     @BindToRegistry("myTerm")
     private SearchTerm term = createSearchTerm();

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSearchTermUriConfigLast24HoursTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSearchTermUriConfigLast24HoursTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MailSearchTermUriConfigLast24HoursTest extends CamelTestSupport {
-    private static final MailboxUser bill = Mailbox.getOrCreateUser("bill", "secret");
+    private static final MailboxUser bill = Mailbox.getOrCreateUser("MailSearchTermUriConfigLast24HoursTest-bill", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailShutdownCompleteAllTasksTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailShutdownCompleteAllTasksTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for shutdown.
  */
 public class MailShutdownCompleteAllTasksTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailShutdownCompleteAllTasksTest-jones", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailShutdownCompleteCurrentTaskOnlyTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailShutdownCompleteCurrentTaskOnlyTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit test for shutdown.
  */
 public class MailShutdownCompleteCurrentTaskOnlyTest extends CamelTestSupport {
-    private static final MailboxUser jones = Mailbox.getOrCreateUser("jones", "secret");
+    private static final MailboxUser jones = Mailbox.getOrCreateUser("MailShutdownCompleteCurrentTaskOnlyTest-jones", "secret");
 
     @Override
     public void doPreSetup() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSplitAttachmentsTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSplitAttachmentsTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests the {@link SplitAttachmentsExpression}.
  */
 public class MailSplitAttachmentsTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailSplitAttachmentsTest-james", "secret");
 
     private Endpoint endpoint;
     private SplitAttachmentsExpression splitAttachmentsExpression;

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSubjectTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailSubjectTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Unit test for Mail subject support.
  */
 public class MailSubjectTest extends CamelTestSupport {
-    private static final MailboxUser james2 = Mailbox.getOrCreateUser("james2", "secret");
+    private static final MailboxUser james2 = Mailbox.getOrCreateUser("MailSubjectTest-james2", "secret");
     private String subject = "Camel rocks";
 
     @Test

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailToMultipleEndpointsTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailToMultipleEndpointsTest.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MailToMultipleEndpointsTest extends CamelTestSupport {
-    private static final MailboxUser james2 = Mailbox.getOrCreateUser("james2", "secret");
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
-    private static final MailboxUser admin = Mailbox.getOrCreateUser("admin", "secret");
+    private static final MailboxUser james2 = Mailbox.getOrCreateUser("MailToMultipleEndpointsTest-james2", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailToMultipleEndpointsTest-james", "secret");
+    private static final MailboxUser admin = Mailbox.getOrCreateUser("MailToMultipleEndpointsTest-admin", "secret");
 
-    private static final MailboxUser a = Mailbox.getOrCreateUser("a", "secret");
-    private static final MailboxUser b = Mailbox.getOrCreateUser("b", "secret");
-    private static final MailboxUser c = Mailbox.getOrCreateUser("c", "secret");
+    private static final MailboxUser a = Mailbox.getOrCreateUser("MailToMultipleEndpointsTest-a", "secret");
+    private static final MailboxUser b = Mailbox.getOrCreateUser("MailToMultipleEndpointsTest-b", "secret");
+    private static final MailboxUser c = Mailbox.getOrCreateUser("MailToMultipleEndpointsTest-c", "secret");
 
     @Test
     public void testMultipleEndpoints() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailUsingCustomSessionTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailUsingCustomSessionTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class MailUsingCustomSessionTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailUsingCustomSessionTest-james", "secret");
 
     @BindToRegistry("myCustomMailSession")
     private Session mailSession = Session.getInstance(new Properties());

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailUsingHeadersTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailUsingHeadersTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Unit test for Mail using camel headers to set recipient subject.
  */
 public class MailUsingHeadersTest extends CamelTestSupport {
-    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("davsclaus", "secret");
+    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("MailUsingHeadersTest-davsclaus", "secret");
 
     @Test
     public void testMailUsingHeaders() throws Exception {
@@ -42,7 +42,7 @@ public class MailUsingHeadersTest extends CamelTestSupport {
 
         // START SNIPPET: e1
         Map<String, Object> map = new HashMap<>();
-        map.put("To", "davsclaus@localhost");
+        map.put("To", davsclaus.getEmail());
         map.put("From", "jstrachan@apache.org");
         map.put("Subject", "Camel rocks");
         map.put("CamelFileName", "fileOne");
@@ -56,7 +56,7 @@ public class MailUsingHeadersTest extends CamelTestSupport {
 
         Mailbox box = davsclaus.getInbox();
         Message msg = box.get(0);
-        assertEquals("davsclaus@localhost", msg.getRecipients(Message.RecipientType.TO)[0].toString());
+        assertEquals(davsclaus.getEmail(), msg.getRecipients(Message.RecipientType.TO)[0].toString());
         assertEquals("jstrachan@apache.org", msg.getFrom()[0].toString());
         assertEquals("Camel rocks", msg.getSubject());
 
@@ -74,12 +74,13 @@ public class MailUsingHeadersTest extends CamelTestSupport {
         String body = "Hello Claus.\nYes it does.\n\nRegards James.";
         template.sendBodyAndHeaders(
                 davsclaus.uriPrefix(Protocol.smtp)
-                                    + "&from=James Strachan <jstrachan@apache.org>&to=davsclaus@localhost&useHeaderSubject=true",
+                                    + "&from=James Strachan <jstrachan@apache.org>&to=" + davsclaus.getEmail()
+                                    + "&useHeaderSubject=true",
                 body, map);
 
         Mailbox box = davsclaus.getInbox();
         Message msg = box.get(0);
-        assertEquals("davsclaus@localhost", msg.getRecipients(Message.RecipientType.TO)[0].toString());
+        assertEquals(davsclaus.getEmail(), msg.getRecipients(Message.RecipientType.TO)[0].toString());
         assertEquals("James Strachan <jstrachan@apache.org>", msg.getFrom()[0].toString());
         assertEquals("Camel rocks", msg.getSubject());
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailUsingOwnComponentTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailUsingOwnComponentTest.java
@@ -30,8 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Unit test for CAMEL-1249
  */
 public class MailUsingOwnComponentTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
-    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("davsclaus", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MailUsingOwnComponentTest-james", "secret");
+    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("MailUsingOwnComponentTest-davsclaus", "secret");
 
     @Override
     protected CamelContext createCamelContext() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMessageConsumeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMessageConsumeTest.java
@@ -47,8 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MimeMessageConsumeTest extends CamelTestSupport {
-    private static final MailboxUser james3 = Mailbox.getOrCreateUser("james3", "secret");
-    private static final MailboxUser james4 = Mailbox.getOrCreateUser("james4", "secret");
+    private static final MailboxUser james3 = Mailbox.getOrCreateUser("MimeMessageConsumeTest-james3", "secret");
+    private static final MailboxUser james4 = Mailbox.getOrCreateUser("MimeMessageConsumeTest-james4", "secret");
     private String body = "hello world!";
 
     @Test
@@ -62,7 +62,7 @@ public class MimeMessageConsumeTest extends CamelTestSupport {
 
         MimeMessage message = new MimeMessage(session);
         populateMimeMessageBody(message);
-        message.setRecipients(Message.RecipientType.TO, "james3@localhost");
+        message.setRecipients(Message.RecipientType.TO, james3.getEmail());
 
         Transport.send(message, james3.getLogin(), james3.getPassword());
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMultipartAlternativeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMultipartAlternativeTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MimeMultipartAlternativeTest extends CamelTestSupport {
-    private static final MailboxUser ryan = Mailbox.getOrCreateUser("ryan", "secret");
+    private static final MailboxUser ryan = Mailbox.getOrCreateUser("MimeMultipartAlternativeTest-ryan", "secret");
     private Logger log = LoggerFactory.getLogger(getClass());
     private String alternativeBody = "hello world! (plain text)";
     private String htmlBody = "<html><body><h1>Hello</h1>World<img src=\"cid:0001\"></body></html>";

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMultipartAlternativeWithContentTypeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMultipartAlternativeWithContentTypeTest.java
@@ -36,7 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MimeMultipartAlternativeWithContentTypeTest extends CamelTestSupport {
-    private static final MailboxUser sachin = Mailbox.getOrCreateUser("sachin", "secret");
+    private static final MailboxUser sachin
+            = Mailbox.getOrCreateUser("MimeMultipartAlternativeWithContentTypeTest-sachin", "secret");
     private Logger log = LoggerFactory.getLogger(getClass());
     private String alternativeBody = "hello world! (plain text)";
     private String htmlBody = "<html><body><h1>Hello</h1>World</body></html>";

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMultipartAlternativeWithLongerFilenameTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MimeMultipartAlternativeWithLongerFilenameTest.java
@@ -40,7 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MimeMultipartAlternativeWithLongerFilenameTest extends CamelTestSupport {
-    private static final MailboxUser ryanWithLongerFilename = Mailbox.getOrCreateUser("ryanWithLongerFilename", "secret");
+    private static final MailboxUser ryanWithLongerFilename
+            = Mailbox.getOrCreateUser("MimeMultipartAlternativeWithLongerFilenameTest-ryanWithLongerFilename", "secret");
     private Logger log = LoggerFactory.getLogger(getClass());
     private String alternativeBody = "hello world! (plain text)";
     private String htmlBody = "<html><body><h1>Hello</h1>World<img src=\"cid:myCoolLogo.jpeg\"></body></html>";

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MultipleDestinationConsumeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MultipleDestinationConsumeTest.java
@@ -43,8 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MultipleDestinationConsumeTest extends CamelTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
-    private static final MailboxUser bar = Mailbox.getOrCreateUser("bar", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("MultipleDestinationConsumeTest-james", "secret");
+    private static final MailboxUser bar = Mailbox.getOrCreateUser("MultipleDestinationConsumeTest-bar", "secret");
     private Logger log = LoggerFactory.getLogger(getClass());
     private String body = "hello world!\r\n";
     private Session mailSession;

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/NestedMimeMessageConsumeTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/NestedMimeMessageConsumeTest.java
@@ -44,8 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class NestedMimeMessageConsumeTest extends CamelTestSupport {
-    private static final MailboxUser james3 = Mailbox.getOrCreateUser("james3", "secret");
-    private static final MailboxUser james4 = Mailbox.getOrCreateUser("james4", "secret");
+    private static final MailboxUser james3 = Mailbox.getOrCreateUser("NestedMimeMessageConsumeTest-james3", "secret");
+    private static final MailboxUser james4 = Mailbox.getOrCreateUser("NestedMimeMessageConsumeTest-james4", "secret");
 
     @Test
     public void testNestedMultipart() throws Exception {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
@@ -34,6 +34,7 @@ import org.apache.camel.component.mail.Mailbox.Protocol;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,13 +45,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Unit test for Mail using camel headers to set recipient subject.
  */
+@Isolated
 public class RawMailMessageTest extends CamelTestSupport {
 
-    private static final MailboxUser jonesPop3 = Mailbox.getOrCreateUser("jonesPop3", "secret");
-    private static final MailboxUser jonesRawPop3 = Mailbox.getOrCreateUser("jonesRawPop3", "secret");
-    private static final MailboxUser jonesImap = Mailbox.getOrCreateUser("jonesImap", "secret");
-    private static final MailboxUser jonesRawImap = Mailbox.getOrCreateUser("jonesRawImap", "secret");
-    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("davsclaus", "secret");
+    private static final MailboxUser jonesPop3 = Mailbox.getOrCreateUser("RawMailMessageTest-jonesPop3", "secret");
+    private static final MailboxUser jonesRawPop3 = Mailbox.getOrCreateUser("RawMailMessageTest-jonesRawPop3", "secret");
+    private static final MailboxUser jonesImap = Mailbox.getOrCreateUser("RawMailMessageTest-jonesImap", "secret");
+    private static final MailboxUser jonesRawImap = Mailbox.getOrCreateUser("RawMailMessageTest-jonesRawImap", "secret");
+    private static final MailboxUser davsclaus = Mailbox.getOrCreateUser("RawMailMessageTest-davsclaus", "secret");
 
     @Override
     protected void setupResources() throws Exception {
@@ -78,7 +80,7 @@ public class RawMailMessageTest extends CamelTestSupport {
 
         getMockEndpoint("mock:mail").expectedMessageCount(1);
         template.sendBodyAndHeaders(
-                "smtp://davsclaus@localhost:" + Mailbox.getPort(Protocol.smtp) + "?password=" + davsclaus.getPassword()
+                "smtp://" + davsclaus.getEmail() + ":" + Mailbox.getPort(Protocol.smtp) + "?password=" + davsclaus.getPassword()
                                     + "&useHeaderRecipients=true&useHeaderFrom=true&useHeaderSubject=true",
                 body, map);
         MockEndpoint.assertIsSatisfied(context);

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/SpringMailSplitAttachmentsTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/SpringMailSplitAttachmentsTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Spring XML version of {@link MailSplitAttachmentsTest}
  */
 public class SpringMailSplitAttachmentsTest extends CamelSpringTestSupport {
-    private static final MailboxUser james = Mailbox.getOrCreateUser("james", "secret");
+    private static final MailboxUser james = Mailbox.getOrCreateUser("SpringMailSplitAttachmentsTest-james", "secret");
 
     private Endpoint endpoint;
     private Exchange exchange;

--- a/components/camel-mail/src/test/resources/org/apache/camel/component/mail/SpringMailSplitAttachmentsTest.xml
+++ b/components/camel-mail/src/test/resources/org/apache/camel/component/mail/SpringMailSplitAttachmentsTest.xml
@@ -28,7 +28,7 @@
 
   <camelContext xmlns="http://camel.apache.org/schema/spring">
     <route>
-      <from uri="imap://james@localhost:3143?password=secret&amp;initialDelay=100&amp;delay=100"/>
+      <from uri="imap://SpringMailSplitAttachmentsTest-james@localhost:3143?password=secret&amp;initialDelay=100&amp;delay=100"/>
       <to uri="log:email"/>
       <split>
         <ref>splitAttachments</ref>


### PR DESCRIPTION
- except for MailSortTerm* and MailSearchTerm* because they are reusing same username between them. These ones are not reported as flaky at all on develocity
- use also `@Isolated` for the most 2 reported as flaky. In fact, using `@Isolated` on all tests might be the next iteration if it is not stabilizing enough because there is a shared MailBox between all tests on which a clear all messages is called always, which could cause trouble. Another alternative would be to clean only the specific users from the specific test now that they are different between most of them

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

