### PR TITLE
CAMEL-24099: camel-bean - Use ServiceHelper for BeanProcessor lifecycle delegation

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanProcessor.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanProcessor.java
@@ -27,6 +27,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.spi.ErrorHandlerAware;
 import org.apache.camel.spi.IdAware;
+import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.support.service.ServiceSupport;
 
 public class BeanProcessor extends ServiceSupport implements AsyncProcessor, ErrorHandlerAware, IdAware {
@@ -124,7 +125,7 @@ public class BeanProcessor extends ServiceSupport implements AsyncProcessor, Err
 
     @Override
     protected void doInit() throws Exception {
-        delegate.init();
+        ServiceHelper.initService(delegate);
     }
 
     @Override
@@ -139,17 +140,17 @@ public class BeanProcessor extends ServiceSupport implements AsyncProcessor, Err
 
     @Override
     protected void doStart() throws Exception {
-        delegate.start();
+        ServiceHelper.startService(delegate);
     }
 
     @Override
     protected void doStop() throws Exception {
-        delegate.doStop();
+        ServiceHelper.stopService(delegate);
     }
 
     @Override
     protected void doShutdown() throws Exception {
-        delegate.shutdown();
+        ServiceHelper.stopAndShutdownService(delegate);
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Fix `BeanProcessor` lifecycle delegation to use `ServiceHelper` instead of direct method calls, ensuring the `BaseService` state machine is properly traversed. The key bug was `doStop()` calling `delegate.doStop()` (raw method), which bypassed state tracking and prevented bean restart.
- All four lifecycle methods now use `ServiceHelper`: `initService`, `startService`, `stopService`, `stopAndShutdownService`.

## Test plan

- [x] `mvn test` passes in `components/camel-bean`
- [ ] CI green

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>