### PR TITLE
CAMEL-24077: camel-amqp - Only append SSL transport options when configured

### DIFF
--- a/components/camel-amqp/src/main/java/org/apache/camel/component/amqp/AMQPComponent.java
+++ b/components/camel-amqp/src/main/java/org/apache/camel/component/amqp/AMQPComponent.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.amqp;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
@@ -116,12 +118,24 @@ public class AMQPComponent extends JmsComponent {
             sb.append(useSsl == Boolean.TRUE ? "amqps://" : "amqp://");
             sb.append(host == null ? AMQP_DEFAULT_HOST : host).append(":").append(port == null ? AMQP_DEFAULT_PORT : port);
             if (useSsl == Boolean.TRUE) {
-                sb.append("?transport.trustStoreLocation=").append(trustStoreLocation == null ? "" : trustStoreLocation);
-                sb.append("&transport.trustStoreType=").append(trustStoreType);
-                sb.append("&transport.trustStorePassword=").append(trustStorePassword == null ? "" : trustStorePassword);
-                sb.append("&transport.keyStoreLocation=").append(keyStoreLocation == null ? "" : keyStoreLocation);
-                sb.append("&transport.keyStoreType=").append(keyStoreType);
-                sb.append("&transport.keyStorePassword=").append(keyStorePassword == null ? "" : keyStorePassword);
+                boolean first = true;
+                if (trustStoreLocation != null) {
+                    sb.append('?');
+                    first = false;
+                    sb.append("transport.trustStoreLocation=").append(urlEncode(trustStoreLocation));
+                    sb.append("&transport.trustStoreType=").append(urlEncode(trustStoreType));
+                    if (trustStorePassword != null) {
+                        sb.append("&transport.trustStorePassword=").append(urlEncode(trustStorePassword));
+                    }
+                }
+                if (keyStoreLocation != null) {
+                    sb.append(first ? '?' : '&');
+                    sb.append("transport.keyStoreLocation=").append(urlEncode(keyStoreLocation));
+                    sb.append("&transport.keyStoreType=").append(urlEncode(keyStoreType));
+                    if (keyStorePassword != null) {
+                        sb.append("&transport.keyStorePassword=").append(urlEncode(keyStorePassword));
+                    }
+                }
             }
             JmsConnectionFactory connectionFactory
                     = new JmsConnectionFactory(getUsername(), getPassword(), sb.toString());
@@ -281,5 +295,9 @@ public class AMQPComponent extends JmsComponent {
 
     public void setTrustStorePassword(String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/components/camel-amqp/src/test/java/org/apache/camel/component/amqp/AMQPConfigTest.java
+++ b/components/camel-amqp/src/test/java/org/apache/camel/component/amqp/AMQPConfigTest.java
@@ -100,10 +100,36 @@ public class AMQPConfigTest {
         JmsConnectionFactory connectionFactory = (JmsConnectionFactory) amqpSslEnabledComponent.getConnectionFactory();
         assertNull(connectionFactory.getUsername());
         assertNull(connectionFactory.getPassword());
-        assertEquals(
-                "amqps://localhost:5672?transport.trustStoreLocation=&transport.trustStoreType=JKS&transport.trustStorePassword=&transport.keyStoreLocation=&transport.keyStoreType=JKS&transport.keyStorePassword=",
-                connectionFactory.getRemoteURI());
+        assertEquals("amqps://localhost:5672", connectionFactory.getRemoteURI());
         assertEquals("topic://", connectionFactory.getTopicPrefix());
+    }
+
+    @Test
+    public void testTrustStoreOnlySslComponent() {
+        AMQPComponent component
+                = contextExtension.getContext().getComponent("amqps-trustonly", AMQPComponent.class);
+        assertTrue(component.getUseSsl());
+        assertEquals("server-ca-truststore.p12", component.getTrustStoreLocation());
+        assertNull(component.getKeyStoreLocation());
+
+        assertTrue(component.getConnectionFactory() instanceof JmsConnectionFactory);
+        JmsConnectionFactory connectionFactory = (JmsConnectionFactory) component.getConnectionFactory();
+        assertEquals(
+                "amqps://localhost:5672?transport.trustStoreLocation=server-ca-truststore.p12&transport.trustStoreType=PKCS12&transport.trustStorePassword=securepass",
+                connectionFactory.getRemoteURI());
+    }
+
+    @Test
+    public void testSslUrlEncodedPassword() {
+        AMQPComponent component
+                = contextExtension.getContext().getComponent("amqps-specialchars", AMQPComponent.class);
+        assertTrue(component.getUseSsl());
+
+        assertTrue(component.getConnectionFactory() instanceof JmsConnectionFactory);
+        JmsConnectionFactory connectionFactory = (JmsConnectionFactory) component.getConnectionFactory();
+        assertEquals(
+                "amqps://localhost:5672?transport.trustStoreLocation=%2Fpath%2Fto%2Fstore.jks&transport.trustStoreType=JKS&transport.trustStorePassword=p%40ss%3Dw%26rd",
+                connectionFactory.getRemoteURI());
     }
 
     @Test
@@ -156,6 +182,19 @@ public class AMQPConfigTest {
         AMQPComponent amqpSslEnabledComponent = new AMQPComponent();
         amqpSslEnabledComponent.setUseSsl(true);
         context.addComponent("amqps-enabled", amqpSslEnabledComponent);
+
+        AMQPComponent amqpTrustOnlyComponent = new AMQPComponent();
+        amqpTrustOnlyComponent.setUseSsl(true);
+        amqpTrustOnlyComponent.setTrustStoreLocation("server-ca-truststore.p12");
+        amqpTrustOnlyComponent.setTrustStorePassword("securepass");
+        amqpTrustOnlyComponent.setTrustStoreType("PKCS12");
+        context.addComponent("amqps-trustonly", amqpTrustOnlyComponent);
+
+        AMQPComponent amqpSpecialCharsComponent = new AMQPComponent();
+        amqpSpecialCharsComponent.setUseSsl(true);
+        amqpSpecialCharsComponent.setTrustStoreLocation("/path/to/store.jks");
+        amqpSpecialCharsComponent.setTrustStorePassword("p@ss=w&rd");
+        context.addComponent("amqps-specialchars", amqpSpecialCharsComponent);
 
         AMQPComponent amqpPortOnlyComponent = new AMQPComponent();
         amqpPortOnlyComponent.setPort(5556);


### PR DESCRIPTION
## Summary

- Only append `transport.*` options to the Qpid JMS connection URI when the corresponding store location is actually configured (non-null). Previously, all six options were always appended with empty strings when `useSsl=true`, causing Qpid JMS to throw `FileNotFoundException` instead of using the JVM default trust store.
- URL-encode transport option values to prevent URI corruption from special characters in store paths or passwords.
- Add tests for trust-store-only TLS (server-only TLS, no client key store) and URL encoding of special characters.

## Test plan

- [x] `testEnabledSslComponent` — verifies `useSsl=true` with no stores produces `amqps://localhost:5672` (no empty query params)
- [x] `testConfiguredSslComponent` — verifies fully configured SSL still works
- [x] `testTrustStoreOnlySslComponent` — verifies trust-store-only TLS (common server-only case)
- [x] `testSslUrlEncodedPassword` — verifies special chars (`@`, `=`, `&`, `/`) are URL-encoded
- [x] Full `camel-amqp` test suite (25 tests pass)

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>