### PR TITLE
CAMEL-24049: Fix flaky JMS Spring tests - queue name isolation and readiness

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsRouteTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.jms;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
@@ -57,7 +58,7 @@ public abstract class JmsRouteTest extends AbstractJMSTest {
         sendExchange("");
         sendExchange(null);
 
-        resultEndpoint.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     protected void assertSendAndReceiveBody(Object expectedBody) throws InterruptedException {
@@ -66,7 +67,7 @@ public abstract class JmsRouteTest extends AbstractJMSTest {
 
         sendExchange(expectedBody);
 
-        resultEndpoint.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     protected void sendExchange(final Object expectedBody) {
@@ -85,8 +86,8 @@ public abstract class JmsRouteTest extends AbstractJMSTest {
 
         return new RouteBuilder() {
             public void configure() {
-                from(startEndpointUri).to(endEndpointUri);
-                from(endEndpointUri).to("mock:result");
+                from(startEndpointUri).routeId("jmsRoute1").to(endEndpointUri);
+                from(endEndpointUri).routeId("jmsRoute2").to("mock:result");
             }
         };
     }
@@ -103,5 +104,8 @@ public abstract class JmsRouteTest extends AbstractJMSTest {
         consumer = camelContextExtension.getConsumerTemplate();
 
         resultEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);
+
+        // Wait for the JMS consumer routes to be fully subscribed to the broker
+        JmsTestHelper.waitForJmsConsumerRoutes(context, "jmsRoute1", "jmsRoute2");
     }
 }

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/JmsSpringLoadBalanceFailOverJMSIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/JmsSpringLoadBalanceFailOverJMSIT.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.jms.integration.spring;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.component.jms.JmsTestHelper;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -45,6 +46,9 @@ public class JmsSpringLoadBalanceFailOverJMSIT extends AbstractSpringJMSITSuppor
 
     @Test
     public void testFailover() throws Exception {
+        // Wait for the JMS consumer routes to be fully subscribed to the broker
+        JmsTestHelper.waitForJmsConsumerRoutes(context, "fooConsumerRoute", "barConsumerRoute");
+
         getMockEndpoint("mock:foo").expectedBodiesReceived("Hello World");
         getMockEndpoint("mock:bar").expectedBodiesReceived("Hello World");
         getMockEndpoint("mock:result").expectedBodiesReceived("Bye World");

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/RouteIdTransactedIT.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/integration/spring/tx/RouteIdTransactedIT.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.jms.integration.spring.tx;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jms.JmsTestHelper;
 import org.apache.camel.component.jms.integration.spring.AbstractSpringJMSITSupport;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.MethodOrderer;
@@ -44,10 +45,13 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
     @Order(1)
     @Test
     public void testRouteId() throws Exception {
+        // Wait for the JMS consumer route to be fully subscribed to the broker
+        JmsTestHelper.waitForJmsConsumerRoutes(context, "myCoolRoute");
+
         getMockEndpoint("mock:error").expectedMessageCount(0);
         getMockEndpoint("mock:result").expectedMessageCount(1);
 
-        template.sendBody("activemq:queue:RouteIdTransactedTest", "Hello World");
+        template.sendBody("activemq:queue:RouteIdTransactedIT", "Hello World");
 
         MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
@@ -58,10 +62,13 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
     @Order(2)
     @Test
     public void testRouteIdFailed() throws Exception {
+        // Wait for the JMS consumer route to be fully subscribed to the broker
+        JmsTestHelper.waitForJmsConsumerRoutes(context, "myCoolRoute");
+
         getMockEndpoint("mock:error").expectedMessageCount(1);
         getMockEndpoint("mock:result").expectedMessageCount(0);
 
-        template.sendBody("activemq:queue:RouteIdTransactedTest", "Kaboom");
+        template.sendBody("activemq:queue:RouteIdTransactedIT", "Kaboom");
 
         MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
@@ -74,7 +81,7 @@ public class RouteIdTransactedIT extends AbstractSpringJMSITSupport {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("activemq:queue:RouteIdTransactedTest?transacted=true").id("myCoolRoute")
+                from("activemq:queue:RouteIdTransactedIT?transacted=true").id("myCoolRoute")
                         .onException(IllegalArgumentException.class).handled(true).to("log:bar").to("mock:error").end()
                         .transacted()
                         .choice()

--- a/components/camel-jms/src/test/resources/org/apache/camel/component/jms/integration/spring/JmsSpringLoadBalanceFailOverIT.xml
+++ b/components/camel-jms/src/test/resources/org/apache/camel/component/jms/integration/spring/JmsSpringLoadBalanceFailOverIT.xml
@@ -41,24 +41,24 @@
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
         <jmxAgent id="agent" disabled="true"/>
 
-        <route>
+        <route id="loadBalanceRoute">
             <from uri="direct:start"/>
             <loadBalance>
                 <failoverLoadBalancer/>
-                <to uri="jms:queue:foo?transferException=true"/>
-                <to uri="jms:queue:bar?transferException=true"/>
+                <to uri="jms:queue:JmsSpringLoadBalanceFailOver.foo?transferException=true"/>
+                <to uri="jms:queue:JmsSpringLoadBalanceFailOver.bar?transferException=true"/>
             </loadBalance>
             <to uri="mock:result"/>
         </route>
 
-        <route>
-            <from uri="jms:queue:foo?transferException=true"/>
+        <route id="fooConsumerRoute">
+            <from uri="jms:queue:JmsSpringLoadBalanceFailOver.foo?transferException=true"/>
             <to uri="mock:foo"/>
             <throwException ref="damn"/>
         </route>
 
-        <route>
-            <from uri="jms:queue:bar?transferException=true"/>
+        <route id="barConsumerRoute">
+            <from uri="jms:queue:JmsSpringLoadBalanceFailOver.bar?transferException=true"/>
             <to uri="mock:bar"/>
             <transform><simple>Bye World</simple></transform>
         </route>


### PR DESCRIPTION
## Summary

Fix flaky JMS tests that use Spring XML configuration by addressing two root causes: queue name collisions between tests sharing a singleton Artemis broker, and race conditions where messages are sent before JMS consumers are fully subscribed.

### Changes

- **Queue name isolation**: Renamed hardcoded generic queue names (`foo`, `bar`) to class-scoped names (e.g., `JmsSpringLoadBalanceFailOver.foo`) in `JmsSpringLoadBalanceFailOverIT.xml` to prevent cross-test contamination via the shared broker
- **Route IDs for readiness**: Added explicit route IDs to Spring XML routes and Java route builders so `JmsTestHelper.waitForJmsConsumerRoutes()` can target them
- **Readiness checks**: Added `JmsTestHelper.waitForJmsConsumerRoutes()` calls before sending messages to ensure JMS consumers are fully subscribed to the broker
- **Timed assertions**: Replaced bare `MockEndpoint.assertIsSatisfied()` calls with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` for deterministic timeouts
- **Queue name fix**: Corrected queue name mismatch in `RouteIdTransactedIT` (was using old class name `RouteIdTransactedTest`)

### Affected tests (7 test classes, 13 test methods)

| Test Class | Fix Applied |
|---|---|
| `JmsSpringLoadBalanceFailOverJMSIT` | Queue isolation + readiness check |
| `RouteIdTransactedIT` | Queue name fix + readiness check |
| `JmsRouteUsingSpringIT` | Route IDs + readiness + timed assertions (via `JmsRouteTest`) |
| `JmsRouteUsingSpringAndJmsNameIT` | Route IDs + readiness + timed assertions (via `JmsRouteTest`) |
| `JmsRouteUsingSpringJMSTemplateIT` | Route IDs + readiness + timed assertions (via `JmsRouteTest`) |
| `JmsRouteUsingSpringWithAutoWireIT` | Route IDs + readiness + timed assertions (via `JmsRouteTest`) |

All 13 test methods pass locally.

_Claude Code on behalf of gnodet_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>