### PR TITLE
CAMEL-24026: Fix flaky XsltFromFileExceptionTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
@@ -21,6 +21,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  *
  */
@@ -33,9 +35,10 @@ public class XsltFromFileExceptionTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello>", Exchange.FILE_NAME, "hello.xml");
 
-        assertMockEndpointsSatisfied();
+        // wait for the file consumer to pick up and process the file before asserting
+        assertTrue(oneExchangeDone.matchesWaitTime(), "Exchange should have completed");
 
-        oneExchangeDone.matchesWaitTime();
+        assertMockEndpointsSatisfied();
 
         assertFileNotExists(testFile("hello.xml"));
         assertFileExists(testFile("ok/hello.xml"));
@@ -49,9 +52,10 @@ public class XsltFromFileExceptionTest extends ContextTestSupport {
         // the last tag is not ended properly
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello", Exchange.FILE_NAME, "hello2.xml");
 
-        assertMockEndpointsSatisfied();
+        // wait for the file consumer to pick up and process the file before asserting
+        assertTrue(oneExchangeDone.matchesWaitTime(), "Exchange should have completed");
 
-        oneExchangeDone.matchesWaitTime();
+        assertMockEndpointsSatisfied();
 
         assertFileNotExists(testFile("hello2.xml"));
         assertFileExists(testFile("error/hello2.xml"));


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `XsltFromFileExceptionTest` by reordering assertions to wait for the file consumer to complete before checking mock expectations.

**Root cause**: The test called `assertMockEndpointsSatisfied()` before `oneExchangeDone.matchesWaitTime()`. On slow CI machines, the file consumer may not have picked up and processed the file yet when the mock assertion starts, causing intermittent timeout failures.

**Fix**:
- Wait for `oneExchangeDone` latch first (confirms file consumer processed the file)
- Then assert mock expectations (which now pass immediately since the exchange already completed)
- Assert the `oneExchangeDone` result with `assertTrue()` for better failure diagnostics

**Develocity data**: 6 failures out of recent runs.

## Test plan

- [x] `XsltFromFileExceptionTest` passes locally (2 tests, 0 failures)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>