### PR TITLE
CAMEL-24037: Fix flaky camel-core tests using timed assertions

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerTest.java
@@ -16,11 +16,14 @@
  */
 package org.apache.camel.component.scheduler;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TwoSchedulerTest extends ContextTestSupport {
 
@@ -29,12 +32,12 @@ public class TwoSchedulerTest extends ContextTestSupport {
         getMockEndpoint("mock:a").expectedMinimumMessageCount(4);
         getMockEndpoint("mock:b").expectedMinimumMessageCount(2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // should use same thread as they share the same scheduler
         String tn1 = getMockEndpoint("mock:a").getReceivedExchanges().get(0).getMessage().getHeader("tn", String.class);
         String tn2 = getMockEndpoint("mock:b").getReceivedExchanges().get(0).getMessage().getHeader("tn", String.class);
-        assertSame(tn1, tn2);
+        assertEquals(tn1, tn2);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.processor.aggregate.MemoryAggregationRepository;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
@@ -52,7 +51,7 @@ public class DistributedTimeoutTest extends AbstractDistributedTest {
         template2.sendBodyAndHeader("direct:start", "B", "id", 123);
 
         // wait a bit until the timeout was triggered
-        await().atMost(2, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
 
         mock.assertIsSatisfied();
         mock2.assertIsSatisfied();
@@ -73,11 +72,8 @@ public class DistributedTimeoutTest extends AbstractDistributedTest {
         template2.sendBodyAndHeader("direct:start", "B", "id", 123);
         template2.sendBodyAndHeader("direct:start", "C", "id", 123);
 
-        Awaitility.await().untilAsserted(() -> {
-            // should complete before timeout
-            mock2.assertIsSatisfied(500);
-            mock.assertIsSatisfied(500);
-        });
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context2, 30, TimeUnit.SECONDS);
 
         // should have not invoked the timeout method anymore
         assertEquals(1, invoked.get());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
@@ -65,8 +65,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
             template.sendBody(url, "MessageRound1 " + i);
         }
         result.expectedMessageCount(size);
-        result.setResultWaitTime(5000);
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // set keepOpen to true
         policy.setKeepOpen(true);
@@ -86,8 +85,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
 
         // should not close b/c keepOpen is true
         result.expectedMessageCount(size + 1);
-        result.setResultWaitTime(2000);
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // set keepOpen to false
         policy.setKeepOpen(false);
@@ -97,8 +95,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
 
         // it should close b/c keepOpen is false — queued messages should now arrive
         result.expectedMessageCount(size * 2 + 1);
-        result.setResultWaitTime(5000);
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix three flaky camel-core tests identified by Develocity:

- **TwoSchedulerTest** (4 flaky/70 builds = 6%): Replace `assertMockEndpointsSatisfied()` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`. Also fix `assertSame(tn1, tn2)` → `assertEquals(tn1, tn2)` since `assertSame` checks reference identity, not value equality, for String objects.
- **DistributedTimeoutTest** (4 flaky/70 builds = 6%): Remove Awaitility wrapping around `MockEndpoint.assertIsSatisfied()` (anti-pattern per project guidelines — MockEndpoint already waits internally via CountDownLatch). Use direct `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` for both contexts. Increase Awaitility `atMost` from 2s to 5s for the aggregation timeout wait.
- **ThrottlingExceptionRoutePolicyOpenViaConfigTest** (11 flaky/275 builds = 4%): Replace three `assertMockEndpointsSatisfied()` calls with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`.

## Test plan

- [x] All three tests pass locally after changes
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)