### PR TITLE
CAMEL-24081: ci - Do not run Windows launcher check on unrelated PRs

### DIFF
--- a/.github/workflows/camel-launcher-windows.yml
+++ b/.github/workflows/camel-launcher-windows.yml
@@ -21,9 +21,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'tooling/camel-exe/**'
+      - 'dsl/camel-jbang/camel-launcher/**'
+      - '.github/workflows/camel-launcher-windows.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'tooling/camel-exe/**'
+      - 'dsl/camel-jbang/camel-launcher/**'
+      - '.github/workflows/camel-launcher-windows.yml'
   workflow_dispatch:
 
 concurrency:
@@ -43,8 +51,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          # 50 commits covers any reasonable push batch; PRs fetch the base ref below.
-          fetch-depth: 50
+          fetch-depth: 0
       - id: changes
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -54,7 +61,6 @@ jobs:
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1
             CHANGED="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
           else
             CHANGED="$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")"


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

The `camel-launcher-windows.yml` workflow was triggering on **every** PR to `main`, even when the PR did not touch any Windows/launcher-related files. The `detect-changes` job then failed with `fatal: origin/main...HEAD: no merge base` due to insufficient git history in the shallow clone, causing a spurious red check on unrelated PRs (e.g. PR #24712).

**Changes:**
- Add `paths:` filters to both `push` and `pull_request` triggers so the workflow only runs when `tooling/camel-exe/`, `dsl/camel-jbang/camel-launcher/`, or the workflow file itself are changed
- Fix the shallow clone issue in `detect-changes` by using `fetch-depth: 0` so the three-dot diff can find a merge base when the workflow does trigger

## Test plan

- [x] Verify unrelated PRs no longer trigger the Windows workflow (the `paths:` filter prevents it at the GitHub level)
- [x] Verify `workflow_dispatch` still runs both jobs unconditionally
- [x] Verify PRs touching only `tooling/camel-exe/` trigger only the `camel-exe` job
- [x] Verify PRs touching `dsl/camel-jbang/camel-launcher/` trigger the `camel-launcher-windows` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>