### PR TITLE
CAMEL-24078: camel-jms/camel-amqp - Fix medium findings from code review

### DIFF
--- a/components/camel-amqp/src/main/java/org/apache/camel/component/amqp/AMQPComponent.java
+++ b/components/camel-amqp/src/main/java/org/apache/camel/component/amqp/AMQPComponent.java
@@ -110,8 +110,9 @@ public class AMQPComponent extends JmsComponent {
                 connectionFactory.setTopicPrefix("topic://");
             }
             getConfiguration().setConnectionFactory(connectionFactory);
-        } else if (host != null || port != null || getUsername() != null || getPassword() != null || useTopicPrefix != null
-                || useSsl != null) {
+        } else if (getConfiguration().getConnectionFactory() == null
+                && (host != null || port != null || getUsername() != null || getPassword() != null || useTopicPrefix != null
+                        || useSsl != null)) {
             StringBuilder sb = new StringBuilder();
             sb.append(useSsl == Boolean.TRUE ? "amqps://" : "amqp://");
             sb.append(host == null ? AMQP_DEFAULT_HOST : host).append(":").append(port == null ? AMQP_DEFAULT_PORT : port);

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsComponent.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsComponent.java
@@ -998,6 +998,7 @@ public class JmsComponent extends HeaderFilterStrategyComponent {
 
     public void setMessageListenerContainerFactory(MessageListenerContainerFactory messageListenerContainerFactory) {
         configuration.setMessageListenerContainerFactory(messageListenerContainerFactory);
+        configuration.setConsumerType(ConsumerType.Custom);
     }
 
     public boolean isIncludeSentJMSMessageID() {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsConsumer.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsConsumer.java
@@ -171,9 +171,6 @@ public class JmsConsumer extends DefaultConsumer implements Suspendable {
         } else {
             prepareAndStartListenerContainer();
         }
-
-        // mark as initialized for the first time
-        initialized = true;
     }
 
     protected void prepareAndStartListenerContainer() {
@@ -187,6 +184,9 @@ public class JmsConsumer extends DefaultConsumer implements Suspendable {
             }
             startListenerContainer();
         }
+
+        // mark as initialized after the auto-startup check
+        initialized = true;
     }
 
     protected void stopAndDestroyListenerContainer() {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsEndpoint.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsEndpoint.java
@@ -1216,6 +1216,11 @@ public class JmsEndpoint extends DefaultEndpoint
     @ManagedAttribute
     public void setIncludeAllJMSXProperties(boolean includeAllJMSXProperties) {
         configuration.setIncludeAllJMSXProperties(includeAllJMSXProperties);
+        // Reset the default header filter strategy so it gets re-created
+        // with the updated includeAllJMSXProperties value
+        if (this.headerFilterStrategy instanceof JmsHeaderFilterStrategy) {
+            this.headerFilterStrategy = null;
+        }
     }
 
     @ManagedAttribute


### PR DESCRIPTION
## Summary

Fixes four medium-severity findings from the camel-jms/camel-amqp code review ([CAMEL-24078](https://issues.apache.org/jira/browse/CAMEL-24078)):

- **M3**: Endpoint-level `includeAllJMSXProperties=true` was silently ignored because the header filter strategy was constructed before URI options were applied. Now resets the cached `JmsHeaderFilterStrategy` when `includeAllJMSXProperties` changes.
- **M4**: Component-level `messageListenerContainerFactory` was silently ignored because `consumerType` was not switched to `Custom`. Aligned with the endpoint-level setter that already does this.
- **M6**: `asyncStartListener=true` defeated `autoStartup=false` due to a race — `initialized` was set before the async task ran, bypassing the auto-startup check. Moved the flag assignment into `prepareAndStartListenerContainer()`.
- **M9**: Setting `username`/`password` on the AMQP component clobbered an explicitly configured `connectionFactory` with a new `localhost:5672` factory. Guarded factory creation with a null check.

## Test plan

- [x] `mvn test` in `components/camel-jms` — all tests pass
- [x] `mvn test` in `components/camel-amqp` — all tests pass
- [ ] CI green

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>