### PR TITLE
CAMEL-24097: camel-ftp - SFTP knownHostsUri/knownHosts clobbered by ~/.ssh/known_hosts fallback

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -333,7 +333,8 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
         }
 
         String knownHostsFile = sftpConfig.getKnownHostsFile();
-        if (knownHostsFile == null && sftpConfig.isUseUserKnownHostsFile()) {
+        if (knownHostsFile == null && !isNotEmpty(sftpConfig.getKnownHostsUri())
+                && sftpConfig.getKnownHosts() == null && sftpConfig.isUseUserKnownHostsFile()) {
             knownHostsFile = HomeHelper.resolveHomeDir() + "/.ssh/known_hosts";
             LOG.info("Known host file not configured, using user known host file: {}", knownHostsFile);
         }


### PR DESCRIPTION
## Summary

- Fix `SftpOperations.createSession` unconditionally applying `~/.ssh/known_hosts` fallback that overwrites any previously configured `knownHostsUri` or `knownHosts` byte array (JSch's `setKnownHosts()` wipes the prior repository)
- The fallback guard now also checks that `knownHostsUri` and `knownHosts` are not set, so it only fires when none of the three explicit known-hosts sources are configured

## Test plan

- [x] `camel-ftp` module compiles
- [ ] Existing SFTP integration tests pass
- [ ] Verify that `knownHostsUri` without `useUserKnownHostsFile=false` no longer gets clobbered

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)