### PR TITLE
CAMEL-24041: Fix flaky tests in camel-core (batch 9)

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaPurgeWhenStoppingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaPurgeWhenStoppingTest.java
@@ -41,7 +41,7 @@ public class SedaPurgeWhenStoppingTest extends ContextTestSupport {
         }
 
         context.getRouteController().startRoute("myRoute");
-        latch.await(2, TimeUnit.SECONDS);
+        latch.await(5, TimeUnit.SECONDS);
         context.getRouteController().stopRoute("myRoute");
         latch2.countDown();
 
@@ -58,7 +58,7 @@ public class SedaPurgeWhenStoppingTest extends ContextTestSupport {
                     @Override
                     public void process(Exchange exchange) throws Exception {
                         latch.countDown();
-                        latch2.await(2, TimeUnit.SECONDS);
+                        latch2.await(5, TimeUnit.SECONDS);
                     }
                 }).to("mock:result");
             }

--- a/core/camel-core/src/test/java/org/apache/camel/issues/RedeliveryErrorHandlerAsyncDelayedTwoCamelContextIssueTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/issues/RedeliveryErrorHandlerAsyncDelayedTwoCamelContextIssueTest.java
@@ -35,7 +35,7 @@ public class RedeliveryErrorHandlerAsyncDelayedTwoCamelContextIssueTest {
         ConsumerTemplate consumer1 = context1.createConsumerTemplate();
         context1.start();
         producer1.sendBody("seda://input", "Hey1");
-        Exchange ex1 = consumer1.receive("seda://output", 5000);
+        Exchange ex1 = consumer1.receive("seda://output", 10000);
 
         DefaultCamelContext context2 = createContext();
         ProducerTemplate producer2 = context2.createProducerTemplate();
@@ -48,7 +48,7 @@ public class RedeliveryErrorHandlerAsyncDelayedTwoCamelContextIssueTest {
         context1.stop();
 
         producer2.sendBody("seda://input", "Hey2");
-        Exchange ex2 = consumer2.receive("seda://output", 5000);
+        Exchange ex2 = consumer2.receive("seda://output", 10000);
 
         assertNotNull(ex1);
         assertEquals("Hey1", ex1.getIn().getBody());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/DefaultConsumerBridgeErrorHandlerContinuedTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/DefaultConsumerBridgeErrorHandlerContinuedTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.processor;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.Component;
 import org.apache.camel.Consumer;
@@ -26,6 +27,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.support.DefaultComponent;
 import org.apache.camel.support.ScheduledPollConsumer;
 import org.apache.camel.support.ScheduledPollEndpoint;
@@ -52,7 +54,7 @@ public class DefaultConsumerBridgeErrorHandlerContinuedTest extends ContextTestS
         // so mock:result should receive messages.
         getMockEndpoint("mock:result").expectedMinimumMessageCount(1);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // Verify the exception is present in the onException route
         Exception cause = getMockEndpoint("mock:onException").getReceivedExchanges().get(0)

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryErrorHandlerNoRedeliveryOnShutdownTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryErrorHandlerNoRedeliveryOnShutdownTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 
@@ -35,14 +38,14 @@ public class RedeliveryErrorHandlerNoRedeliveryOnShutdownTest extends ContextTes
 
         template.sendBody("seda:foo", "Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // should not take long to stop the route
         StopWatch watch = new StopWatch();
         context.getRouteController().stopRoute("foo");
         watch.taken();
 
-        assertTrue(watch.taken() < 4000, "Should stop route faster, was " + watch.taken());
+        assertTrue(watch.taken() < 8000, "Should stop route faster, was " + watch.taken());
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamIgnoreInvalidExchangesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamIgnoreInvalidExchangesTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,7 +38,7 @@ public class ResequenceStreamIgnoreInvalidExchangesTest extends ContextTestSuppo
         template.sendBodyAndHeader("direct:start", "C", "seqno", 3);
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -48,7 +51,7 @@ public class ResequenceStreamIgnoreInvalidExchangesTest extends ContextTestSuppo
         template.sendBodyAndHeader("direct:start", "C", "seqno", 3);
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -61,7 +64,7 @@ public class ResequenceStreamIgnoreInvalidExchangesTest extends ContextTestSuppo
         template.sendBody("direct:start", "A");
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -74,7 +77,7 @@ public class ResequenceStreamIgnoreInvalidExchangesTest extends ContextTestSuppo
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
         template.sendBody("direct:start", "A");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamNotIgnoreInvalidExchangesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/ResequenceStreamNotIgnoreInvalidExchangesTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.camel.processor;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,7 +42,7 @@ public class ResequenceStreamNotIgnoreInvalidExchangesTest extends ContextTestSu
         template.sendBodyAndHeader("direct:start", "C", "seqno", 3);
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -53,7 +56,7 @@ public class ResequenceStreamNotIgnoreInvalidExchangesTest extends ContextTestSu
         template.sendBodyAndHeader("direct:start", "C", "seqno", 3);
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -68,7 +71,7 @@ public class ResequenceStreamNotIgnoreInvalidExchangesTest extends ContextTestSu
 
         template.sendBodyAndHeader("direct:start", "B", "seqno", 2);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -82,7 +85,7 @@ public class ResequenceStreamNotIgnoreInvalidExchangesTest extends ContextTestSu
         assertThrows(CamelExecutionException.class, () -> template.sendBody("direct:start", "A"),
                 "Should have thrown an exception");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/AggregateTimeoutTest.java
@@ -48,10 +48,10 @@ public class AggregateTimeoutTest extends ContextTestSupport {
 
         // wait about 0.2 second so that the timeout kicks in, but it was
         // discarded
-        mock.assertIsSatisfied(200);
+        mock.assertIsSatisfied(500);
 
         // should invoke the timeout method
-        await().atMost(Duration.ofSeconds(2))
+        await().atMost(Duration.ofSeconds(5))
                 .untilAsserted(() -> assertEquals(1, invoked.get()));
 
         assertNotNull(receivedExchange);
@@ -69,10 +69,10 @@ public class AggregateTimeoutTest extends ContextTestSupport {
         template.sendBodyAndHeader("direct:start", "C", "id", 123);
 
         // should complete before timeout
-        mock.assertIsSatisfied(150);
+        mock.assertIsSatisfied(500);
 
         // should have not invoked the timeout method anymore
-        await().atMost(Duration.ofSeconds(2))
+        await().atMost(Duration.ofSeconds(5))
                 .untilAsserted(() -> assertEquals(1, invoked.get()));
     }
 


### PR DESCRIPTION
## Summary

Fix flaky tests identified by [Develocity](https://develocity.apache.org) in camel-core:

- **RedeliveryErrorHandlerNoRedeliveryOnShutdownTest**: Replace `assertMockEndpointsSatisfied()` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`, increase time assertion tolerance from `< 4000` to `< 8000`
- **DefaultConsumerBridgeErrorHandlerContinuedTest**: Replace `assertMockEndpointsSatisfied()` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)`
- **ResequenceStreamNotIgnoreInvalidExchangesTest**: Replace 4× `assertMockEndpointsSatisfied()` with timed variant
- **ResequenceStreamIgnoreInvalidExchangesTest**: Replace 4× `assertMockEndpointsSatisfied()` with timed variant
- **AggregateTimeoutTest**: Increase `assertIsSatisfied` timeouts from 150/200ms to 500ms, Awaitility from 2s to 5s
- **SedaPurgeWhenStoppingTest**: Increase latch await timeouts from 2s to 5s
- **RedeliveryErrorHandlerAsyncDelayedTwoCamelContextIssueTest**: Increase `consumer.receive` timeouts from 5s to 10s

## Test plan

- [x] All 7 modified tests pass locally (13 test methods, 0 failures)
- [x] Code formatted with `mvn formatter:format impsort:sort`

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)