### PR TITLE
CAMEL-24083: camel-sjms - Use consumer exception handler for async failures

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/consumer/EndpointMessageListener.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/consumer/EndpointMessageListener.java
@@ -456,10 +456,8 @@ public class EndpointMessageListener implements SessionMessageListener {
                     // method and rethrow it
                     exchange.setException(rce);
                 } else {
-                    // we were done async, so use the exception handler
-                    if (endpoint.getExceptionHandler() != null) {
-                        endpoint.getExceptionHandler().handleException(rce);
-                    }
+                    // we were done async, so use the consumer exception handler
+                    consumer.getExceptionHandler().handleException("Error processing exchange", exchange, rce);
                 }
             }
 


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

Same bug as CAMEL-24069 (camel-spring-rabbitmq), but in camel-sjms.

When `asyncConsumer=true` and an exchange fails after the listener returns (async completion), the failure was silently dropped because `EndpointMessageListener` called `endpoint.getExceptionHandler()` which is `null` by default, with no fallback.

The fix uses `consumer.getExceptionHandler()` instead, which always has a default `LoggingExceptionHandler` (set by `DefaultConsumer` constructor). This matches the canonical pattern used by `DefaultConsumer.DefaultConsumerCallback` and other components like camel-pulsar.

## Changes

- **`EndpointMessageListener.java`** (camel-sjms): Changed the async failure path from `endpoint.getExceptionHandler()` (nullable, no fallback) to `consumer.getExceptionHandler()` (always non-null)

## Test plan

- [x] All existing tests pass (`mvn verify` — 4 tests, 0 failures)