### PR TITLE
CAMEL-23980: Fix flaky JmsAddAndRemoveRouteManagementIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsAddAndRemoveRouteManagementIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsAddAndRemoveRouteManagementIT.java
@@ -27,6 +27,7 @@ import javax.management.ObjectName;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractJMSTest;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -75,7 +76,11 @@ public class JmsAddAndRemoveRouteManagementIT extends AbstractJMSTest {
 
         Set<ObjectName> before = mbeanServer.queryNames(query, null);
 
-        getMockEndpoint("mock:result").expectedMessageCount(1);
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+        // Allow extra time for the JMS consumer to subscribe to the broker
+        // after the route is started (the default 10 s can be too short on slow CI)
+        mock.setResultWaitTime(30_000);
 
         context.addRoutes(new RouteBuilder() {
             @Override
@@ -95,6 +100,11 @@ public class JmsAddAndRemoveRouteManagementIT extends AbstractJMSTest {
                     "There should be at least one new thread pool in JMX");
             duringRef.set(during);
         });
+
+        // Wait for the route to be fully started — thread pool registration in JMX
+        // does not guarantee the JMS consumer has subscribed to the broker yet
+        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> context.getRouteController().getRouteStatus("myNewRoute") == ServiceStatus.Started);
 
         // Identify the thread pools added by the new route
         Set<ObjectName> addedPools = new HashSet<>(duringRef.get());

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsAddAndRemoveRouteManagementIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsAddAndRemoveRouteManagementIT.java
@@ -27,9 +27,9 @@ import javax.management.ObjectName;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ProducerTemplate;
-import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractJMSTest;
+import org.apache.camel.component.jms.JmsTestHelper;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.infra.core.CamelContextExtension;
@@ -101,10 +101,9 @@ public class JmsAddAndRemoveRouteManagementIT extends AbstractJMSTest {
             duringRef.set(during);
         });
 
-        // Wait for the route to be fully started — thread pool registration in JMX
-        // does not guarantee the JMS consumer has subscribed to the broker yet
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
-                .until(() -> context.getRouteController().getRouteStatus("myNewRoute") == ServiceStatus.Started);
+        // Wait for the JMS consumer to actually subscribe to the broker —
+        // thread pool registration in JMX does not guarantee the listener is ready
+        JmsTestHelper.waitForJmsConsumerRoutes(context, "myNewRoute");
 
         // Identify the thread pools added by the new route
         Set<ObjectName> addedPools = new HashSet<>(duringRef.get());


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `JmsAddAndRemoveRouteManagementIT` test (14% failure rate on Develocity — 45 failures out of 323 runs).

**Root cause:** Race condition between route Started status and JMS consumer readiness. After `addRoutes()`, thread pool registration in JMX does not guarantee the JMS consumer has subscribed to the broker. On slow CI environments, the message sent immediately after `addRoutes()` may sit in the queue while the consumer is still subscribing, and `MockEndpoint`'s default 10-second wait times out.

**Fix:**
- Use `JmsTestHelper.waitForJmsConsumerRoutes()` (introduced in CAMEL-21438) after the thread pool check — this waits for the route uptime to exceed 100 ms, a proven heuristic for JMS listener registration on the broker
- Set `MockEndpoint.setResultWaitTime(30_000)` to accommodate the asynchronous JMS consumer subscription on slow CI

**JIRA:** [CAMEL-23980](https://issues.apache.org/jira/browse/CAMEL-23980)

## Test plan

- [x] Verified test compiles and passes locally
- [x] Post-fix 30x validation: **30/30 PASS** (0% failure rate, down from 14%)
- [x] CI passes