### PR TITLE
CAMEL-23941: Fail startup in prod when authentication is enabled with…

### DIFF
--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/DefaultMainHttpServerFactory.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/DefaultMainHttpServerFactory.java
@@ -123,10 +123,7 @@ public class DefaultMainHttpServerFactory implements CamelContextAware, MainHttp
             JWTAuthenticationConfigurer auth = new JWTAuthenticationConfigurer();
             auth.configureAuthentication(server.getConfiguration().getAuthenticationConfig(), configuration);
         } else {
-            LOG.warn("Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is"
-                     + " configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore"
-                     + " (jwtKeystoreType) is set. The HTTP server will start WITHOUT authentication. Configure an"
-                     + " authentication mechanism, or set authenticationEnabled=false to disable authentication.");
+            handleMissingAuthenticationMechanism(server.getCamelContext(), "HTTP server");
         }
     }
 
@@ -141,12 +138,27 @@ public class DefaultMainHttpServerFactory implements CamelContextAware, MainHttp
             JWTAuthenticationConfigurer auth = new JWTAuthenticationConfigurer();
             auth.configureAuthentication(server.getConfiguration().getAuthenticationConfig(), configuration);
         } else {
-            LOG.warn("Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is"
-                     + " configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore"
-                     + " (jwtKeystoreType) is set. The HTTP management server will start WITHOUT authentication."
-                     + " Configure an authentication mechanism, or set authenticationEnabled=false to disable"
-                     + " authentication.");
+            handleMissingAuthenticationMechanism(server.getCamelContext(), "HTTP management server");
         }
+    }
+
+    private void handleMissingAuthenticationMechanism(CamelContext camelContext, String serverName) {
+        if ("prod".equals(camelContext.getCamelContextExtension().getProfile())) {
+            throw new IllegalStateException(
+                    "Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is "
+                                            + "configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore "
+                                            + "(jwtKeystoreType) is set. Refusing to start the " + serverName
+                                            + " in the prod profile without authentication. Configure an authentication mechanism, "
+                                            + "or set authenticationEnabled=false to disable authentication.");
+        }
+
+        LOG.warn(
+                "Authentication is enabled (authenticationEnabled=true) but no authentication mechanism is "
+                 + "configured: neither a basic-auth properties file (basicPropertiesFile) nor a JWT keystore "
+                 + "(jwtKeystoreType) is set. The {} will start WITHOUT authentication. "
+                 + "Configure an authentication mechanism, or set authenticationEnabled=false to disable "
+                 + "authentication.",
+                serverName);
     }
 
 }

--- a/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/authentication/AuthenticationConfigurationMainHttpServerTest.java
+++ b/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/authentication/AuthenticationConfigurationMainHttpServerTest.java
@@ -84,6 +84,16 @@ public class AuthenticationConfigurationMainHttpServerTest {
         }
     }
 
+    @Test
+    public void testAuthenticationEnabledWithoutMechanismProdProfile() {
+        Main main = MainHttpServerAuthenticationTestSupport.createMain(
+                "auth-no-mechanism.properties", port, new PlatformHttpRouteBuilder());
+
+        main.configure().withProfile("prod");
+
+        assertThrows(IllegalStateException.class, main::start);
+    }
+
     private static class PlatformHttpRouteBuilder extends RouteBuilder {
         @Override
         public void configure() throws Exception {

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -182,6 +182,18 @@ the message, consistent with the inbound header filtering already performed by t
 Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
 content, set them explicitly after unmarshalling.
 
+=== camel-platform-http-main
+
+When `authenticationEnabled=true` but neither a basic-auth properties file
+(`basicPropertiesFile`) nor a JWT keystore (`jwtKeystoreType`) is configured,
+Camel now behaves differently under the `prod` profile
+(`camel.main.profile=prod`).
+
+Under the `prod` profile, startup now fails instead of starting the embedded
+HTTP server without authentication. Under the `dev` profile and with no profile
+configured, the existing warning-only behavior is retained for backward
+compatibility.
+
 === camel-kafka - metadataMaxAgeMs option moved from producer to common
 
 The `metadataMaxAgeMs` (`metadata.max.age.ms`) option was incorrectly labeled as producer-only,


### PR DESCRIPTION
# Description

This PR follows up on CAMEL-23767 by enforcing fail-closed behavior when HTTP authentication is enabled without a configured authentication mechanism under the `prod` profile.

Previously, when `authenticationEnabled=true` was configured without either a basic authentication properties file (`basicPropertiesFile`) or a JWT keystore (`jwtKeystoreType`), Camel logged a warning and still started the embedded HTTP server (and management HTTP server) without authentication. This behavior was intentionally retained by CAMEL-23767 for backward compatibility.

This change aligns the embedded HTTP server behavior with Camel's profile-based security policy:

- Under the `prod` profile (`camel.main.profile=prod`), startup now fails with an `IllegalStateException` instead of starting an unauthenticated server.
- Under the `dev` profile and when no profile is configured, the existing warning-only behavior is preserved to maintain backward compatibility.

Implementation changes:
- Extracted the duplicated "missing authentication mechanism" handling into a shared helper method.
- Applied the shared logic to both the embedded HTTP server and the management HTTP server authentication configuration.
- Added a test verifying that startup fails under the `prod` profile when authentication is enabled but no mechanism is configured.
- Updated the Camel 4.22 upgrade guide to document the new production profile behavior.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a JIRA issue filed for the change (CAMEL-23941).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
  Attempted the full root build, but it failed in the unrelated `camel-kserve` module during protobuf generation. The affected `camel-platform-http-main` module builds successfully and all its tests pass.

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

