### PR TITLE
CAMEL-24028: Fix flaky JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/tx/JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/tx/JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentTransacted;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -104,9 +105,15 @@ public class JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT exten
         assertTrue(notify.matches(30, TimeUnit.SECONDS), "Exchange should be done");
 
         // as we do not handle new exception, then the exception propagates back
-        // and causes the transaction to rollback, and we can find the message in the DLQ
-        Object dlqBody = consumer.receiveBody("activemq:" + DLQ_NAME, 10000);
-        assertEquals("Hello World", dlqBody);
+        // and causes the transaction to rollback, and we can find the message in the DLQ.
+        // Use Awaitility to retry: the transacted session may be briefly closed after
+        // the rollback, causing "Session is closed" on the first receiveBody attempt.
+        await().atMost(30, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    Object dlqBody = consumer.receiveBody("activemq:" + DLQ_NAME, 2000);
+                    assertEquals("Hello World", dlqBody);
+                });
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT` by retrying the DLQ read on transient session-closed errors.

**Root cause**: After a transaction rollback, the transacted JMS session used by the consumer template can be briefly in a closed state. When the test immediately calls `consumer.receiveBody("activemq:" + DLQ_NAME)`, it encounters a `Session is closed` `IllegalStateException` from Spring JMS.

**Develocity data**: 11 failures + 13 flaky out of 368 runs (~6.5% failure rate). Error: `org.springframework.jms.IllegalStateException: Session is closed`.

**Fix**:
- Wrap the DLQ read in `Awaitility.await().ignoreExceptions().untilAsserted()` to retry on transient session-closed errors
- Reduce inner receive timeout from 10s to 2s for faster retries within the 30s Awaitility window
- This ensures the test gets a fresh JMS session on retry after the transacted session recovers

## Test plan

- [x] `JmsTransactedDeadLetterChannelNotHandlerRollbackOnExceptionIT` passes locally (1 test, 0 failures)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>