### PR TITLE
CAMEL-24067: Fix SpringInjector not injecting CamelContext into CamelContextAware beans via factory method

### DIFF
--- a/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/spi/SpringInjectorFactoryMethodTest.java
+++ b/components/camel-spring-parent/camel-spring-xml/src/test/java/org/apache/camel/spring/spi/SpringInjectorFactoryMethodTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.spring.spi;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.spring.SpringCamelContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class SpringInjectorFactoryMethodTest {
+
+    @Test
+    void factoryMethodBeanGetsCamelContext() throws Exception {
+        try (AnnotationConfigApplicationContext appCtx = new AnnotationConfigApplicationContext()) {
+            appCtx.refresh();
+            SpringCamelContext camel = new SpringCamelContext(appCtx);
+            camel.start();
+            try {
+                MyBean bean = camel.getInjector().newInstance(MyBean.class, "createMyBean");
+                assertNotNull(bean, "Factory method should return a non-null bean");
+                assertNotNull(bean.getCamelContext(), "CamelContext should be injected into CamelContextAware bean");
+                assertSame(camel, bean.getCamelContext());
+            } finally {
+                camel.stop();
+            }
+        }
+    }
+
+    @Test
+    void factoryMethodWithFactoryClassGetsCamelContext() throws Exception {
+        try (AnnotationConfigApplicationContext appCtx = new AnnotationConfigApplicationContext()) {
+            appCtx.refresh();
+            SpringCamelContext camel = new SpringCamelContext(appCtx);
+            camel.start();
+            try {
+                MyBean bean = camel.getInjector().newInstance(MyBean.class, MyBean.class, "createMyBean");
+                assertNotNull(bean, "Factory method should return a non-null bean");
+                assertNotNull(bean.getCamelContext(), "CamelContext should be injected into CamelContextAware bean");
+                assertSame(camel, bean.getCamelContext());
+            } finally {
+                camel.stop();
+            }
+        }
+    }
+
+    public static class MyBean implements CamelContextAware {
+        private CamelContext camelContext;
+
+        public static MyBean createMyBean() {
+            return new MyBean();
+        }
+
+        @Override
+        public CamelContext getCamelContext() {
+            return camelContext;
+        }
+
+        @Override
+        public void setCamelContext(CamelContext camelContext) {
+            this.camelContext = camelContext;
+        }
+    }
+}

--- a/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
+++ b/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/spring/SpringCamelContext.java
@@ -216,8 +216,10 @@ public class SpringCamelContext extends DefaultCamelContext
 
     @Override
     protected Injector createInjector() {
-        if (applicationContext instanceof ConfigurableApplicationContext) {
-            return new SpringInjector((ConfigurableApplicationContext) applicationContext);
+        if (applicationContext instanceof ConfigurableApplicationContext cac) {
+            SpringInjector answer = new SpringInjector(cac);
+            answer.setCamelContext(this);
+            return answer;
         } else {
             LOG.warn("Cannot use SpringInjector as applicationContext is not a ConfigurableApplicationContext as its: {}",
                     applicationContext);

--- a/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/spring/spi/SpringInjector.java
+++ b/components/camel-spring-parent/camel-spring/src/main/java/org/apache/camel/spring/spi/SpringInjector.java
@@ -19,6 +19,8 @@ package org.apache.camel.spring.spi;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.Injector;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -29,6 +31,7 @@ import org.springframework.context.ConfigurableApplicationContext;
  */
 public class SpringInjector implements Injector {
     private final ConfigurableApplicationContext applicationContext;
+    private CamelContext camelContext;
     private int autowireMode = AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR;
     private boolean dependencyCheck;
 
@@ -58,6 +61,8 @@ public class SpringInjector implements Injector {
                 Object obj = fm.invoke(null);
                 answer = type.cast(obj);
             }
+            // inject camel context if needed
+            CamelContextAware.trySetCamelContext(answer, camelContext);
         } catch (Exception e) {
             throw new RuntimeCamelException("Error invoking factory method: " + factoryMethod + " on class: " + target, e);
         }
@@ -94,6 +99,14 @@ public class SpringInjector implements Injector {
 
     public void setDependencyCheck(boolean dependencyCheck) {
         this.dependencyCheck = dependencyCheck;
+    }
+
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
     }
 
     public ConfigurableApplicationContext getApplicationContext() {


### PR DESCRIPTION
## Summary

- `SpringInjector.newInstance(type, factoryClass, factoryMethod)` was missing the `CamelContextAware.trySetCamelContext()` call that `DefaultInjector` has, so `CamelContextAware` beans created through `#class:...#factoryMethod` syntax did not get the `CamelContext` injected when running in Spring/Spring Boot
- Added a `CamelContext` field to `SpringInjector` and set it from `SpringCamelContext.createInjector()`

## Test plan

- [x] New `SpringInjectorFactoryMethodTest` with two tests verifying CamelContext injection via both `newInstance(type, factoryMethod)` and `newInstance(type, factoryClass, factoryMethod)`
- [ ] Verify no regressions in existing camel-spring-xml tests

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>