### PR TITLE
CAMEL-24095: camel-file - Add missing Move branch to handleExistingTarget for tempFileName with eagerDeleteTargetFile=false

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileProducer.java
@@ -254,6 +254,9 @@ public class GenericFileProducer<T> extends DefaultAsyncProducer {
             return doIgnore(target);
         } else if (endpoint.getFileExist() == GenericFileExist.Fail) {
             throwFileAlreadyExistException(target);
+        } else if (endpoint.getFileExist() == GenericFileExist.Move) {
+            // move any existing file first
+            this.endpoint.getMoveExistingFileStrategy().moveExistingFile(endpoint, operations, target);
         } else if (endpoint.getFileExist() == GenericFileExist.Override) {
             // we override the target so we do this by deleting
             // it so the temp file can be renamed later

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/FileProducerMoveExistingTest.java
@@ -107,14 +107,21 @@ public class FileProducerMoveExistingTest extends ContextTestSupport {
         template.sendBodyAndHeader(
                 fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=false"),
                 "Second File", Exchange.FILE_NAME, filename);
-        // we should be okay as we will just delete any existing file
-        template.sendBodyAndHeader(
-                fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=false"),
-                "Third File", Exchange.FILE_NAME, filename);
 
-        // we could  write the new file so the old context should be moved
-        assertFileExists(testFile(filename), "Third File");
-        // and the renamed file should not be overridden
+        // should fail because the move destination already exists and eagerDeleteTargetFile=false
+        CamelExecutionException e = assertThrows(CamelExecutionException.class, () -> {
+            template.sendBodyAndHeader(
+                    fileUri("?tempFileName=${file:onlyname}.temp&fileExist=Move&moveExisting=${file:parent}/renamed-${file:onlyname}&eagerDeleteTargetFile=false"),
+                    "Third File", Exchange.FILE_NAME, filename);
+        }, "Should have thrown an exception");
+
+        GenericFileOperationFailedException cause
+                = assertIsInstanceOf(GenericFileOperationFailedException.class, e.getCause());
+        assertTrue(cause.getMessage().startsWith("Cannot move existing file"));
+
+        // we could not write the new file so the previous content should be there
+        assertFileExists(testFile(filename), "Second File");
+        // and the renamed file should be untouched
         assertFileExists(testFile("renamed-" + filename), "First File");
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

`GenericFileProducer.handleExistingTarget` (the non-eager path used when writing via `tempFileName`/`tempPrefix` with `eagerDeleteTargetFile=false`) handled `Ignore`, `Fail`, and `Override` but had **no `Move` branch**. This meant `fileExist=Move` with `eagerDeleteTargetFile=false` and `tempFileName` silently overwrote the existing target instead of moving it to the `moveExisting` destination.

The eager twin `handleExistingTargetEager` has had the `Move` branch since CAMEL-15822 (2020), but the non-eager method was never patched.

### Changes

- **`GenericFileProducer.java`**: Added the missing `Move` branch to `handleExistingTarget`, mirroring `handleExistingTargetEager` — calls `endpoint.getMoveExistingFileStrategy().moveExistingFile()`.
- **`FileProducerMoveExistingTest.java`**: Updated `testFailOnMoveExistingFileExistsEagerDeleteFalseTempFileName` to assert correct behavior: when the move destination already exists and `eagerDeleteTargetFile=false`, the move strategy should throw `GenericFileOperationFailedException` (consistent with the non-tempFileName variant `testFailOnMoveExistingFileExistsEagerDeleteFalse`).

## Test plan

- [x] `FileProducerMoveExistingTest` — all 14 tests pass (including the corrected test)
- [x] Full reactor build passes (`mvn clean install -DskipTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>