### PR TITLE
CAMEL-24014: Fix flaky JmsDurableTopicIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsDurableTopicIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsDurableTopicIT.java
@@ -21,8 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractPersistentJMSTest;
+import org.apache.camel.component.jms.JmsTestHelper;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -32,6 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Timeout(30)
 public class JmsDurableTopicIT extends AbstractPersistentJMSTest {
+
+    // topic subscriptions take a little longer to register than queue consumers, so keep the longer 200ms threshold
+    private static final long TOPIC_ROUTE_UPTIME_MILLIS = 200;
+
     private MockEndpoint mock;
     private MockEndpoint mock2;
 
@@ -43,7 +47,11 @@ public class JmsDurableTopicIT extends AbstractPersistentJMSTest {
         mock2 = getMockEndpoint("mock:result2");
         mock2.expectedBodiesReceived("Hello World");
 
-        Awaitility.await().until(() -> context.getRoute("route-2").getUptimeMillis() > 200);
+        // Wait for BOTH durable topic consumer routes to be ready before sending.
+        // The original code only waited for route-2, so route-1's subscriber could
+        // still be registering when the message was published, causing mock:result
+        // to miss the message intermittently.
+        JmsTestHelper.waitForJmsConsumerRoutes(context, TOPIC_ROUTE_UPTIME_MILLIS, "route-1", "route-2");
     }
 
     @Test


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `JmsDurableTopicIT` (~2.8% failure rate — 2 failed, 12 flaky out of 494 CI runs).

- **Root cause**: The `@BeforeEach` setup only waited for `route-2` to reach 200ms uptime before the test sent a message to the durable topic. `route-1`'s durable subscriber could still be registering with the broker, so `mock:result` intermittently missed the message.
- **Fix**: Use the shared `JmsTestHelper.waitForJmsConsumerRoutes()` helper (introduced in CAMEL-21438) to wait for **both** `route-1` and `route-2` before sending, consistent with the pattern used in `SingleMessageSameTopicIT` and `JmsAddAndRemoveRouteManagementIT`.

## Test plan

- [x] `mvn test -pl components/camel-jms -Dtest=JmsDurableTopicIT` passes locally
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)