### PR TITLE
CAMEL-24117: camel-rest-openapi - Create per-endpoint strategy instance

### DIFF
--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiComponent.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiComponent.java
@@ -178,7 +178,13 @@ public final class RestOpenApiComponent extends DefaultComponent implements SSLC
         }
         endpoint.setMissingOperation(getMissingOperation());
         endpoint.setMockIncludePattern(getMockIncludePattern());
-        endpoint.setRestOpenapiProcessorStrategy(getRestOpenapiProcessorStrategy());
+        if (restOpenapiProcessorStrategy != null) {
+            endpoint.setRestOpenapiProcessorStrategy(restOpenapiProcessorStrategy);
+        } else {
+            DefaultRestOpenapiProcessorStrategy perEndpoint = new DefaultRestOpenapiProcessorStrategy();
+            CamelContextAware.trySetCamelContext(perEndpoint, getCamelContext());
+            endpoint.setRestOpenapiProcessorStrategy(perEndpoint);
+        }
         setProperties(endpoint, parameters);
         return endpoint;
     }
@@ -195,10 +201,6 @@ public final class RestOpenApiComponent extends DefaultComponent implements SSLC
                 base = getCamelContext().getCamelContextExtension().getBasePackageScan();
             }
             bindingPackageScan = base;
-        }
-        if (restOpenapiProcessorStrategy == null) {
-            restOpenapiProcessorStrategy = new DefaultRestOpenapiProcessorStrategy();
-            CamelContextAware.trySetCamelContext(restOpenapiProcessorStrategy, getCamelContext());
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix shared `DefaultRestOpenapiProcessorStrategy` instance causing cross-talk between multiple `rest().openApi()` consumers
- Each endpoint now gets its own strategy instance (unless the user explicitly supplies a custom one at the component level)
- Fixes `missingOperation`/`mockIncludePattern` overwrite, silent fail-fast loss, and `uris` list mixing across consumers

## Root cause

`RestOpenApiComponent.doInit()` created ONE `DefaultRestOpenapiProcessorStrategy` and `createEndpoint()` shared it across all endpoints. Each consumer's `afterPropertiesConfigured()` then called `setMissingOperation()` / `setMockIncludePattern()` on the shared object — last writer wins. Combined with `ServiceHelper.initService` idempotency, the second consumer's null `missingOperation` was never resolved, causing `validateOpenApi()` to silently skip all fail/ignore/mock branches.

## Changes

- **`RestOpenApiComponent.createEndpoint()`**: Create a fresh `DefaultRestOpenapiProcessorStrategy` per endpoint when no user-supplied custom strategy exists. Share only an explicitly user-supplied strategy.
- **`RestOpenApiComponent.doInit()`**: Remove auto-creation of shared default strategy (no longer needed).

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>