### PR TITLE
CAMEL-24005: Fix flaky JmsTransactedDeadLetterChannel*RollbackOnExceptionIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/tx/JmsTransactedDeadLetterChannelHandlerRollbackOnExceptionIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/tx/JmsTransactedDeadLetterChannelHandlerRollbackOnExceptionIT.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.integration.tx;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.jms.ConnectionFactory;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -23,6 +25,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Handler;
 import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.test.infra.artemis.common.ConnectionFactoryHelper;
@@ -36,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentTransacted;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tags({ @Tag("not-parallel"), @Tag("transaction") })
 public class JmsTransactedDeadLetterChannelHandlerRollbackOnExceptionIT extends CamelTestSupport {
@@ -86,11 +90,17 @@ public class JmsTransactedDeadLetterChannelHandlerRollbackOnExceptionIT extends 
 
     @Test
     public void shouldNotLoseMessagesOnExceptionInErrorHandler() {
+        // wait for the exchange to be fully done (processed + transaction committed/rolled back)
+        // before checking the DLQ, to avoid a race between route processing and the assertion
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+
         template.sendBody(testingEndpoint, "Hello World");
+
+        assertTrue(notify.matches(30, TimeUnit.SECONDS), "Exchange should be done");
 
         // as we handle new exception, then the exception is ignored
         // and causes the transaction to commit, so there is no message in the DLQ queue
-        Object dlqBody = consumer.receiveBody("activemq:" + DLQ_NAME, 10000);
+        Object dlqBody = consumer.receiveBody("activemq:" + DLQ_NAME, 2000);
         assertNull(dlqBody, "Should not rollback the transaction");
     }
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/tx/JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/tx/JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.integration.tx;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.jms.ConnectionFactory;
 
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -25,6 +27,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Handler;
 import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.test.infra.artemis.common.ConnectionFactoryHelper;
@@ -38,6 +41,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentTransacted;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tags({ @Tag("not-parallel"), @Tag("transaction") })
 public class JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT extends CamelTestSupport {
@@ -91,11 +95,17 @@ public class JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT exten
 
     @Test
     public void shouldNotLoseMessagesOnExceptionInErrorHandler() {
+        // wait for the exchange to be fully done (processed + transaction rolled back)
+        // before checking the DLQ, to avoid a race between route processing and the assertion
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+
         template.sendBody(testingEndpoint, "Hello World");
+
+        assertTrue(notify.matches(30, TimeUnit.SECONDS), "Exchange should be done");
 
         // as we do not handle new exception, then the exception propagates back
         // and causes the transaction to rollback, and we can find the message in the DLQ
-        Object dlqBody = consumer.receiveBody("activemq:" + DLQ_NAME, 30000);
+        Object dlqBody = consumer.receiveBody("activemq:" + DLQ_NAME, 10000);
         assertEquals("Hello World", dlqBody);
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `JmsTransactedDeadLetterChannelHandlerRollbackOnExceptionIT` and `JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT` integration tests.

**Develocity data** (last 10 days on CI):
- `HandlerRollbackOnExceptionIT`: 41 failures + 5 flaky out of 517 runs (**8.9% failure rate**)
- `NotHandlerRollbackOnExceptionIT`: 11 failures + 14 flaky

**Root cause**: Both tests check the DLQ contents immediately after `template.sendBody()`, without waiting for the transacted route to fully process the exchange and commit/rollback the transaction. Under CI load, the route processing may not complete before the DLQ assertion runs, causing the test to see the message in the DLQ when the transaction hasn't committed yet (Handler test), or not see it when the rollback hasn't completed yet (NotHandler test).

**Fix**: Use `NotifyBuilder.whenDone(1)` to wait until the exchange is fully processed (including transaction commit/rollback) before checking the DLQ contents. This eliminates the race condition between the asynchronous route processing and the test assertion. The `receiveBody` timeout is also adjusted since `NotifyBuilder` already ensures the exchange is done.

## Test plan
- [x] `JmsTransactedDeadLetterChannelHandlerRollbackOnExceptionIT` passes locally
- [x] `JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT` passes locally
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)