### PR TITLE
chore: move CAMEL-23839 TUI theme upgrade note to the 4.22 guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -32,9 +32,6 @@ The project exported by `camel export` now includes additional guidance for AI c
 `readme.md` gained a _For AI coding assistants_ section linking to the Apache Camel website LLM index,
 and a new `AGENTS.md` file is generated at the project root. This applies to all runtimes (Camel Main, Spring Boot and Quarkus).
 
-The Camel TUI (`camel tui`) theme is now backed by CSS stylesheets and ships a switchable light/dark palette.
-Press *F4* to toggle at runtime; the selection is persisted as `camel.tui.theme` in `.camel-jbang-user.properties`.
-
 === camel-micrometer
 
 The `MicrometerExchangeEventNotifier` now always includes the `routeId` tag on exchange event metrics.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -49,6 +49,9 @@ file. Each key is read from and written back to the file where it currently live
 the local `./camel-cli.properties` stays local (project override), while every other key defaults to
 the global `~/.camel-cli.properties`.
 
+The Camel TUI (`camel tui`) theme is now backed by CSS stylesheets and ships a switchable light/dark palette.
+Press *F4* to toggle at runtime; the selection is persisted as `camel.tui.theme` in `.camel-cli.properties`.
+
 The Camel CLI user configuration file has been renamed from `camel-jbang-user.properties` to
 `camel-cli.properties` (global `~/.camel-cli.properties`, local `./camel-cli.properties`). The dot
 convention is unchanged: the global file is a hidden dotfile, the local file is visible. On first


### PR DESCRIPTION
# Description

Follow-up to a [review comment on #24322](https://github.com/apache/camel/pull/24322#pullrequestreview-4702333394): the CSS-backed TUI theme / F4-toggle note landed in `camel-4x-upgrade-guide-4_21.adoc`, but `main` is `4.22.0-SNAPSHOT`, so the feature actually ships in 4.22. This moves the note to `camel-4x-upgrade-guide-4_22.adoc`, placing it next to the related `--theme=dark|light` flag and F2 *Settings…* entries already documented there.

While moving it, the referenced config file name was updated from `.camel-jbang-user.properties` to `.camel-cli.properties`, since that rename (CAMEL-23867) is already on `main` and the old name would have been stale in the 4.22 guide.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_This PR was created with Claude Code on behalf of Adriano Machado (@ammachado)._