### PR TITLE
CAMEL-24063: Fix flaky DirectProducerBlockingTest.testProducerBlocksResumeTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/direct/DirectProducerBlockingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/direct/DirectProducerBlockingTest.java
@@ -85,8 +85,10 @@ public class DirectProducerBlockingTest extends ContextTestSupport {
             public void run() {
                 try {
                     // Wait for the main thread to enter TIMED_WAITING state
-                    // (blocked on condition in DirectComponent.getConsumer)
-                    await().atMost(2, TimeUnit.SECONDS)
+                    // (blocked on condition in DirectComponent.getConsumer).
+                    // Use a generous timeout — on slow CI the thread state
+                    // detection can take longer than 2 s.
+                    await().atMost(10, TimeUnit.SECONDS)
                             .pollInterval(10, TimeUnit.MILLISECONDS)
                             .until(() -> mainThread.getState() == Thread.State.TIMED_WAITING);
 
@@ -98,8 +100,10 @@ public class DirectProducerBlockingTest extends ContextTestSupport {
             }
         });
 
-        // This call will block until the route is resumed by the background thread
-        template.sendBody("direct:suspended?block=true&timeout=2000", "hello world");
+        // This call will block until the route is resumed by the background thread.
+        // Use a generous timeout so the background thread has enough headroom to
+        // detect the TIMED_WAITING state and resume the route even under CI load.
+        template.sendBody("direct:suspended?block=true&timeout=10000", "hello world");
 
         assertMockEndpointsSatisfied();
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/direct/DirectProducerBlockingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/direct/DirectProducerBlockingTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.component.direct;
 
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelExchangeException;
@@ -28,7 +28,6 @@ import org.apache.camel.util.StopWatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -74,36 +73,26 @@ public class DirectProducerBlockingTest extends ContextTestSupport {
 
     @Test
     public void testProducerBlocksResumeTest() throws Exception {
-        getMockEndpoint("mock:result").expectedMessageCount(1);
-
         context.getRouteController().suspendRoute("foo");
 
-        Thread mainThread = Thread.currentThread();
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    // Wait for the main thread to enter TIMED_WAITING state
-                    // (blocked on condition in DirectComponent.getConsumer).
-                    // Use a generous timeout — on slow CI the thread state
-                    // detection can take longer than 2 s.
-                    await().atMost(10, TimeUnit.SECONDS)
-                            .pollInterval(10, TimeUnit.MILLISECONDS)
-                            .until(() -> mainThread.getState() == Thread.State.TIMED_WAITING);
-
-                    log.info("Resuming consumer");
-                    context.getRouteController().resumeRoute("foo");
-                } catch (Exception e) {
-                    log.error("Error in background thread", e);
-                }
+        // Schedule route resume after 200ms. This is race-tolerant by design:
+        // - If resume fires before sendBody starts blocking: route is already
+        //   resumed, sendBody finds the consumer immediately and succeeds
+        // - If resume fires while sendBody is blocking: sendBody gets unblocked
+        // Either outcome produces a passing test.
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        executor.schedule(() -> {
+            try {
+                log.info("Resuming consumer");
+                context.getRouteController().resumeRoute("foo");
+            } catch (Exception e) {
+                log.error("Error resuming route", e);
             }
-        });
+        }, 200, TimeUnit.MILLISECONDS);
 
-        // This call will block until the route is resumed by the background thread.
-        // Use a generous timeout so the background thread has enough headroom to
-        // detect the TIMED_WAITING state and resume the route even under CI load.
-        template.sendBody("direct:suspended?block=true&timeout=10000", "hello world");
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:suspended?block=true&timeout=1000", "hello world");
 
         assertMockEndpointsSatisfied();
 


### PR DESCRIPTION
## Summary

Fix flaky `DirectProducerBlockingTest.testProducerBlocksResumeTest` by reverting the Awaitility-based `TIMED_WAITING` approach (introduced in CAMEL-19549, Jun 25/29) back to a race-tolerant design.

### Root cause

The original test used `Thread.sleep(200)` + `timeout=1000` and was **stable for 6 years** (2020–2026). The CAMEL-19549 changes replaced this with an Awaitility `await().until(mainThread.getState() == TIMED_WAITING)` approach that imposed a **strict thread-ordering dependency**, introducing new failure modes:

- The `atMost(2s)` and `sendBody` `timeout=2000` raced each other — on slow CI, both could expire
- `Thread.State.TIMED_WAITING` detection via polling is fragile under GC pauses and load
- Develocity data confirms flakiness **increased** after the Awaitility changes landed on `main`

The original code worked because it is **race-tolerant** — both race outcomes produce a passing test:
- If `resumeRoute()` fires **before** `sendBody` starts blocking → route is already resumed, `sendBody` finds the consumer immediately
- If `resumeRoute()` fires **while** `sendBody` is blocking → `sendBody` gets unblocked

### Fix

Replace the Awaitility approach with `ScheduledExecutorService.schedule(200ms)` — same race-tolerant semantics as the original `Thread.sleep(200)`, without using `Thread.sleep`. Restore `timeout=1000` (800ms of headroom).

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>