### PR TITLE
CAMEL-24130: camel-jpa - JpaMessageIdRepository should not reuse EntityManager from exchange header

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
@@ -90,7 +90,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
     @Override
     public boolean add(final Exchange exchange, final String messageId) {
         final EntityManager entityManager
-                = getTargetEntityManager(exchange, entityManagerFactory, true, sharedEntityManager, true);
+                = getTargetEntityManager(exchange, entityManagerFactory, false, sharedEntityManager, true);
         // Run this in single transaction.
         final Boolean[] rc = new Boolean[1];
         transactionStrategy.executeInTransaction(() -> {
@@ -139,7 +139,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
     @Override
     public boolean contains(final Exchange exchange, final String messageId) {
         final EntityManager entityManager
-                = getTargetEntityManager(exchange, entityManagerFactory, true, sharedEntityManager, true);
+                = getTargetEntityManager(exchange, entityManagerFactory, false, sharedEntityManager, true);
 
         // Run this in single transaction.
         final Boolean[] rc = new Boolean[1];
@@ -181,7 +181,7 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
     @Override
     public boolean remove(final Exchange exchange, final String messageId) {
         final EntityManager entityManager
-                = getTargetEntityManager(exchange, entityManagerFactory, true, sharedEntityManager, true);
+                = getTargetEntityManager(exchange, entityManagerFactory, false, sharedEntityManager, true);
 
         Boolean[] rc = new Boolean[1];
         transactionStrategy.executeInTransaction(() -> {
@@ -231,7 +231,8 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
     @Override
     @ManagedOperation(description = "Clear the store")
     public void clear() {
-        final EntityManager entityManager = getTargetEntityManager(null, entityManagerFactory, true, sharedEntityManager, true);
+        final EntityManager entityManager
+                = getTargetEntityManager(null, entityManagerFactory, false, sharedEntityManager, true);
 
         transactionStrategy.executeInTransaction(() -> {
             if (isJoinTransaction()) {


### PR DESCRIPTION
## Summary

`JpaMessageIdRepository` hardcodes `usePassedInEntityManager=true` in all `getTargetEntityManager()` calls, which causes it to grab the `EntityManager` from the exchange's `CamelEntityManager` header. When used downstream of a JPA consumer (which puts its own poll-scoped EM in that header), the repository then **closes** the consumer's EM in its `finally` block, causing `IllegalStateException: EntityManager is closed` during the consumer's subsequent flush/clear.

## Fix

Changed `usePassedInEntityManager` from `true` to `false` in all four `getTargetEntityManager()` calls (`add`, `contains`, `remove`, `clear`). This makes the repository always create its own EM via its own `entityManagerFactory`, matching `JpaEndpoint`'s default behavior. The existing `finally` close logic is then correct — the repository only closes EMs it created itself.

_Claude Code on behalf of davsclaus_