### PR TITLE
CAMEL-24072: camel-jms - Fix transacted=true breaking ConnectionFactory autowiring

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsComponent.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsComponent.java
@@ -1126,7 +1126,7 @@ public class JmsComponent extends HeaderFilterStrategyComponent {
     @Override
     protected void doInit() throws Exception {
         // only attempt to set connection factory if there is no transaction manager
-        if (configuration.getConnectionFactory() == null && configuration.getOrCreateTransactionManager() == null
+        if (configuration.getConnectionFactory() == null && configuration.getTransactionManager() == null
                 && isAllowAutoWiredConnectionFactory()) {
             Set<ConnectionFactory> beans = getCamelContext().getRegistry().findByType(ConnectionFactory.class);
             if (beans.size() == 1) {

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsTransactedAutowiredConnectionFactoryTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsTransactedAutowiredConnectionFactoryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jms;
+
+import jakarta.jms.ConnectionFactory;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.infra.artemis.services.ArtemisService;
+import org.apache.camel.test.infra.artemis.services.ArtemisServiceFactory;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that component-level transacted=true does not prevent ConnectionFactory autowiring from the registry.
+ *
+ * Reproducer for CAMEL-24072.
+ */
+public class JmsTransactedAutowiredConnectionFactoryTest extends CamelTestSupport {
+
+    @RegisterExtension
+    public static ArtemisService service = ArtemisServiceFactory.createVMService();
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+
+        // register the CF in the registry so it can be autowired
+        ConnectionFactory cf = new ActiveMQConnectionFactory(service.serviceAddress());
+        camelContext.getRegistry().bind("myConnectionFactory", cf);
+
+        // add a JMS component with transacted=true but NO explicit ConnectionFactory
+        JmsComponent jms = new JmsComponent();
+        jms.setTransacted(true);
+        camelContext.addComponent("jms", jms);
+
+        return camelContext;
+    }
+
+    @Test
+    public void testTransactedComponentAutowiresConnectionFactory() {
+        JmsComponent jms = context.getComponent("jms", JmsComponent.class);
+        assertNotNull(jms);
+
+        JmsConfiguration config = jms.getConfiguration();
+        assertNotNull(config.getConnectionFactory(), "ConnectionFactory should have been autowired from the registry");
+        assertTrue(config.isTransacted(), "transacted should still be true");
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("jms:queue:CAMEL-24072").to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes component-level `transacted=true` breaking `ConnectionFactory` autowiring during startup with `IllegalArgumentException: connectionFactory must be specified`.

The guard condition in `JmsComponent.doInit()` used `getOrCreateTransactionManager()` which eagerly creates a `JmsTransactionManager` — and that requires a `ConnectionFactory` that hasn't been autowired yet (since the autowiring is the body of the very if-statement being evaluated). Changed to `getTransactionManager()` (plain getter, no side effects) so the guard only checks whether a TM was explicitly configured, without triggering lazy creation.

- **Root cause**: CAMEL-14220 changed `getTransactionManager()` → `getOrCreateTransactionManager()` to fix camel-activemq (which overrides `createConnectionFactory()` and is unaffected). Plain camel-jms has no such override and throws.
- **Fix**: Revert the guard to `getTransactionManager()`. The lazy TM creation still happens later when the endpoint/consumer is actually created.
- **Tests**: Added `JmsTransactedAutowiredConnectionFactoryTest` — reproducer that fails without the fix. All camel-jms (437 tests), camel-activemq, and camel-activemq6 tests pass.

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>