### PR TITLE
CAMEL-24032: Add rolling 1-minute exchange rate metric

### DIFF
--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsumerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsumerDevConsole.java
@@ -237,6 +237,7 @@ public class ConsumerDevConsole extends AbstractDevConsole {
             stats.put("p50ProcessingTime", mr.getProcessingTimeP50());
             stats.put("p95ProcessingTime", mr.getProcessingTimeP95());
             stats.put("p99ProcessingTime", mr.getProcessingTimeP99());
+            stats.put("exchangeRate1m", mr.getExchangeRate1m());
         }
         if (mr.getExchangesTotal() > 0) {
             stats.put("lastProcessingTime", mr.getLastProcessingTime());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ContextDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ContextDevConsole.java
@@ -191,6 +191,7 @@ public class ContextDevConsole extends AbstractDevConsole {
                     stats.put("p50ProcessingTime", mb.getProcessingTimeP50());
                     stats.put("p95ProcessingTime", mb.getProcessingTimeP95());
                     stats.put("p99ProcessingTime", mb.getProcessingTimeP99());
+                    stats.put("exchangeRate1m", mb.getExchangeRate1m());
                 }
                 if (mb.getExchangesTotal() > 0) {
                     stats.put("lastProcessingTime", mb.getLastProcessingTime());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
@@ -340,6 +340,7 @@ public class ProcessorDevConsole extends AbstractDevConsole {
             stats.put("p50ProcessingTime", mp.getProcessingTimeP50());
             stats.put("p95ProcessingTime", mp.getProcessingTimeP95());
             stats.put("p99ProcessingTime", mp.getProcessingTimeP99());
+            stats.put("exchangeRate1m", mp.getExchangeRate1m());
         }
         if (mp.getExchangesTotal() > 0) {
             stats.put("lastProcessingTime", mp.getLastProcessingTime());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
@@ -493,6 +493,7 @@ public class RouteDevConsole extends AbstractDevConsole {
             stats.put("p50ProcessingTime", mrb.getProcessingTimeP50());
             stats.put("p95ProcessingTime", mrb.getProcessingTimeP95());
             stats.put("p99ProcessingTime", mrb.getProcessingTimeP99());
+            stats.put("exchangeRate1m", mrb.getExchangeRate1m());
         }
         if (mrb.getExchangesTotal() > 0) {
             stats.put("lastProcessingTime", mrb.getLastProcessingTime());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
@@ -184,6 +184,7 @@ public class RouteGroupDevConsole extends AbstractDevConsole {
                 stats.put("p50ProcessingTime", mrg.getProcessingTimeP50());
                 stats.put("p95ProcessingTime", mrg.getProcessingTimeP95());
                 stats.put("p99ProcessingTime", mrg.getProcessingTimeP99());
+                stats.put("exchangeRate1m", mrg.getExchangeRate1m());
             }
             if (mrg.getExchangesTotal() > 0) {
                 stats.put("lastProcessingTime", mrg.getLastProcessingTime());

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TopDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TopDevConsole.java
@@ -261,6 +261,7 @@ public class TopDevConsole extends AbstractDevConsole {
             stats.put("p50ProcessingTime", mpb.getProcessingTimeP50());
             stats.put("p95ProcessingTime", mpb.getProcessingTimeP95());
             stats.put("p99ProcessingTime", mpb.getProcessingTimeP99());
+            stats.put("exchangeRate1m", mpb.getExchangeRate1m());
         }
         return stats;
     }

--- a/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedPerformanceCounterMBean.java
+++ b/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedPerformanceCounterMBean.java
@@ -111,6 +111,12 @@ public interface ManagedPerformanceCounterMBean extends ManagedCounterMBean {
     @ManagedAttribute(description = "99th percentile of recent processing times [milliseconds]. Requires Extended statistics level, returns -1 otherwise.")
     long getProcessingTimeP99();
 
+    /**
+     * @since 4.22
+     */
+    @ManagedAttribute(description = "Rolling 1-minute exchange rate [exchanges/minute]. Requires Extended statistics level, returns -1 otherwise.")
+    long getExchangeRate1m();
+
     @ManagedAttribute(description = "Statistics enabled")
     boolean isStatisticsEnabled();
 

--- a/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedPerformanceCounter.java
+++ b/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedPerformanceCounter.java
@@ -65,6 +65,11 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
     private long[] percentileWindow;
     private int percentileIndex;
     private int percentileCount;
+    // rolling 1-minute exchange rate (Extended statistics only)
+    private static final int EXCHANGE_RATE_WINDOW_SECONDS = 60;
+    private final Object exchangeRateLock = new Object();
+    private long[] exchangeRateSeconds;
+    private long[] exchangeRateCounts;
 
     @Override
     public void init(ManagementStrategy strategy) {
@@ -96,6 +101,9 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
         percentileWindow = new long[PERCENTILE_WINDOW_SIZE];
         percentileIndex = 0;
         percentileCount = 0;
+
+        exchangeRateSeconds = new long[EXCHANGE_RATE_WINDOW_SECONDS];
+        exchangeRateCounts = new long[EXCHANGE_RATE_WINDOW_SECONDS];
     }
 
     @Override
@@ -126,6 +134,10 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
         if (percentileWindow != null) {
             percentileIndex = 0;
             percentileCount = 0;
+        }
+        if (exchangeRateSeconds != null) {
+            Arrays.fill(exchangeRateSeconds, 0);
+            Arrays.fill(exchangeRateCounts, 0);
         }
     }
 
@@ -202,6 +214,27 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
     @Override
     public long getProcessingTimeP99() {
         return getPercentile(0.99);
+    }
+
+    @Override
+    public long getExchangeRate1m() {
+        if (exchangeRateSeconds == null) {
+            return -1;
+        }
+
+        long currentSecond = System.currentTimeMillis() / 1000;
+        long rate = 0;
+
+        synchronized (exchangeRateLock) {
+            for (int i = 0; i < EXCHANGE_RATE_WINDOW_SECONDS; i++) {
+                long age = currentSecond - exchangeRateSeconds[i];
+                if (age >= 0 && age < EXCHANGE_RATE_WINDOW_SECONDS) {
+                    rate += exchangeRateCounts[i];
+                }
+            }
+        }
+
+        return rate;
     }
 
     @Override
@@ -329,6 +362,7 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
         }
 
         lastExchangeCompletedTimestamp.updateValue(now);
+        updateExchangeRate(now);
         if (firstExchangeCompletedExchangeId == null) {
             firstExchangeCompletedExchangeId = exchange.getExchangeId();
         }
@@ -362,10 +396,29 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
         }
 
         lastExchangeFailureTimestamp.updateValue(now);
+        updateExchangeRate(now);
         if (firstExchangeFailureExchangeId == null) {
             firstExchangeFailureExchangeId = exchange.getExchangeId();
         }
         lastExchangeFailureExchangeId = exchange.getExchangeId();
+    }
+
+    private void updateExchangeRate(long now) {
+        if (exchangeRateSeconds == null) {
+            return;
+        }
+
+        long currentSecond = now / 1000;
+        int bucket = (int) (currentSecond % EXCHANGE_RATE_WINDOW_SECONDS);
+
+        synchronized (exchangeRateLock) {
+            if (exchangeRateSeconds[bucket] != currentSecond) {
+                exchangeRateSeconds[bucket] = currentSecond;
+                exchangeRateCounts[bucket] = 1;
+            } else {
+                exchangeRateCounts[bucket]++;
+            }
+        }
     }
 
     private long getPercentile(double percentile) {
@@ -399,6 +452,7 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
             sb.append(String.format(" p50ProcessingTime=\"%s\"", getProcessingTimeP50()));
             sb.append(String.format(" p95ProcessingTime=\"%s\"", getProcessingTimeP95()));
             sb.append(String.format(" p99ProcessingTime=\"%s\"", getProcessingTimeP99()));
+            sb.append(String.format(" exchangeRate1m=\"%s\"", getExchangeRate1m()));
         }
         sb.append(String.format(" idleSince=\"%s\"", getIdleSince()));
 
@@ -451,6 +505,7 @@ public abstract class ManagedPerformanceCounter extends ManagedCounter
             jo.put("p50ProcessingTime", getProcessingTimeP50());
             jo.put("p95ProcessingTime", getProcessingTimeP95());
             jo.put("p99ProcessingTime", getProcessingTimeP99());
+            jo.put("exchangeRate1m", getExchangeRate1m());
         }
         jo.put("idleSince", getIdleSince());
         if (fullStats) {

--- a/core/camel-management/src/test/java/org/apache/camel/management/ManagedPercentileStatisticsTest.java
+++ b/core/camel-management/src/test/java/org/apache/camel/management/ManagedPercentileStatisticsTest.java
@@ -59,12 +59,14 @@ public class ManagedPercentileStatisticsTest extends ManagementTestSupport {
         Long p50 = (Long) mbeanServer.getAttribute(on, "ProcessingTimeP50");
         Long p95 = (Long) mbeanServer.getAttribute(on, "ProcessingTimeP95");
         Long p99 = (Long) mbeanServer.getAttribute(on, "ProcessingTimeP99");
+        Long rate = (Long) mbeanServer.getAttribute(on, "ExchangeRate1m");
 
         assertTrue(p50 >= 0, "p50 should be >= 0, was: " + p50);
         assertTrue(p95 >= 0, "p95 should be >= 0, was: " + p95);
         assertTrue(p99 >= 0, "p99 should be >= 0, was: " + p99);
         assertTrue(p50 <= p95, "p50 should be <= p95, was p50=" + p50 + " p95=" + p95);
         assertTrue(p95 <= p99, "p95 should be <= p99, was p95=" + p95 + " p99=" + p99);
+        assertEquals(5, rate.longValue());
     }
 
     @Test
@@ -83,10 +85,12 @@ public class ManagedPercentileStatisticsTest extends ManagementTestSupport {
         Long p50 = (Long) mbeanServer.getAttribute(on, "ProcessingTimeP50");
         Long p95 = (Long) mbeanServer.getAttribute(on, "ProcessingTimeP95");
         Long p99 = (Long) mbeanServer.getAttribute(on, "ProcessingTimeP99");
+        Long rate = (Long) mbeanServer.getAttribute(on, "ExchangeRate1m");
 
         assertTrue(p50 >= 0, "p50 should be >= 0, was: " + p50);
         assertTrue(p95 >= 0, "p95 should be >= 0, was: " + p95);
         assertTrue(p99 >= 0, "p99 should be >= 0, was: " + p99);
+        assertEquals(3, rate.longValue());
     }
 
     @Override


### PR DESCRIPTION
# Description

This PR implements **CAMEL-24032** by adding a rolling 1-minute exchange rate metric to `ManagedPerformanceCounter`.

The new metric tracks the number of exchanges completed or failed during the last 60 seconds and is available when the Management Statistics Level is set to `Extended`. When extended statistics are not enabled, the metric returns `-1`, consistent with the existing percentile metrics.

The metric is exposed through:
- JMX (`ExchangeRate1m`)
- XML statistics output
- JSON statistics output
- Camel Dev Console

A unit test has also been added to verify the new metric is exposed correctly through JMX for both route and context statistics.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a JIRA issue filed for the change: **CAMEL-24032**.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.
I attempted to run ./mvnw clean install -DskipTests from the repository root, but the build failed in the unrelated camel-kserve module. The changes in camel-management and camel-console build successfully, and the relevant tests pass.

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

