### PR TITLE
CAMEL-24027: Fix flaky InOutQueueProducerAsyncLoadTest

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/InOutQueueProducerAsyncLoadTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/InOutQueueProducerAsyncLoadTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.component.sjms.producer;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
@@ -34,9 +36,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class InOutQueueProducerAsyncLoadTest extends JmsTestSupport {
@@ -73,32 +75,36 @@ public class InOutQueueProducerAsyncLoadTest extends JmsTestSupport {
      */
     @Test
     public void testInOutQueueProducer() throws Exception {
+        final int messageCount = 500;
+        final CountDownLatch latch = new CountDownLatch(messageCount);
+        final AtomicInteger failures = new AtomicInteger();
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
-        for (int i = 1; i <= 5000; i++) {
+        for (int i = 1; i <= messageCount; i++) {
             final int tempI = i;
-            Runnable worker = new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        final String requestText = "Message " + tempI;
-                        final String responseText = "Response Message " + tempI;
-                        String response = template.requestBody("direct:start", requestText, String.class);
-                        assertNotNull(response);
-                        assertEquals(responseText, response);
-                    } catch (Exception e) {
-                        log.error("Failed to process message {}", tempI, e);
-                    }
+            executor.execute(() -> {
+                try {
+                    final String requestText = "Message " + tempI;
+                    final String responseText = "Response Message " + tempI;
+                    String response = template.requestBody("direct:start", requestText, String.class);
+                    assertNotNull(response);
+                    assertEquals(responseText, response);
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                    log.error("Failed to process message {}", tempI, e);
+                } finally {
+                    latch.countDown();
                 }
-            };
-            executor.execute(worker);
+            });
         }
-        // shut down the executor and wait for all submitted tasks to complete
+        // wait for all submitted tasks to complete
+        assertTrue(latch.await(60, SECONDS), "Not all messages were processed within the timeout");
+        assertEquals(0, failures.get(), "Some messages failed during processing");
+
         executor.shutdown();
-        await().atMost(30, SECONDS)
-                .until(() -> executor.isTerminated());
+        assertTrue(executor.awaitTermination(10, SECONDS), "Executor did not terminate in time");
+
         // verify all inflight messages have completed
         assertEquals(0, context.getInflightRepository().size());
     }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `InOutQueueProducerAsyncLoadTest` by reducing the message count and improving synchronization.

**Root cause**: The test sent 5000 InOut JMS request-reply messages via a 2-thread executor with only a 30-second Awaitility timeout. On slow CI machines, processing 5000 round-trip messages through an embedded ActiveMQ broker frequently exceeded the timeout. Additionally, test failures inside the executor threads were silently swallowed.

**Fix**:
- Reduce message count from 5000 to 500 (still validates concurrent InOut load behavior)
- Replace `Awaitility.await().until(executor::isTerminated)` with a `CountDownLatch` for precise completion tracking
- Add `AtomicInteger` to count and assert zero failures (previously swallowed)
- Use `executor.awaitTermination()` with explicit 10s timeout instead of polling
- Increase overall completion timeout to 60 seconds
- Modernize anonymous `Runnable` to lambda

## Test plan

- [x] `InOutQueueProducerAsyncLoadTest` passes locally (1 test, 0 failures, 4.7s)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>