### PR TITLE
CAMEL-24017: Fix flaky DynamicRouteIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/DynamicRouteIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/DynamicRouteIT.java
@@ -17,11 +17,13 @@
 package org.apache.camel.component.jms.integration;
 
 import org.apache.camel.BindToRegistry;
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Header;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jms.AbstractJMSTest;
+import org.apache.camel.component.jms.JmsTestHelper;
 import org.apache.camel.test.infra.core.CamelContextExtension;
 import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,14 +42,18 @@ public class DynamicRouteIT extends AbstractJMSTest {
     private final MyBean myBean = new MyBean();
     private final String componentName = "jms";
     protected ProducerTemplate template;
+    protected CamelContext context;
 
     @Test
     void testDynamicRouteWithJms() {
-        String response = template.requestBody("jms:queue:request?replyTo=bar", "foo", String.class);
-        assertEquals("response is foo", response);
-        response = template.requestBody("jms:queue:request", "bar", String.class);
-        assertEquals("response is bar", response);
+        // Wait for the JMS consumer to be fully subscribed to the broker
+        JmsTestHelper.waitForJmsConsumerRoutes(context, "jmsConsumer");
 
+        String response
+                = template.requestBody("jms:queue:DynamicRouteIT.request?replyTo=DynamicRouteIT.reply", "foo", String.class);
+        assertEquals("response is foo", response);
+        response = template.requestBody("jms:queue:DynamicRouteIT.request", "bar", String.class);
+        assertEquals("response is bar", response);
     }
 
     @Test
@@ -63,7 +69,7 @@ public class DynamicRouteIT extends AbstractJMSTest {
 
         return new RouteBuilder() {
             public void configure() {
-                from("jms:queue:request")
+                from("jms:queue:DynamicRouteIT.request").routeId("jmsConsumer")
                         .dynamicRouter().method(MyDynamicRouter.class, "route");
                 from("direct:start")
                         .dynamicRouter(method(new MyDynamicRouter()));
@@ -107,6 +113,7 @@ public class DynamicRouteIT extends AbstractJMSTest {
 
     @BeforeEach
     void setUpRequirements() {
+        context = camelContextExtension.getContext();
         template = camelContextExtension.getProducerTemplate();
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `DynamicRouteIT` (3.8% failure rate — 10 failed, 8 flaky out of 476 CI runs in the last 2 weeks).

**Root cause**: Race between route `Started` status and JMS consumer readiness. The test sends request-reply messages to `jms:queue:request` immediately without waiting for the JMS consumer route to be fully subscribed to the broker. If the consumer is not ready when the first message arrives, the 20s request-reply timeout expires and the test fails.

**Fix**:
- Add `routeId("jmsConsumer")` to the JMS consumer route for referencing
- Use `JmsTestHelper.waitForJmsConsumerRoutes(context, "jmsConsumer")` before sending messages — the same pattern used in CAMEL-21438 and CAMEL-23980
- Rename generic queue names (`request`, `bar`) to test-specific names (`DynamicRouteIT.request`, `DynamicRouteIT.reply`) to avoid cross-test message interference on the shared embedded Artemis broker

## Test plan

- [x] `mvn verify -pl components/camel-jms -Dit.test=DynamicRouteIT` — 2/2 tests pass
- [ ] CI green on this PR

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>