### PR TITLE
chore: ignore .mcp.json (Claude Code project MCP config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ mvnd.zip*
 .mvn/.develocity/develocity-workspace-id
 backlog
 .claude
+.mcp.json
 .omc


### PR DESCRIPTION
## Description

Adds `.mcp.json` to `.gitignore`.

`.mcp.json` is Claude Code's project-scoped MCP server configuration file. It is a local developer-tooling artifact and should not be committed to the repository, similar to the existing `.claude` entry it is grouped next to.

## Rationale

- Prevents contributors who use Claude Code from accidentally committing personal/local MCP server definitions.
- Consistent with the already-ignored `.claude` directory (AI tooling artifacts).

No production, build, or runtime code is affected.

---
_Claude Code on behalf of ammachado_

🤖 Generated with [Claude Code](https://claude.com/claude-code)