### PR TITLE
CAMEL-24029: Fix flaky camel-core tests using timed assertions

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
@@ -70,7 +70,9 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
         resetMocks();
         mock.expectedBodiesReceived("B");
         context.resume();
-        assertMockEndpointsSatisfied();
+        // after resume, the seda consumer may need a moment to restart polling
+        // and deliver the queued message "B" — use a timed assertion
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         assertFalse(context.isSuspended());
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/StopRouteAbortAfterTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/StopRouteAbortAfterTimeoutTest.java
@@ -53,7 +53,8 @@ public class StopRouteAbortAfterTimeoutTest extends ContextTestSupport {
             template.sendBody("seda:start", "message-" + i);
         }
 
-        mockEP.assertIsSatisfied();
+        // use timed assertion to avoid flaky failures on slow CI
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/processor/LoopNoBreakOnShutdownTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/LoopNoBreakOnShutdownTest.java
@@ -37,10 +37,13 @@ class LoopNoBreakOnShutdownTest extends ContextTestSupport {
         mock.expectedMinimumMessageCount(LOOP_COUNT);
 
         CompletableFuture<Object> future = template.asyncSendBody("seda:foo", "foo");
-        await().atMost(1, SECONDS).until(future::isDone);
+        // asyncSendBody to seda completes almost instantly (just enqueues), but on
+        // slow CI the handoff can take longer — use a generous timeout
+        await().atMost(10, SECONDS).until(future::isDone);
 
         context.stop();
 
+        // after context.stop(), all shutdown-deferred processing has completed
         mock.assertIsSatisfied();
     }
 


### PR DESCRIPTION
## Summary

Fix three flaky camel-core tests identified by [Develocity](https://develocity.apache.org):

- **StopRouteAbortAfterTimeoutTest**: Use `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` instead of untimed `mockEP.assertIsSatisfied()` — the SEDA consumer with 100ms delay can be slow on CI
- **LoopNoBreakOnShutdownTest**: Increase Awaitility timeout from 1s to 10s — the async seda handoff can lag on slow CI
- **DefaultCamelContextSuspendResumeRouteTest**: Use timed assertion after `context.resume()` — the SEDA consumer needs time to restart polling after resume

All three tests use `seda:` endpoints where timing depends on thread scheduling, making them vulnerable to CI jitter.

## Test plan

- [x] All three tests pass locally with `mvn test -pl core/camel-core`
- [ ] CI passes

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)