### PR TITLE
CAMEL-24126 - Ensure no message sent before the VertxWebsocket is fully configured

### DIFF
--- a/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketClientConsumer.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketClientConsumer.java
@@ -43,7 +43,7 @@ public class VertxWebsocketClientConsumer extends DefaultConsumer {
 
     @Override
     protected void doStart() throws Exception {
-        configureWebSocketHandlers(getEndpoint().getWebSocket());
+        getEndpoint().getWebSocket(this::configureWebSocketHandlers);
     }
 
     protected void configureWebSocketHandlers(WebSocket webSocket) {
@@ -58,7 +58,7 @@ public class VertxWebsocketClientConsumer extends DefaultConsumer {
                 Vertx vertx = getEndpoint().getVertx();
                 vertx.setPeriodic(configuration.getReconnectInitialDelay(), configuration.getReconnectInterval(), timerId -> {
                     vertx.executeBlocking(() -> {
-                        configureWebSocketHandlers(getEndpoint().getWebSocket());
+                        getEndpoint().getWebSocket(this::configureWebSocketHandlers);
                         vertx.cancelTimer(timerId);
                         return null;
                     }, false)

--- a/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketEndpoint.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketEndpoint.java
@@ -152,6 +152,16 @@ public class VertxWebsocketEndpoint extends DefaultEndpoint implements EndpointS
     }
 
     protected WebSocket getWebSocket() throws Exception {
+        return getWebSocket((java.util.function.Consumer<WebSocket>) null);
+    }
+
+    /**
+     * Connects to the WebSocket server, optionally invoking a setup callback on the socket <em>before</em> the blocking
+     * {@code future.get()} returns. This guarantees that any message/close/exception handlers supplied by the callback
+     * are registered atomically with the connection, so no messages sent by the server immediately after the handshake
+     * can be missed.
+     */
+    protected WebSocket getWebSocket(java.util.function.Consumer<WebSocket> setupCallback) throws Exception {
         if (client == null) {
             resolvedClientOptions = configuration.getClientOptions();
             if (resolvedClientOptions == null) {
@@ -171,8 +181,17 @@ public class VertxWebsocketEndpoint extends DefaultEndpoint implements EndpointS
             CompletableFuture<WebSocket> future = new CompletableFuture<>();
             client.connect(connectOptions).onComplete(result -> {
                 if (result.succeeded()) {
-                    LOG.info("Connected to WebSocket on {}", result.result().remoteAddress());
-                    future.complete(result.result());
+                    WebSocket ws = result.result();
+                    LOG.info("Connected to WebSocket on {}", ws.remoteAddress());
+                    if (setupCallback != null) {
+                        try {
+                            setupCallback.accept(ws);
+                        } catch (Exception e) {
+                            future.completeExceptionally(e);
+                            return;
+                        }
+                    }
+                    future.complete(ws);
                 } else {
                     webSocket = null;
                     future.completeExceptionally(result.cause());


### PR DESCRIPTION
it was visible with flaky test
VertxWebsocketHandshakeHeadersTest.testHandshakeHeadersAsConsumer see rtx-websocket:surefire:test@default-test/details/org.apache.camel.component.vertx.websocket.VertxWebsocketHandshakeHeadersTest/testHandshakeHeadersAsConsumer?top-execution=1

Co-authored-by: IBM Bob IDE 2.0.1

On main branch, i reproduce the flakiness something like 1 out of 3 times. With this PR, it has never failed in 10 runs

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

