### PR TITLE
CAMEL-24115: camel-rest-openapi - Write generated operationId back to Operation for dispatch

### DIFF
--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/DefaultRestOpenapiProcessorStrategy.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/DefaultRestOpenapiProcessorStrategy.java
@@ -83,7 +83,11 @@ public class DefaultRestOpenapiProcessorStrategy extends ServiceSupport
         for (var e : openAPI.getPaths().entrySet()) {
             for (var o : e.getValue().readOperationsMap().entrySet()) {
                 Operation op = o.getValue();
-                String id = op.getOperationId() != null ? op.getOperationId() : generateOperationId(e.getKey(), o.getKey());
+                String id = op.getOperationId();
+                if (id == null) {
+                    id = generateOperationId(e.getKey(), o.getKey());
+                    op.setOperationId(id);
+                }
                 ids.add(component + "://" + id);
             }
         }

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenapiProcessorStrategyTest.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenapiProcessorStrategyTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.rest.openapi;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
@@ -48,6 +49,43 @@ class RestOpenapiProcessorStrategyTest extends ManagedCamelTestSupport {
         assertTrue(ex.getMessage().contains("direct:GENOPID_GET.users"));
         assertTrue(ex.getMessage().contains("direct:GENOPID_GET.user._id_"));
 
+    }
+
+    @Test
+    void testMissingOperationIdSetsGeneratedIdOnOperation() throws Exception {
+        // Add routes matching the generated GENOPID names so validation passes
+        camelContext.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:GENOPID_GET.users").setBody(constant("ok"));
+                from("direct:GENOPID_GET.user._id_").setBody(constant("ok"));
+            }
+        });
+
+        DefaultRestOpenapiProcessorStrategy strategy = new DefaultRestOpenapiProcessorStrategy();
+        strategy.setCamelContext(camelContext);
+        strategy.setMissingOperation("fail");
+
+        OpenAPI openAPI = getOpenApi();
+
+        // Verify operationIds are initially null
+        for (var entry : openAPI.getPaths().entrySet()) {
+            for (Operation op : entry.getValue().readOperations()) {
+                assertNull(op.getOperationId(),
+                        "operationId should be null initially for path: " + entry.getKey());
+            }
+        }
+
+        // Validation should pass since routes match the generated IDs
+        strategy.validateOpenApi(openAPI, null, mock(PlatformHttpConsumerAware.class));
+
+        // Verify generated operationIds were written back to the Operations
+        // so that process() can dispatch to the correct direct endpoint
+        Operation usersOp = openAPI.getPaths().get("/users").getGet();
+        assertEquals("GENOPID_GET.users", usersOp.getOperationId());
+
+        Operation userByIdOp = openAPI.getPaths().get("/user/{id}").getGet();
+        assertEquals("GENOPID_GET.user._id_", userByIdOp.getOperationId());
     }
 
     private OpenAPI getOpenApi() {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

When an OpenAPI spec has operations without `operationId`, `validateOpenApi()` correctly generates synthetic IDs (`GENOPID_<VERB><sanitized_path>`) and validates against them. However, the generated ID was never written back to the `Operation` object, so `process()` called `operation.getOperationId()` which returned `null`, dispatching every request to `direct:null` instead of the generated endpoint.

**Fix:** Write the generated operationId back to the `Operation` object in `validateOpenApi()`, so both validation and runtime dispatch use the same ID.

**Failure scenario (before fix):**
- Spec with `GET /users` and no `operationId`
- `missingOperation=fail`: startup tells user to add `direct:GENOPID_GET.users`; user adds it; validation passes; every request resolves `direct:null` → `DirectConsumerNotAvailableException` → HTTP 500
- `missingOperation=mock/ignore`: user-defined GENOPID route is silently never invoked

## Test plan

- [x] New test `testMissingOperationIdSetsGeneratedIdOnOperation` verifies operationIds are written back after validation
- [x] Existing test `testMissingOperationId` still passes (validation error message unchanged)
- [x] All 135 tests in `camel-rest-openapi` pass
- [ ] CI validates no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)