### PR TITLE
CAMEL-24001: Fix RestBindingAdvice setting Content-Type on body-less responses

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetContentTypeEmptyBodyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/rest/FromRestGetContentTypeEmptyBodyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.rest;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.Registry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class FromRestGetContentTypeEmptyBodyTest extends ContextTestSupport {
+
+    @Override
+    protected Registry createCamelRegistry() throws Exception {
+        Registry jndi = super.createCamelRegistry();
+        jndi.bind("dummy-rest", new DummyRestConsumerFactory());
+        return jndi;
+    }
+
+    @Test
+    public void testNoContentTypeOnEmptyBody() {
+        Exchange out = template.request("seda:delete-say-hello", exchange -> {
+            // no body
+        });
+
+        assertNotNull(out);
+        assertNull(out.getMessage().getBody(), "Body should be null");
+        assertNull(out.getMessage().getHeader(Exchange.CONTENT_TYPE),
+                "Content-Type should not be set on a body-less response");
+    }
+
+    @Test
+    public void testContentTypeSetOnNonEmptyBody() {
+        Exchange out = template.request("seda:get-say-hello", exchange -> {
+            // no body
+        });
+
+        assertNotNull(out);
+        assertEquals("{ \"name\" : \"Donald\" }", out.getMessage().getBody());
+        assertEquals("application/json", out.getMessage().getHeader(Exchange.CONTENT_TYPE));
+    }
+
+    @Test
+    public void testContentTypeJsonWhenMultiValueProduces() {
+        Exchange out = template.request("seda:get-say-multi", exchange -> {
+            // no body
+        });
+
+        assertNotNull(out);
+        assertEquals("{ \"name\" : \"Donald\" }", out.getMessage().getBody());
+        assertEquals("application/json", out.getMessage().getHeader(Exchange.CONTENT_TYPE));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                restConfiguration().host("localhost");
+
+                rest("/say/hello")
+                        .produces("application/json")
+                        .delete().to("direct:delete")
+                        .get().to("direct:hello");
+
+                rest("/say/multi")
+                        .produces("application/json,text/plain")
+                        .get().to("direct:hello");
+
+                from("direct:delete")
+                        .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(204))
+                        .setBody(constant(null));
+
+                from("direct:hello")
+                        .setBody(constant("{ \"name\" : \"Donald\" }"));
+            }
+        };
+    }
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/RestBindingAdvice.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/RestBindingAdvice.java
@@ -392,6 +392,11 @@ public class RestBindingAdvice extends ServiceSupport implements CamelInternalPr
         // need to prepare exchange first
         ExchangeHelper.prepareOutToIn(exchange);
 
+        // is the body empty (no Content-Type should be set for body-less responses such as 204 No Content)
+        if (exchange.getMessage().getBody() == null) {
+            return;
+        }
+
         // ensure there is a content type header (even if binding is off)
         ensureHeaderContentType(produces, isXml, isJson, exchange);
 
@@ -402,11 +407,6 @@ public class RestBindingAdvice extends ServiceSupport implements CamelInternalPr
 
         // is there any marshaller at all
         if (jsonMarshal == null && xmlMarshal == null) {
-            return;
-        }
-
-        // is the body empty
-        if (exchange.getMessage().getBody() == null) {
             return;
         }
 
@@ -484,27 +484,18 @@ public class RestBindingAdvice extends ServiceSupport implements CamelInternalPr
     }
 
     private void ensureHeaderContentType(String contentType, boolean isXml, boolean isJson, Exchange exchange) {
-        // favor given content type
-        if (contentType != null) {
-            String type = ExchangeHelper.getContentType(exchange);
-            if (type == null) {
-                exchange.getIn().setHeader(Exchange.CONTENT_TYPE, contentType);
-            }
+        String type = ExchangeHelper.getContentType(exchange);
+        if (type != null) {
+            return;
         }
 
-        // favor json over xml
+        // favor json over xml as a concrete single media type
         if (isJson) {
-            // make sure there is a content-type with json
-            String type = ExchangeHelper.getContentType(exchange);
-            if (type == null) {
-                exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/json");
-            }
+            exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/json");
         } else if (isXml) {
-            // make sure there is a content-type with xml
-            String type = ExchangeHelper.getContentType(exchange);
-            if (type == null) {
-                exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/xml");
-            }
+            exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/xml");
+        } else if (contentType != null) {
+            exchange.getIn().setHeader(Exchange.CONTENT_TYPE, contentType);
         }
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes two bugs in `RestBindingAdvice.marshal()` related to Content-Type handling:

**Bug 1 - Content-Type set on body-less responses:** `ensureHeaderContentType()` was called before the null-body check, so responses with no body (e.g. 204 No Content) got a spurious Content-Type header. Moved the null-body check to before the `ensureHeaderContentType()` call.

**Bug 2 - Multi-value `produces` used as Content-Type:** `ensureHeaderContentType()` set the raw comma-separated `produces` string (e.g. `application/json,text/plain`) as Content-Type before the `isJson`/`isXml` fallback branches had a chance to set a proper single media type. Reordered the priority so `isJson`/`isXml` are checked first (setting `application/json` or `application/xml`), with the raw `produces` string only used as a last resort.

## Test plan

- [x] New test `FromRestGetContentTypeEmptyBodyTest` with 3 test cases:
  - `testNoContentTypeOnEmptyBody` - verifies no Content-Type on null-body response
  - `testContentTypeSetOnNonEmptyBody` - verifies `application/json` set on response with body
  - `testContentTypeJsonWhenMultiValueProduces` - verifies `application/json` (not multi-value) when `produces` contains multiple media types
- [x] All existing `FromRest*` tests pass (35 tests, 0 failures)
- [x] Full `camel-core` test suite passes (7264 tests, 0 failures)
- [x] Full reactor build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>