### PR TITLE
CAMEL-24100: camel-bean - class: endpoint honors scope option

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanEndpoint.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanEndpoint.java
@@ -112,6 +112,17 @@ public class BeanEndpoint extends DefaultEndpoint {
                 } else {
                     holder = registryBean;
                 }
+            } else if (holder instanceof ConstantTypeBeanHolder typeBeanHolder && scope == BeanScope.Singleton) {
+                // ClassComponent pre-sets a ConstantTypeBeanHolder which creates a new instance per exchange,
+                // so for singleton scope we must cache the bean instance
+                holder = typeBeanHolder.createCacheHolder();
+            } else if (holder instanceof ConstantBeanHolder && scope == BeanScope.Prototype) {
+                // ClassComponent pre-sets a ConstantBeanHolder (single instance) when bean.xxx options are present,
+                // so for prototype scope we must use a type holder that creates new instances per exchange
+                ParameterMappingStrategy strategy
+                        = ParameterMappingStrategyHelper.createParameterMappingStrategy(getCamelContext());
+                BeanComponent bean = getCamelContext().getComponent("bean", BeanComponent.class);
+                holder = new ConstantTypeBeanHolder(holder.getBeanInfo().getType(), getCamelContext(), strategy, bean);
             }
             if (scope == BeanScope.Request) {
                 // wrap in registry scoped

--- a/components/camel-bean/src/main/java/org/apache/camel/component/beanclass/ClassComponent.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/beanclass/ClassComponent.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.beanclass;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.camel.Endpoint;
@@ -54,7 +55,9 @@ public class ClassComponent extends BeanComponent {
 
         // the bean.xxx options is for the bean
         Map<String, Object> options = PropertiesHelper.extractProperties(parameters, "bean.");
-        endpoint.setParameters(options);
+        // store a copy because setProperties below removes bound entries from the original map,
+        // but BeanEndpoint needs the options to apply them per-exchange for prototype scope
+        endpoint.setParameters(options.isEmpty() ? options : new LinkedHashMap<>(options));
 
         BeanHolder holder;
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/ClassComponentScopeTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/ClassComponentScopeTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ClassComponentScopeTest extends ContextTestSupport {
+
+    @Test
+    public void testDefaultSingletonScope() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello A", "Hello B");
+
+        int before = MyCountingBean.getInstanceCount();
+        template.sendBody("direct:singleton", "A");
+        template.sendBody("direct:singleton", "B");
+
+        assertMockEndpointsSatisfied();
+
+        assertEquals(0, MyCountingBean.getInstanceCount() - before,
+                "Singleton scope should not create new bean instances per exchange");
+    }
+
+    @Test
+    public void testPrototypeScope() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello A", "Hello B");
+
+        int before = MyCountingBean.getInstanceCount();
+        template.sendBody("direct:prototype", "A");
+        template.sendBody("direct:prototype", "B");
+
+        assertMockEndpointsSatisfied();
+
+        assertEquals(2, MyCountingBean.getInstanceCount() - before,
+                "Prototype scope should create a new bean per exchange");
+    }
+
+    @Test
+    public void testSingletonScopeWithBeanOptions() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived("Bye A", "Bye B");
+
+        int before = MyCountingBean.getInstanceCount();
+        template.sendBody("direct:singletonWithOptions", "A");
+        template.sendBody("direct:singletonWithOptions", "B");
+
+        assertMockEndpointsSatisfied();
+
+        assertEquals(0, MyCountingBean.getInstanceCount() - before,
+                "Singleton scope with bean options should not create new bean instances per exchange");
+    }
+
+    @Test
+    public void testPrototypeScopeWithBeanOptions() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceived("Bye A", "Bye B");
+
+        int before = MyCountingBean.getInstanceCount();
+        template.sendBody("direct:prototypeWithOptions", "A");
+        template.sendBody("direct:prototypeWithOptions", "B");
+
+        assertMockEndpointsSatisfied();
+
+        assertEquals(2, MyCountingBean.getInstanceCount() - before,
+                "Prototype scope with bean options should create a new bean per exchange");
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:singleton")
+                        .to("class:org.apache.camel.component.bean.MyCountingBean")
+                        .to("mock:result");
+
+                from("direct:prototype")
+                        .to("class:org.apache.camel.component.bean.MyCountingBean?scope=Prototype")
+                        .to("mock:result");
+
+                from("direct:singletonWithOptions")
+                        .to("class:org.apache.camel.component.bean.MyCountingBean?bean.prefix=Bye")
+                        .to("mock:result");
+
+                from("direct:prototypeWithOptions")
+                        .to("class:org.apache.camel.component.bean.MyCountingBean?scope=Prototype&bean.prefix=Bye")
+                        .to("mock:result");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/MyCountingBean.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/MyCountingBean.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MyCountingBean {
+    private static final AtomicInteger INSTANCES = new AtomicInteger();
+
+    private String prefix = "Hello";
+
+    public MyCountingBean() {
+        INSTANCES.incrementAndGet();
+    }
+
+    public static int getInstanceCount() {
+        return INSTANCES.get();
+    }
+
+    public static void resetInstanceCount() {
+        INSTANCES.set(0);
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String hello(String s) {
+        return prefix + " " + s;
+    }
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Fix `class:` endpoint ignoring the `scope` option: default Singleton scope was creating a new bean instance per exchange, and Prototype scope with `bean.xxx` options silently behaved as Singleton
- In `BeanEndpoint.doInit()`, apply scope-aware logic when a `BeanHolder` is pre-set by `ClassComponent`: cache the instance for Singleton, use a type-based holder for Prototype
- In `ClassComponent.createEndpoint()`, store a copy of the bean options map so `setProperties()` doesn't consume the options needed for per-exchange property binding in Prototype scope

Fixes: https://issues.apache.org/jira/browse/CAMEL-24100

## Test plan

- [x] `ClassComponentScopeTest` — 4 new tests covering all scope x options combinations
- [x] All 350+ existing bean component tests pass
- [x] `BeanSingletonTest` (existing scope test for `bean:` component) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>