### PR TITLE
CAMEL-24040: Fix flaky tests - timing issues in seda, throttle, aggregation, file, and JMS tests

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsDeadLetterChannelInOutIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/JmsDeadLetterChannelInOutIT.java
@@ -44,7 +44,7 @@ public class JmsDeadLetterChannelInOutIT extends AbstractPersistentJMSTest {
         assertNotNull(out);
 
         // should be in DLQ
-        Object dead = consumer.receiveBody("activemq:queue:JmsDeadLetterChannelInOutIT.error", 5000);
+        Object dead = consumer.receiveBody("activemq:queue:JmsDeadLetterChannelInOutIT.error", 10000);
         assertEquals("Hello World", dead);
     }
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/JmsToJmsTransactedIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/JmsToJmsTransactedIT.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.integration.spring.tx;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -94,7 +96,7 @@ public final class JmsToJmsTransactedIT extends CamelSpringTestSupport {
 
         template.sendBody("activemq:queue:JmsToJmsTransactedIT", "Hello World");
 
-        String reply = consumer.receiveBody("activemq:queue:JmsToJmsTransactedIT.reply", 5000, String.class);
+        String reply = consumer.receiveBody("activemq:queue:JmsToJmsTransactedIT.reply", 10000, String.class);
         assertEquals("Hello World", reply);
     }
 
@@ -123,7 +125,7 @@ public final class JmsToJmsTransactedIT extends CamelSpringTestSupport {
 
         template.sendBody("activemq:queue:JmsToJmsTransactedIT", "Hello World");
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Order(3)
@@ -151,7 +153,7 @@ public final class JmsToJmsTransactedIT extends CamelSpringTestSupport {
 
         template.sendBody("activemq:queue:JmsToJmsTransactedIT", "Hello World");
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // it should be moved to DLQ in JMS broker
         Object body = consumer.receiveBody("activemq:queue:" + DLQ_NAME, 10000);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileConsumePollEnrichFileTest.java
@@ -62,7 +62,7 @@ public class FileConsumePollEnrichFileTest extends ContextTestSupport {
                         .to("mock:start")
                         .pollEnrich(
                                 fileUri("enrichdata?initialDelay=0&delay=10&move=.done"),
-                                1000)
+                                5000)
                         .to("mock:result");
             }
         };

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaBlockWhenFullTest.java
@@ -94,13 +94,12 @@ public class SedaBlockWhenFullTest extends ContextTestSupport {
     @Test
     public void testAsyncSedaBlockingWhenFull() throws Exception {
         getMockEndpoint(MOCK_URI).setExpectedMessageCount(QUEUE_SIZE + 1);
-        getMockEndpoint(MOCK_URI).setResultWaitTime(DELAY_LONG * 3);
 
         SedaEndpoint seda = context.getEndpoint(BLOCK_WHEN_FULL_URI, SedaEndpoint.class);
         assertEquals(QUEUE_SIZE, seda.getQueue().remainingCapacity());
 
         asyncSendTwoOverCapacity(BLOCK_WHEN_FULL_URI, QUEUE_SIZE + 4);
-        assertMockEndpointsSatisfied(5, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     /**

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaInOutChainedTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaInOutChainedTimeoutTest.java
@@ -41,7 +41,7 @@ public class SedaInOutChainedTimeoutTest extends ContextTestSupport {
 
         long delta = watch.taken();
 
-        assertTrue(delta < 4000, "Should be faster than 4000 millis, was: " + delta);
+        assertTrue(delta < 8000, "Should be faster than 8000 millis, was: " + delta);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultCamelContextSuspendResumeRouteTest.java
@@ -39,7 +39,7 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
 
         template.sendBody("seda:foo", "A");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         log.info("Suspending");
 
@@ -57,7 +57,7 @@ public class DefaultCamelContextSuspendResumeRouteTest extends ContextTestSuppor
                 .atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assertions.assertDoesNotThrow(() -> template.sendBody("seda:foo", "B")));
 
-        mock.assertIsSatisfied(1000);
+        mock.assertIsSatisfied(5000);
 
         assertTrue(context.isSuspended());
         assertFalse(context.getStatus().isStarted());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateDiscardOnTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateDiscardOnTimeoutTest.java
@@ -49,7 +49,7 @@ public class AggregateDiscardOnTimeoutTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "E", "id", 456);
 
         // should complete before timeout
-        assertTrue(mock.await(1000, TimeUnit.MILLISECONDS));
+        assertTrue(mock.await(5000, TimeUnit.MILLISECONDS));
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest.java
@@ -75,7 +75,7 @@ public class ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest extends Conte
         final ServiceSupport consumer = (ServiceSupport) context.getRoute("foo").getConsumer();
 
         // wait long enough to have the consumer suspended
-        await().atMost(5, TimeUnit.SECONDS).until(consumer::isSuspended);
+        await().atMost(10, TimeUnit.SECONDS).until(consumer::isSuspended);
 
         // send more messages
         // but should get there (yet)
@@ -94,7 +94,7 @@ public class ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest extends Conte
         result.expectedBodiesReceivedInAnyOrder(bodies);
 
         // wait long enough to have the consumer resumed
-        await().atMost(5, TimeUnit.SECONDS).until(consumer::isStarted);
+        await().atMost(10, TimeUnit.SECONDS).until(consumer::isStarted);
 
         // send message
         // should get through


### PR DESCRIPTION
## Summary

Fix 8 flaky tests by increasing tight timeouts that cause intermittent failures on loaded CI systems.

**Fixed tests:**
- `SedaBlockWhenFullTest`: Removed tight `setResultWaitTime`, use 30s timed assertion
- `SedaInOutChainedTimeoutTest`: Increased time assertion from 4s to 8s
- `ThrottlingExceptionRoutePolicyHalfOpenHandlerSedaTest`: Increased Awaitility timeouts from 5s to 10s
- `DefaultCamelContextSuspendResumeRouteTest`: Replaced `assertMockEndpointsSatisfied()`, increased `assertIsSatisfied` from 1s to 5s
- `AggregateDiscardOnTimeoutTest`: Increased `mock.await` timeout from 1s to 5s
- `FileConsumePollEnrichFileTest`: Increased `pollEnrich` timeout from 1s to 5s
- `JmsToJmsTransactedIT`: Added explicit 30s timeout to `assertIsSatisfied`, increased `consumer.receiveBody` from 5s to 10s
- `JmsDeadLetterChannelInOutIT`: Increased `consumer.receiveBody` timeout from 5s to 10s

_Claude Code on behalf of gnodet_