### PR TITLE
CAMEL-24069: camel-spring-rabbitmq - Use consumer exception handler for async failures

### DIFF
--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/EndpointMessageListener.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/EndpointMessageListener.java
@@ -251,10 +251,8 @@ public class EndpointMessageListener implements ChannelAwareMessageListener {
                     // method and rethrow it
                     exchange.setException(rce);
                 } else {
-                    // we were done async, so use the endpoint error handler
-                    if (endpoint.getExceptionHandler() != null) {
-                        endpoint.getExceptionHandler().handleException(rce);
-                    }
+                    // we were done async, so use the consumer error handler
+                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, rce);
                 }
             }
 


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

When `asyncConsumer=true` and an exchange fails after the listener method has already returned (async completion), the failure was silently dropped because `EndpointMessageListener` called `endpoint.getExceptionHandler()` which is `null` by default, with no fallback.

The fix uses `consumer.getExceptionHandler()` instead, which always has a default `LoggingExceptionHandler` (set by `DefaultConsumer` constructor). This matches the canonical pattern used by `DefaultConsumer.DefaultConsumerCallback` and other components like camel-pulsar.

The same bug in camel-sjms has been filed as CAMEL-24083.

## Changes

- **`EndpointMessageListener.java`**: Changed the async failure path from `endpoint.getExceptionHandler()` (nullable, no fallback) to `consumer.getExceptionHandler()` (always non-null)

## Test plan

- [x] All existing tests pass (`mvn verify` — 35 tests, 0 failures)