### PR TITLE
CAMEL-24131: camel-jpa - Guard consumeDelete handler against Object[] from native queries

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaConsumer.java
@@ -471,7 +471,15 @@ public class JpaConsumer extends ScheduledBatchPollingConsumer {
             }
         }
         if (getEndpoint().isConsumeDelete()) {
-            return (EntityManager em, Object entityBean, Exchange exchange) -> em.remove(entityBean);
+            return (EntityManager em, Object entityBean, Exchange exchange) -> {
+                if (entityBean != null && !entityBean.getClass().isArray()) {
+                    em.remove(entityBean);
+                } else {
+                    LOG.warn("Cannot auto-delete entity of type {} (e.g. native query result without resultClass)."
+                             + " Set consumeDelete=false or configure a resultClass.",
+                            entityBean != null ? entityBean.getClass().getName() : "null");
+                }
+            };
         }
 
         return (EntityManager em, Object entityBean, Exchange exchange) -> {


### PR DESCRIPTION
## Summary

When a JPA consumer uses `nativeQuery` without `resultClass`, results are returned as `Object[]`. The default `consumeDelete=true` handler calls `em.remove(entityBean)` unconditionally, which throws `IllegalArgumentException` on `Object[]` since it's not a managed entity. This causes the row to never be deleted and reprocessed on every poll — an infinite reprocessing loop.

## Fix

Added an array type guard to the `consumeDelete` handler, matching the pattern already used by `lockEntity()` (line 376) which anticipates `Object[]` from native queries. When the entity bean is an array, the delete is skipped and a WARN log is emitted advising the user to set `consumeDelete=false` or configure a `resultClass`.

_Claude Code on behalf of davsclaus_