### PR TITLE
CAMEL-24043: Fix flaky tests (batch 11)

### DIFF
--- a/components/camel-flatpack/src/test/java/org/apache/camel/component/flatpack/FixedLengthAllowShortTest.java
+++ b/components/camel-flatpack/src/test/java/org/apache/camel/component/flatpack/FixedLengthAllowShortTest.java
@@ -52,7 +52,8 @@ public class FixedLengthAllowShortTest {
     @Test
     public void testCamel() throws Exception {
         results.expectedMessageCount(4);
-        results.assertIsSatisfied(30_000);
+        results.setResultWaitTime(30_000);
+        results.assertIsSatisfied();
 
         int counter = 0;
         List<Exchange> list = results.getReceivedExchanges();
@@ -70,7 +71,8 @@ public class FixedLengthAllowShortTest {
     @Test
     public void testFlatpackDataFormat() throws Exception {
         resultsdf.expectedMessageCount(1);
-        resultsdf.assertIsSatisfied(30_000);
+        resultsdf.setResultWaitTime(30_000);
+        resultsdf.assertIsSatisfied();
 
         Exchange exchange = resultsdf.getReceivedExchanges().get(0);
         DataSetList data = exchange.getIn().getBody(DataSetList.class);
@@ -84,7 +86,8 @@ public class FixedLengthAllowShortTest {
     @Test
     public void testFlatpackDataFormatXML() throws Exception {
         resultsxml.expectedMessageCount(1);
-        resultsxml.assertIsSatisfied(30_000);
+        resultsxml.setResultWaitTime(30_000);
+        resultsxml.assertIsSatisfied();
 
         Exchange exchange = resultsxml.getReceivedExchanges().get(0);
         DataSetList data = exchange.getIn().getBody(DataSetList.class);

--- a/components/camel-flatpack/src/test/java/org/apache/camel/component/flatpack/FixedLengthAllowShortTest.java
+++ b/components/camel-flatpack/src/test/java/org/apache/camel/component/flatpack/FixedLengthAllowShortTest.java
@@ -52,7 +52,7 @@ public class FixedLengthAllowShortTest {
     @Test
     public void testCamel() throws Exception {
         results.expectedMessageCount(4);
-        results.assertIsSatisfied();
+        results.assertIsSatisfied(30_000);
 
         int counter = 0;
         List<Exchange> list = results.getReceivedExchanges();
@@ -70,7 +70,7 @@ public class FixedLengthAllowShortTest {
     @Test
     public void testFlatpackDataFormat() throws Exception {
         resultsdf.expectedMessageCount(1);
-        resultsdf.assertIsSatisfied();
+        resultsdf.assertIsSatisfied(30_000);
 
         Exchange exchange = resultsdf.getReceivedExchanges().get(0);
         DataSetList data = exchange.getIn().getBody(DataSetList.class);
@@ -84,7 +84,7 @@ public class FixedLengthAllowShortTest {
     @Test
     public void testFlatpackDataFormatXML() throws Exception {
         resultsxml.expectedMessageCount(1);
-        resultsxml.assertIsSatisfied();
+        resultsxml.assertIsSatisfied(30_000);
 
         Exchange exchange = resultsxml.getReceivedExchanges().get(0);
         DataSetList data = exchange.getIn().getBody(DataSetList.class);

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapConsumerTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastReplicatedmapConsumerTest.java
@@ -84,7 +84,7 @@ public class HazelcastReplicatedmapConsumerTest extends CamelTestSupport {
         out.expectedMessageCount(1);
 
         map.put("4711", "my-foo");
-        MockEndpoint.assertIsSatisfied(context, 5000, TimeUnit.MILLISECONDS);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         this.checkHeaders(out.getExchanges().get(0).getIn().getHeaders(), HazelcastConstants.ADDED);
     }
@@ -110,11 +110,11 @@ public class HazelcastReplicatedmapConsumerTest extends CamelTestSupport {
         // Wait for the ADDED event to be fully processed before removing,
         // otherwise the remove may execute before the async ADDED event is delivered.
         MockEndpoint added = getMockEndpoint("mock:added");
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await().atMost(10, TimeUnit.SECONDS)
                 .until(() -> added.getReceivedCounter() >= 1);
 
         map.remove("4711");
-        MockEndpoint.assertIsSatisfied(context, 5000, TimeUnit.MILLISECONDS);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
         this.checkHeaders(out.getExchanges().get(0).getIn().getHeaders(), HazelcastConstants.REMOVED);
     }
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentDuplicateNamesTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentDuplicateNamesTest.java
@@ -70,7 +70,8 @@ public class MailAttachmentDuplicateNamesTest extends CamelTestSupport {
 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.assertIsSatisfied(30_000);
+        mock.setResultWaitTime(30_000);
+        mock.assertIsSatisfied();
         Exchange out = mock.assertExchangeReceived(0);
 
         // plain text

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentDuplicateNamesTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailAttachmentDuplicateNamesTest.java
@@ -70,7 +70,7 @@ public class MailAttachmentDuplicateNamesTest extends CamelTestSupport {
 
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(1);
-        mock.assertIsSatisfied();
+        mock.assertIsSatisfied(30_000);
         Exchange out = mock.assertExchangeReceived(0);
 
         // plain text

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/FilterCreateCamelContextPerClassTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/FilterCreateCamelContextPerClassTest.java
@@ -40,7 +40,8 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
 
         template.sendBodyAndHeader("direct:start", expectedBody, "foo", "bar");
 
-        endpoint.assertIsSatisfied(30_000);
+        endpoint.setResultWaitTime(30_000);
+        endpoint.assertIsSatisfied();
     }
 
     @Test
@@ -51,7 +52,10 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
 
         template.sendBodyAndHeader("direct:start", "<notMatched/>", "foo", "notMatchedHeaderValue");
 
-        endpoint.assertIsSatisfied(30_000);
+        // No timeout param needed for expectedCount=0 — assertIsSatisfied()
+        // returns immediately when no messages are expected (the default
+        // sleepForEmptyTest=0 is correct here)
+        endpoint.assertIsSatisfied();
     }
 
     @Override

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/FilterCreateCamelContextPerClassTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/FilterCreateCamelContextPerClassTest.java
@@ -40,7 +40,7 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
 
         template.sendBodyAndHeader("direct:start", expectedBody, "foo", "bar");
 
-        endpoint.assertIsSatisfied();
+        endpoint.assertIsSatisfied(30_000);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
 
         template.sendBodyAndHeader("direct:start", "<notMatched/>", "foo", "notMatchedHeaderValue");
 
-        endpoint.assertIsSatisfied();
+        endpoint.assertIsSatisfied(30_000);
     }
 
     @Override

--- a/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/FilterCreateCamelContextPerClassTest.java
+++ b/components/camel-test/camel-test-junit5/src/test/java/org/apache/camel/test/junit5/patterns/FilterCreateCamelContextPerClassTest.java
@@ -52,9 +52,6 @@ public class FilterCreateCamelContextPerClassTest extends CamelTestSupport {
 
         template.sendBodyAndHeader("direct:start", "<notMatched/>", "foo", "notMatchedHeaderValue");
 
-        // No timeout param needed for expectedCount=0 — assertIsSatisfied()
-        // returns immediately when no messages are expected (the default
-        // sleepForEmptyTest=0 is correct here)
         endpoint.assertIsSatisfied();
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/CamelPostProcessorHelperTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/CamelPostProcessorHelperTest.java
@@ -107,7 +107,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -138,10 +138,10 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         template.sendBody("seda:foo", "Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // give UoW a bit of time
-        await("onDone invokation").atMost(1, TimeUnit.SECONDS).until(mySynchronization::isOnDone);
+        await("onDone invokation").atMost(5, TimeUnit.SECONDS).until(mySynchronization::isOnDone);
     }
 
     @Test
@@ -157,10 +157,10 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         my.produceSomething("Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // give UoW a bit of time
-        await("onDone invocation").atMost(1, TimeUnit.SECONDS).until(mySynchronization::isOnDone);
+        await("onDone invocation").atMost(5, TimeUnit.SECONDS).until(mySynchronization::isOnDone);
     }
 
     @Test
@@ -185,7 +185,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
         assertNotNull(bean.getProducer());
         bean.send("Hello World");
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -214,7 +214,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         bean.send(exchange);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -243,7 +243,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
         Exchange exchange = bean.consume();
         template.send("mock:result", exchange);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -269,7 +269,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         bean.send(exchange);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -295,7 +295,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         bean.send(exchange);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -321,7 +321,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         bean.send(exchange);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -623,7 +623,7 @@ public class CamelPostProcessorHelperTest extends ContextTestSupport {
 
         myBean.sendExchange(exchange);
 
-        assertMockEndpointsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky tests across multiple modules by replacing bare `assertIsSatisfied()` calls with properly timed assertions, giving slow CI environments enough time to complete.

### Changes

| Test | Module | Fix |
|------|--------|-----|
| `CamelPostProcessorHelperTest` | camel-core | Use `MockEndpoint.assertIsSatisfied(context, 30, SECONDS)` |
| `HazelcastReplicatedmapConsumerTest` | camel-hazelcast | Use `MockEndpoint.assertIsSatisfied(context, 30, SECONDS)` |
| `FixedLengthAllowShortTest` | camel-flatpack | Use `setResultWaitTime(30_000)` + `assertIsSatisfied()` |
| `MailAttachmentDuplicateNamesTest` | camel-mail | Use `setResultWaitTime(30_000)` + `assertIsSatisfied()` |
| `FilterCreateCamelContextPerClassTest` | camel-test-junit5 | Use `setResultWaitTime(30_000)` for expectedCount>0; keep no-arg for expectedCount=0 |

### Important API note

The instance method `mock.assertIsSatisfied(long)` parameter is `timeoutForEmptyEndpoints` — it is **only used when `expectedCount == 0`**. When `expectedCount > 0`, the parameter is silently ignored and the latch uses the default 10s `resultWaitTime`. The correct approaches are:
- `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` (static method)
- `mock.setResultWaitTime(30_000)` before `mock.assertIsSatisfied()` (instance method)

## Test plan

- [x] `CamelPostProcessorHelperTest` — passes
- [x] `HazelcastReplicatedmapConsumerTest` — passes
- [x] `FixedLengthAllowShortTest` — 3 tests pass
- [x] `MailAttachmentDuplicateNamesTest` — passes
- [x] `FilterCreateCamelContextPerClassTest` — 2 tests pass
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)