### PR TITLE
CAMEL-24123: camel-smb - Fix readLock=changed with recursive=true

### DIFF
--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/strategy/SmbExclusiveReadLockCheck.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/strategy/SmbExclusiveReadLockCheck.java
@@ -84,7 +84,7 @@ public class SmbExclusiveReadLockCheck {
 
         String path = file.getParent();
         if (operations instanceof SmbOperations smbOperations) {
-            return smbOperations.listFiles(path, file.getFileName());
+            return smbOperations.listFiles(path, file.getFileNameOnly());
         }
         return operations.listFiles(path);
     }


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Fix `readLock=changed` with `recursive=true` never consuming files in sub-directories
- `SmbExclusiveReadLockCheck.getSmbFiles()` was passing `file.getFileName()` (relative path, e.g. `sub/hello.txt`) as the SMB search pattern instead of `file.getFileNameOnly()` (plain name, e.g. `hello.txt`)
- SMB QueryDirectory search patterns must be plain names/wildcards; a pattern containing a path separator matches nothing, so the lock check always saw `newLength=0 < minLength` and the read lock was never acquired

## Test plan

- [ ] Verify build passes: `cd components/camel-smb && mvn install -DskipTests`
- [ ] Run existing camel-smb tests: `cd components/camel-smb && mvn test`
- [ ] Verify with `recursive=true` and `readLock=changed` that files in sub-directories are consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>