### PR TITLE
CAMEL-24065: camel-spring - Fix ConcurrentModificationException in EventComponent

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/component/event/EventComponentConcurrencyTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/component/event/EventComponentConcurrencyTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.event;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.spring.SpringCamelContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class EventComponentConcurrencyTest {
+
+    @Test
+    void stoppingRouteDuringEventDispatchMustNotThrow() throws Exception {
+        try (AnnotationConfigApplicationContext appCtx = new AnnotationConfigApplicationContext()) {
+            appCtx.refresh();
+
+            SpringCamelContext camel = new SpringCamelContext(appCtx);
+            appCtx.addApplicationListener(camel);
+
+            camel.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("spring-event:first").routeId("first")
+                            .process(e -> e.getContext().getRouteController().stopRoute("second"));
+                    from("spring-event:second").routeId("second")
+                            .to("log:second");
+                }
+            });
+            camel.start();
+
+            try {
+                assertDoesNotThrow(() -> appCtx.publishEvent(new TestEvent(this)));
+            } finally {
+                camel.stop();
+            }
+        }
+    }
+
+    @Test
+    void survivingEndpointStillReceivesEventsAfterAnotherIsStopped() throws Exception {
+        try (AnnotationConfigApplicationContext appCtx = new AnnotationConfigApplicationContext()) {
+            appCtx.refresh();
+
+            SpringCamelContext camel = new SpringCamelContext(appCtx);
+            appCtx.addApplicationListener(camel);
+
+            camel.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("spring-event:endpointA").routeId("routeA")
+                            .to("mock:a");
+                    from("spring-event:endpointB").routeId("routeB")
+                            .to("mock:b");
+                }
+            });
+            camel.start();
+
+            MockEndpoint mockA = camel.getEndpoint("mock:a", MockEndpoint.class);
+            MockEndpoint mockB = camel.getEndpoint("mock:b", MockEndpoint.class);
+
+            // both endpoints receive the first event
+            mockA.expectedMinimumMessageCount(1);
+            mockB.expectedMinimumMessageCount(1);
+            appCtx.publishEvent(new TestEvent(this));
+            MockEndpoint.assertIsSatisfied(camel);
+
+            // stop routeA, routeB must still receive events
+            camel.getRouteController().stopRoute("routeA");
+            mockB.reset();
+            mockB.expectedMinimumMessageCount(1);
+            appCtx.publishEvent(new TestEvent(this));
+            MockEndpoint.assertIsSatisfied(camel);
+
+            camel.stop();
+        }
+    }
+
+    static class TestEvent extends ApplicationEvent {
+        TestEvent(Object source) {
+            super(source);
+        }
+    }
+}

--- a/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/component/event/EventComponent.java
+++ b/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/component/event/EventComponent.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.component.event;
 
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
@@ -37,7 +37,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 public class EventComponent extends DefaultComponent implements ApplicationContextAware {
     private static final Logger LOG = LoggerFactory.getLogger(EventComponent.class);
     private ApplicationContext applicationContext;
-    private final Set<EventEndpoint> endpoints = new LinkedHashSet<>();
+    private final Set<EventEndpoint> endpoints = new CopyOnWriteArraySet<>();
 
     public EventComponent() {
     }

--- a/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/component/event/EventEndpoint.java
+++ b/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/component/event/EventEndpoint.java
@@ -134,8 +134,10 @@ public class EventEndpoint extends DefaultEndpoint implements ApplicationContext
     public void consumerStopped(EventConsumer consumer) {
         lock.lock();
         try {
-            getComponent().consumerStopped(this);
             getLoadBalancer().removeProcessor(consumer.getAsyncProcessor());
+            if (getLoadBalancer().getProcessors().isEmpty()) {
+                getComponent().consumerStopped(this);
+            }
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24065](https://issues.apache.org/jira/browse/CAMEL-24065).

`EventComponent.endpoints` was a plain `LinkedHashSet` iterated by `onApplicationEvent()` and mutated by `consumerStarted()`/`consumerStopped()` without synchronization, causing `ConcurrentModificationException` when a `spring-event` route is stopped while events are dispatched.

- Replace `LinkedHashSet` with `CopyOnWriteArraySet` — ideal for this write-rare, read-frequent pattern
- Fix premature endpoint removal in `EventEndpoint.consumerStopped()` — only remove the endpoint from the component's set when the load balancer has no processors left, preventing a surviving consumer from silently losing events

## Test plan

- [x] New `EventComponentConcurrencyTest.stoppingRouteDuringEventDispatchMustNotThrow` — verifies no exception when stopping a route during event dispatch (the reported bug)
- [x] New `EventComponentConcurrencyTest.survivingEndpointStillReceivesEventsAfterAnotherIsStopped` — verifies that remaining endpoints still receive events after another is stopped
- [x] Existing `EventRouteTest` passes

_Claude Code on behalf of davsclaus_