### PR TITLE
CAMEL-23844: Camel-PQC - use the mapped JCE algorithm name when restoring the secret key

### DIFF
--- a/components/camel-pqc/src/main/java/org/apache/camel/component/pqc/PQCProducer.java
+++ b/components/camel-pqc/src/main/java/org/apache/camel/component/pqc/PQCProducer.java
@@ -603,7 +603,12 @@ public class PQCProducer extends DefaultProducer {
             throw new IllegalArgumentException("Symmetric Algorithm needs to be specified");
         }
 
-        SecretKey restoredKey = new SecretKeySpec(payload.getEncoded(), getConfiguration().getSymmetricKeyAlgorithm());
+        // Use the mapped JCE algorithm name (as extractEncapsulation does), not the raw enum name: for algorithms
+        // whose enum name differs from the JCE name (for example GOST3412_2015 -> GOST3412-2015) the raw name is not a
+        // resolvable cipher algorithm, so the restored key would carry an unusable algorithm label
+        SecretKey restoredKey = new SecretKeySpec(
+                payload.getEncoded(),
+                PQCSymmetricAlgorithms.valueOf(getConfiguration().getSymmetricKeyAlgorithm()).getAlgorithm());
 
         if (!getConfiguration().isStoreExtractedSecretKeyAsHeader()) {
             exchange.getMessage().setBody(restoredKey, SecretKey.class);
@@ -770,8 +775,10 @@ public class PQCProducer extends DefaultProducer {
             throw new IllegalArgumentException("Symmetric Algorithm needs to be specified");
         }
 
-        // Create a new SecretKeySpec with the correct algorithm
-        SecretKey restoredKey = new SecretKeySpec(hybridSecretKey.getEncoded(), getConfiguration().getSymmetricKeyAlgorithm());
+        // Create a new SecretKeySpec with the mapped JCE algorithm name (not the raw enum name)
+        SecretKey restoredKey = new SecretKeySpec(
+                hybridSecretKey.getEncoded(),
+                PQCSymmetricAlgorithms.valueOf(getConfiguration().getSymmetricKeyAlgorithm()).getAlgorithm());
 
         if (!getConfiguration().isStoreExtractedSecretKeyAsHeader()) {
             exchange.getMessage().setBody(restoredKey, SecretKey.class);

--- a/components/camel-pqc/src/test/java/org/apache/camel/component/pqc/PQCExtractSecretKeyAlgorithmNameTest.java
+++ b/components/camel-pqc/src/test/java/org/apache/camel/component/pqc/PQCExtractSecretKeyAlgorithmNameTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.pqc;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+import java.security.Security;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The secret key restored by extractSecretKeyFromEncapsulation must carry the mapped JCE algorithm name, not the raw
+ * PQCSymmetricAlgorithms enum name. For GOST3412_2015 the raw name is not a resolvable cipher algorithm at all.
+ */
+public class PQCExtractSecretKeyAlgorithmNameTest extends CamelTestSupport {
+
+    @EndpointInject("mock:gost")
+    protected MockEndpoint resultGost;
+
+    @EndpointInject("mock:desede")
+    protected MockEndpoint resultDesede;
+
+    @BeforeAll
+    public static void startup() {
+        ensureProviders();
+    }
+
+    /**
+     * PQCEndpoint removes the BouncyCastle providers from the JVM when it stops, so with more than one test method in
+     * the class they must be (re-)registered before each CamelContext is built.
+     */
+    private static void ensureProviders() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(BouncyCastlePQCProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastlePQCProvider());
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:gost")
+                        .to("pqc:keyenc?operation=generateSecretKeyEncapsulation"
+                            + "&symmetricKeyAlgorithm=GOST3412_2015&symmetricKeyLength=256")
+                        .to("pqc:keyenc?operation=extractSecretKeyEncapsulation"
+                            + "&symmetricKeyAlgorithm=GOST3412_2015&symmetricKeyLength=256")
+                        .to("pqc:keyenc?operation=extractSecretKeyFromEncapsulation"
+                            + "&symmetricKeyAlgorithm=GOST3412_2015&symmetricKeyLength=256")
+                        .to("mock:gost");
+
+                from("direct:desede")
+                        .to("pqc:keyenc?operation=generateSecretKeyEncapsulation"
+                            + "&symmetricKeyAlgorithm=DESEDE&symmetricKeyLength=192")
+                        .to("pqc:keyenc?operation=extractSecretKeyEncapsulation"
+                            + "&symmetricKeyAlgorithm=DESEDE&symmetricKeyLength=192")
+                        .to("pqc:keyenc?operation=extractSecretKeyFromEncapsulation"
+                            + "&symmetricKeyAlgorithm=DESEDE&symmetricKeyLength=192")
+                        .to("mock:desede");
+            }
+        };
+    }
+
+    @Test
+    void testGost3412RestoredKeyUsesJceAlgorithmName() throws Exception {
+        resultGost.expectedMessageCount(1);
+        template.sendBody("direct:gost", "Hello");
+        resultGost.assertIsSatisfied();
+
+        SecretKey restored = resultGost.getExchanges().get(0).getMessage().getBody(SecretKey.class);
+        assertNotNull(restored);
+        // the enum name is GOST3412_2015 but the JCE name is GOST3412-2015
+        assertEquals(PQCSymmetricAlgorithms.GOST3412_2015.getAlgorithm(), restored.getAlgorithm());
+        assertEquals("GOST3412-2015", restored.getAlgorithm());
+        // with the raw enum name this throws NoSuchAlgorithmException, so the restored key was unusable
+        assertDoesNotThrow(() -> Cipher.getInstance(restored.getAlgorithm(), BouncyCastleProvider.PROVIDER_NAME));
+    }
+
+    @Test
+    void testDesedeRestoredKeyUsesJceAlgorithmName() throws Exception {
+        resultDesede.expectedMessageCount(1);
+        template.sendBody("direct:desede", "Hello");
+        resultDesede.assertIsSatisfied();
+
+        SecretKey restored = resultDesede.getExchanges().get(0).getMessage().getBody(SecretKey.class);
+        assertNotNull(restored);
+        assertEquals(PQCSymmetricAlgorithms.DESEDE.getAlgorithm(), restored.getAlgorithm());
+        assertEquals("DESede", restored.getAlgorithm());
+        assertDoesNotThrow(() -> Cipher.getInstance(restored.getAlgorithm(), BouncyCastleProvider.PROVIDER_NAME));
+    }
+
+    @BindToRegistry("Keypair")
+    public KeyPair setKeyPair()
+            throws NoSuchAlgorithmException, NoSuchProviderException,
+            InvalidAlgorithmParameterException {
+        ensureProviders();
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(PQCKeyEncapsulationAlgorithms.MLKEM.getAlgorithm(),
+                PQCKeyEncapsulationAlgorithms.MLKEM.getBcProvider());
+        kpg.initialize(MLKEMParameterSpec.ml_kem_512, new SecureRandom());
+        return kpg.generateKeyPair();
+    }
+
+    @BindToRegistry("KeyGenerator")
+    public KeyGenerator setKeyGenerator() throws NoSuchAlgorithmException, NoSuchProviderException {
+        ensureProviders();
+        return KeyGenerator.getInstance(PQCKeyEncapsulationAlgorithms.MLKEM.getAlgorithm(),
+                PQCKeyEncapsulationAlgorithms.MLKEM.getBcProvider());
+    }
+}


### PR DESCRIPTION
# CAMEL-23844: Camel-PQC — use the mapped JCE algorithm name when restoring the secret key

## The bug

`PQCProducer.extractSecretKeyFromEncapsulation()` built the restored key as:

```java
new SecretKeySpec(payload.getEncoded(), getConfiguration().getSymmetricKeyAlgorithm())
```

That passes the **raw `PQCSymmetricAlgorithms` enum name** as the `SecretKeySpec` algorithm, whereas
`extractEncapsulation()` correctly maps it via `PQCSymmetricAlgorithms.valueOf(...).getAlgorithm()`.

Only two enum names differ from their JCE names, and the impact is very different for each:

| Enum name | JCE name | `Cipher.getInstance(<enum name>)` |
|---|---|---|
| `DESEDE` | `DESede` | **OK** — JCA lookup is case-insensitive |
| `GOST3412_2015` | `GOST3412-2015` | **`NoSuchAlgorithmException`** — underscore is not a valid JCE name |

So for **GOST3412_2015** the secret key handed back to the route carried an algorithm label that
cannot be resolved to a cipher at all, making the restored key unusable downstream (verified against
BouncyCastle 1.85).

The existing KEM round-trip tests do not catch this because they encrypt with an explicitly configured
`CryptoDataFormat("DESede")` and never read the key's own label.

## The fix

Use `PQCSymmetricAlgorithms.valueOf(getConfiguration().getSymmetricKeyAlgorithm()).getAlgorithm()` —
the same mapping `extractEncapsulation()` already uses — in **both** extract paths:
`extractSecretKeyFromEncapsulation` and `hybridExtractSecretKeyFromEncapsulation`.

## Testing

New `PQCExtractSecretKeyAlgorithmNameTest` (2 tests) runs a full
generate → extract → extract-secret-key route and asserts the restored key's algorithm is the **JCE**
name, and that `Cipher.getInstance(key.getAlgorithm())` resolves.

Verified it is a true regression test — **without** the fix it fails with:

```
expected: <GOST3412-2015> but was: <GOST3412_2015>
expected: <DESede> but was: <DESEDE>
```

All 17 existing KEM round-trip tests still pass. Full reactor build green.

## Note for reviewers (not changed here)

`generateEncapsulation()` passes the same **raw** enum name into `KEMGenerateSpec`, so the
`SecretKeyWithEncapsulation` it produces is labelled `GOST3412_2015` / `DESEDE` too. I deliberately left
that alone: the name there is only a label (it is not part of the KEM derivation — generate and extract
already disagree today and the round trip still works), and changing it would alter a **visible** output
label and require updating existing test assertions. Happy to align it in a follow-up if you'd prefer
full consistency.

## Backport

This is a bug → **4.18.x (4.18.4)** and **4.14.x (4.14.9)**. On those branches only the standard extract
path exists (the hybrid operations came later), so the backport is the single-line fix plus the test.

---
_Claude Code on behalf of Andrea Cosentino._
