### PR TITLE
camel-lumberjack: fix flaky tests by awaiting Netty shutdown

### DIFF
--- a/components/camel-lumberjack/src/main/java/org/apache/camel/component/lumberjack/io/LumberjackServer.java
+++ b/components/camel-lumberjack/src/main/java/org/apache/camel/component/lumberjack/io/LumberjackServer.java
@@ -107,9 +107,11 @@ public final class LumberjackServer {
             // Wait for the channel to be indeed closed before shutting the groups & service
             channel.close().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
-            executorService.shutdownGracefully();
+            // Await graceful shutdown of all thread groups so the port is fully released
+            // before the next test (or consumer restart) binds a new server
+            bossGroup.shutdownGracefully().syncUninterruptibly();
+            workerGroup.shutdownGracefully().syncUninterruptibly();
+            executorService.shutdownGracefully().syncUninterruptibly();
         }
 
         LOG.info("LUMBERJACK server is stopped (host={}, port={}).", host, port);

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackDisconnectionTest.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackDisconnectionTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.lumberjack;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -76,12 +77,11 @@ public class LumberjackDisconnectionTest extends CamelTestSupport {
      * This processor throws an exception as the fourth message received.
      */
     private static final class ErrorProcessor implements Processor {
-        int count;
+        private final AtomicInteger count = new AtomicInteger();
 
         @Override
         public void process(Exchange exchange) {
-            count++;
-            if (count == 4) {
+            if (count.incrementAndGet() == 4) {
                 throw new RuntimeCamelException("Ooops");
             }
         }

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLEngine;
 
@@ -94,16 +95,16 @@ final class LumberjackUtil {
             // send 5 frame windows, without pausing
             windows.stream().forEach(window -> channel.writeAndFlush(readSample(String.format("io/window%s.bin", window))));
             if (waitForResult) {
-                Awaitility.await().until(() -> windows.size() == responses.size());
+                Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> windows.size() == responses.size());
             }
 
-            channel.close();
+            channel.close().sync();
 
             synchronized (responses) {
                 return responses;
             }
         } finally {
-            eventLoopGroup.shutdownGracefully();
+            eventLoopGroup.shutdownGracefully().syncUninterruptibly();
         }
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fix flaky lumberjack tests caused by incomplete Netty resource cleanup between test runs:

- **Await `shutdownGracefully()` in `LumberjackServer.stop()`**: the three Netty thread groups (`bossGroup`, `workerGroup`, `executorService`) were shut down fire-and-forget, so the server port could still be in use when the next `@Isolated` test tried to bind. Now awaits completion with `syncUninterruptibly()`.
- **Await client channel close and event loop in `LumberjackUtil`**: `channel.close()` was fire-and-forget and `shutdownGracefully()` on the client event loop was not awaited, which could leave half-open connections that cause spurious ack count mismatches on the server side.
- **Thread-safe `ErrorProcessor.count`**: the `int count` field in `LumberjackDisconnectionTest.ErrorProcessor` was read/written from Netty executor threads without synchronization. Replaced with `AtomicInteger`.
- **Explicit Awaitility timeout**: the `Awaitility.await()` call in `LumberjackUtil.sendMessages()` relied on the 10-second default, which can be tight on slow CI nodes (especially for SSL tests). Now uses an explicit 30-second timeout.

## Test plan

- [x] `mvn test` in `components/camel-lumberjack` — all 5 tests pass
- [ ] CI validates no regressions across platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)