### PR TITLE
Fix flaky HazelcastReplicatedmapConsumerTest (18% failure rate)

### DIFF
--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapConsumerTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Route;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
@@ -56,9 +57,18 @@ public class HazelcastReplicatedmapConsumerTest extends CamelTestSupport {
     }
 
     @BeforeEach
-    public void resetState() {
+    public void resetState() throws Exception {
+        // Stop routes to deregister the Hazelcast entry listener before clearing
+        // the map. This prevents async REMOVED events from clear() from bleeding
+        // into the next test's mock expectations.
+        for (Route route : context.getRoutes()) {
+            context.getRouteController().stopRoute(route.getRouteId());
+        }
         map.clear();
         MockEndpoint.resetMocks(context);
+        for (Route route : context.getRoutes()) {
+            context.getRouteController().startRoute(route.getRouteId());
+        }
     }
 
     @Override
@@ -83,19 +93,26 @@ public class HazelcastReplicatedmapConsumerTest extends CamelTestSupport {
      * mail from talip (hazelcast) on 21.02.2011: MultiMap doesn't support eviction yet. We can and should add this feature.
      */
     @Test
-    public void testEvict() {
+    public void testEvict() throws InterruptedException {
         MockEndpoint out = getMockEndpoint("mock:evicted");
         out.expectedMessageCount(1);
         map.put("4711", "my-foo", 100, TimeUnit.MILLISECONDS);
-        Awaitility.await().atMost(30000, TimeUnit.MILLISECONDS).untilAsserted(
-                () -> MockEndpoint.assertIsSatisfied(context));
+        MockEndpoint.assertIsSatisfied(context, 30000, TimeUnit.MILLISECONDS);
     }
 
     @Test
     public void testRemove() throws InterruptedException {
         MockEndpoint out = getMockEndpoint("mock:removed");
         out.expectedMessageCount(1);
+
         map.put("4711", "my-foo");
+
+        // Wait for the ADDED event to be fully processed before removing,
+        // otherwise the remove may execute before the async ADDED event is delivered.
+        MockEndpoint added = getMockEndpoint("mock:added");
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> added.getReceivedCounter() >= 1);
+
         map.remove("4711");
         MockEndpoint.assertIsSatisfied(context, 5000, TimeUnit.MILLISECONDS);
         this.checkHeaders(out.getExchanges().get(0).getIn().getHeaders(), HazelcastConstants.REMOVED);


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fixes the persistent flakiness of `HazelcastReplicatedmapConsumerTest` (18% failure rate on Develocity — 35/194 runs failing). The prior fix ([CAMEL-22506](https://issues.apache.org/jira/browse/CAMEL-22506)) added `map.clear()` + mock reset in `@BeforeEach`, but that approach itself introduces the flakiness because `clear()` fires async REMOVED events through the still-active Hazelcast entry listener.

**Root cause:** `map.clear()` in `@BeforeEach` fires async REMOVED events that bleed between tests because the Hazelcast `EntryListener` is still registered. Additionally, `testRemove()` calls `map.remove()` immediately after `map.put()` without waiting for the ADDED event to be processed, creating a race condition.

**Fix:**
- **`@BeforeEach`**: Stop routes before clearing the map to deregister the entry listener (via `HazelcastReplicatedmapConsumer.doStop()`), preventing stale REMOVED events from reaching mock endpoints. Restart routes after clearing and resetting mocks.
- **`testRemove()`**: Wait for the ADDED event to be delivered before calling `remove()`, eliminating the put/remove race.
- **`testEvict()`**: Replace redundant Awaitility-wrapped `MockEndpoint.assertIsSatisfied()` with the native latch-based timed assertion (per project conventions — Awaitility polls on top of an already-waiting mechanism).

## Test plan

- [x] All 3 tests pass locally
- [x] Validated with **100 consecutive runs — 0 failures** (vs. ~18 expected failures without fix)
- [x] Code formatted with `mvn formatter:format impsort:sort`
- [x] CI build passed (Java 17 ✅, Java 25 ✅) — [run 29100025144](https://github.com/apache/camel/actions/runs/29100025144)