### PR TITLE
CAMEL-24047: camel-sql - verifyTableName accepts schema-qualified names

### DIFF
--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
@@ -240,8 +240,9 @@ public class JdbcAggregationRepository extends ServiceSupport
     }
 
     // Useful to verify if the table name does not contain invalid characters.
+    // Allows simple names (my_table) and schema-qualified names (myschema.my_table).
     protected static void verifyTableName(String tableName) {
-        if (!tableName.matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
+        if (!tableName.matches("[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)?")) {
             throw new IllegalArgumentException("Invalid repository name: " + tableName);
         }
     }

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryVerifyTableNameTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepositoryVerifyTableNameTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JdbcAggregationRepositoryVerifyTableNameTest {
+
+    @Test
+    public void testSimpleNameAccepted() {
+        assertDoesNotThrow(() -> JdbcAggregationRepository.verifyTableName("aggregation"));
+    }
+
+    @Test
+    public void testSimpleNameWithUnderscoreAccepted() {
+        assertDoesNotThrow(() -> JdbcAggregationRepository.verifyTableName("camel_agg"));
+    }
+
+    @Test
+    public void testNameStartingWithUnderscoreAccepted() {
+        assertDoesNotThrow(() -> JdbcAggregationRepository.verifyTableName("_my_table"));
+    }
+
+    @Test
+    public void testSchemaQualifiedNameAccepted() {
+        assertDoesNotThrow(() -> JdbcAggregationRepository.verifyTableName("myschema.camel_agg"));
+    }
+
+    @Test
+    public void testSchemaQualifiedCompletedNameAccepted() {
+        assertDoesNotThrow(() -> JdbcAggregationRepository.verifyTableName("myschema.camel_agg_completed"));
+    }
+
+    @Test
+    public void testSqlInjectionRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName("foo; DROP TABLE bar"));
+    }
+
+    @Test
+    public void testEmptyNameRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName(""));
+    }
+
+    @Test
+    public void testNameStartingWithDigitRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName("1table"));
+    }
+
+    @Test
+    public void testDoubleDotRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName("schema..table"));
+    }
+
+    @Test
+    public void testTrailingDotRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName("schema."));
+    }
+
+    @Test
+    public void testLeadingDotRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName(".table"));
+    }
+
+    @Test
+    public void testMultipleDotsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> JdbcAggregationRepository.verifyTableName("catalog.schema.table"));
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -436,3 +436,10 @@ The aggregation tables used with these repositories must have the `version BIGIN
 already required by `JdbcAggregationRepository` for reading and updating aggregates. When
 `recoveryByInstance` is enabled, the completed table must have the `instance_id VARCHAR(255)`
 column as documented.
+
+=== camel-sql - Schema-qualified aggregation repository names
+
+The table-name validation in `JdbcAggregationRepository` now accepts schema-qualified names
+such as `myschema.aggregation`. Previously the validation regex only allowed simple identifiers
+(`[a-zA-Z_][a-zA-Z0-9_]*`), rejecting any name containing a dot. Names starting with a digit,
+containing spaces, or with multiple dots (e.g. `catalog.schema.table`) are still rejected.


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

The `verifyTableName` regex in `JdbcAggregationRepository` rejected schema-qualified table names like `myschema.camel_agg` because the pattern `[a-zA-Z_][a-zA-Z0-9_]*` does not allow dots. This is an unreleased regression from commit 1d2568f00236.

- Updated the regex to accept an optional schema qualifier: `[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?`
- Added 12 unit tests covering valid names (simple, underscored, schema-qualified) and invalid names (SQL injection, empty, leading digit, double dot, trailing dot, leading dot, three-part names)
- Added upgrade guide entry in `camel-4x-upgrade-guide-4_22.adoc`

Fixes: [CAMEL-24047](https://issues.apache.org/jira/browse/CAMEL-24047)

## Test plan

- [x] `JdbcAggregationRepositoryVerifyTableNameTest` — 12 tests all pass
- [x] Simple names like `aggregation` still accepted
- [x] Schema-qualified names like `myschema.camel_agg` now accepted
- [x] SQL injection attempts like `foo; DROP TABLE bar` still rejected
- [x] Three-part names like `catalog.schema.table` correctly rejected (only one dot allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)