### PR TITLE
CAMEL-24105: camel-bean - Do not register annotation-driven EIP processors as CamelContext services

### DIFF
--- a/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodInfo.java
+++ b/components/camel-bean/src/main/java/org/apache/camel/component/bean/MethodInfo.java
@@ -139,12 +139,6 @@ public class MethodInfo {
         if (routingSlipAnnotation != null) {
             routingSlip = PluginHelper.getAnnotationBasedProcessorFactory(camelContext)
                     .createRoutingSlip(camelContext, routingSlipAnnotation);
-            // add created routingSlip as a service so we have its lifecycle managed
-            try {
-                camelContext.addService(routingSlip);
-            } catch (Exception e) {
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
-            }
         }
 
         DynamicRouter dynamicRouterAnnotation
@@ -152,12 +146,6 @@ public class MethodInfo {
         if (dynamicRouterAnnotation != null) {
             dynamicRouter = PluginHelper.getAnnotationBasedProcessorFactory(camelContext)
                     .createDynamicRouter(camelContext, dynamicRouterAnnotation);
-            // add created dynamicRouter as a service so we have its lifecycle managed
-            try {
-                camelContext.addService(dynamicRouter);
-            } catch (Exception e) {
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
-            }
         }
 
         RecipientList recipientListAnnotation
@@ -165,12 +153,6 @@ public class MethodInfo {
         if (recipientListAnnotation != null) {
             recipientList = PluginHelper.getAnnotationBasedProcessorFactory(camelContext)
                     .createRecipientList(camelContext, recipientListAnnotation);
-            // add created recipientList as a service so we have its lifecycle managed
-            try {
-                camelContext.addService(recipientList);
-            } catch (Exception e) {
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
-            }
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanAnnotationServiceLeakTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/bean/BeanAnnotationServiceLeakTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean;
+
+import java.util.Set;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.RoutingSlip;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test that @RoutingSlip/@RecipientList/@DynamicRouter annotation processors are not registered as CamelContext
+ * services, which would cause a service leak when BeanInfo cache entries are evicted and re-created.
+ */
+public class BeanAnnotationServiceLeakTest extends ContextTestSupport {
+
+    @Test
+    public void testRoutingSlipAnnotationDoesNotLeakServices() throws Exception {
+        getMockEndpoint("mock:foo").expectedBodiesReceived("Hello");
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello");
+
+        template.sendBody("direct:start", "Hello");
+
+        assertMockEndpointsSatisfied();
+
+        Set<org.apache.camel.processor.RoutingSlip> services
+                = context.hasServices(org.apache.camel.processor.RoutingSlip.class);
+        assertTrue(services.isEmpty(),
+                "RoutingSlip processor should not be registered as a CamelContext service, but found: " + services.size());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start").bean(new MyRoutingSlipBean());
+            }
+        };
+    }
+
+    public static class MyRoutingSlipBean {
+        @RoutingSlip
+        public String[] route(String body) {
+            return new String[] { "mock:foo", "mock:result" };
+        }
+    }
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

The `MethodInfo` constructor registered `@RoutingSlip`, `@RecipientList`, and `@DynamicRouter` annotation-driven EIP processors as CamelContext services via `camelContext.addService()`. These services were never removed when the owning `BeanInfo` was evicted from the LRU cache in `BeanComponent`, causing unbounded growth of the context's internal services list over long uptimes.

The fix removes the three `addService` calls. The processors are already started lazily on first use (checked via `ServiceHelper.isStarted()` before each invocation), so the `addService` registration was redundant — it only served to pin stale processor instances in the services list.

- Removed `camelContext.addService(routingSlip/dynamicRouter/recipientList)` from the `MethodInfo` constructor
- Added `BeanAnnotationServiceLeakTest` verifying that `@RoutingSlip` processors are not registered as CamelContext services

## Test plan

- [x] New `BeanAnnotationServiceLeakTest` verifies no service leak
- [x] Existing `RoutingSlipPOJOTest` passes (annotation-based routing slip still works)
- [x] Existing `AsyncEndpointRoutingSlipBean*Test` tests pass
- [x] Existing `BeanRecipientListTest`, `BeanRecipientListInterfaceAnnotationTest` pass
- [x] Existing `DynamicRouterAnnotationTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>