### PR TITLE
CAMEL-24098: camel-ftp - Use per-session config for SFTP ciphers and keyExchangeProtocols

### DIFF
--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpOperations.java
@@ -33,7 +33,6 @@ import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.locks.Lock;
@@ -230,19 +229,6 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
 
         SftpConfiguration sftpConfig = (SftpConfiguration) configuration;
 
-        if (isNotEmpty(sftpConfig.getCiphers())) {
-            LOG.debug("Using ciphers: {}", sftpConfig.getCiphers());
-            Hashtable<String, String> ciphers = new Hashtable<>();
-            ciphers.put("cipher.s2c", sftpConfig.getCiphers());
-            ciphers.put("cipher.c2s", sftpConfig.getCiphers());
-            JSch.setConfig(ciphers);
-        }
-
-        if (isNotEmpty(sftpConfig.getKeyExchangeProtocols())) {
-            LOG.debug("Using KEX: {}", sftpConfig.getKeyExchangeProtocols());
-            JSch.setConfig("kex", sftpConfig.getKeyExchangeProtocols());
-        }
-
         // Resolve certificate bytes once — used for both identity loading and key type detection
         byte[] certData = resolveCertificateBytes(sftpConfig);
 
@@ -343,6 +329,17 @@ public class SftpOperations implements RemoteFileOperations<SftpRemoteFile> {
         }
 
         final Session session = jsch.getSession(configuration.getUsername(), configuration.getHost(), configuration.getPort());
+
+        if (isNotEmpty(sftpConfig.getCiphers())) {
+            LOG.debug("Using ciphers: {}", sftpConfig.getCiphers());
+            session.setConfig("cipher.s2c", sftpConfig.getCiphers());
+            session.setConfig("cipher.c2s", sftpConfig.getCiphers());
+        }
+
+        if (isNotEmpty(sftpConfig.getKeyExchangeProtocols())) {
+            LOG.debug("Using KEX: {}", sftpConfig.getKeyExchangeProtocols());
+            session.setConfig("kex", sftpConfig.getKeyExchangeProtocols());
+        }
 
         if (isNotEmpty(sftpConfig.getStrictHostKeyChecking())) {
             LOG.debug("Using StrictHostKeyChecking: {}", sftpConfig.getStrictHostKeyChecking());

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpCipherGlobalConfigIT.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/sftp/integration/SftpCipherGlobalConfigIT.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote.sftp.integration;
+
+import java.io.File;
+
+import com.jcraft.jsch.JSch;
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIf(value = "org.apache.camel.test.infra.ftp.services.embedded.SftpUtil#hasRequiredAlgorithms('src/test/resources/hostkey.pem')")
+public class SftpCipherGlobalConfigIT extends SftpServerTestSupport {
+
+    @Test
+    public void testCiphersDoNotMutateGlobalJSchConfig() {
+        String defaultCipherS2C = JSch.getConfig("cipher.s2c");
+        String defaultCipherC2S = JSch.getConfig("cipher.c2s");
+        String defaultKex = JSch.getConfig("kex");
+
+        String uri
+                = "sftp://localhost:{{ftp.server.port}}/{{ftp.root.dir}}?username=admin&password=admin&ciphers=aes256-ctr"
+                  + "&keyExchangeProtocols=diffie-hellman-group-exchange-sha256"
+                  + "&knownHostsFile=" + service.getKnownHostsFile();
+        template.sendBodyAndHeader(uri, "Hello World", Exchange.FILE_NAME, "hello.txt");
+
+        File file = ftpFile("hello.txt").toFile();
+        assertTrue(file.exists(), "File should exist: " + file);
+
+        assertEquals(defaultCipherS2C, JSch.getConfig("cipher.s2c"),
+                "JSch global cipher.s2c must not be mutated by per-endpoint config");
+        assertEquals(defaultCipherC2S, JSch.getConfig("cipher.c2s"),
+                "JSch global cipher.c2s must not be mutated by per-endpoint config");
+        assertEquals(defaultKex, JSch.getConfig("kex"),
+                "JSch global kex must not be mutated by per-endpoint config");
+    }
+}


### PR DESCRIPTION
## Summary

`SftpOperations.createSession()` applied the `ciphers` and `keyExchangeProtocols` endpoint options via `JSch.setConfig(...)` — which is **static and JVM-global** — on every (re)connect. This caused cross-endpoint contamination: one endpoint's cipher/kex settings permanently altered the JSch defaults for every other SFTP endpoint in the JVM.

This PR moves both options to use `session.setConfig(...)` (per-session), consistent with every other option in the same method (`StrictHostKeyChecking`, `compression.*`, `PreferredAuthentications`, `server_host_key`, `PubkeyAcceptedAlgorithms`, `kex`, `ca_signature_algorithms`).

**Changes:**
- Replace `JSch.setConfig(ciphers)` (global) with `session.setConfig("cipher.s2c"/cipher.c2s", ...)` (per-session)
- Replace `JSch.setConfig("kex", ...)` (global) with `session.setConfig("kex", ...)` (per-session)
- Remove unused `Hashtable` import

## Test plan

- [x] New `SftpCipherGlobalConfigIT` — records JSch global defaults, sends a message through an endpoint with custom ciphers and kex, asserts the globals are unchanged
- [x] Existing `SftpSetCipherIT` passes (functional cipher test)
- [x] Existing `SftpKeyExchangeProtocolsIT` passes (functional kex test)
- [x] Full `mvn verify` on `camel-ftp` passes

_Claude Code on behalf of davsclaus_