### PR TITLE
CAMEL-24064: Fix module registration in jackson3 type converter and wrap JacksonException in data type transformers

### DIFF
--- a/components/camel-jackson3/src/main/java/org/apache/camel/component/jackson3/converter/JacksonTypeConverters.java
+++ b/components/camel-jackson3/src/main/java/org/apache/camel/component/jackson3/converter/JacksonTypeConverters.java
@@ -305,7 +305,7 @@ public final class JacksonTypeConverters {
             lock.lock();
             try {
                 if (defaultMapper == null) {
-                    ObjectMapper mapper = new ObjectMapper();
+                    JsonMapper.Builder builder = JsonMapper.builder();
                     if (moduleClassNames != null) {
                         for (Object o : ObjectHelper.createIterable(moduleClassNames)) {
                             Class<JacksonModule> type
@@ -313,11 +313,11 @@ public final class JacksonTypeConverters {
                             JacksonModule module = camelContext.getInjector().newInstance(type);
 
                             LOG.debug("Registering module: {} -> {}", o, module);
-                            mapper = JsonMapper.builder().addModule(module).build();
+                            builder.addModule(module);
                         }
                     }
 
-                    defaultMapper = mapper;
+                    defaultMapper = builder.build();
                 }
             } finally {
                 lock.unlock();

--- a/components/camel-jackson3/src/main/java/org/apache/camel/component/jackson3/transform/JsonPojoDataTypeTransformer.java
+++ b/components/camel-jackson3/src/main/java/org/apache/camel/component/jackson3/transform/JsonPojoDataTypeTransformer.java
@@ -35,6 +35,7 @@ import org.apache.camel.spi.MimeType;
 import org.apache.camel.spi.Transformer;
 import org.apache.camel.util.ObjectHelper;
 import tools.jackson.core.FormatSchema;
+import tools.jackson.core.JacksonException;
 
 /**
  * Data type able to unmarshal Exchange body to Java object. Supports both Json schema types and uses Jackson object
@@ -71,7 +72,7 @@ public class JsonPojoDataTypeTransformer extends Transformer implements CamelCon
             }
 
             message.setBody(getJavaObject(message, schemaType, schema, contentType));
-        } catch (InvalidPayloadException | IOException | ClassNotFoundException e) {
+        } catch (InvalidPayloadException | IOException | JacksonException | ClassNotFoundException e) {
             throw new CamelExecutionException("Failed to apply Java object data type on exchange", message.getExchange(), e);
         }
     }

--- a/components/camel-jackson3/src/main/java/org/apache/camel/component/jackson3/transform/JsonStructDataTypeTransformer.java
+++ b/components/camel-jackson3/src/main/java/org/apache/camel/component/jackson3/transform/JsonStructDataTypeTransformer.java
@@ -29,6 +29,7 @@ import org.apache.camel.spi.DataType;
 import org.apache.camel.spi.DataTypeTransformer;
 import org.apache.camel.spi.MimeType;
 import org.apache.camel.spi.Transformer;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 
 /**
@@ -61,7 +62,7 @@ public class JsonStructDataTypeTransformer extends Transformer {
             message.setBody(unmarshalled);
 
             message.setHeader(Exchange.CONTENT_TYPE, MimeType.STRUCT.type());
-        } catch (InvalidPayloadException | ClassNotFoundException e) {
+        } catch (InvalidPayloadException | JacksonException | ClassNotFoundException e) {
             throw new CamelExecutionException("Failed to apply Json input data type on exchange", message.getExchange(), e);
         }
     }

--- a/components/camel-jackson3/src/test/java/org/apache/camel/component/jackson3/converter/JacksonConversionsMultipleModulesTest.java
+++ b/components/camel-jackson3/src/test/java/org/apache/camel/component/jackson3/converter/JacksonConversionsMultipleModulesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jackson3.converter;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jackson3.JacksonConstants;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.module.SimpleModule;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JacksonConversionsMultipleModulesTest extends CamelTestSupport {
+
+    @Test
+    public void shouldRegisterAllConfiguredModules() {
+        context.getGlobalOptions().put(JacksonConstants.ENABLE_TYPE_CONVERTER, "true");
+        context.getGlobalOptions().put(JacksonConstants.TYPE_CONVERTER_TO_POJO, "true");
+        context.getGlobalOptions().put(JacksonConstants.TYPE_CONVERTER_MODULE_CLASS_NAMES,
+                FooModule.class.getName() + "," + BarModule.class.getName());
+
+        String foo = (String) template.requestBody("direct:test", new Foo());
+        String bar = (String) template.requestBody("direct:test", new Bar());
+
+        assertEquals("\"foo\"", foo);
+        assertEquals("\"bar\"", bar);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:test").convertBodyTo(String.class);
+            }
+        };
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+
+    public static class FooModule extends SimpleModule {
+        public FooModule() {
+            super("foo-module");
+            addSerializer(Foo.class, new ValueSerializer<Foo>() {
+                @Override
+                public void serialize(Foo value, JsonGenerator gen, SerializationContext ctxt) {
+                    gen.writeString("foo");
+                }
+            });
+        }
+    }
+
+    public static class BarModule extends SimpleModule {
+        public BarModule() {
+            super("bar-module");
+            addSerializer(Bar.class, new ValueSerializer<Bar>() {
+                @Override
+                public void serialize(Bar value, JsonGenerator gen, SerializationContext ctxt) {
+                    gen.writeString("bar");
+                }
+            });
+        }
+    }
+
+}

--- a/components/camel-jackson3/src/test/java/org/apache/camel/component/jackson3/transform/JsonPojoDataTypeTransformerTest.java
+++ b/components/camel-jackson3/src/test/java/org/apache/camel/component/jackson3/transform/JsonPojoDataTypeTransformerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.component.jackson3.transform;
 
+import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.jackson3.SchemaHelper;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -110,6 +111,17 @@ class JsonPojoDataTypeTransformerTest {
         Assertions.assertEquals(Person.class, exchange.getMessage().getBody().getClass());
         Assertions.assertEquals("Donald", exchange.getMessage().getBody(Person.class).name());
         Assertions.assertEquals(19, exchange.getMessage().getBody(Person.class).age());
+    }
+
+    @Test
+    void shouldWrapMalformedJsonInCamelExecutionException() {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.setProperty(SchemaHelper.CONTENT_CLASS, Person.class.getName());
+        exchange.getMessage().setBody("{ this is no json }");
+
+        Assertions.assertThrows(CamelExecutionException.class,
+                () -> transformer.transform(exchange.getMessage(), DataType.ANY, DataType.ANY));
     }
 
     @Test

--- a/components/camel-jackson3/src/test/java/org/apache/camel/component/jackson3/transform/JsonStructDataTypeTransformerTest.java
+++ b/components/camel-jackson3/src/test/java/org/apache/camel/component/jackson3/transform/JsonStructDataTypeTransformerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.component.jackson3.transform;
 
+import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.jackson3.SchemaHelper;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -91,6 +92,16 @@ class JsonStructDataTypeTransformerTest {
         JSONAssert.assertEquals("""
                     {"name":"Donald","age":19}
                 """, exchange.getMessage().getBody(String.class), true);
+    }
+
+    @Test
+    void shouldWrapMalformedJsonInCamelExecutionException() {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setBody("{ this is no json }");
+
+        Assertions.assertThrows(CamelExecutionException.class,
+                () -> transformer.transform(exchange.getMessage(), DataType.ANY, DataType.ANY));
     }
 
     @Test


### PR DESCRIPTION
Fixes two regressions in `camel-jackson3` from the Jackson 2 → Jackson 3 port (CAMEL-22857):

1. **Type converter drops all but the last configured Jackson module** — `JacksonTypeConverters.resolveObjectMapper()` replaced the mapper with a fresh `JsonMapper.builder().addModule(module).build()` on every loop iteration over `CamelJacksonTypeConverterModuleClassNames`, so only the last module was registered. Now all modules are accumulated on a single builder (matching the Jackson 2 behavior of `registerModule`).

2. **Jackson exceptions escape data type transformers unwrapped** — `JsonStructDataTypeTransformer` and `JsonPojoDataTypeTransformer` still caught the checked `IOException` that Jackson 3 read/write calls no longer throw, so malformed JSON escaped as a raw unchecked `JacksonException` instead of being wrapped in `CamelExecutionException` with the exchange attached (as `JsonDataTypeTransformer` already does). Added `JacksonException` to the catch clauses.

Each new test was verified to fail against the unfixed code and pass with the fix; the full `camel-jackson3` suite passes (103 tests).

Note: `camel-jackson3` was introduced in 4.19.0, so no backport to `camel-4.18.x` is applicable.

JIRA: https://issues.apache.org/jira/browse/CAMEL-24064

_Claude Code on behalf of Croway_
