### PR TITLE
CAMEL-24093: camel-file - idempotent read-lock strategies must use original path as key

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileIdempotentChangedRepositoryReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileIdempotentChangedRepositoryReadLockStrategy.java
@@ -115,6 +115,8 @@ public class FileIdempotentChangedRepositoryReadLockStrategy extends ServiceSupp
     public void releaseExclusiveReadLockOnAbort(
             GenericFileOperations<File> operations, GenericFile<File> file, Exchange exchange)
             throws Exception {
+        String key = asKey(exchange, file);
+        idempotentRepository.remove(exchange, key);
         changed.releaseExclusiveReadLockOnAbort(operations, file, exchange);
     }
 
@@ -313,9 +315,12 @@ public class FileIdempotentChangedRepositoryReadLockStrategy extends ServiceSupp
     }
 
     protected String asKey(Exchange exchange, GenericFile<File> file) {
-        // use absolute file path as default key, but evaluate if an expression
-        // key was configured
-        String key = file.getAbsoluteFilePath();
+        // use the copy from absolute path as that was the original path of the
+        // file when the lock was acquired
+        // for example if the file consumer uses preMove then the file is moved
+        // and therefore has another name that would no longer match
+        String key = file.getCopyFromAbsoluteFilePath() != null
+                ? file.getCopyFromAbsoluteFilePath() : file.getAbsoluteFilePath();
         if (endpoint.getIdempotentKey() != null) {
             Exchange dummy = GenericFileHelper.createDummy(endpoint, exchange, () -> file);
             key = endpoint.getIdempotentKey().evaluate(dummy, String.class);

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileIdempotentRenameRepositoryReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileIdempotentRenameRepositoryReadLockStrategy.java
@@ -107,6 +107,8 @@ public class FileIdempotentRenameRepositoryReadLockStrategy extends ServiceSuppo
     public void releaseExclusiveReadLockOnAbort(
             GenericFileOperations<File> operations, GenericFile<File> file, Exchange exchange)
             throws Exception {
+        String key = asKey(exchange, file);
+        idempotentRepository.remove(exchange, key);
         rename.releaseExclusiveReadLockOnAbort(operations, file, exchange);
     }
 
@@ -227,9 +229,12 @@ public class FileIdempotentRenameRepositoryReadLockStrategy extends ServiceSuppo
     }
 
     protected String asKey(Exchange exchange, GenericFile<File> file) {
-        // use absolute file path as default key, but evaluate if an expression
-        // key was configured
-        String key = file.getAbsoluteFilePath();
+        // use the copy from absolute path as that was the original path of the
+        // file when the lock was acquired
+        // for example if the file consumer uses preMove then the file is moved
+        // and therefore has another name that would no longer match
+        String key = file.getCopyFromAbsoluteFilePath() != null
+                ? file.getCopyFromAbsoluteFilePath() : file.getAbsoluteFilePath();
         if (endpoint.getIdempotentKey() != null) {
             Exchange dummy = GenericFileHelper.createDummy(endpoint, exchange, () -> file);
             key = endpoint.getIdempotentKey().evaluate(dummy, String.class);

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileIdempotentRepositoryReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/FileIdempotentRepositoryReadLockStrategy.java
@@ -95,7 +95,8 @@ public class FileIdempotentRepositoryReadLockStrategy extends ServiceSupport
     public void releaseExclusiveReadLockOnAbort(
             GenericFileOperations<File> operations, GenericFile<File> file, Exchange exchange)
             throws Exception {
-        // noop
+        String key = asKey(exchange, file);
+        idempotentRepository.remove(exchange, key);
     }
 
     @Override
@@ -276,9 +277,12 @@ public class FileIdempotentRepositoryReadLockStrategy extends ServiceSupport
     }
 
     protected String asKey(Exchange exchange, GenericFile<File> file) {
-        // use absolute file path as default key, but evaluate if an expression
-        // key was configured
-        String key = file.getAbsoluteFilePath();
+        // use the copy from absolute path as that was the original path of the
+        // file when the lock was acquired
+        // for example if the file consumer uses preMove then the file is moved
+        // and therefore has another name that would no longer match
+        String key = file.getCopyFromAbsoluteFilePath() != null
+                ? file.getCopyFromAbsoluteFilePath() : file.getAbsoluteFilePath();
         if (endpoint.getIdempotentKey() != null) {
             Exchange dummy = GenericFileHelper.createDummy(endpoint, exchange, () -> file);
             key = endpoint.getIdempotentKey().evaluate(dummy, String.class);

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileIdempotentReadLockPreMoveTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/strategy/FileIdempotentReadLockPreMoveTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.strategy;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that idempotent read lock correctly removes the key on rollback when preMove is used. Before the fix, the
+ * release key was computed from the post-preMove path, which didn't match the acquire key (original path), so the
+ * original key leaked in the repository and same-named files were never consumed again.
+ */
+public class FileIdempotentReadLockPreMoveTest extends ContextTestSupport {
+
+    final MemoryIdempotentRepository myRepo = new MemoryIdempotentRepository();
+
+    @Override
+    protected Registry createCamelRegistry() throws Exception {
+        Registry jndi = super.createCamelRegistry();
+        jndi.bind("myRepo", myRepo);
+        return jndi;
+    }
+
+    @Test
+    public void testIdempotentReadLockKeyRemovedOnRollbackWithPreMove() throws Exception {
+        assertEquals(0, myRepo.getCacheSize());
+
+        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "hello.txt");
+
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+
+        // the route throws an exception so the file is rolled back
+        // with readLockRemoveOnRollback=true (default), the key must be removed
+        // from the repository so the file can be retried
+        assertEquals(0, myRepo.getCacheSize());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                errorHandler(noErrorHandler());
+
+                from(fileUri(
+                        "?initialDelay=0&delay=10&readLock=idempotent&idempotentRepository=#myRepo&preMove=work&moveFailed=error"))
+                        .throwException(new IllegalStateException("Forced failure"));
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fix two bugs in all three idempotent read-lock strategies (`FileIdempotentRepositoryReadLockStrategy`, `FileIdempotentChangedRepositoryReadLockStrategy`, `FileIdempotentRenameRepositoryReadLockStrategy`):

- **Key mismatch after preMove**: `asKey()` used `file.getAbsoluteFilePath()` which reflects the post-preMove path. The acquire call stores a key based on the original path, but release computes the key from the renamed path — `remove`/`confirm` targets a key that was never added, and the original key stays in the repository forever. Same-named files arriving later are silently never consumed. Now uses `getCopyFromAbsoluteFilePath()` when available, matching the pattern already used by `MarkerFileExclusiveReadLockStrategy.asReadLockKey` and `GenericFileHelper.asExclusiveReadLockKey`.

- **Abort leaks idempotent key**: `releaseExclusiveReadLockOnAbort` was a no-op in `FileIdempotentRepositoryReadLockStrategy` and only delegated to the inner strategy (without touching the idempotent repository) in the other two. An abort after successful acquire leaked the key permanently.

## Test plan

- [x] New `FileIdempotentReadLockPreMoveTest` — consumer with `readLock=idempotent&preMove=work` and a failing route; asserts the original-path key is removed from the repository on rollback
- [x] All existing idempotent read lock tests pass (6/6)

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)