### PR TITLE
CAMEL-24084: Sync knative structured-mode CloudEvent header-filtering upgrade notes to 4_18 and 4_14 guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -23,6 +23,17 @@ the message, consistent with the inbound header filtering already performed by t
 Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
 content, set them explicitly after unmarshalling.
 
+=== camel-knative - structured-mode CloudEvent header filtering
+
+When consuming a CloudEvent in structured content mode (`application/cloudevents+json`), the Knative component now
+applies a `HeaderFilterStrategy` to the event fields (extensions) mapped from the payload onto the Camel message.
+Camel-internal headers (the `Camel*` namespace, matched case-insensitively) present as structured-event fields are
+no longer mapped onto the message, consistent with the inbound header filtering already performed on the binary
+content-mode / HTTP header path.
+
+Ordinary CloudEvent extension attributes are unaffected. If a route relied on `Camel*`-named fields being
+propagated from the structured payload, set them explicitly after consuming the event.
+
 == Upgrading from 4.14.3 to 4.14.8
 
 === camel-jackson - potential breaking change

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -50,6 +50,17 @@ the message, consistent with the inbound header filtering already performed by t
 Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the MIME
 content, set them explicitly after unmarshalling.
 
+=== camel-knative - structured-mode CloudEvent header filtering
+
+When consuming a CloudEvent in structured content mode (`application/cloudevents+json`), the Knative component now
+applies a `HeaderFilterStrategy` to the event fields (extensions) mapped from the payload onto the Camel message.
+Camel-internal headers (the `Camel*` namespace, matched case-insensitively) present as structured-event fields are
+no longer mapped onto the message, consistent with the inbound header filtering already performed on the binary
+content-mode / HTTP header path.
+
+Ordinary CloudEvent extension attributes are unaffected. If a route relied on `Camel*`-named fields being
+propagated from the structured payload, set them explicitly after consuming the event.
+
 == Upgrading from 4.18.1 to 4.18.3
 
 === camel-jackson - potential breaking change


### PR DESCRIPTION
Doc-sync for CAMEL-24084 (main fix apache/camel#24724; backports #24753 [4.18.x] and #24751 [4.14.x]).

Per the backport upgrade-guide policy, the version-specific upgrade guides for all release lines live on `main`. This adds the camel-knative structured-mode CloudEvent header-filtering note to the `4_18` and `4_14` upgrade guides (the `4_22` note ships with the main fix PR #24724).

Docs only — no code change.

- JIRA: [CAMEL-24084](https://issues.apache.org/jira/browse/CAMEL-24084)

_Claude Code on behalf of Andrea Cosentino (@oscerd)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
