### PR TITLE
CAMEL-24042: Fix flaky tests in camel-core (batch 10)

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerNoForcedWritesTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerNoForcedWritesTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.file;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -33,7 +35,7 @@ public class FileProducerNoForcedWritesTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         assertFileExists(testFile("output.txt"));
         assertEquals("Hello World",

--- a/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTimeClauseTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/mock/MockEndpointTimeClauseTest.java
@@ -44,7 +44,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
 
         template.sendBody("direct:a", "A");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
 
         template.sendBody("direct:a", "A");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -171,7 +171,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 2);
         template.sendBody("direct:a", "C");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -185,7 +185,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
                 .until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
                 .until(() -> mock.getReceivedCounter() >= 1);
         template.sendBody("direct:a", "B");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -217,7 +217,7 @@ public class MockEndpointTimeClauseTest extends ContextTestSupport {
         await().atMost(5, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 4);
         template.sendBody("direct:a", "E");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/StopTimeoutRouteTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/StopTimeoutRouteTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +44,7 @@ public class StopTimeoutRouteTest extends ContextTestSupport {
 
         template.sendBody("direct:foo", "Hello Foo");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         assertEquals(ServiceStatus.Stopped, context.getRouteController().getRouteStatus("start"));
         assertEquals(ServiceStatus.Started, context.getRouteController().getRouteStatus("foo"));

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
@@ -51,7 +51,7 @@ public class DistributedTimeoutTest extends AbstractDistributedTest {
         template2.sendBodyAndHeader("direct:start", "B", "id", 123);
 
         // wait a bit until the timeout was triggered
-        await().atMost(5, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
 
         mock.assertIsSatisfied();
         mock2.assertIsSatisfied();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
@@ -75,7 +75,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
         template.sendBody(url, "MessageTrigger");
 
         // wait for the circuit to open (consumer suspended)
-        await().atMost(5, TimeUnit.SECONDS).until(consumer::isSuspended);
+        await().atMost(10, TimeUnit.SECONDS).until(consumer::isSuspended);
 
         // send next set of messages
         // should NOT go through b/c circuit is open
@@ -91,7 +91,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
         policy.setKeepOpen(false);
 
         // wait for the consumer to resume since keepOpen is now false
-        await().atMost(5, TimeUnit.SECONDS).until(consumer::isStarted);
+        await().atMost(10, TimeUnit.SECONDS).until(consumer::isStarted);
 
         // it should close b/c keepOpen is false — queued messages should now arrive
         result.expectedMessageCount(size * 2 + 1);

--- a/core/camel-core/src/test/java/org/apache/camel/support/task/task/ForegroundTaskTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/task/task/ForegroundTaskTest.java
@@ -34,7 +34,7 @@ public class ForegroundTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max iterations when using a supplier")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMoreSupplier() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -57,7 +57,7 @@ public class ForegroundTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max iterations when using a supplier")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMoreSupplierWithDelay() {
         ForegroundTask task = Tasks.foregroundTask()
                 .withBudget(Budgets.iterationBudget()
@@ -73,7 +73,7 @@ public class ForegroundTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max iterations when using a predicate and an initial delay")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicate() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -90,7 +90,7 @@ public class ForegroundTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task stops running once the predicate is true")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateDeterministic() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -107,7 +107,7 @@ public class ForegroundTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task stops running once the predicate is true when the test is slow")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateDeterministicSlow() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -124,7 +124,7 @@ public class ForegroundTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task stops running once the predicate is true when the test is slow")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateDeterministicSlowWithDelay() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()

--- a/core/camel-core/src/test/java/org/apache/camel/support/task/task/ForegroundTimeTaskTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/task/task/ForegroundTimeTaskTest.java
@@ -34,7 +34,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max iterations when using a supplier")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMoreSupplier() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -58,7 +58,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max iterations when using a supplier and an initial delay")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMoreSupplierWithDelay() {
         // this should run 5 times in a total duration of 6 seconds (5s executing + 1s delay)
         ForegroundTask task = Tasks.foregroundTask()
@@ -76,7 +76,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max iterations when using a predicate and an initial delay")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicate() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -94,7 +94,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task does not run for more than the max duration when using a predicate and an initial delay")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateMaxDuration() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -112,7 +112,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task stops running once the predicate is true")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateDeterministic() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -130,7 +130,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task stops running once the predicate is true when the test is slow")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateDeterministicSlow() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()
@@ -148,7 +148,7 @@ class ForegroundTimeTaskTest extends TaskTestSupport {
 
     @DisplayName("Test that the task stops running once the predicate is true when the test is slow")
     @Test
-    @Timeout(10)
+    @Timeout(20)
     void testRunNoMorePredicateDeterministicSlowWithDelay() {
         // It should run 5 times in 4 seconds because there is no delay
         ForegroundTask task = Tasks.foregroundTask()


### PR DESCRIPTION
## Summary

Fix flaky tests identified by [Develocity](https://develocity.apache.org) in camel-core:

- **ThrottlingExceptionRoutePolicyOpenViaConfigTest**: Increase Awaitility timeouts from 5s to 10s
- **DistributedTimeoutTest**: Increase Awaitility timeout from 5s to 10s
- **MockEndpointTimeClauseTest**: Replace 8× bare `assertMockEndpointsSatisfied()` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` (2 intentional bare calls left: assertThrows and timing-critical test)
- **FileProducerNoForcedWritesTest**: Replace `assertMockEndpointsSatisfied()` with timed variant
- **StopTimeoutRouteTest**: Replace `assertMockEndpointsSatisfied()` with timed variant
- **ForegroundTaskTest**: Increase `@Timeout` from 10s to 20s (slow test predicates sleep 2s/iteration, tight under CI load)
- **ForegroundTimeTaskTest**: Increase `@Timeout` from 10s to 20s

## Test plan

- [x] All 28 test methods pass locally (0 failures)
- [x] Code formatted with `mvn formatter:format impsort:sort`

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)