### PR TITLE
CAMEL-23358 - Adapt SSLContextParametersTest.testSignatureSchemesFilter for JDK 26

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/support/jsse/SSLContextParametersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/jsse/SSLContextParametersTest.java
@@ -986,7 +986,7 @@ public class SSLContextParametersTest extends AbstractJsseParametersTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_21)
+    @EnabledForJreRange(min = JRE.JAVA_21, max = JRE.JAVA_25)
     public void testSignatureSchemesFilter() throws Exception {
         // Note: SSLParameters.getSignatureSchemes() returns null by default (unlike getNamedGroups()),
         // so filters operate on explicitly provided schemes rather than JDK defaults.
@@ -1045,6 +1045,68 @@ public class SSLContextParametersTest extends AbstractJsseParametersTest {
         assertEquals(0, getSignatureSchemes(engine.getSSLParameters()).length);
         assertEquals(0, getSignatureSchemes(socket.getSSLParameters()).length);
         assertEquals(0, getSignatureSchemes(serverSocket.getSSLParameters()).length);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_26)
+    public void testSignatureSchemesFilter_postJDK26() throws Exception {
+        // Note: SSLParameters.getSignatureSchemes() returns non-null by default (unlike on JDK 25-)
+
+        // default - no filter, keeps defaults (null)
+        SSLContextParameters scp = new SSLContextParameters();
+        SSLContext context = scp.createSSLContext(null);
+
+        SSLEngine engine = context.createSSLEngine();
+        SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket();
+        SSLServerSocket serverSocket = (SSLServerSocket) context.getServerSocketFactory().createServerSocket();
+
+        assertNotNull(getSignatureSchemes(engine.getSSLParameters()));
+        assertNotNull(getSignatureSchemes(socket.getSSLParameters()));
+        assertNotNull(getSignatureSchemes(serverSocket.getSSLParameters()));
+
+        int defaultSignatureSchemeNumber = getSignatureSchemes(engine.getSSLParameters()).length;
+
+        // empty filter - no includes means no schemes match (empty array)
+        FilterParameters filter = new FilterParameters();
+        scp.setSignatureSchemesFilter(filter);
+        context = scp.createSSLContext(null);
+        engine = context.createSSLEngine();
+        socket = (SSLSocket) context.getSocketFactory().createSocket();
+        serverSocket = (SSLServerSocket) context.getServerSocketFactory().createServerSocket();
+
+        assertEquals(0, getSignatureSchemes(engine.getSSLParameters()).length);
+        assertEquals(0, getSignatureSchemes(socket.getSSLParameters()).length);
+        assertEquals(0, getSignatureSchemes(serverSocket.getSSLParameters()).length);
+
+        // explicit schemes override filter - filter ignored when schemes are set
+        SignatureSchemesParameters ssp = new SignatureSchemesParameters();
+        List<String> allSchemes = new LinkedList<>();
+        allSchemes.add("ecdsa_secp256r1_sha256");
+        allSchemes.add("ecdsa_secp384r1_sha384");
+        allSchemes.add("rsa_pss_rsae_sha256");
+        allSchemes.add("ed25519");
+        ssp.setSignatureScheme(allSchemes);
+        scp.setSignatureSchemes(ssp);
+
+        filter.getInclude().add("ecdsa_.*");
+        context = scp.createSSLContext(null);
+        engine = context.createSSLEngine();
+
+        // explicit schemes take precedence over filter
+        assertEquals(4, getSignatureSchemes(engine.getSSLParameters()).length);
+
+        // clear explicit schemes, keep filter - now filter applies to JDK defaults
+        scp.setSignatureSchemes(null);
+        filter.getInclude().clear();
+        filter.getInclude().add(".*");
+        context = scp.createSSLContext(null);
+        engine = context.createSSLEngine();
+        socket = (SSLSocket) context.getSocketFactory().createSocket();
+        serverSocket = (SSLServerSocket) context.getServerSocketFactory().createServerSocket();
+
+        assertEquals(defaultSignatureSchemeNumber, getSignatureSchemes(engine.getSSLParameters()).length);
+        assertEquals(defaultSignatureSchemeNumber, getSignatureSchemes(socket.getSSLParameters()).length);
+        assertEquals(defaultSignatureSchemeNumber, getSignatureSchemes(serverSocket.getSSLParameters()).length);
     }
 
     @Test


### PR DESCRIPTION
for JDK 26

The method getSignatureSchemes is now providing a non-empty list. Consequently, the tests need to be adapted. I choose to create a dedicated test to see a bit clearer the difference with previous JDK version.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

