### PR TITLE
CAMEL-23921 - reduce flakiness for mina sftp tests

### DIFF
--- a/components/camel-mina-sftp/src/test/java/org/apache/camel/component/file/remote/mina/integration/MinaSftpConcurrencyIT.java
+++ b/components/camel-mina-sftp/src/test/java/org/apache/camel/component/file/remote/mina/integration/MinaSftpConcurrencyIT.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Integration tests for MINA SFTP concurrency and thread safety.
  */
 @EnabledIf(value = "org.apache.camel.test.infra.ftp.services.embedded.SftpUtil#hasRequiredAlgorithms('src/test/resources/hostkey.pem')")
-@Tag("not-parallel")
+@Tag("isolated")
 public class MinaSftpConcurrencyIT extends MinaSftpServerTestSupport {
 
     private static final Logger log = LoggerFactory.getLogger(MinaSftpConcurrencyIT.class);

--- a/components/camel-mina-sftp/src/test/java/org/apache/camel/component/file/remote/mina/sftp/SftpChangedReadLockIT.java
+++ b/components/camel-mina-sftp/src/test/java/org/apache/camel/component/file/remote/mina/sftp/SftpChangedReadLockIT.java
@@ -18,12 +18,14 @@ package org.apache.camel.component.file.remote.mina.sftp;
 
 import java.io.FileOutputStream;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.test.junit6.TestSupport;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.camel.test.junit6.TestSupport.createDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("isolated")
 @EnabledIf(value = "org.apache.camel.test.infra.ftp.services.embedded.SftpUtil#hasRequiredAlgorithms('src/test/resources/sftp/hostkey.pem')")
 public class SftpChangedReadLockIT extends SftpServerTestSupport {
 
@@ -65,7 +68,7 @@ public class SftpChangedReadLockIT extends SftpServerTestSupport {
 
         String content = context.getTypeConverter().convertTo(String.class, testDirectory.resolve("out/slowfile.dat").toFile());
         String[] lines = content.split(LS);
-        assertEquals(20, lines.length, "There should be 20 lines in the file");
+        assertEquals(20, lines.length, "There should be 20 lines in the file.\n" + Arrays.toString(lines));
         for (int i = 0; i < 20; i++) {
             assertEquals("Line " + i, lines[i]);
         }


### PR DESCRIPTION
* one tests had tags not-parallel but this was not configured for this component, it was surely a copy-paster from ftp component. Changed to isolated which is used in this component.
* move to isolated SftpChangedReadLockIT which was flaky locally and include a better error message to help investigate in case it still happens

note1: wondering if we should not be enough to use `@Isolated` JUnit annotation instead of a specific Maven config and specific `@Tag`

note 2: in case these changes are not enough to stabilize the tests, I think we could try to remove the parallelism completely for all IT tests on this module.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

