### PR TITLE
[backport camel-4.14.x] CAMEL-23942: contain Azure Storage Blob/DataLake fileDir downloads within the configured directory

### DIFF
--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperations.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperations.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -145,7 +146,7 @@ public class BlobOperations {
             throw new IllegalArgumentException("In order to download a blob, you will need to specify the fileDir in the URI");
         }
 
-        final File fileToDownload = new File(fileDir, client.getBlobName());
+        final File fileToDownload = resolveWithinDirectory(fileDir, client.getBlobName());
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
         final BlobRange blobRange = configurationProxy.getBlobRange(exchange);
         final ParallelTransferOptions parallelTransferOptions = configurationProxy.getParallelTransferOptions(exchange);
@@ -634,5 +635,19 @@ public class BlobOperations {
         if (leaseClient != null) {
             leaseClient.releaseLease();
         }
+    }
+
+    private static File resolveWithinDirectory(String fileDir, String name) {
+        final File target = new File(fileDir, name);
+        // normalize lexically (removes ./ and ../ segments) and compare on path-segment boundaries so a sibling
+        // directory whose name merely extends fileDir is not considered contained
+        final Path normalizedDir = new File(fileDir).toPath().normalize();
+        final Path normalizedTarget = target.toPath().normalize();
+        if (!normalizedTarget.startsWith(normalizedDir)) {
+            throw new IllegalArgumentException(
+                    "Cannot download to file '" + name
+                                               + "' as it resolves outside the configured fileDir directory: " + fileDir);
+        }
+        return target;
     }
 }

--- a/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperationsTest.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/test/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperationsTest.java
@@ -125,6 +125,19 @@ class BlobOperationsTest extends CamelTestSupport {
     }
 
     @Test
+    void testDownloadBlobToFileRejectsPathTraversalName() {
+        // a blob name is influenced by whoever writes to the container and may contain ../ segments;
+        // the download must stay within the configured fileDir
+        configuration.setFileDir("/tmp/camel-azure-blob-download");
+        when(client.getBlobName()).thenReturn("../escaped/PROOF_PWNED");
+
+        final BlobOperations operations = new BlobOperations(configuration, client);
+        final Exchange exchange = new DefaultExchange(context);
+
+        assertThrows(IllegalArgumentException.class, () -> operations.downloadBlobToFile(exchange));
+    }
+
+    @Test
     void testUploadBlockBlob() throws Exception {
         // mocking
         final BlockBlobItem blockBlobItem = new BlockBlobItem("testTag", OffsetDateTime.now(), null, false, null);

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileOperations.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileOperations.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -106,7 +107,7 @@ public class DataLakeFileOperations {
             throw new IllegalArgumentException("to download a file, you need to specify the fileDir in the URI");
         }
         final DataLakeFileClientWrapper fileClientWrapper = getFileClientWrapper(exchange);
-        final File recieverFile = new File(fileDir, fileClientWrapper.getFileName());
+        final File recieverFile = resolveWithinDirectory(fileDir, fileClientWrapper.getFileName());
         final FileCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
         final FileRange fileRange = configurationProxy.getFileRange(exchange);
         final ParallelTransferOptions parallelTransferOptions = configurationProxy.getParallelTransferOptions(exchange);
@@ -252,5 +253,19 @@ public class DataLakeFileOperations {
     private DataLakeFileClientWrapper getFileClientWrapper(final Exchange exchange) {
         final DataLakeFileClient fileClient = configurationProxy.getFileClient(exchange);
         return null == fileClient ? client : new DataLakeFileClientWrapper(fileClient);
+    }
+
+    private static File resolveWithinDirectory(String fileDir, String name) {
+        final File target = new File(fileDir, name);
+        // normalize lexically (removes ./ and ../ segments) and compare on path-segment boundaries so a sibling
+        // directory whose name merely extends fileDir is not considered contained
+        final Path normalizedDir = new File(fileDir).toPath().normalize();
+        final Path normalizedTarget = target.toPath().normalize();
+        if (!normalizedTarget.startsWith(normalizedDir)) {
+            throw new IllegalArgumentException(
+                    "Cannot download to file '" + name
+                                               + "' as it resolves outside the configured fileDir directory: " + fileDir);
+        }
+        return target;
     }
 }

--- a/components/camel-azure/camel-azure-storage-datalake/src/test/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileOperationTest.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/test/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileOperationTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -91,6 +92,19 @@ public class DataLakeFileOperationTest extends CamelTestSupport {
         assertNotNull(secondResponse);
         assertNotNull(secondResponse.getBody());
         assertNotNull(secondResponse.getHeaders());
+    }
+
+    @Test
+    void testDownloadToFileRejectsPathTraversalName() {
+        // a file name is influenced by whoever writes to the file system and may contain ../ segments;
+        // the download must stay within the configured fileDir
+        configuration.setFileDir("/tmp/camel-azure-datalake-download");
+        when(client.getFileName()).thenReturn("../escaped/PROOF_PWNED");
+
+        final DataLakeFileOperations operations = new DataLakeFileOperations(configuration, client);
+        final Exchange exchange = new DefaultExchange(context);
+
+        assertThrows(IllegalArgumentException.class, () -> operations.downloadToFile(exchange));
     }
 
     @Test

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -1333,3 +1333,13 @@ non-`Camel`-prefixed application headers and map them to the corresponding
 the `salesforce:` `to`. As defence-in-depth, strip inbound Camel-internal headers
 arriving from untrusted producers with `removeHeaders("CamelSalesforce*")` (or the
 broader `removeHeaders("Camel*")`) before the producer.
+
+=== camel-azure-storage-blob / camel-azure-storage-datalake - download contained within fileDir
+
+When `fileDir` is configured, the Azure Storage Blob and DataLake consumers now ensure the downloaded
+local file stays within the configured directory, so a remote object name containing `../` sequences
+can no longer resolve to a path outside it. This is consistent with the containment already performed
+by the file-based consumers.
+
+Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
+`IllegalArgumentException`.


### PR DESCRIPTION
Backport of #24542 to `camel-4.14.x`.

## What

When `fileDir` is configured, the Azure Storage Blob and DataLake consumers build the local download target from the remote object name via `new File(fileDir, name)` with no containment check, so a name containing `../` segments could resolve to a location outside `fileDir`. This aligns them with the containment already performed by the file-based consumers.

## How

`camel-azure-common` does not exist on this branch (it was introduced in 4.19), so the shared `AzureFileNameHelper` from the main-branch fix cannot be reused here. Instead, the same guard is added as a small `private static` method in each of `BlobOperations` and `DataLakeFileOperations`: it resolves the name against `fileDir`, normalizes lexically, and verifies the result stays within `fileDir` on path-segment boundaries (`java.nio.file`), throwing `IllegalArgumentException` otherwise.

## Tests

- Wiring test in `BlobOperationsTest` / `DataLakeFileOperationTest` asserting a `../`-bearing object name is rejected at the download call site.

## Notes

- Upgrade-guide note added to `camel-4x-upgrade-guide-4_14.adoc`. The matching entry will also be synced to `main`'s copy of that guide per the backport upgrade-guide policy.

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
