### PR TITLE
CAMEL-20141: camel-joor - Fix hot-reload of inline bean scripts with multiple Java files

### DIFF
--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/ByteArrayClassLoader.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/ByteArrayClassLoader.java
@@ -30,6 +30,11 @@ final class ByteArrayClassLoader extends ClassLoader {
         this.classes = classes;
     }
 
+    public ByteArrayClassLoader(ClassLoader parent, Map<String, byte[]> classes) {
+        super(parent);
+        this.classes = classes;
+    }
+
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
         byte[] bytes = classes.get(name);

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/CamelJoorClassLoader.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/CamelJoorClassLoader.java
@@ -75,7 +75,11 @@ public class CamelJoorClassLoader extends URLClassLoader {
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        return doLoadClass(name);
+        Class<?> c = doLoadClass(name);
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
     }
 
     public Class<?> doLoadClass(String name) throws ClassNotFoundException {

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/CamelJoorClassLoader.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/CamelJoorClassLoader.java
@@ -53,8 +53,7 @@ public class CamelJoorClassLoader extends URLClassLoader {
         CompileStrategy cs = camelContext.getCamelContextExtension().getContextPlugin(CompileStrategy.class);
         if (cs != null && cs.getWorkDir() != null) {
             try {
-                File dir = new File(cs.getWorkDir() + "/joor");
-                answer.add(dir.toURI().toURL());
+                answer.add(new File(cs.getWorkDir()).toURI().toURL());
             } catch (MalformedURLException e) {
                 // ignore
             }

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/CamelJoorClassLoader.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/CamelJoorClassLoader.java
@@ -73,6 +73,11 @@ public class CamelJoorClassLoader extends URLClassLoader {
         return doLoadClass(name);
     }
 
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        return doLoadClass(name);
+    }
+
     public Class<?> doLoadClass(String name) throws ClassNotFoundException {
         // first try JavaJoorClassLoader
         ClassLoader joorClassLoader = camelContext.getClassResolver().getClassLoader("JavaJoorClassLoader");

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorScriptingCompiler.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorScriptingCompiler.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,7 +46,7 @@ public class JoorScriptingCompiler extends ServiceSupport implements StaticServi
 
     private static final Logger LOG = LoggerFactory.getLogger(JoorScriptingCompiler.class);
     private static final AtomicInteger UUID = new AtomicInteger();
-    private final Set<String> compiledClassNames = new LinkedHashSet<>();
+    private final Set<String> compiledClassNames = ConcurrentHashMap.newKeySet();
     private CamelContext camelContext;
     private JavaJoorClassLoader classLoader;
     private Set<String> imports = new TreeSet<>();

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorScriptingCompiler.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorScriptingCompiler.java
@@ -45,6 +45,7 @@ public class JoorScriptingCompiler extends ServiceSupport implements StaticServi
 
     private static final Logger LOG = LoggerFactory.getLogger(JoorScriptingCompiler.class);
     private static final AtomicInteger UUID = new AtomicInteger();
+    private final Set<String> compiledClassNames = new LinkedHashSet<>();
     private CamelContext camelContext;
     private JavaJoorClassLoader classLoader;
     private Set<String> imports = new TreeSet<>();
@@ -92,7 +93,7 @@ public class JoorScriptingCompiler extends ServiceSupport implements StaticServi
             // use work dir for classloader as it writes compiled classes to disk
             CompileStrategy cs = context.getCamelContextExtension().getContextPlugin(CompileStrategy.class);
             if (cs != null && cs.getWorkDir() != null) {
-                classLoader.setCompileDirectory(cs.getWorkDir() + "/joor");
+                classLoader.setCompileDirectory(cs.getWorkDir());
             }
         }
     }
@@ -107,6 +108,15 @@ public class JoorScriptingCompiler extends ServiceSupport implements StaticServi
     public JoorScriptingMethod compile(
             CamelContext camelContext, String script, Map<String, Object> bindings, boolean singleQuotes) {
         StopWatch watch = new StopWatch();
+
+        // clean up previously compiled script classes to prevent classloader leak during reloads
+        if (classLoader != null && !compiledClassNames.isEmpty()) {
+            for (String old : compiledClassNames) {
+                LOG.debug("Removing old compiled class: {}", old);
+                classLoader.removeClass(old);
+            }
+            compiledClassNames.clear();
+        }
 
         JoorScriptingMethod answer;
         String className = nextFQN();
@@ -131,6 +141,10 @@ public class JoorScriptingCompiler extends ServiceSupport implements StaticServi
             if (clazz != null) {
                 LOG.debug("Compiled to Java class: {}", clazz);
                 answer = (JoorScriptingMethod) clazz.getConstructor(CamelContext.class).newInstance(camelContext);
+                // register compiled class for proper lifecycle management
+                byte[] byteCode = result.getByteCode(className);
+                classLoader.addClass(className, clazz, byteCode);
+                compiledClassNames.add(className);
             } else {
                 answer = null;
             }

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/MultiCompile.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/MultiCompile.java
@@ -183,7 +183,7 @@ public final class MultiCompile {
             // We need a private-access lookup from the class in that stack frame in order to get
             // private-access to any local interfaces at that location.
             int index = 2;
-            ByteArrayClassLoader c = new ByteArrayClassLoader(fileManager.classes());
+            ByteArrayClassLoader c = new ByteArrayClassLoader(cl, fileManager.classes());
             for (CharSequenceJavaFileObject f : files) {
                 String className = f.getClassName();
 

--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaRoutesBuilderLoader.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaRoutesBuilderLoader.java
@@ -219,6 +219,9 @@ public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
                 try (InputStream is = resourceInputStream(entry.getValue())) {
                     if (is != null) {
                         String content = IOHelper.loadText(is);
+                        for (CompilePreProcessor pre : getCompilePreProcessors()) {
+                            pre.preCompile(getCamelContext(), entry.getKey(), content);
+                        }
                         unit.addClass(entry.getKey(), content);
                         classLoader.removeClass(entry.getKey());
                     }

--- a/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaRoutesBuilderLoader.java
+++ b/dsl/camel-java-joor-dsl/src/main/java/org/apache/camel/dsl/java/joor/JavaRoutesBuilderLoader.java
@@ -158,7 +158,7 @@ public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
 
                             // inject context and resource
                             CamelContextAware.trySetCamelContext(obj, getCamelContext());
-                            ResourceAware.trySetResource(obj, nameToResource.remove(className));
+                            ResourceAware.trySetResource(obj, nameToResource.get(className));
                         }
                     } catch (Exception e) {
                         throw new RuntimeCamelException("Cannot create instance of class: " + className, e);
@@ -212,6 +212,22 @@ public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
             }
         }
 
+        // During hot-reload only the changed file is passed in, but all Java files
+        // must be recompiled together so class identity is consistent across classloaders
+        for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
+            if (!unit.getInput().containsKey(entry.getKey())) {
+                try (InputStream is = resourceInputStream(entry.getValue())) {
+                    if (is != null) {
+                        String content = IOHelper.loadText(is);
+                        unit.addClass(entry.getKey(), content);
+                        classLoader.removeClass(entry.getKey());
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Could not read previously compiled resource: {}", entry.getValue(), e);
+                }
+            }
+        }
+
         // include classloader from Camel, so we can load any already compiled and loaded classes
         ClassLoader parent = resolveParentClassLoader();
         if (parent instanceof URLClassLoader ucl) {
@@ -227,7 +243,8 @@ public class JavaRoutesBuilderLoader extends ExtendedRouteBuilderLoaderSupport {
 
         // remember the last loaded resource-set if route reloading is enabled
         if (getCamelContext().hasService(RouteWatcherReloadStrategy.class) != null) {
-            getCamelContext().getRegistry().bind(RouteWatcherReloadStrategy.RELOAD_RESOURCES, nameToResource.values());
+            getCamelContext().getRegistry().bind(RouteWatcherReloadStrategy.RELOAD_RESOURCES,
+                    new ArrayList<>(nameToResource.values()));
         }
 
         for (String className : result.getClassNames()) {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes [CAMEL-20141](https://issues.apache.org/jira/browse/CAMEL-20141): when running `camel run * --dev` with YAML routes that use inline Java bean scripts referencing multiple `.java` files (e.g. a `Customer` POJO and a `CustomerBuilder`), editing any `.java` file caused a reload failure with `NoSuchBeanException: Creating bean using script returned null`.

**Root cause:** During hot-reload, only the changed `.java` file was recompiled in a new `ByteArrayClassLoader`. Other Java files (e.g. a builder class) stayed loaded from the original classloader. When the builder's `build()` method created an object of the changed class, JVM class identity rules meant the returned object's class (from the old classloader) didn't match the `resultType` (resolved from the new classloader), so `convertTo()` returned null.

**Fix:**
- `JavaRoutesBuilderLoader` now tracks all previously compiled Java resources and includes them in any recompilation, ensuring all classes share the same `ByteArrayClassLoader` and class identity is consistent. Re-added resources go through the `CompilePreProcessor` chain.
- `ByteArrayClassLoader` now accepts a custom parent classloader so `MultiCompile` can set `CamelJoorClassLoader` as parent, enabling proper class resolution through the `JavaJoorClassLoader` chain
- `CamelJoorClassLoader` overrides `loadClass(String, boolean)` to delegate through `doLoadClass()` which checks `JavaJoorClassLoader` first, and honors the `resolve` parameter
- `JoorScriptingCompiler` cleans up previously compiled script classes to prevent classloader leaks during reloads, using thread-safe `ConcurrentHashMap.newKeySet()` for tracking

## Test plan

- [x] All existing tests pass (53 in camel-joor, 29 in camel-java-joor-dsl)
- [x] Manual test: `camel run * --dev` with the `bean-inlined-code` example — editing `Customer.java` now correctly reloads the route without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>