### PR TITLE
CAMEL-24039: Fix flaky core tests - seda, scheduler, and redelivery tests

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerRepeatCountTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerRepeatCountTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.scheduler;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -29,7 +31,7 @@ public class SchedulerRepeatCountTest extends ContextTestSupport {
         mock.expectedMessageCount(3);
         mock.setAssertPeriod(1000);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/SchedulerRouteTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.scheduler;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.ContextTestSupport;
@@ -37,7 +38,7 @@ public class SchedulerRouteTest extends ContextTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMinimumMessageCount(2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         assertTrue(bean.counter.get() >= 2, "Should have fired 2 or more times was: " + bean.counter.get());
     }

--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerConcurrentTasksOneRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerConcurrentTasksOneRouteTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.camel.component.scheduler;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 public class TwoSchedulerConcurrentTasksOneRouteTest extends ContextTestSupport {
@@ -32,7 +34,7 @@ public class TwoSchedulerConcurrentTasksOneRouteTest extends ContextTestSupport 
     public void testTwoScheduler() throws Exception {
         getMockEndpoint("mock:done").expectedMinimumMessageCount(10);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerConcurrentTasksTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerConcurrentTasksTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.component.scheduler;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 public class TwoSchedulerConcurrentTasksTest extends ContextTestSupport {
@@ -27,7 +30,7 @@ public class TwoSchedulerConcurrentTasksTest extends ContextTestSupport {
         getMockEndpoint("mock:a").expectedMinimumMessageCount(4);
         getMockEndpoint("mock:b").expectedMinimumMessageCount(2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaAsyncProducerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaAsyncProducerTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.seda;
 
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
@@ -50,7 +51,7 @@ public class SedaAsyncProducerTest extends ContextTestSupport {
         // I should happen before mock
         route = route + "send";
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         assertEquals("sendprocess", route, "Send should occur before processor");
 
@@ -74,7 +75,7 @@ public class SedaAsyncProducerTest extends ContextTestSupport {
         // I should not happen before mock
         route = route + "send";
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         assertEquals("processsend", route, "Send should occur before processor");
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaMultipleConsumersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaMultipleConsumersTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.component.seda;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 public class SedaMultipleConsumersTest extends ContextTestSupport {
@@ -30,7 +33,7 @@ public class SedaMultipleConsumersTest extends ContextTestSupport {
         template.sendBody("seda:foo", "Hello World");
         template.sendBody("seda:bar", "Bye World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -42,7 +45,7 @@ public class SedaMultipleConsumersTest extends ContextTestSupport {
         template.sendBody("seda:foo", "Hello World");
         template.sendBody("seda:bar", "Bye World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         context.addRoutes(new RouteBuilder() {
             @Override
@@ -62,7 +65,7 @@ public class SedaMultipleConsumersTest extends ContextTestSupport {
             template.sendBody("seda:foo", "Hello World");
             template.sendBody("seda:bar", "Bye World");
         }
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
         resetMocks();
 
         context.getRouteController().suspendRoute("testRoute");
@@ -74,7 +77,7 @@ public class SedaMultipleConsumersTest extends ContextTestSupport {
             template.sendBody("seda:foo", "Hello World");
             template.sendBody("seda:bar", "Bye World");
         }
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingDeadLetterChannelTest.java
@@ -40,7 +40,7 @@ public class NotAllowRedeliveryWhileStoppingDeadLetterChannelTest extends Contex
 
         template.sendBody("seda:start", "Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // wait for the error handler to start the redelivery cycle
         await().pollDelay(500, TimeUnit.MILLISECONDS)

--- a/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/NotAllowRedeliveryWhileStoppingTest.java
@@ -38,7 +38,7 @@ public class NotAllowRedeliveryWhileStoppingTest extends ContextTestSupport {
 
         template.sendBody("seda:start", "Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // wait for the error handler to start the redelivery cycle
         await().pollDelay(500, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
## Summary

Fix 8 flaky core tests by replacing `assertMockEndpointsSatisfied()` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` to provide explicit, generous timeouts.

**Fixed tests:**
- `NotAllowRedeliveryWhileStoppingDeadLetterChannelTest`
- `NotAllowRedeliveryWhileStoppingTest`
- `SedaMultipleConsumersTest`
- `SedaAsyncProducerTest`
- `TwoSchedulerConcurrentTasksOneRouteTest`
- `TwoSchedulerConcurrentTasksTest`
- `SchedulerRouteTest`
- `SchedulerRepeatCountTest`

**Root cause:** The deprecated `assertMockEndpointsSatisfied()` relies on the default internal timeout (10 seconds) which can be insufficient on loaded CI systems, causing intermittent failures.

**Fix:** Use the explicit timed overload `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` which provides a 30-second latch-based wait — returning immediately when expectations are met but allowing enough time under load.

_Claude Code on behalf of gnodet_