### PR TITLE
CAMEL-24109: camel-xslt-saxon - remove duplicated doInit/doStart lifecycle

### DIFF
--- a/components/camel-xslt-saxon/src/main/java/org/apache/camel/component/xslt/saxon/XsltSaxonEndpoint.java
+++ b/components/camel-xslt-saxon/src/main/java/org/apache/camel/component/xslt/saxon/XsltSaxonEndpoint.java
@@ -53,7 +53,6 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.support.EndpointHelper;
-import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.support.builder.ExpressionBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,31 +184,6 @@ public class XsltSaxonEndpoint extends XsltEndpoint {
      */
     public void setUseJsonBody(boolean useJsonBody) {
         this.useJsonBody = useJsonBody;
-    }
-
-    @Override
-    protected void doInit() throws Exception {
-        super.doInit();
-
-        // the processor is the xslt builder
-        setXslt(createXsltBuilder());
-
-        // must load resource first which sets a template and do a stylesheet compilation to catch errors early
-        // load resource from classpath otherwise load in doStart()
-        if (isContentCache() && ResourceHelper.isClasspathUri(getResourceUri())) {
-            loadResource(getResourceUri(), getXslt());
-        }
-
-        setProcessor(getXslt());
-    }
-
-    @Override
-    protected void doStart() throws Exception {
-        super.doStart();
-
-        if (isContentCache() && !ResourceHelper.isClasspathUri(getResourceUri())) {
-            loadResource(getResourceUri(), getXslt());
-        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Remove duplicated `doInit()` and `doStart()` overrides from `XsltSaxonEndpoint` — the parent `XsltEndpoint` already performs the full lifecycle through virtual dispatch to the overridden `createXsltBuilder()` and `loadResource()`, so the stylesheet was being created, loaded, and compiled twice on every startup.
- Copy-paste remnant from the CAMEL-14176 module split.

## Test plan

- [x] All 37 existing camel-xslt-saxon tests pass

🤖 Generated with [Claude Code](https://claude.ai/code) on behalf of @davsclaus

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>