### PR TITLE
CAMEL-24034: Fix flaky SingleMessageSameTopicIT

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/consumers/SingleMessageSameTopicIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/consumers/SingleMessageSameTopicIT.java
@@ -31,8 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SingleMessageSameTopicIT extends AbstractPersistentJMSTest {
 
-    // topic subscriptions take a little longer to register than queue consumers, so keep the longer 200ms threshold
-    private static final long TOPIC_ROUTE_UPTIME_MILLIS = 200;
+    // topic subscriptions take longer to register than queue consumers on slow CI;
+    // 200ms was too tight — use 2000ms to avoid flaky failures
+    private static final long TOPIC_ROUTE_UPTIME_MILLIS = 2000;
 
     @BeforeEach
     void waitAndPrepare() {


### PR DESCRIPTION
## Summary

Fix flaky `SingleMessageSameTopicIT` identified by [Develocity](https://develocity.apache.org) (14 flaky occurrences).

Increase topic subscription uptime threshold from 200ms to 2000ms. On slow CI, the JMS listener may not register with the broker in 200ms, causing topic messages to be lost before the subscription is active.

## Test plan

- [x] Code change reviewed (simple constant increase)
- [ ] CI passes

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)