### PR TITLE
CAMEL-24106: camel-xslt - source option silently ignored when body is InputStream

### DIFF
--- a/components/camel-xslt-saxon/src/test/java/org/apache/camel/component/xslt/saxon/XsltSaxonSourceInputStreamBodyTest.java
+++ b/components/camel-xslt-saxon/src/test/java/org/apache/camel/component/xslt/saxon/XsltSaxonSourceInputStreamBodyTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.xslt.saxon;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the XSLT source option is respected when the message body is an InputStream or StreamCache, ensuring the
+ * configured source expression is evaluated instead of silently transforming the body.
+ */
+public class XsltSaxonSourceInputStreamBodyTest extends CamelTestSupport {
+
+    private static final String HEADER_XML = "<mail><subject>FromHeader</subject><body>header body</body></mail>";
+    private static final String BODY_XML = "<mail><subject>FromBody</subject><body>message body</body></mail>";
+
+    @Test
+    public void testSourceHeaderWithInputStreamBody() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:sourceHeader");
+        mock.expectedMessageCount(1);
+
+        template.send("direct:sourceHeader", exchange -> {
+            exchange.getIn().setHeader("xmlSource", HEADER_XML);
+            exchange.getIn().setBody(new ByteArrayInputStream(BODY_XML.getBytes(StandardCharsets.UTF_8)));
+        });
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String xml = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertNotNull(xml, "The transformed XML should not be null");
+        assertTrue(xml.contains("<subject>FromHeader</subject>"), "Should transform header source, not body. Got: " + xml);
+    }
+
+    @Test
+    public void testSourceVariableWithInputStreamBody() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:sourceVariable");
+        mock.expectedMessageCount(1);
+
+        template.send("direct:sourceVariable", exchange -> {
+            exchange.setVariable("xmlSource", HEADER_XML);
+            exchange.getIn().setBody(new ByteArrayInputStream(BODY_XML.getBytes(StandardCharsets.UTF_8)));
+        });
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String xml = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertNotNull(xml, "The transformed XML should not be null");
+        assertTrue(xml.contains("<subject>FromHeader</subject>"), "Should transform variable source, not body. Got: " + xml);
+    }
+
+    @Test
+    public void testSourcePropertyWithInputStreamBody() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:sourceProperty");
+        mock.expectedMessageCount(1);
+
+        template.send("direct:sourceProperty", exchange -> {
+            exchange.setProperty("xmlSource", HEADER_XML);
+            exchange.getIn().setBody(new ByteArrayInputStream(BODY_XML.getBytes(StandardCharsets.UTF_8)));
+        });
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String xml = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertNotNull(xml, "The transformed XML should not be null");
+        assertTrue(xml.contains("<subject>FromHeader</subject>"), "Should transform property source, not body. Got: " + xml);
+    }
+
+    @Test
+    public void testSourceHeaderWithStreamCacheBody() throws Exception {
+        context.setStreamCaching(true);
+
+        MockEndpoint mock = getMockEndpoint("mock:sourceHeader");
+        mock.expectedMessageCount(1);
+
+        template.send("direct:sourceHeader", exchange -> {
+            exchange.getIn().setHeader("xmlSource", HEADER_XML);
+            exchange.getIn().setBody(new ByteArrayInputStream(BODY_XML.getBytes(StandardCharsets.UTF_8)));
+        });
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String xml = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertNotNull(xml, "The transformed XML should not be null");
+        assertTrue(xml.contains("<subject>FromHeader</subject>"),
+                "Should transform header source, not stream-cached body. Got: " + xml);
+    }
+
+    @Test
+    public void testSourceVariableWithStreamCacheBody() throws Exception {
+        context.setStreamCaching(true);
+
+        MockEndpoint mock = getMockEndpoint("mock:sourceVariable");
+        mock.expectedMessageCount(1);
+
+        template.send("direct:sourceVariable", exchange -> {
+            exchange.setVariable("xmlSource", HEADER_XML);
+            exchange.getIn().setBody(new ByteArrayInputStream(BODY_XML.getBytes(StandardCharsets.UTF_8)));
+        });
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String xml = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertNotNull(xml, "The transformed XML should not be null");
+        assertTrue(xml.contains("<subject>FromHeader</subject>"),
+                "Should transform variable source, not stream-cached body. Got: " + xml);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:sourceHeader")
+                        .to("xslt-saxon:xslt/transform.xsl?source=header:xmlSource")
+                        .to("mock:sourceHeader");
+
+                from("direct:sourceVariable")
+                        .to("xslt-saxon:classpath:xslt/transform.xsl?source=variable:xmlSource")
+                        .to("mock:sourceVariable");
+
+                from("direct:sourceProperty")
+                        .to("xslt-saxon:classpath:xslt/transform.xsl?source=property:xmlSource")
+                        .to("mock:sourceProperty");
+            }
+        };
+    }
+}

--- a/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XmlSourceHandlerFactoryImpl.java
+++ b/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XmlSourceHandlerFactoryImpl.java
@@ -58,12 +58,16 @@ public class XmlSourceHandlerFactoryImpl implements SourceHandlerFactory {
 
     @Override
     public Source getSource(Exchange exchange, Expression source) throws Exception {
+        if (source != null) {
+            Object body = source.evaluate(exchange, Object.class);
+            return getSource(exchange, body);
+        }
         // only convert to input stream if really needed
         if (isInputStreamNeeded(exchange)) {
             InputStream is = exchange.getIn().getBody(InputStream.class);
             return getSource(exchange, is);
         } else {
-            Object body = source != null ? source.evaluate(exchange, Object.class) : exchange.getMessage().getBody();
+            Object body = exchange.getMessage().getBody();
             return getSource(exchange, body);
         }
     }


### PR DESCRIPTION
## Summary

`XmlSourceHandlerFactoryImpl.getSource(Exchange, Expression)` checked `isInputStreamNeeded(exchange)` against the **message body** before evaluating the configured `source` expression. When the body was an `InputStream`, `StreamCache`, or any type without a direct `Source` converter — which is the common case with `file`, `http`, `ftp`, `netty` consumers or stream caching — `source=header:x` / `source=variable:x` / `source=property:x` silently transformed the **body** instead of the configured source. No error, wrong output.

### Fix

Evaluate the `source` expression **first** when it is configured, and pass the result directly to the type-based conversion method. The `isInputStreamNeeded` optimization is only applied when no source expression is configured (i.e. the body is the intended input).

This follows the same pattern already used by `JsonSourceHandlerFactoryImpl` in `camel-xj`, which correctly evaluates the `source` expression before handling by type.

### Affected components

- `xslt` — fix in `XmlSourceHandlerFactoryImpl`
- `xslt-saxon` — inherits the fix (does not override `getSource(Exchange, Expression)`)
- `xj` (XML→JSON) — **not affected** (already correct)

### Tests

Added `XsltSaxonSourceInputStreamBodyTest` with 5 tests covering:
- `source=header` with `InputStream` body
- `source=variable` with `InputStream` body
- `source=property` with `InputStream` body
- `source=header` with stream caching enabled (body wrapped as `StreamCache`)
- `source=variable` with stream caching enabled

_Claude Code on behalf of davsclaus_