### PR TITLE
CAMEL-24078: camel-jms - Make JmsPollingConsumer.receive(timeout) thread-safe

### DIFF
--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsPollingConsumer.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsPollingConsumer.java
@@ -55,13 +55,16 @@ public class JmsPollingConsumer extends PollingConsumerSupport {
 
     @Override
     public Exchange receive(long timeout) {
-        setReceiveTimeout(timeout);
         Message message;
-        // using the selector
-        if (ObjectHelper.isNotEmpty(jmsEndpoint.getSelector())) {
-            message = template.receiveSelected(jmsEndpoint.getSelector());
-        } else {
-            message = template.receive();
+        // synchronize to make set-timeout + receive atomic, as the polling consumer
+        // may be shared across concurrent pollEnrich / ConsumerTemplate callers
+        synchronized (template) {
+            setReceiveTimeout(timeout);
+            if (ObjectHelper.isNotEmpty(jmsEndpoint.getSelector())) {
+                message = template.receiveSelected(jmsEndpoint.getSelector());
+            } else {
+                message = template.receive();
+            }
         }
         if (message != null) {
             return getEndpoint().createExchange(message, null);


### PR DESCRIPTION
## Summary

- Synchronize `setReceiveTimeout` + `receive` on the shared `JmsTemplate` in `JmsPollingConsumer` to prevent concurrent `pollEnrich` / `ConsumerTemplate` callers from overwriting each other's timeout values.

M2 finding from the camel-jms/camel-amqp code review ([CAMEL-24078](https://issues.apache.org/jira/browse/CAMEL-24078)).

## Test plan

- [x] `mvn test` in `components/camel-jms` — all tests pass
- [ ] CI green

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>