### PR TITLE
CAMEL-24089: camel-file - Loop transferTo to handle files larger than 2 GB

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/FileOperations.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/FileOperations.java
@@ -522,7 +522,11 @@ public class FileOperations implements GenericFileOperations<File> {
             try (FileOutputStream fos = new FileOutputStream(target);
                  FileChannel out = fos.getChannel()) {
                 LOG.trace("writeFileByFile using FileChannel: {} -> {}", source, target);
-                channel.transferTo(0, channel.size(), out);
+                long size = channel.size();
+                long position = 0;
+                while (position < size) {
+                    position += channel.transferTo(position, size - position, out);
+                }
             }
         } else {
             // use regular file copy


### PR DESCRIPTION
## Summary

- Fix `FileChannel.transferTo()` in `FileOperations.writeFileByFile` to loop until all bytes are transferred, preventing silent file truncation for files larger than ~2 GB when using `readLock=fileLock` on Linux.

## Details

`FileChannel.transferTo()` is documented to possibly transfer fewer bytes than requested. On Linux, the JDK caps each call at `Integer.MAX_VALUE` bytes (~2 GB) via `sendfile(2)`. The existing code made a single call and discarded the return value, so any file larger than ~2 GB was silently truncated while the producer reported success.

The fix replaces the single call with the standard `transferTo` loop pattern — the same pattern the pre-2017 code in this area used before it was removed in d8c0a53b6787.

Only the `readLock=fileLock` code path is affected. The non-locked path uses `Files.copy()` which handles large files correctly.

## Test plan

- [x] `mvn verify` passes in `components/camel-file`

_Claude Code on behalf of @davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>