### PR TITLE
test-infra: enable prepared transactions in the postgres container

### DIFF
--- a/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-postgres/src/main/java/org/apache/camel/test/infra/postgres/services/PostgresLocalContainerInfraService.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.test.infra.postgres.services;
 
+import java.util.Arrays;
+
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
@@ -62,6 +64,16 @@ public class PostgresLocalContainerInfraService implements PostgresInfraService,
 
                 ContainerEnvironmentUtil.configurePort(this, fixedPort, 5432);
                 withLogConsumer(new Slf4jLogConsumer(LOG));
+
+                // PostgreSQL disables prepared transactions by default
+                // (max_prepared_transactions = 0), which rejects the PREPARE TRANSACTION
+                // issued by XA two-phase commit. Append to the command configured by
+                // testcontainers ("postgres -c fsync=off") instead of replacing it.
+                String[] command = getCommandParts();
+                String[] augmented = Arrays.copyOf(command, command.length + 2);
+                augmented[command.length] = "-c";
+                augmented[command.length + 1] = "max_prepared_transactions=100";
+                setCommand(augmented);
             }
         }
 


### PR DESCRIPTION
Enable real 2PC capabilities

I've tested the Camel components that uses test-infra-postgres successfully

# Description

PostgreSQL ships with `max_prepared_transactions = 0`, which disables prepared transactions entirely — any XA two-phase commit against it fails at prepare time with:

```
ERROR: prepared transactions are disabled
Hint: Set "max_prepared_transactions" to a nonzero value.
```

This is easy to miss because a JTA transaction with a *single* participant never issues `PREPARE TRANSACTION` (one-phase-commit optimization); the failure only appears once a second resource (e.g. JMS) enlists in the same transaction. The parameter can only be changed with a server restart, so it cannot be fixed after the fact on a running container.

This change starts the `camel-test-infra-postgres` container with `-c max_prepared_transactions=100`, appended to the command already configured by testcontainers so the existing `-c fsync=off` is preserved. It benefits both test-infra consumers (e.g. enables writing real two-resource 2PC tests for camel-jta) and `camel infra run postgres` users running distributed XA examples.

Risk to existing tests is minimal: the setting is purely additive capacity (shared-memory slots for prepared transactions) and changes nothing for clients that never issue `PREPARE TRANSACTION`. Verified by starting the service and checking `SHOW max_prepared_transactions` returns `100` with the container command `postgres -c fsync=off -c max_prepared_transactions=100`.