### PR TITLE
CAMEL-24104: camel-bean - Fix racy Processor-adapter lookup in AbstractBeanProcessor

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/AbstractBeanProcessor.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/AbstractBeanProcessor.java
@@ -37,9 +37,9 @@ public abstract class AbstractBeanProcessor extends AsyncProcessorSupport {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractBeanProcessor.class);
 
     private final BeanHolder beanHolder;
-    private transient Processor processor;
+    private transient volatile Processor processor;
     private transient Object bean;
-    private transient boolean lookupProcessorDone;
+    private transient volatile boolean lookupProcessorDone;
     private final Lock lock = new ReentrantLock();
     private BeanScope scope;
     private String method;
@@ -130,10 +130,15 @@ public abstract class AbstractBeanProcessor extends AsyncProcessorSupport {
                 if (!lookupProcessorDone) {
                     lock.lock();
                     try {
-                        lookupProcessorDone = true;
-                        // so if there is a custom type converter for the bean to processor
-                        target = exchange.getContext().getTypeConverter().tryConvertTo(Processor.class, exchange, beanTmp);
-                        processor = target;
+                        if (!lookupProcessorDone) {
+                            // so if there is a custom type converter for the bean to processor
+                            target = exchange.getContext().getTypeConverter().tryConvertTo(Processor.class, exchange,
+                                    beanTmp);
+                            processor = target;
+                            lookupProcessorDone = true;
+                        } else {
+                            target = processor;
+                        }
                     } finally {
                         lock.unlock();
                     }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Make `processor` and `lookupProcessorDone` fields `volatile` so racing threads see consistent values
- Add double-check of `lookupProcessorDone` after acquiring the lock to prevent duplicate conversions
- Move `lookupProcessorDone = true` after the conversion succeeds so a conversion failure doesn't permanently disable the lookup

Fixes: https://issues.apache.org/jira/browse/CAMEL-24104

## Test plan

- [x] All 346 existing bean component tests pass — no regressions
- No new test: the visibility race is non-deterministic and not reliably reproducible in a unit test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>