### PR TITLE
CAMEL-23886: Fix flaky NatsConsumerWithRedeliveryIT

### DIFF
--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerWithRedeliveryIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/integration/NatsConsumerWithRedeliveryIT.java
@@ -20,13 +20,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.EndpointInject;
 import org.apache.camel.LoggingLevel;
+import org.apache.camel.Route;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.nats.NatsConsumer;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NatsConsumerWithRedeliveryIT extends NatsITSupport {
 
@@ -43,16 +44,17 @@ public class NatsConsumerWithRedeliveryIT extends NatsITSupport {
         mockResultEndpoint.setExpectedMessageCount(1);
         exception.setExpectedMessageCount(1);
 
+        // Wait for the NATS consumer to be subscribed before sending messages,
+        // since core NATS does not persist messages for inactive subscribers
+        await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> context.getRoutes().stream()
+                        .map(Route::getConsumer)
+                        .anyMatch(c -> c instanceof NatsConsumer nc && nc.isActive()));
+
         template.sendBody("direct:send", "test");
         template.sendBody("direct:send", "golang");
 
-        await().atMost(30, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertEquals(1, exception.getReceivedCounter(),
-                            "mock:exception should have received the message after redelivery exhaustion");
-                    assertEquals(1, mockResultEndpoint.getReceivedCounter(),
-                            "mock:result should have received the non-failing message");
-                });
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix the intermittently failing `NatsConsumerWithRedeliveryIT.testConsumer` test (CAMEL-23886).

**Root cause:** `NatsConsumer.doStart()` submits the subscription task asynchronously via `executor.submit()`. On slow CI machines, messages sent to NATS can arrive before the consumer subscription is active. Since core NATS does not persist messages for inactive subscribers, those messages are silently lost — causing `mock:exception` to receive 0 messages instead of 1.

**Evidence from Develocity:** The test showed 6 flaky runs out of 231 total CI builds (~2.6% failure rate) over the past 2 weeks. A prior fix (CAMEL-23884) improved assertion timing but did not address this root cause.

**Changes:**
- Wait for the `NatsConsumer` to be active (subscription established) before sending any messages, using Awaitility to poll `NatsConsumer.isActive()`
- Replace Awaitility-based assertion with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` which is latch-based (more efficient than polling)

## Test plan

- [x] Code compiles successfully
- [x] Formatting and import sort checks pass
- [ ] CI integration test passes (requires Docker/Testcontainers)
- [ ] Monitor CI for flaky test recurrence after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)