### PR TITLE
CAMEL-24013: Fix flaky RawMailMessageTest

### DIFF
--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/RawMailMessageTest.java
@@ -69,8 +69,6 @@ public class RawMailMessageTest extends CamelTestSupport {
 
     @Test
     public void testGetRawJavaMailMessage() throws Exception {
-        Mailbox.clearAll();
-
         Map<String, Object> map = new HashMap<>();
         map.put("To", davsclaus.getEmail());
         map.put("From", "jstrachan@apache.org");
@@ -188,7 +186,7 @@ public class RawMailMessageTest extends CamelTestSupport {
                      + "&closeFolder=false&initialDelay=100&delay=100&delete=true&mapMailMessage=false")
                         .to("mock://rawMessagePop3");
 
-                from(jonesImap.uriPrefix(Protocol.imap)
+                from(jonesRawImap.uriPrefix(Protocol.imap)
                      + "&closeFolder=false&initialDelay=100&delay=100&delete=true&mapMailMessage=false")
                         .to("mock://rawMessageImap");
 


### PR DESCRIPTION
## Summary

Fix flaky `RawMailMessageTest` (12.4% failure rate in CI) caused by two race conditions:

1. **Wrong mailbox user in IMAP raw route**: The route for raw IMAP messages was consuming from `jonesImap` instead of `jonesRawImap`. This meant two routes (raw IMAP and normal IMAP) competed for the same single message in the `jonesImap` mailbox, both with `delete=true`. Whichever route polled first consumed and deleted the message, leaving the other route with an empty mailbox and a failing assertion.

2. **Premature `Mailbox.clearAll()` in `testGetRawJavaMailMessage`**: This call wiped all mailbox contents (including messages prepared by `setupResources()`) before the consumer routes for other tests had necessarily consumed their messages, causing intermittent failures depending on test execution order.

## Changes

- Fixed the IMAP raw message route to consume from `jonesRawImap` (matching the POP3 raw route which correctly uses `jonesRawPop3`)
- Removed the `Mailbox.clearAll()` call from `testGetRawJavaMailMessage` (cleanup is already handled by `cleanupResources()`)

## Test plan

- [x] `mvn test -pl components/camel-mail -Dtest=RawMailMessageTest` — all 5 tests pass
- [ ] CI build passes

_Claude Code on behalf of gnodet_