### PR TITLE
CAMEL-23887: Fix flaky SjmsConnectionRecoveryTest timing issues

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
@@ -133,7 +133,7 @@ public class SjmsConnectionRecoveryTest extends CamelTestSupport {
         // Phase 1: verify normal consumption (also confirms consumer is fully started)
         mock.expectedMessageCount(1);
         template.sendBody(SJMS_QUEUE_NAME, "before-failure");
-        mock.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
         mock.reset();
 
         // Phase 2: simulate a transient JMS connection exception.
@@ -145,29 +145,31 @@ public class SjmsConnectionRecoveryTest extends CamelTestSupport {
         ExceptionListener container = (ExceptionListener) containerField.get(sjmsConsumer);
         container.onException(new JMSException("Simulated transient connection failure"));
 
-        // Phase 3: wait for recovery to complete and for multiple recovery intervals to pass.
-        // With recoveryInterval=1000ms and BackgroundTask initial delay=1s:
-        //   t=0s: onException fires, consumers/sessions nullified, recovery scheduled
-        //   t=1s: recovery iteration 1 — creates new connection + consumers
-        //   t=2s: BUG: iteration 2 — creates another connection, skips consumer re-creation
-        //   t=3s: BUG: iteration 3 — creates yet another connection
-        // By t=4s, if the bug is present, 3+ connections were created.
-        await().pollDelay(4 * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
-                .atMost(5 * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
-                .until(() -> true);
+        // Phase 3: wait for recovery to create a new connection.
+        // This uses a condition-based wait instead of a hardcoded sleep, so it
+        // adapts to CI environments where recovery may take longer.
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> countingFactory.createCount.get() > connectionsBefore);
 
-        // Phase 4: assert recovery happened exactly once and stopped.
-        int connectionsAfter = countingFactory.createCount.get();
-        int recoveryConnections = connectionsAfter - connectionsBefore;
-        assertEquals(1, recoveryConnections,
-                "Recovery should create exactly one new connection and stop, "
-                                             + "but created " + recoveryConnections
-                                             + " — the recovery loop did not stop after successful reconnection");
+        // Phase 4: verify recovery created exactly one connection and then stopped.
+        // First confirm exactly one new connection was created.
+        int connectionsAfterRecovery = countingFactory.createCount.get();
+        assertEquals(connectionsBefore + 1, connectionsAfterRecovery,
+                "Recovery should create exactly one new connection");
+
+        // Then wait several recovery intervals to confirm no additional connections
+        // are created — this catches the infinite-loop bug where recovery keeps
+        // destroying and recreating connections.
+        await().pollDelay(3 * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
+                .atMost(5 * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertEquals(connectionsAfterRecovery,
+                        countingFactory.createCount.get(),
+                        "Recovery loop should have stopped — connection count should remain stable"));
 
         // Phase 5: verify messages are consumed after recovery.
         mock.expectedMessageCount(1);
         template.sendBody(SJMS_QUEUE_NAME, "after-failure");
-        mock.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fixes [CAMEL-23887](https://issues.apache.org/jira/browse/CAMEL-23887) — flaky `SjmsConnectionRecoveryTest` in camel-sjms surefire tests with ~13% failure rate (23 failures + 7 flaky out of 241 CI runs in the last 10 days on Develocity).

**Root cause**: The test used a disguised `Thread.sleep()` via `await().until(() -> true)` — a hardcoded 4-second wait that doesn't adapt to slow CI environments. When recovery takes longer than expected, the assertion fires too early (wrong count) or the mock assertion hangs (10-minute surefire timeout).

**Changes**:
- **Phase 1/5**: Use `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` instead of the instance method with default 10s timeout. The route uses `asyncStartListener=true`, so consumers may need more time on slow CI.
- **Phase 3**: Replace `await().pollDelay(4s).until(() -> true)` (sleep disguised as Awaitility) with a condition-based wait: `await().atMost(30s).until(() -> createCount > connectionsBefore)`. This adapts to any CI speed.
- **Phase 4**: Add a stabilization check — after confirming one recovery connection was created, wait 3 more recovery intervals and assert the count hasn't increased. This correctly detects the infinite-loop bug without relying on hardcoded timing.

## Test plan

- [x] Compilation passes (`mvn compile test-compile -pl components/camel-sjms -am`)
- [ ] `SjmsConnectionRecoveryTest` passes on CI (requires Docker for Testcontainers/Artemis)
- [ ] No regressions in other camel-sjms surefire tests
- [ ] Verify reduced flake rate on Develocity after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)