### PR TITLE
CAMEL-24038: Fix flaky AsyncWiretapTest in telemetry modules

### DIFF
--- a/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/AsyncWiretapTest.java
+++ b/components/camel-telemetry-dev/src/test/java/org/apache/camel/telemetrydev/AsyncWiretapTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.telemetrydev;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
@@ -28,6 +28,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.telemetry.Op;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -50,15 +51,23 @@ public class AsyncWiretapTest extends TelemetryDevTracerTestSupport {
     }
 
     @Test
-    void testRouteMultipleRequests() throws InterruptedException, IOException {
+    void testRouteMultipleRequests() throws Exception {
         int j = 10;
         MockEndpoint mock = getMockEndpoint("mock:end");
         mock.expectedMessageCount(j);
-        mock.setAssertPeriod(5000);
         for (int i = 0; i < j; i++) {
             context.createProducerTemplate().sendBody("direct:start", "Hello!");
         }
-        mock.assertIsSatisfied(1000);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        // Wait for async trace writing to complete — traces are written asynchronously
+        // after exchange processing, so we poll until all traces with expected spans arrive.
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            Map<String, DevTrace> traces = tracesFromLog();
+            assertEquals(j, traces.size());
+            for (DevTrace trace : traces.values()) {
+                assertEquals(7, trace.getSpans().size());
+            }
+        });
         Map<String, DevTrace> traces = tracesFromLog();
         // Each trace should have a unique trace id. It is enough to assert that
         // the number of elements in the map is the same of the requests to prove
@@ -68,7 +77,6 @@ public class AsyncWiretapTest extends TelemetryDevTracerTestSupport {
         for (DevTrace trace : traces.values()) {
             checkTrace(trace, "Hello!");
         }
-
     }
 
     private void checkTrace(DevTrace trace, String expectedBody) {

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/AsyncWiretapTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/AsyncWiretapTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.telemetry;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
@@ -30,6 +31,7 @@ import org.apache.camel.telemetry.mock.MockTracer;
 import org.apache.camel.test.junit6.ExchangeTestSupport;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -53,17 +55,23 @@ public class AsyncWiretapTest extends ExchangeTestSupport {
     }
 
     @Test
-    void testRouteMultipleRequests() throws InterruptedException {
+    void testRouteMultipleRequests() throws Exception {
         int j = 10;
         MockEndpoint mock = getMockEndpoint("mock:end");
         mock.expectedMessageCount(j);
-        mock.setAssertPeriod(5000);
         for (int i = 0; i < j; i++) {
             context.createProducerTemplate().sendBody("direct:start", "Hello!");
         }
-        mock.assertIsSatisfied(1000);
-        // We must wait a safe time to let the context completing the async writing to the log trace.
-        Thread.sleep(10000);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        // Wait for async trace writing to complete — traces are written asynchronously
+        // after exchange processing, so we poll until all traces with expected spans arrive.
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            Map<String, MockTrace> traces = mockTracer.traces();
+            assertEquals(j, traces.size());
+            for (MockTrace trace : traces.values()) {
+                assertEquals(7, trace.spans().size());
+            }
+        });
         Map<String, MockTrace> traces = mockTracer.traces();
         // Each trace should have a unique trace id. It is enough to assert that
         // the number of elements in the map is the same of the requests to prove
@@ -73,7 +81,6 @@ public class AsyncWiretapTest extends ExchangeTestSupport {
         for (MockTrace trace : traces.values()) {
             checkTrace(trace, "Hello!");
         }
-
     }
 
     private void checkTrace(MockTrace trace, String expectedBody) {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `AsyncWiretapTest` in both `camel-telemetry` and `camel-telemetry-dev` modules. Both tests had ~5-7% flaky rate in CI.

**Root cause:** The tests send 10 messages through an async wiretap route with a 2-second delay. Traces are written asynchronously after exchange processing. The assertions on trace data need to wait for the async writing to complete.

**Changes:**
- **camel-telemetry AsyncWiretapTest**: Replace `Thread.sleep(10000)` with Awaitility polling until all 10 traces with 7 spans each arrive. Replace `mock.setAssertPeriod(5000)` + `mock.assertIsSatisfied(1000)` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`.
- **camel-telemetry-dev AsyncWiretapTest**: Add Awaitility polling for trace completion (previously had no wait at all). Same mock assertion fix.

## Test plan

- [x] Both tests pass locally after changes
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)