### PR TITLE
CAMEL-24076: camel-jms - Wire browseLimit config into queue endpoints

### DIFF
--- a/components/camel-activemq/src/main/java/org/apache/camel/component/activemq/ActiveMQQueueEndpoint.java
+++ b/components/camel-activemq/src/main/java/org/apache/camel/component/activemq/ActiveMQQueueEndpoint.java
@@ -37,7 +37,7 @@ import org.springframework.jms.core.JmsOperations;
  */
 @ManagedResource(description = "Managed JMS Queue Endpoint")
 public class ActiveMQQueueEndpoint extends ActiveMQEndpoint implements JmsBrowsableEndpoint, BrowsableEndpoint {
-    private int maximumBrowseSize = 100;
+    private int maximumBrowseSize = -1;
     private final QueueBrowseStrategy queueBrowseStrategy;
 
     public ActiveMQQueueEndpoint(String uri, JmsComponent component, String destination,
@@ -71,6 +71,17 @@ public class ActiveMQQueueEndpoint extends ActiveMQEndpoint implements JmsBrowsa
         super(endpointUri, destination, false);
         setDestinationType("queue");
         queueBrowseStrategy = createQueueBrowseStrategy();
+    }
+
+    @Override
+    protected void doInit() throws Exception {
+        super.doInit();
+        if (maximumBrowseSize < 0) {
+            JmsConfiguration config = getConfiguration();
+            if (config != null) {
+                maximumBrowseSize = config.getBrowseLimit();
+            }
+        }
     }
 
     @ManagedAttribute

--- a/components/camel-activemq6/src/main/java/org/apache/camel/component/activemq6/ActiveMQQueueEndpoint.java
+++ b/components/camel-activemq6/src/main/java/org/apache/camel/component/activemq6/ActiveMQQueueEndpoint.java
@@ -37,7 +37,7 @@ import org.springframework.jms.core.JmsOperations;
  */
 @ManagedResource(description = "Managed JMS Queue Endpoint")
 public class ActiveMQQueueEndpoint extends ActiveMQEndpoint implements JmsBrowsableEndpoint, BrowsableEndpoint {
-    private int maximumBrowseSize = 100;
+    private int maximumBrowseSize = -1;
     private final QueueBrowseStrategy queueBrowseStrategy;
 
     public ActiveMQQueueEndpoint(String uri, JmsComponent component, String destination,
@@ -71,6 +71,17 @@ public class ActiveMQQueueEndpoint extends ActiveMQEndpoint implements JmsBrowsa
         super(endpointUri, destination, false);
         setDestinationType("queue");
         queueBrowseStrategy = createQueueBrowseStrategy();
+    }
+
+    @Override
+    protected void doInit() throws Exception {
+        super.doInit();
+        if (maximumBrowseSize < 0) {
+            JmsConfiguration config = getConfiguration();
+            if (config != null) {
+                maximumBrowseSize = config.getBrowseLimit();
+            }
+        }
     }
 
     @ManagedAttribute

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsQueueEndpoint.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsQueueEndpoint.java
@@ -68,6 +68,17 @@ public class JmsQueueEndpoint extends JmsEndpoint implements JmsBrowsableEndpoin
         queueBrowseStrategy = createQueueBrowseStrategy();
     }
 
+    @Override
+    protected void doInit() throws Exception {
+        super.doInit();
+        if (maximumBrowseSize < 0) {
+            JmsConfiguration config = getConfiguration();
+            if (config != null) {
+                maximumBrowseSize = config.getBrowseLimit();
+            }
+        }
+    }
+
     @ManagedAttribute
     public int getMaximumBrowseSize() {
         return maximumBrowseSize;

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/BrowsableQueueTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/BrowsableQueueTest.java
@@ -102,6 +102,24 @@ public class BrowsableQueueTest extends AbstractJMSTest {
     }
 
     @Test
+    public void testSendMessagesThenBrowseQueueWithBrowseLimit() {
+        final String queueName = queueNameForClass("activemq:BrowsableQueueTest.d", this.getClass());
+        // send some messages
+        for (int i = 0; i < expectedBodies.length; i++) {
+            Object expectedBody = expectedBodies[i];
+            template.sendBodyAndHeader(queueName, expectedBody, "counter", i);
+        }
+
+        // now lets browse the queue using the browseLimit URI option
+        JmsQueueEndpoint endpoint = getMandatoryEndpoint(queueName + "?browseLimit=6", JmsQueueEndpoint.class);
+        assertEquals(6, endpoint.getMaximumBrowseSize());
+        assertEquals(6, endpoint.getBrowseLimit());
+        List<Exchange> list = endpoint.getExchanges();
+        LOG.debug("Received: {}", list);
+        assertEquals(6, list.size(), "Size of list");
+    }
+
+    @Test
     public void testSendMessagesThenBrowseQueueNoMax() {
         final String queueName = queueNameForClass("activemq:BrowsableQueueTest.b", this.getClass());
 
@@ -113,7 +131,7 @@ public class BrowsableQueueTest extends AbstractJMSTest {
 
         // now lets browse the queue
         JmsQueueEndpoint endpoint = getMandatoryEndpoint(queueName, JmsQueueEndpoint.class);
-        assertEquals(-1, endpoint.getMaximumBrowseSize());
+        assertEquals(100, endpoint.getMaximumBrowseSize());
         List<Exchange> list = endpoint.getExchanges();
         LOG.debug("Received: {}", list);
         assertEquals(8, endpoint.getExchanges().size(), "Size of list");


### PR DESCRIPTION
## Summary

- Wire `configuration.getBrowseLimit()` into `JmsQueueEndpoint`, `ActiveMQQueueEndpoint` (camel-activemq), and `ActiveMQQueueEndpoint` (camel-activemq6) via `doInit()`, so the `browseLimit` URI option actually takes effect
- The generated configurer routes `browseLimit` to `JmsConfiguration.setBrowseLimit()`, but `JmsQueueEndpoint` uses its own `maximumBrowseSize` field which was never populated from the config — making the option dead code since commit caa51c5da0a8
- Add test for the `browseLimit` URI option in `BrowsableQueueTest`

## Test plan

- [x] `BrowsableQueueTest` passes (4 tests including new `testSendMessagesThenBrowseQueueWithBrowseLimit`)
- [ ] CI green

_Claude Code on behalf of davsclaus_
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>