### PR TITLE
chore: ignore .codex (Codex local config dir)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ mvnd.zip*
 .mvn/.develocity/develocity-workspace-id
 backlog
 .claude
+.codex
 .mcp.json
 .omc


### PR DESCRIPTION
## Description

Adds `.codex` to `.gitignore`.

`.codex` is Codex's project-scoped configuration directory (e.g. `config.toml`). It is a local developer-tooling artifact and should not be committed to the repository, similar to the existing `.claude` entry it is grouped next to.

## Rationale

- Prevents contributors who use Codex from accidentally committing personal/local Codex configuration.
- Consistent with the already-ignored `.claude` directory and `.mcp.json` file (AI tooling artifacts).

No production, build, or runtime code is affected.

---
_Claude Code on behalf of ammachado_

🤖 Generated with [Claude Code](https://claude.com/claude-code)