### PR TITLE
CAMEL-24129: camel-jpa - JpaConsumer should use getPreDeleteHandler() instead of createPreDeleteHandler()

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
@@ -196,7 +196,7 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
             pendingExchanges = total - index - 1;
             if (lockEntity(result, batchEntityManager)) {
                 // Run the @PreConsumed callback
-                createPreDeleteHandler().deleteObject(batchEntityManager, result, exchange);
+                getPreDeleteHandler().deleteObject(batchEntityManager, result, exchange);
 
                 // process the current exchange
                 LOG.debug("Processing exchange: {}", exchange);

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaPreDeleteHandlerTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/JpaPreDeleteHandlerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.jpa;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jpa.JpaEndpoint;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.examples.SendEmail;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JpaPreDeleteHandlerTest extends AbstractJpaTest {
+    protected static final String SELECT_ALL_STRING = "select x from " + SendEmail.class.getName() + " x";
+
+    private final AtomicBoolean preDeleteHandlerCalled = new AtomicBoolean();
+
+    @Test
+    public void testCustomPreDeleteHandlerIsInvoked() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", new SendEmail("someone@example.com"));
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        assertTrue(preDeleteHandlerCalled.get(), "Custom preDeleteHandler should have been invoked");
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start").to("jpa://" + SendEmail.class.getName());
+
+                JpaEndpoint jpa = getContext().getEndpoint(
+                        "jpa://" + SendEmail.class.getName(),
+                        JpaEndpoint.class);
+                jpa.setPreDeleteHandler((em, entityBean, exchange) -> preDeleteHandlerCalled.set(true));
+
+                from(jpa).to("mock:result");
+            }
+        };
+    }
+
+    @Override
+    protected String routeXml() {
+        return "org/apache/camel/processor/jpa/springJpaRouteTest.xml";
+    }
+
+    @Override
+    protected String selectAllString() {
+        return SELECT_ALL_STRING;
+    }
+}


### PR DESCRIPTION
## Summary

`JpaConsumer.processBatch()` calls `createPreDeleteHandler()` directly instead of the cached accessor `getPreDeleteHandler()`, causing two bugs:

1. A user-supplied `preDeleteHandler` (configured via the `@UriParam` option on `JpaEndpoint`) is **never invoked** — `createPreDeleteHandler()` always re-derives the handler from the `@PreConsumed` annotation scan, completely bypassing anything set via `setPreDeleteHandler()`.
2. `createPreDeleteHandler()` runs `AnnotationHelper.findMethodsWithAnnotation()` — a reflective scan of the entity's methods — for **every entity of every poll batch**, instead of once per consumer lifetime.

The `@Consumed`/`getDeleteHandler()` counterpart a few lines below already uses the correct cached accessor pattern.

## Fix

Changed line 199 from `createPreDeleteHandler()` to `getPreDeleteHandler()`, mirroring the existing `getDeleteHandler()` pattern.

## Test

Added `JpaPreDeleteHandlerTest` that sets a custom `preDeleteHandler` programmatically on the endpoint and verifies it is actually invoked when entities are consumed.

_Claude Code on behalf of davsclaus_