### PR TITLE
CAMEL-24018: Fix flaky OpensearchIndexIT

### DIFF
--- a/components/camel-opensearch/src/test/java/org/apache/camel/component/opensearch/integration/OpensearchIndexIT.java
+++ b/components/camel-opensearch/src/test/java/org/apache/camel/component/opensearch/integration/OpensearchIndexIT.java
@@ -16,12 +16,14 @@
  */
 package org.apache.camel.component.opensearch.integration;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.opensearch.OpensearchConstants;
 import org.apache.camel.component.opensearch.OpensearchOperation;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 
@@ -31,6 +33,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OpensearchIndexIT extends OpensearchTestSupport {
+
+    @AfterEach
+    void cleanupIndex() throws IOException {
+        try {
+            client.indices().delete(new DeleteIndexRequest.Builder().index("twitter").build());
+        } catch (Exception e) {
+            // index may not exist, ignore
+        }
+    }
 
     @Test
     void testIndex() {

--- a/test-infra/camel-test-infra-opensearch/src/main/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-opensearch/src/main/java/org/apache/camel/test/infra/opensearch/services/OpenSearchLocalContainerInfraService.java
@@ -70,6 +70,10 @@ public class OpenSearchLocalContainerInfraService implements OpenSearchInfraServ
                 withEnv("OPENSEARCH_JAVA_OPTS",
                         "-Dopensearch.cgroups.hierarchy.override=/ -Dopensearch.plugin.disable=opensearch-observability");
 
+                // Disable disk watermarks to prevent "disk usage exceeded flood-stage watermark"
+                // errors when running on CI machines with limited disk space (CAMEL-24018)
+                withEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
+
                 ContainerEnvironmentUtil.configurePort(this, fixedPort, OPEN_SEARCH_PORT);
             }
         }


### PR DESCRIPTION
## Summary
Fix flaky `OpensearchIndexIT` test that fails intermittently in CI due to disk pressure causing OpenSearch flood-stage watermark to block all writes.

**Root cause**: CI environments have limited disk space, which triggers OpenSearch's flood-stage disk watermark. Once triggered, OpenSearch blocks all index write operations with HTTP 429 errors, causing test assertions to fail.

**Fix**:
- Disable disk allocation watermarks in the test container by setting `cluster.routing.allocation.disk.threshold_enabled=false`
- Add `@AfterEach` cleanup to delete the "twitter" index between test methods, preventing data accumulation

## Test plan
- [x] Verified test passes locally
- [x] Confirmed only OpenSearch-related files are changed

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)