### PR TITLE
CAMEL-24024: Improve reliability of InOutQueueProducerAsyncLoadTest

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/InOutQueueProducerAsyncLoadTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/producer/InOutQueueProducerAsyncLoadTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.component.sjms.producer;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
@@ -34,14 +36,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class InOutQueueProducerAsyncLoadTest extends JmsTestSupport {
 
     private static final String TEST_DESTINATION_NAME = "in.out.queue.producer.test.InOutQueueProducerAsyncLoadTest";
+    private static final int MESSAGE_COUNT = 500;
     private MessageConsumer mc1;
     private MessageConsumer mc2;
 
@@ -75,30 +78,37 @@ public class InOutQueueProducerAsyncLoadTest extends JmsTestSupport {
     public void testInOutQueueProducer() throws Exception {
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(MESSAGE_COUNT);
+        AtomicInteger failures = new AtomicInteger();
 
-        for (int i = 1; i <= 5000; i++) {
+        for (int i = 1; i <= MESSAGE_COUNT; i++) {
             final int tempI = i;
-            Runnable worker = new Runnable() {
 
-                @Override
-                public void run() {
-                    try {
-                        final String requestText = "Message " + tempI;
-                        final String responseText = "Response Message " + tempI;
-                        String response = template.requestBody("direct:start", requestText, String.class);
-                        assertNotNull(response);
-                        assertEquals(responseText, response);
-                    } catch (Exception e) {
-                        log.error("Failed to process message {}", tempI, e);
-                    }
+            executor.execute(() -> {
+                try {
+                    final String requestText = "Message " + tempI;
+                    final String responseText = "Response Message " + tempI;
+
+                    String response = template.requestBody("direct:start", requestText, String.class);
+
+                    assertNotNull(response);
+                    assertEquals(responseText, response);
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                    log.error("Failed to process message {}", tempI, e);
+                } finally {
+                    latch.countDown();
                 }
-            };
-            executor.execute(worker);
+            });
         }
-        // shut down the executor and wait for all submitted tasks to complete
+
         executor.shutdown();
-        await().atMost(30, SECONDS)
-                .until(() -> executor.isTerminated());
+
+        assertTrue(latch.await(30, SECONDS));
+        assertTrue(executor.awaitTermination(30, SECONDS));
+
+        assertEquals(0, failures.get(), "Some async requests failed");
+
         // verify all inflight messages have completed
         assertEquals(0, context.getInflightRepository().size());
     }


### PR DESCRIPTION
# Description

This PR addresses **CAMEL-24024** by improving the reliability of `InOutQueueProducerAsyncLoadTest`, which was reported as flaky in CI due to high load and timeout-based synchronization.

Previously, the test submitted 5000 asynchronous requests using a 2-thread executor and relied on Awaitility to wait for executor termination. Under resource-constrained CI environments, the large workload could exceed the 30-second timeout, resulting in intermittent failures.

To make the test more deterministic while preserving its intent, this change:

- Reduces the message count from 5000 to 500, which is sufficient to validate the asynchronous InOut request/reply behavior.
- Replaces Awaitility-based polling with a `CountDownLatch` to reliably track completion of all submitted tasks.
- Introduces an `AtomicInteger` to track asynchronous request failures and verifies that all requests complete successfully.

These changes preserve the purpose of the test while reducing its susceptibility to CI timing and resource constraints.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a JIRA issue filed for the change (**CAMEL-24024**).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
I ran mvn clean install -DskipTests from the project root. The build reached camel-kserve and failed due to an unrelated protobuf-maven-plugin/protoc generation error. The modified camel-sjms module builds successfully.

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

