### PR TITLE
CAMEL-23994: Fix off-by-one when writing to offset repository

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/AsyncCommitManager.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/AsyncCommitManager.java
@@ -94,7 +94,10 @@ public class AsyncCommitManager extends AbstractCommitManager {
         if (exception == null) {
             if (offsetRepository != null) {
                 for (var entry : committed.entrySet()) {
-                    saveStateToOffsetRepository(entry.getKey(), entry.getValue().offset(), offsetRepository);
+                    // Store the last read offset (Kafka committed offset - 1) to match
+                    // the contract in OffsetPartitionAssignmentAdapter.resumeFromOffset
+                    // which seeks to state + 1
+                    saveStateToOffsetRepository(entry.getKey(), entry.getValue().offset() - 1, offsetRepository);
                 }
             }
         }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/SyncCommitManager.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/SyncCommitManager.java
@@ -75,7 +75,7 @@ public class SyncCommitManager extends AbstractCommitManager {
         consumer.commitSync(offsets, Duration.ofMillis(timeout));
 
         if (offsetRepository != null) {
-            saveStateToOffsetRepository(partition, lastOffset, offsetRepository);
+            saveStateToOffsetRepository(partition, offset, offsetRepository);
         }
 
         offsetCache.removeCommittedEntries(offsets, null);

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/commit/BaseManualCommitTestSupport.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/commit/BaseManualCommitTestSupport.java
@@ -97,8 +97,8 @@ abstract class BaseManualCommitTestSupport extends BaseKafkaTestSupport {
 
         final String state = Awaitility.await().until(() -> stateRepository.getState(topic + "/0"),
                 Matchers.notNullValue());
-        // We send 5 records initially, so we expect the offset to be 5 after first step execution
-        assertEquals("5", state, "5 messages were sent in the first step, therefore the offset should be 5");
+        // We send 5 records (offsets 0-4), so we expect the last read offset (4) to be stored
+        assertEquals("4", state, "5 messages were sent in the first step, therefore the last read offset should be 4");
 
         // Second step: We shut down our route, we expect nothing will be recovered by our route
         contextExtension.getContext().getRouteController().stopRoute("foo");


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes the fourth bug reported in [CAMEL-23994](https://issues.apache.org/jira/browse/CAMEL-23994): `SyncCommitManager` and `AsyncCommitManager` stored `offset+1` in the offset repository, but `OffsetPartitionAssignmentAdapter.resumeFromOffset` adds `+1` when seeking (`state+1`). This double increment caused one message per partition to be lost on every restart when using an `offsetRepository`.

**The round-trip before the fix:**
- Record at offset 41 processed → repo stores 42 → on restart seeks to 42+1=43 → record 42 is lost

**After the fix:**
- Record at offset 41 processed → repo stores 41 → on restart seeks to 41+1=42 → correct

**Changes:**
- `SyncCommitManager`: save the raw record offset (`offset`) instead of `lastOffset` (offset+1) to the offset repository. The Kafka commit still correctly uses `offset+1` (Kafka convention).
- `AsyncCommitManager`: save `committed offset - 1` (the raw record offset) to the repository instead of the already-incremented `OffsetAndMetadata.offset()`.
- Updated `BaseManualCommitTestSupport` assertion from `"5"` to `"4"` to reflect the corrected stored value (last read offset, not next-to-read offset).

Both managers now match the contract established by `CommitToOffsetManager` (which already stored the raw offset correctly) and the comment in `resumeFromOffset`: _"The state contains the last read offset, so you need to seek from the next one"_.

**Bug present since:** CAMEL-18717 (Nov 2022).

## Test plan

- [x] All 141 unit tests pass
- [x] Updated `BaseManualCommitTestSupport` offset assertion to match new behavior
- [ ] CI integration tests (`KafkaConsumerSyncWithOffsetRepoCommitIT`, `KafkaConsumerAsyncWithOffsetRepoCommitIT`) will validate the full round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>