### PR TITLE
CAMEL-24060: Use reflection for optional PQCMicrometerMetrics to avoid GraalVM native image failure

### DIFF
--- a/components/camel-pqc/src/main/java/org/apache/camel/component/pqc/PQCProducer.java
+++ b/components/camel-pqc/src/main/java/org/apache/camel/component/pqc/PQCProducer.java
@@ -42,7 +42,6 @@ import org.apache.camel.component.pqc.crypto.hybrid.HybridSignature;
 import org.apache.camel.component.pqc.lifecycle.KeyLifecycleManager;
 import org.apache.camel.component.pqc.lifecycle.KeyMetadata;
 import org.apache.camel.component.pqc.metrics.PQCMetrics;
-import org.apache.camel.component.pqc.metrics.PQCMicrometerMetrics;
 import org.apache.camel.component.pqc.stateful.StatefulKeyState;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
@@ -242,12 +241,18 @@ public class PQCProducer extends DefaultProducer {
 
     private PQCMetrics createMetrics() {
         CamelContext camelContext = getEndpoint().getCamelContext();
-        // Only touch Micrometer if it is actually on the classpath, keeping it an optional dependency
+        // Only touch Micrometer if it is actually on the classpath, keeping it an optional dependency.
+        // Use reflection to avoid a static class reference that GraalVM native image would follow.
         if (camelContext.getClassResolver().resolveClass("io.micrometer.core.instrument.MeterRegistry") == null) {
             return PQCMetrics.NOOP;
         }
         try {
-            return PQCMicrometerMetrics.create(camelContext);
+            Class<?> clazz = camelContext.getClassResolver()
+                    .resolveClass("org.apache.camel.component.pqc.metrics.PQCMicrometerMetrics");
+            if (clazz == null) {
+                return PQCMetrics.NOOP;
+            }
+            return (PQCMetrics) clazz.getMethod("create", CamelContext.class).invoke(null, camelContext);
         } catch (Throwable t) {
             LOG.debug("Micrometer metrics are not available for the PQC producer: {}", t.getMessage());
             return PQCMetrics.NOOP;


### PR DESCRIPTION
## Summary

- `PQCProducer.createMetrics()` directly references `PQCMicrometerMetrics`, causing GraalVM native image compilation to fail with `NoClassDefFoundError: io/micrometer/core/instrument/Meter` when micrometer is not on the classpath
- Replace the direct class reference with reflection via `CamelContext.getClassResolver()` so GraalVM's static analysis never follows the link to micrometer classes
- The existing runtime classpath guard and catch-all are preserved

## Test plan

- [x] `mvn install -f components/camel-pqc` passes
- [ ] Camel Quarkus PQC native integration test passes without adding micrometer-core dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)