### PR TITLE
CAMEL-23994: Fix pollOnError seek skipping messages on all partitions

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/BridgeErrorStrategy.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/BridgeErrorStrategy.java
@@ -48,7 +48,7 @@ public class BridgeErrorStrategy implements PollExceptionStrategy {
         // use bridge error handler to route with exception
         recordFetcher.getBridge().handleException(exception);
         // skip this poison message and seek to the next message
-        SeekUtil.seekToNextOffset(consumer, partitionLastOffset);
+        SeekUtil.seekToNextOffset(consumer, exception);
 
         if (exception instanceof AuthenticationException || exception instanceof AuthorizationException) {
             continueFlag = false;

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/DiscardErrorStrategy.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/DiscardErrorStrategy.java
@@ -40,6 +40,6 @@ public class DiscardErrorStrategy implements PollExceptionStrategy {
         LOG.warn("Requesting the consumer to discard the message and continue to the next based on polling exception strategy");
 
         // skip this poison message and seek to the next message
-        SeekUtil.seekToNextOffset(consumer, partitionLastOffset);
+        SeekUtil.seekToNextOffset(consumer, exception);
     }
 }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/SeekUtil.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/consumer/errorhandler/SeekUtil.java
@@ -17,10 +17,9 @@
 
 package org.apache.camel.component.kafka.consumer.errorhandler;
 
-import java.util.Set;
-
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,33 +30,16 @@ final class SeekUtil {
 
     }
 
-    public static void seekToNextOffset(Consumer<?, ?> consumer, long partitionLastOffset) {
-        boolean logged = false;
-        Set<TopicPartition> tps = consumer.assignment();
-        if (tps != null && partitionLastOffset != -1) {
-            long next = partitionLastOffset + 1;
-
-            for (TopicPartition tp : tps) {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info(
-                            "Consumer seeking to next offset {} to continue polling next message from topic {} on partition {}",
-                            next, tp.topic(), tp.partition());
-                }
-
-                consumer.seek(tp, next);
-            }
-        } else if (tps != null) {
-            for (TopicPartition tp : tps) {
-                long next = consumer.position(tp) + 1;
-                if (!logged) {
-                    LOG.info(
-                            "Consumer seeking to next offset {} to continue polling next message from topic {} on partition {}",
-                            next,
-                            tp.topic(), tp.partition());
-                    logged = true;
-                }
-                consumer.seek(tp, next);
-            }
+    public static void seekToNextOffset(Consumer<?, ?> consumer, Exception exception) {
+        if (exception instanceof RecordDeserializationException rde) {
+            TopicPartition tp = rde.topicPartition();
+            long next = rde.offset() + 1;
+            LOG.info("Consumer seeking to next offset {} to skip poison message on topic {} partition {}",
+                    next, tp.topic(), tp.partition());
+            consumer.seek(tp, next);
+        } else {
+            LOG.warn("Non-record exception caught during poll, not advancing any partition offsets: {}",
+                    exception.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes the second bug reported in [CAMEL-23994](https://issues.apache.org/jira/browse/CAMEL-23994): when a poll-loop exception was caught with `pollOnError=DISCARD` or `ERROR_HANDLER`, `SeekUtil.seekToNextOffset` was called with a hardcoded offset of -1 (lost during refactoring in CAMEL-16064), causing it to seek `position(tp) + 1` on ALL assigned partitions — silently dropping one unread message per partition.

**Before:** Any exception during polling → seek position+1 on every partition → silent message loss on all partitions
**After:**
- `RecordDeserializationException` (poison message) → seek only the affected partition to `offset+1`
- Other exceptions (transient Kafka errors, commit failures) → no position advancement since the error may not be record-related

**Changes:**
- Rewrote `SeekUtil.seekToNextOffset` to accept the `Exception` and use `RecordDeserializationException.topicPartition()` / `offset()` for targeted seeking
- Updated `DiscardErrorStrategy` and `BridgeErrorStrategy` to pass the exception
- The `PollExceptionStrategy.handle(long, Exception)` public API is unchanged

**Note:** The `partitionLastOffset` parameter in `PollExceptionStrategy.handle()` has been effectively dead since the CAMEL-16064 refactoring (always -1). The strategies now use the exception for seeking instead.

## Test plan

- [x] All 141 unit tests pass
- [ ] CI integration tests will validate poll error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>