### PR TITLE
CAMEL-24025: observability-services docs - Spring Boot customization is now supported

### DIFF
--- a/components/camel-observability-services/src/main/docs/observability-services.adoc
+++ b/components/camel-observability-services/src/main/docs/observability-services.adoc
@@ -96,7 +96,7 @@ NOTE: the management port is available since version 4.12.0. In previous version
 
 If you need to customize each of the different components provided within this service, then, you can specify in the `application.properties` each of the configuration as it would be done normally when you provide the individual component.
 
-WARNING: The customization of the configuration for this component is not available for Spring Boot runtime due to a https://github.com/spring-projects/spring-boot/issues/24688[known limitation]. You can use this component in Spring Boot runtime with the default settings only. If you need to provide any customization, you'll need to configure each component separately.
+NOTE: The customization of the configuration is available for the Spring Boot runtime since version 4.22.0: the starter contributes its defaults as the lowest precedence property source, so any user-provided configuration overrides them following the standard Spring Boot precedence rules. In earlier versions the starter packaged its defaults in `classpath:/config/application.properties`, which took precedence over the application's own `application.properties` due to a https://github.com/spring-projects/spring-boot/issues/24688[known limitation], so the defaults could only be overridden via higher precedence sources such as environment variables or system properties.
 
 == Default logging metrics on shutdown
 


### PR DESCRIPTION
Docs follow-up for [CAMEL-24025](https://issues.apache.org/jira/browse/CAMEL-24025), implemented in apache/camel-spring-boot#1847.

Since camel-spring-boot 4.22.0, `camel-observability-services-starter` contributes its defaults through an `EnvironmentPostProcessor` as the lowest precedence property source, instead of a packaged `classpath:/config/application.properties`. User configuration in `application.properties` now overrides the starter defaults following standard Spring Boot precedence rules.

This replaces the obsolete WARNING in `observability-services.adoc` (which stated customization was not available on Spring Boot due to spring-projects/spring-boot#24688) with a NOTE explaining that customization works since 4.22.0 and how it behaved in earlier versions.

---
_This PR was generated by Claude Code on behalf of Federico Mariani_

🤖 Generated with [Claude Code](https://claude.com/claude-code)