### PR TITLE
CAMEL-24121: camel-smb - Add connectIfNecessary to existsFile and storeFileDirectly

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbOperations.java
@@ -201,7 +201,13 @@ public class SmbOperations implements SmbFileOperations {
 
     @Override
     public boolean existsFile(String name) throws GenericFileOperationFailedException {
-        return share.fileExists(name);
+        connectIfNecessary();
+        try {
+            return share.fileExists(name);
+        } catch (SMBRuntimeException smbre) {
+            safeDisconnect(smbre);
+            throw smbre;
+        }
     }
 
     @Override
@@ -526,6 +532,7 @@ public class SmbOperations implements SmbFileOperations {
 
     @Override
     public boolean storeFileDirectly(String name, String payload) throws GenericFileOperationFailedException {
+        connectIfNecessary();
         ByteArrayInputStream bis = new ByteArrayInputStream(payload.getBytes());
         try {
             try (File shareFile = share.openFile(name, EnumSet.of(AccessMask.FILE_WRITE_DATA),

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbProducerTempPrefixIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbProducerTempPrefixIT.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.smb;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SmbProducerTempPrefixIT extends SmbServerTestSupport {
+
+    protected String getSmbUrl() {
+        return String.format(
+                "smb:%s/%s?username=%s&password=%s&tempPrefix=.uploading",
+                service.address(), service.shareName(), service.userName(), service.password());
+    }
+
+    @Test
+    public void testProduceTempPrefix() {
+        sendFile(getSmbUrl(), "Hello World", "tempprefix.txt");
+
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals("Hello World",
+                        new String(copyFileContentFromContainer("/data/rw/tempprefix.txt"))));
+    }
+}


### PR DESCRIPTION
## Summary

`SmbOperations.existsFile()` accesses the `share` field without calling `connectIfNecessary()` first. When `tempPrefix` or `tempFileName` is configured on the producer, `GenericFileProducer.processExchange()` calls `existsFile()` **before** any `storeFile()`, and since `SmbEndpoint.isSingletonProducer()` returns `false`, every exchange gets a fresh, unconnected `SmbOperations` — so `share` is always `null`, causing an NPE on every message.

### Changes

- **`SmbOperations.existsFile()`** — added `connectIfNecessary()` and `safeDisconnect` error handling, matching the pattern used by `deleteFile()`, `existsFolder()`, `renameFile()`, etc.
- **`SmbOperations.storeFileDirectly()`** — added `connectIfNecessary()` (used for checksum file writing, had the same missing guard).
- **New IT: `SmbProducerTempPrefixIT`** — verifies that `tempPrefix=.uploading` works on the SMB producer.

## Test plan

- [x] New `SmbProducerTempPrefixIT` passes (sends a file with `tempPrefix`, verifies it arrives at the expected path)
- [x] Full camel-smb test suite passes (81 tests, 0 failures)

_Claude Code on behalf of @davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>