### PR TITLE
CAMEL-24102: camel-bean - AmbiguousMethodCallException lists actual candidates

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/BeanInfo.java
@@ -885,7 +885,7 @@ public class BeanInfo {
             // let's try converting
             Object newBody = null;
             MethodInfo matched = null;
-            int matchCounter = 0;
+            List<MethodInfo> candidates = new ArrayList<>();
             for (MethodInfo methodInfo : operationList) {
                 if (methodInfo.getBodyParameterType() != null) {
                     if (methodInfo.getBodyParameterType().isInstance(body)) {
@@ -900,14 +900,14 @@ public class BeanInfo {
                             LOG.trace("Converted body from: {} to: {}",
                                     body.getClass().getCanonicalName(), methodInfo.getBodyParameterType().getCanonicalName());
                         }
-                        matchCounter++;
+                        candidates.add(methodInfo);
                         newBody = value;
                         matched = methodInfo;
                     }
                 }
             }
-            if (matchCounter > 1) {
-                throw new AmbiguousMethodCallException(exchange, Arrays.asList(matched, matched));
+            if (candidates.size() > 1) {
+                throw new AmbiguousMethodCallException(exchange, candidates);
             }
             if (matched != null) {
                 LOG.trace("Setting converted body: {}", body);

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanAmbiguousBodyConversionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanAmbiguousBodyConversionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BeanAmbiguousBodyConversionTest extends ContextTestSupport {
+
+    @Test
+    public void testAmbiguousExceptionListsDistinctCandidates() {
+        CamelExecutionException e = assertThrows(CamelExecutionException.class,
+                () -> template.sendBody("direct:start", "123"));
+
+        AmbiguousMethodCallException cause = assertInstanceOf(AmbiguousMethodCallException.class, e.getCause());
+        Collection<MethodInfo> methods = cause.getMethods();
+
+        assertEquals(2, methods.size(), "Should list exactly two distinct candidates");
+        ArrayList<MethodInfo> list = new ArrayList<>(methods);
+        assertTrue(list.get(0) != list.get(1),
+                "The two candidates should be different method instances");
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .bean(MyAmbiguousBean.class)
+                        .to("mock:result");
+            }
+        };
+    }
+
+    @SuppressWarnings("unused")
+    public static class MyAmbiguousBean {
+        public String foo(Integer num) {
+            return "foo:" + num;
+        }
+
+        public String bar(Double num) {
+            return "bar:" + num;
+        }
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanAmbiguousBodyConversionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanAmbiguousBodyConversionTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.bean;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 import org.apache.camel.CamelExecutionException;
@@ -24,10 +23,10 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BeanAmbiguousBodyConversionTest extends ContextTestSupport {
 
@@ -40,9 +39,7 @@ public class BeanAmbiguousBodyConversionTest extends ContextTestSupport {
         Collection<MethodInfo> methods = cause.getMethods();
 
         assertEquals(2, methods.size(), "Should list exactly two distinct candidates");
-        ArrayList<MethodInfo> list = new ArrayList<>(methods);
-        assertTrue(list.get(0) != list.get(1),
-                "The two candidates should be different method instances");
+        assertThat(methods).doesNotHaveDuplicates();
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Fix `AmbiguousMethodCallException` in body-conversion matching to list the actual distinct method candidates instead of the same method listed twice
- Collect convertible candidates in a list during the matching loop instead of only keeping the last match

Fixes: https://issues.apache.org/jira/browse/CAMEL-24102

## Test plan

- [x] `BeanAmbiguousBodyConversionTest` — verifies the exception lists 2 distinct candidates
- [x] All existing ambiguous method tests pass (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>