### PR TITLE
CAMEL-24020: Fix flaky SjmsConnectionRecoveryTest

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
@@ -130,10 +130,20 @@ public class SjmsConnectionRecoveryTest extends CamelTestSupport {
     public void testRecoveryStopsAfterSuccessfulReconnection() throws Exception {
         MockEndpoint mock = getMockEndpoint(MOCK_RESULT);
 
-        // Phase 1: verify normal consumption (also confirms consumer is fully started)
-        mock.expectedMessageCount(1);
-        template.sendBody(SJMS_QUEUE_NAME, "before-failure");
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        // Phase 1: verify normal consumption (also confirms consumer is fully started).
+        // With asyncStartListener=true, the consumer starts in the background and may not be
+        // subscribed yet when the first message is sent. The message would be lost (delivered
+        // to a queue with no subscriber). Use Awaitility to retry the send+assert cycle until
+        // the async consumer is ready.
+        // NOTE: This is NOT redundant Awaitility wrapping of MockEndpoint — we are retrying
+        // the send operation itself, not just the assertion wait.
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    mock.reset();
+                    mock.expectedMessageCount(1);
+                    template.sendBody(SJMS_QUEUE_NAME, "before-failure");
+                    mock.assertIsSatisfied();
+                });
         mock.reset();
 
         // Phase 2: simulate a transient JMS connection exception.
@@ -160,16 +170,22 @@ public class SjmsConnectionRecoveryTest extends CamelTestSupport {
         // Then wait several recovery intervals to confirm no additional connections
         // are created — this catches the infinite-loop bug where recovery keeps
         // destroying and recreating connections.
-        await().pollDelay(3 * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
-                .atMost(5 * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        await().pollDelay(3L * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
+                .atMost(5L * RECOVERY_INTERVAL_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> assertEquals(connectionsAfterRecovery,
                         countingFactory.createCount.get(),
                         "Recovery loop should have stopped — connection count should remain stable"));
 
         // Phase 5: verify messages are consumed after recovery.
-        mock.expectedMessageCount(1);
-        template.sendBody(SJMS_QUEUE_NAME, "after-failure");
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        // After recovery, consumers may need a moment to be fully re-established.
+        // Use Awaitility to retry the send+assert cycle (same rationale as Phase 1).
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    mock.reset();
+                    mock.expectedMessageCount(1);
+                    template.sendBody(SJMS_QUEUE_NAME, "after-failure");
+                    mock.assertIsSatisfied();
+                });
     }
 
     @Override


### PR DESCRIPTION
Fix flaky `SjmsConnectionRecoveryTest` by addressing race conditions in the test phases.

## Changes

**Phase 1 & 5 (send + assert):** With `asyncStartListener=true`, the consumer starts in the background and may not be subscribed when the first message is sent — the message would be lost. Wrap the send+assert in an Awaitility retry loop so the test adapts to async consumer startup timing. This is NOT redundant wrapping of `MockEndpoint.assertIsSatisfied` — we are retrying the *send* operation itself.

**Phase 4 (stability check):** Use `3L * RECOVERY_INTERVAL_MS` (long multiplication) to avoid integer overflow risk.

## Test plan

- [x] Rebased on latest `main` (after CAMEL-23887 merge)
- [ ] CI passes
- [ ] Verified the test passes locally with the fix

_Claude Code on behalf of gnodet_

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>