### PR TITLE
CAMEL-24053: Pin golden test fixtures to LF for Windows CI

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/.gitattributes
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/.gitattributes
@@ -1,0 +1,4 @@
+# CamelSalesforceMojoOutputTest compares codegen output (LF) against golden .java fixtures
+# read as raw UTF-8 bytes. Pin generated fixtures to LF so a Windows checkout
+# (core.autocrlf=true) does not convert them to CRLF and break the assertions.
+src/test/resources/generated/** text eol=lf

--- a/core/camel-java-io/.gitattributes
+++ b/core/camel-java-io/.gitattributes
@@ -1,0 +1,4 @@
+# JavaDslModelWriterTest compares generator output (LF) against .txt fixtures read as
+# raw UTF-8 bytes. Pin fixtures to LF so a Windows checkout (core.autocrlf=true) does
+# not convert them to CRLF and break the equality assertions.
+*.txt text eol=lf

--- a/tooling/openapi-rest-dsl-generator/.gitattributes
+++ b/tooling/openapi-rest-dsl-generator/.gitattributes
@@ -1,0 +1,5 @@
+# The generator emits source with LF line endings, and the tests compare that
+# output byte-for-byte against these .txt fixtures. Pin the fixtures to LF so a
+# Windows checkout (core.autocrlf=true) does not convert them to CRLF and break
+# the equality assertions.
+*.txt text eol=lf


### PR DESCRIPTION
## Summary

Several modules have tests that generate source with `\n` line endings and compare it byte-for-byte against git-tracked fixtures read as raw UTF-8 bytes. On a Windows checkout (`core.autocrlf=true`) those fixtures are converted to CRLF while generator output still uses LF, so equality assertions fail with visually identical `expected:`/`but was:` output. This is a latent main-branch bug surfaced by the new `camel-launcher` Windows CI job under CAMEL-23703.

**Fix:** add module `.gitattributes` rules pinning the affected fixtures to `text eol=lf`. Fixtures are already stored as LF in the index, so no renormalization is needed.

### Affected modules

| Module | Test class | Fixture rule |
|--------|-----------|--------------|
| `tooling/openapi-rest-dsl-generator` | `RestDslGeneratorV3Test`, `RestDslYamlGeneratorV3*Test`, `RestDslXmlGeneratorV3*Test`, … | `*.txt` |
| `core/camel-java-io` | `JavaDslModelWriterTest` | `*.txt` |
| `components/camel-salesforce/camel-salesforce-maven-plugin` | `CamelSalesforceMojoOutputTest` | `src/test/resources/generated/**` |

Example pattern (openapi-rest-dsl-generator):

```java
final String expectedContent = new String(Files.readAllBytes(Paths.get(file)), StandardCharsets.UTF_8);
assertThat(code.toString()).isEqualTo(expectedContent);
```

## Test plan

- [x] `git check-attr` / `git ls-files --eol` — fixtures resolve to `attr/text eol=lf`
- [x] `mvn test -pl tooling/openapi-rest-dsl-generator -Dtest='RestDsl*Test'`
- [x] `mvn test -pl core/camel-java-io -Dtest=JavaDslModelWriterTest`
- [x] `mvn test -pl components/camel-salesforce/camel-salesforce-maven-plugin -Dtest=CamelSalesforceMojoOutputTest`
- [ ] Windows CI (`camel-launcher` / Alternative OS Build) confirms fixtures checkout as LF

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] [CAMEL-24053](https://issues.apache.org/jira/browse/CAMEL-24053)

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] This is a `.gitattributes`-only change with no code or generated output.

# AI-assisted contributions

- [x] Commits include `Co-authored-by` trailers; this PR description identifies the AI tool used.

---
_Claude Code (Opus 4.8) on behalf of ammachado_