### PR TITLE
CAMEL-24002: Fix cmd send exit code and terminated launcher ambiguity

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/ActionBaseCommand.java
@@ -95,22 +95,27 @@ abstract class ActionBaseCommand extends CamelCommand {
                     JsonObject root = loadStatus(ph.pid());
                     // there must be a status file for the running Camel integration
                     if (root != null) {
+                        // skip terminated processes (e.g. launcher process for spring-boot/quarkus runtimes)
+                        JsonObject context = (JsonObject) root.get("context");
+                        if (context != null) {
+                            int phase = context.getIntegerOrDefault("phase", 0);
+                            if (phase >= 9) {
+                                return;
+                            }
+                        }
                         String pName = ProcessHelper.extractName(root, ph);
                         // ignore file extension, so it is easier to match by name
                         pName = FileUtil.onlyName(pName);
                         if (pName != null && !pName.isEmpty() && PatternHelper.matchPattern(pName, pattern)) {
                             pids.add(ph.pid());
-                        } else {
+                        } else if (context != null) {
                             // try camel context name
-                            JsonObject context = (JsonObject) root.get("context");
-                            if (context != null) {
-                                pName = context.getString("name");
-                                if ("CamelJBang".equals(pName)) {
-                                    pName = null;
-                                }
-                                if (pName != null && !pName.isEmpty() && PatternHelper.matchPattern(pName, pattern)) {
-                                    pids.add(ph.pid());
-                                }
+                            pName = context.getString("name");
+                            if ("CamelJBang".equals(pName)) {
+                                pName = null;
+                            }
+                            if (pName != null && !pName.isEmpty() && PatternHelper.matchPattern(pName, pattern)) {
+                                pids.add(ph.pid());
                             }
                         }
                     }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSendAction.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/action/CamelSendAction.java
@@ -225,12 +225,10 @@ public class CamelSendAction extends ActionBaseCommand {
         this.pid = pids.get(0);
 
         Path outputFile = writeSendData();
-        showStatus(outputFile);
-
-        return 0;
+        return showStatus(outputFile);
     }
 
-    protected void showStatus(Path outputFile) throws Exception {
+    protected int showStatus(Path outputFile) throws Exception {
         try {
             // wait longer than timeout
             JsonObject jo = getJsonObject(outputFile, timeout + 10000);
@@ -278,8 +276,14 @@ public class CamelSendAction extends ActionBaseCommand {
                         printer().println(table);
                     }
                 }
+                String status = jo.getString("status");
+                if ("failed".equals(status) || "error".equals(status) || "timeout".equals(status)) {
+                    return 1;
+                }
+                return 0;
             } else {
                 printer().println("Send timeout");
+                return 1;
             }
         } finally {
             // delete output file after use


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- **Fix ambiguous name matching**: `findPids` in `ActionBaseCommand` now checks `context.phase` from the status JSON and skips entries with phase >= 9 (Terminated). This prevents stale launcher processes from exported runtimes (spring-boot/quarkus) from matching alongside the real application process.
- **Fix exit code**: `showStatus` in `CamelSendAction` changed from `void` to `int`, returning 1 on timeout, failed, or error status. `doCall(name)` now propagates this exit code instead of hardcoding `return 0`.

Fixes: https://issues.apache.org/jira/browse/CAMEL-24002

## Test plan

- [ ] Run `camel run route.yaml --runtime=spring-boot --name=test` and verify `camel ps` shows Terminated + Running entries
- [ ] Run `camel cmd send test --endpoint=direct:foo --body=hello` and verify it targets only the Running process
- [ ] Verify `echo $?` returns non-zero on send timeout or failure
- [ ] Verify `echo $?` returns 0 on successful send

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>