### PR TITLE
CAMEL-24033: Fix flaky camel-core tests using timed assertions

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class FileConsumePollEnrichFileTest extends ContextTestSupport {
 
     @Test
-    public void testPollEnrich() {
+    public void testPollEnrich() throws Exception {
         getMockEndpoint("mock:start").expectedBodiesReceived("Start");
 
         MockEndpoint mock = getMockEndpoint("mock:result");
@@ -39,13 +39,18 @@ public class FileConsumePollEnrichFileTest extends ContextTestSupport {
         template.sendBodyAndHeader(fileUri("enrich"), "Start", Exchange.FILE_NAME,
                 "AAA.fin");
 
-        log.info("Sleeping for 1/4 sec before writing enrichdata file");
-        Awaitility.await().pollDelay(250, TimeUnit.MILLISECONDS).untilAsserted(() -> {
-            template.sendBodyAndHeader(fileUri("enrichdata"), "Big file",
-                    Exchange.FILE_NAME, "AAA.dat");
-            log.info("... write done");
-            assertMockEndpointsSatisfied();
-        });
+        // Wait for the file consumer to pick up the trigger file before writing
+        // the enrichdata file — avoids a race where pollEnrich runs before the
+        // data file exists
+        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> getMockEndpoint("mock:start").getReceivedCounter() >= 1);
+
+        log.info("Writing enrichdata file");
+        template.sendBodyAndHeader(fileUri("enrichdata"), "Big file",
+                Exchange.FILE_NAME, "AAA.dat");
+        log.info("... write done");
+
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -85,7 +86,9 @@ public class SedaBlockWhenFullTest extends ContextTestSupport {
         assertEquals(QUEUE_SIZE, seda.getQueue().remainingCapacity());
 
         sendTwoOverCapacity(BLOCK_WHEN_FULL_URI, QUEUE_SIZE);
-        assertMockEndpointsSatisfied();
+        // use timed assertion — the SEDA consumer with 130ms delay needs
+        // time to drain the queue on slow CI
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/issues/SplitterParallelAsyncProcessorIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/SplitterParallelAsyncProcessorIssueTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.*;
 
 import org.apache.camel.*;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spi.ThreadPoolProfile;
 import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
 import org.junit.jupiter.api.Assertions;
@@ -50,7 +51,10 @@ public class SplitterParallelAsyncProcessorIssueTest extends ContextTestSupport 
 
         template.sendBody("direct:start", xmlBody);
 
-        assertMockEndpointsSatisfied();
+        // the 10 elements are processed in parallel with 250ms delays
+        // in both the async processor and the route — use a timed assertion
+        // to avoid flaky failures on slow CI
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         log.info("{} Threads in use: {}", threads.size(), threads);
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
@@ -84,7 +84,9 @@ public class ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest extends Conte
         log.debug("sending message three");
         sendMessage("Message Three");
 
-        assertMockEndpointsSatisfied();
+        // use timed assertion — consumer suspend/resume and SEDA queue
+        // draining can be slow on CI
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         result.reset();
         result.expectedMessageCount(2);
@@ -99,7 +101,7 @@ public class ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest extends Conte
         log.debug("sending message four");
         sendMessage("Message Four");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix four flaky camel-core tests identified by [Develocity](https://develocity.apache.org):

- **SedaBlockWhenFullTest** (15 flaky): use `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` instead of untimed `assertMockEndpointsSatisfied()`
- **FileConsumePollEnrichFileTest** (13 flaky): wait for trigger file pickup before writing enrichdata file; replace Awaitility-wrapped `assertMockEndpointsSatisfied` with timed `MockEndpoint.assertIsSatisfied`
- **ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest** (13 flaky): use timed assertions for both mock verification points
- **SplitterParallelAsyncProcessorIssueTest** (13 flaky): use timed assertion for parallel split with async processing

## Test plan

- [x] All four tests pass locally with `mvn test -pl core/camel-core`
- [ ] CI passes

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)