### PR TITLE
CAMEL-24016: Fix flaky JmsSpringLoadBalanceFailOverJMSIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/JmsSpringLoadBalanceFailOverJMSIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/JmsSpringLoadBalanceFailOverJMSIT.java
@@ -16,10 +16,13 @@
  */
 package org.apache.camel.component.jms.integration.spring;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -31,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @Tags({ @Tag("not-parallel"), @Tag("spring") })
 @Isolated
+@Timeout(60)
 public class JmsSpringLoadBalanceFailOverJMSIT extends AbstractSpringJMSITSupport {
 
     @Override
@@ -48,7 +52,7 @@ public class JmsSpringLoadBalanceFailOverJMSIT extends AbstractSpringJMSITSuppor
         String out = template.requestBody("direct:start", "Hello World", String.class);
         assertEquals("Bye World", out);
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
 }


### PR DESCRIPTION
## Summary

- Increase `MockEndpoint.assertIsSatisfied` timeout from default 10s to 30s using the timed overload `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`
- Add `@Timeout(60)` to prevent the test from hanging indefinitely

The test exercises a failover load balancer over JMS queues, which involves multiple JMS round-trips (send to foo queue, exception reply, retry to bar queue, success reply). Under CI load, the default 10-second `MockEndpoint` timeout is insufficient for this multi-hop JMS flow, causing a 3.8% flake rate (10 failed, 8 flaky out of 479 CI runs).

## Test plan

- [x] Run `mvn test -pl components/camel-jms -Dtest=JmsSpringLoadBalanceFailOverJMSIT -am`
- [x] Verify code formatting with `mvn formatter:format impsort:sort`

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)