### PR TITLE
CAMEL-24092: camel-file - readLock=fileLock must return false on IOException

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileLockExclusiveReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileLockExclusiveReadLockStrategy.java
@@ -116,9 +116,8 @@ public class FileLockExclusiveReadLockStrategy extends MarkerFileExclusiveReadLo
             // somehow hold a lock to a file
             // such as AntiVirus or MS Office that has special locks for it's
             // supported files
-            if (handleIOException(e)) {
-                return false;
-            }
+            handleIOException(e);
+            return false;
         } finally {
             // close channels if we did not grab the lock
             if (!exclusive) {
@@ -139,19 +138,10 @@ public class FileLockExclusiveReadLockStrategy extends MarkerFileExclusiveReadLo
         return true;
     }
 
-    private boolean handleIOException(IOException e) {
-        if (timeout == 0) {
-            // if not using timeout, then we cant retry, so return false
-            return true;
+    private void handleIOException(IOException e) {
+        if (timeout > 0) {
+            LOG.debug("Cannot acquire read lock due to an IOException, will skip the file.", e);
         }
-        LOG.debug("Cannot acquire read lock. Will try again.", e);
-        boolean interrupted = sleep();
-        if (interrupted) {
-            // we were interrupted while sleeping, we are likely being
-            // shutdown so return false
-            return true;
-        }
-        return false;
     }
 
     @Override
@@ -162,7 +152,8 @@ public class FileLockExclusiveReadLockStrategy extends MarkerFileExclusiveReadLo
 
         FileLock lock = exchange.getProperty(asExclusiveReadLockKey(file, Exchange.FILE_LOCK_EXCLUSIVE_LOCK), FileLock.class);
         RandomAccessFile rac
-                = exchange.getProperty(asExclusiveReadLockKey(file, Exchange.FILE_LOCK_EXCLUSIVE_LOCK), RandomAccessFile.class);
+                = exchange.getProperty(asExclusiveReadLockKey(file, Exchange.FILE_LOCK_RANDOM_ACCESS_FILE),
+                        RandomAccessFile.class);
         Channel channel
                 = exchange.getProperty(asExclusiveReadLockKey(file, Exchange.FILE_LOCK_CHANNEL_FILE), FileChannel.class);
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileLockExclusiveReadLockStrategyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileLockExclusiveReadLockStrategyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.strategy;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.file.FileComponent;
+import org.apache.camel.component.file.GenericFile;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisabledOnOs(OS.WINDOWS)
+public class FileLockExclusiveReadLockStrategyTest {
+
+    @TempDir
+    Path tempDir;
+
+    private DefaultCamelContext camelContext;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        camelContext = new DefaultCamelContext();
+        camelContext.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (camelContext != null) {
+            camelContext.stop();
+        }
+    }
+
+    @Test
+    void testIOExceptionReturnsFalseAndCleansMarker() throws Exception {
+        Path target = tempDir.resolve("testfile.txt");
+        Files.writeString(target, "test content");
+
+        // make the file read-only so RandomAccessFile("rw") throws IOException
+        assertTrue(target.toFile().setWritable(false));
+
+        FileLockExclusiveReadLockStrategy strategy = new FileLockExclusiveReadLockStrategy();
+        strategy.setTimeout(10000);
+
+        GenericFile<File> genericFile = new GenericFile<>();
+        genericFile.setFile(target.toFile());
+        genericFile.setAbsoluteFilePath(target.toAbsolutePath().toString());
+        genericFile.setFileName(target.getFileName().toString());
+
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        boolean acquired = strategy.acquireExclusiveReadLock(null, genericFile, exchange);
+
+        assertFalse(acquired, "acquireExclusiveReadLock should return false when IOException occurs");
+
+        File markerFile = new File(target.toAbsolutePath() + FileComponent.DEFAULT_LOCK_FILE_POSTFIX);
+        assertFalse(markerFile.exists(), "marker file should be cleaned up after failed lock acquisition");
+
+        // restore writable so @TempDir cleanup succeeds
+        target.toFile().setWritable(true);
+    }
+}


### PR DESCRIPTION
## Summary

Fix two bugs in `FileLockExclusiveReadLockStrategy`:

- **IOException fall-through returns `true` with no lock held**: When `IOException` occurs during lock acquisition (file deleted between poll and lock, permission error, Windows AV lock) with `timeout > 0`, `handleIOException` returned `false`, causing the catch block to NOT return `false`. Control fell through: the `finally` block deleted the `.camelLock` marker file (via `releaseExclusiveReadLockOnAbort`), then the method returned `true` with `lock = null` — the consumer would process the file with no OS lock and no marker protection, enabling duplicate consumption by competing consumers. Now always returns `false` on `IOException`.

- **Wrong property key in `doReleaseExclusiveReadLock`**: Used `FILE_LOCK_EXCLUSIVE_LOCK` instead of `FILE_LOCK_RANDOM_ACCESS_FILE` to retrieve the `RandomAccessFile`, so `rac` was always `null`. No fd leak today only because closing the `FileLock`'s channel closes the shared fd, but the code was silently wrong.

The IOException fall-through dates to CAMEL-1195 (2008, deliberate "process anyway on Windows-AV" degradation). CAMEL-5324 (2012) later layered marker files into this strategy, and CAMEL-7988 (2014) added the `finally` cleanup — the combination silently dropped the cross-JVM protection that CAMEL-5324 added.

## Test plan

- [x] New `FileLockExclusiveReadLockStrategyTest` — makes file read-only so `RandomAccessFile("rw")` throws, asserts `acquireExclusiveReadLock` returns `false` and marker file is cleaned up

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)