### PR TITLE
CAMEL-24019: Fix flaky VertxWebsocketHandshakeHeadersTest

### DIFF
--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketHandshakeHeadersTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketHandshakeHeadersTest.java
@@ -137,7 +137,6 @@ public class VertxWebsocketHandshakeHeadersTest extends VertxWebSocketTestSuppor
 
     @Test
     public void testHandshakeHeadersAsConsumer() throws Exception {
-        CountDownLatch latch = new CountDownLatch(1);
         Vertx vertx = Vertx.vertx();
         Router router = Router.router(vertx);
         Route route = router.route("/ws");
@@ -177,7 +176,7 @@ public class VertxWebsocketHandshakeHeadersTest extends VertxWebSocketTestSuppor
                             // Send a text message to consumer
                             ServerWebSocket webSocket = toWebSocket.result();
                             webSocket.writeTextMessage("Hello World");
-                            webSocket.writeTextMessage("Ping").onComplete(event -> latch.countDown());
+                            webSocket.writeTextMessage("Ping");
                         } else {
                             // the upgrade failed
                             context.fail(toWebSocket.cause());
@@ -205,13 +204,14 @@ public class VertxWebsocketHandshakeHeadersTest extends VertxWebSocketTestSuppor
             }
         });
 
+        // Set up mock expectations BEFORE starting the context to avoid race conditions
+        // where messages arrive before expectations are configured
+        MockEndpoint mockEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);
+        mockEndpoint.expectedBodiesReceivedInAnyOrder("Hello World", "Ping");
+
         context.start();
         try {
-            assertTrue(latch.await(10, TimeUnit.SECONDS));
-
-            MockEndpoint mockEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);
-            mockEndpoint.expectedBodiesReceivedInAnyOrder("Hello World", "Ping");
-            mockEndpoint.assertIsSatisfied();
+            MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
         } finally {
             try {
                 host.stop();


### PR DESCRIPTION
## Summary

Fix flaky `VertxWebsocketHandshakeHeadersTest.testHandshakeHeadersAsConsumer` test.

**Develocity data (last 12 days):** 8 failures and 7 flaky runs out of 295 total runs.

**Root cause:** Race condition where `MockEndpoint` expectations (`expectedBodiesReceivedInAnyOrder`) were set _after_ `context.start()` and after a `CountDownLatch` wait. On CI, the WebSocket messages could arrive and be consumed before expectations were configured, causing:
- `mock://result Message with body Hello World was expected but not found in [Ping]` (partial message loss)
- `mock://result Received message count. Expected: <2> but was: <0>` (complete message loss)

**Fix:**
- Move `MockEndpoint` expectations setup **before** `context.start()` so they are registered before any messages can arrive
- Replace `CountDownLatch` + `assertIsSatisfied()` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` for a proper timed assertion
- Remove the now-unnecessary `CountDownLatch` from the consumer test

## Test plan

- [x] Run test locally 5+ times with no failures
- [ ] CI build passes

_Claude Code on behalf of gnodet_