### PR TITLE
CAMEL-23942: sync Azure Storage fileDir containment note to the 4.18/4.14 upgrade guides on main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -1575,3 +1575,13 @@ non-`Camel`-prefixed application headers and map them to the corresponding
 the `salesforce:` `to`. As defence-in-depth, strip inbound Camel-internal headers
 arriving from untrusted producers with `removeHeaders("CamelSalesforce*")` (or the
 broader `removeHeaders("Camel*")`) before the producer.
+
+=== camel-azure-storage-blob / camel-azure-storage-datalake - download contained within fileDir
+
+When `fileDir` is configured, the Azure Storage Blob and DataLake consumers now ensure the downloaded
+local file stays within the configured directory, so a remote object name containing `../` sequences
+can no longer resolve to a path outside it. This is consistent with the containment already performed
+by the file-based consumers.
+
+Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
+`IllegalArgumentException`.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -1876,3 +1876,13 @@ is migrated to JSON the next time the metadata is updated.
 
 Because older versions cannot read the new JSON metadata, downgrading after new key metadata has been
 written is not supported.
+
+=== camel-azure-storage-blob / camel-azure-storage-datalake - download contained within fileDir
+
+When `fileDir` is configured, the Azure Storage Blob and DataLake consumers now ensure the downloaded
+local file stays within the configured directory, so a remote object name containing `../` sequences
+can no longer resolve to a path outside it. This is consistent with the containment already performed
+by the file-based consumers.
+
+Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
+`IllegalArgumentException`.


### PR DESCRIPTION
Documentation sync to `main` (no code change).

Adds the Azure Storage `fileDir` containment note to `main`'s copies of the 4.18 and 4.14 upgrade guides, matching the notes shipped on the maintenance branches in #24581 (camel-4.18.x) and #24582 (camel-4.14.x). Per the backport upgrade-guide policy, the per-version `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the canonical history and must also carry the entries added on the maintenance branches.

The corresponding `main` (4.22) entry ships in #24542 (`camel-4x-upgrade-guide-4_22.adoc`).

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
