### PR TITLE
CAMEL-24071: camel-spring-rabbitmq - Trim queue names and reject multi-queue polling

### DIFF
--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/DefaultListenerContainerFactory.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/DefaultListenerContainerFactory.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.springrabbit;
 
+import java.util.Arrays;
+
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -39,7 +41,8 @@ public class DefaultListenerContainerFactory implements ListenerContainerFactory
         }
 
         if (endpoint.getQueues() != null) {
-            listener.setQueueNames(endpoint.getQueues().split(","));
+            listener.setQueueNames(
+                    Arrays.stream(endpoint.getQueues().split(",")).map(String::trim).toArray(String[]::new));
         }
         listener.setAcknowledgeMode(endpoint.getAcknowledgeMode());
         listener.setExclusive(endpoint.isExclusive());

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitPollingConsumer.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitPollingConsumer.java
@@ -51,11 +51,12 @@ public class SpringRabbitPollingConsumer extends PollingConsumerSupport {
     @Override
     public Exchange receive(long timeout) {
         try {
+            String queue = jmsEndpoint.getQueues().trim();
             Message message;
             if (timeout == 0) {
-                message = template.receive(jmsEndpoint.getQueues());
+                message = template.receive(queue);
             } else {
-                message = template.receive(jmsEndpoint.getQueues(), timeout);
+                message = template.receive(queue, timeout);
             }
             if (message != null) {
                 return getEndpoint().createExchange(message);
@@ -70,6 +71,11 @@ public class SpringRabbitPollingConsumer extends PollingConsumerSupport {
     protected void doInit() throws Exception {
         if (getEndpoint().getQueues() == null) {
             throw new IllegalArgumentException("Queues must be configured when using PollingConsumer");
+        }
+        if (getEndpoint().getQueues().contains(",")) {
+            throw new IllegalArgumentException(
+                    "PollingConsumer does not support multiple queues. Configure a single queue name instead of: "
+                                               + getEndpoint().getQueues());
         }
     }
 

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/DefaultListenerContainerFactoryTest.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/DefaultListenerContainerFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.springrabbit;
+
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class DefaultListenerContainerFactoryTest extends CamelTestSupport {
+
+    @Test
+    void queueNamesShouldBeTrimmedAfterSplit() throws Exception {
+        SpringRabbitMQEndpoint endpoint
+                = context.getEndpoint("spring-rabbitmq:default?queues=myqueue, myotherqueue", SpringRabbitMQEndpoint.class);
+        endpoint.setConnectionFactory(new CachingConnectionFactory("localhost"));
+
+        DefaultListenerContainerFactory factory = new DefaultListenerContainerFactory();
+        AbstractMessageListenerContainer listener = factory.createListenerContainer(endpoint);
+
+        assertArrayEquals(new String[] { "myqueue", "myotherqueue" }, listener.getQueueNames(),
+                "queue names must be trimmed after splitting on comma");
+    }
+}

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/SpringRabbitPollingConsumerTest.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/test/java/org/apache/camel/component/springrabbit/SpringRabbitPollingConsumerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.springrabbit;
+
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SpringRabbitPollingConsumerTest extends CamelTestSupport {
+
+    @Test
+    void multipleQueuesShouldBeRejected() throws Exception {
+        SpringRabbitMQEndpoint endpoint
+                = context.getEndpoint("spring-rabbitmq:default?queues=q1,q2", SpringRabbitMQEndpoint.class);
+        CachingConnectionFactory cf = new CachingConnectionFactory("localhost");
+        endpoint.setConnectionFactory(cf);
+        RabbitTemplate template = new RabbitTemplate(cf);
+
+        SpringRabbitPollingConsumer consumer = new SpringRabbitPollingConsumer(endpoint, template);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, consumer::doInit);
+        assertTrue(ex.getMessage().contains("does not support multiple queues"),
+                "error message should explain that polling consumer does not support multiple queues");
+    }
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- **DefaultListenerContainerFactory**: `split(",")` on the `queues` option now trims each entry, consistent with `declareElements()`. Previously `queues=q1, q2` would make the listener subscribe to `" q2"` (leading space) while declaring `"q2"` — causing a mismatch at runtime.
- **SpringRabbitPollingConsumer**: Rejects multiple comma-separated queues in `doInit()` with a clear error, since `RabbitTemplate.receive()` only accepts a single queue name. Also trims the queue name in `receive()`.

## Test plan

- [x] `DefaultListenerContainerFactoryTest` — verifies queue names are trimmed after splitting `"myqueue, myotherqueue"`
- [x] `SpringRabbitPollingConsumerTest` — verifies `doInit()` throws `IllegalArgumentException` for multi-queue config
- [x] Full module test suite passes (6 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>