### PR TITLE
CAMEL-24066: Fix SpringScheduledPollConsumerScheduler ignoring startScheduler=false

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerSchedulerStartSchedulerTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerSchedulerStartSchedulerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.pollingconsumer;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.spring.processor.SpringTestHelper.createSpringCamelContext;
+import static org.awaitility.Awaitility.await;
+
+public class SpringScheduledPollConsumerSchedulerStartSchedulerTest extends ContextTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        return createSpringCamelContext(this,
+                "org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerSchedulerStartSchedulerTest.xml");
+    }
+
+    @Test
+    public void testStartSchedulerFalseMustNotPoll() throws Exception {
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+
+        getMockEndpoint("mock:result").expectedMessageCount(0);
+
+        // startScheduler=false should prevent polling even with scheduler=spring
+        await().during(3, TimeUnit.SECONDS).atMost(4, TimeUnit.SECONDS)
+                .untilAsserted(() -> getMockEndpoint("mock:result").assertIsSatisfied());
+    }
+}

--- a/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerSchedulerStartSchedulerTest.xml
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/resources/org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerSchedulerStartSchedulerTest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+  <camelContext xmlns="http://camel.apache.org/schema/spring">
+    <jmxAgent id="jmx" disabled="true"/>
+    <route id="foo">
+      <from uri="file:{{testDirectory}}?noop=true&amp;startScheduler=false&amp;scheduler=spring&amp;scheduler.cron=0/1+*+*+*+*+?"/>
+      <to uri="mock:result"/>
+    </route>
+  </camelContext>
+
+</beans>

--- a/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerScheduler.java
+++ b/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/spring/pollingconsumer/SpringScheduledPollConsumerScheduler.java
@@ -69,12 +69,15 @@ public class SpringScheduledPollConsumerScheduler extends ServiceSupport
 
     @Override
     public void startScheduler() {
-        // we start the scheduler in doStart
+        if (future == null) {
+            LOG.debug("Scheduling cron trigger {}", getCron());
+            future = taskScheduler.schedule(runnable, trigger);
+        }
     }
 
     @Override
     public boolean isSchedulerStarted() {
-        return taskScheduler != null && !taskScheduler.getScheduledExecutor().isShutdown();
+        return future != null && !future.isCancelled();
     }
 
     @Override
@@ -126,8 +129,6 @@ public class SpringScheduledPollConsumerScheduler extends ServiceSupport
             destroyTaskScheduler = true;
         }
 
-        LOG.debug("Scheduling cron trigger {}", getCron());
-        future = taskScheduler.schedule(runnable, trigger);
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Fix `SpringScheduledPollConsumerScheduler` violating the `ScheduledPollConsumerScheduler` SPI contract by scheduling the cron task in `doStart()` instead of `startScheduler()`
- Move `taskScheduler.schedule(runnable, trigger)` from `doStart()` to `startScheduler()` with an idempotent guard, aligning with `DefaultScheduledPollConsumerScheduler`
- Fix `isSchedulerStarted()` to check actual scheduling state (`future != null && !future.isCancelled()`) instead of executor liveness

## What was wrong

The Spring scheduler implementation scheduled the cron trigger unconditionally inside `doStart()`, which is called via `ServiceHelper.startService(scheduler)` **before** the `isStartScheduler()` gate in `ScheduledPollConsumer.doStart()`. This meant `startScheduler=false` was silently ignored — the cron started firing as soon as the route started.

This affected file, FTP, SFTP, SMB consumers and `GenericFilePollingConsumer` (`pollEnrich()`) when combined with `scheduler=spring`, as they set `startScheduler=false` internally.

## Test plan

- [x] New test verifies `startScheduler=false` prevents polling with `scheduler=spring`
- [x] Existing `FileConsumerSpringSchedulerTest` still passes (normal scheduling works)

Follow-up: [CAMEL-24079](https://issues.apache.org/jira/browse/CAMEL-24079) — Quartz scheduler has the same structural pattern.

_Claude Code on behalf of davsclaus_