### PR TITLE
CAMEL-24111: camel-xslt - Remove dead InputStream close logic in XsltBuilder

### DIFF
--- a/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XsltBuilder.java
+++ b/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XsltBuilder.java
@@ -50,7 +50,6 @@ import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.SynchronizationAdapter;
 import org.apache.camel.support.builder.xml.XMLConverterHelper;
 import org.apache.camel.util.FileUtil;
-import org.apache.camel.util.IOHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,8 +115,6 @@ public class XsltBuilder implements Processor {
         Message out = exchange.getOut();
         out.copyFrom(exchange.getIn());
 
-        // the underlying input stream, which we need to close to avoid locking files or other resources
-        InputStream is = null;
         try {
             Source source = getSourceHandlerFactory().getSource(exchange, this.source);
 
@@ -133,8 +130,6 @@ public class XsltBuilder implements Processor {
             resultHandler.setBody(out);
         } finally {
             releaseTransformer(transformer, gen);
-            // IOHelper can handle if null
-            IOHelper.close(is);
         }
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Remove dead `InputStream is = null` variable and `IOHelper.close(is)` in `XsltBuilder.process()` that have been no-ops since the CAMEL-13851 SourceHandlerFactory refactoring (3.0)
- Remove the stale comment and unused `IOHelper` import

The variable was never assigned after the refactoring moved InputStream acquisition into `XmlSourceHandlerFactoryImpl.getSource()`. The SAX/StAX parser chain closes the stream on all standard paths.

## Test plan

- [x] `camel-xslt` module builds cleanly
- [x] All 60 XSLT tests in `camel-core` pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>