### PR TITLE
CAMEL-24132: camel-jpa - Fix medium-severity findings from component review

### DIFF
--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaPollingConsumer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaPollingConsumer.java
@@ -124,11 +124,21 @@ public class JpaPollingConsumer extends PollingConsumerSupport {
 
     @Override
     public Exchange receive() {
-        Exchange exchange = getEndpoint().createExchange();
+        return doReceive(true);
+    }
 
+    @Override
+    public Exchange receiveNoWait() {
+        // do not use locking so the call returns immediately without blocking on row locks
+        return doReceive(false);
+    }
+
+    private Exchange doReceive(boolean useLocking) {
         // resolve the entity manager before evaluating the expression
-        final EntityManager entityManager = getTargetEntityManager(exchange, entityManagerFactory,
+        final EntityManager entityManager = getTargetEntityManager(null, entityManagerFactory,
                 getEndpoint().isUsePassedInEntityManager(), getEndpoint().isSharedEntityManager(), true);
+
+        Exchange exchange = getEndpoint().createExchange();
         exchange.getIn().setHeader(JpaConstants.ENTITY_MANAGER, entityManager);
         transactionStrategy.executeInTransaction(new Runnable() {
             @Override
@@ -140,7 +150,9 @@ public class JpaPollingConsumer extends PollingConsumerSupport {
                 Query innerQuery = getQueryFactory().createQuery(entityManager);
                 configureParameters(innerQuery);
 
-                if (getEndpoint().isConsumeLockEntity()) {
+                // only apply lock mode when locking is enabled and not using native queries
+                // as JPA spec does not support setLockMode on native queries
+                if (useLocking && getEndpoint().isConsumeLockEntity() && nativeQuery == null) {
                     innerQuery.setLockMode(getLockModeType());
                 }
 
@@ -183,12 +195,6 @@ public class JpaPollingConsumer extends PollingConsumerSupport {
     }
 
     @Override
-    public Exchange receiveNoWait() {
-        // call receive as-is
-        return receive();
-    }
-
-    @Override
     public Exchange receive(long timeout) {
         // need to use a thread pool to perform the task so we can support timeout
         if (executorService == null) {
@@ -205,7 +211,8 @@ public class JpaPollingConsumer extends PollingConsumerSupport {
         } catch (ExecutionException e) {
             throw RuntimeCamelException.wrapRuntimeCamelException(e);
         } catch (TimeoutException e) {
-            // ignore as we hit timeout then return null
+            // cancel the task so it does not keep running in the background holding DB locks
+            future.cancel(true);
         }
 
         return null;

--- a/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/component/jpa/JpaProducer.java
@@ -145,22 +145,21 @@ public class JpaProducer extends DefaultProducer {
     public boolean isUseExecuteUpdate() {
         if (useExecuteUpdate == null) {
             if (query != null) {
-                if (query.regionMatches(true, 0, "select", 0, 6)) {
-                    useExecuteUpdate = false;
-                } else {
-                    useExecuteUpdate = true;
-                }
+                useExecuteUpdate = isUpdateQuery(query);
             } else if (nativeQuery != null) {
-                if (nativeQuery.regionMatches(true, 0, "select", 0, 6)) {
-                    useExecuteUpdate = false;
-                } else {
-                    useExecuteUpdate = true;
-                }
+                useExecuteUpdate = isUpdateQuery(nativeQuery);
             } else {
                 useExecuteUpdate = false;
             }
         }
         return useExecuteUpdate;
+    }
+
+    private static boolean isUpdateQuery(String queryText) {
+        String trimmed = queryText.stripLeading();
+        return trimmed.regionMatches(true, 0, "insert", 0, 6)
+                || trimmed.regionMatches(true, 0, "update", 0, 6)
+                || trimmed.regionMatches(true, 0, "delete", 0, 6);
     }
 
     @Override

--- a/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/processor/idempotent/jpa/JpaMessageIdRepository.java
@@ -107,14 +107,20 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
                     processed.setCreatedAt(new Date());
                     entityManager.persist(processed);
                     entityManager.flush();
-                    entityManager.close();
                     rc[0] = Boolean.TRUE;
                 } else {
                     rc[0] = Boolean.FALSE;
                 }
             } catch (Exception ex) {
-                String contextInfo = String.format(SOMETHING_WENT_WRONG, ex.getMessage());
-                throw new PersistenceException(contextInfo, ex);
+                if (isConstraintViolation(ex)) {
+                    // concurrent insert of the same messageId detected via unique constraint
+                    // treat as duplicate rather than failing the exchange
+                    LOG.debug("Duplicate message detected during concurrent insert: {}", messageId);
+                    rc[0] = Boolean.FALSE;
+                } else {
+                    String contextInfo = String.format(SOMETHING_WENT_WRONG, ex.getMessage());
+                    throw new PersistenceException(contextInfo, ex);
+                }
             } finally {
                 try {
                     if (entityManager.isOpen()) {
@@ -300,6 +306,20 @@ public class JpaMessageIdRepository extends ServiceSupport implements Idempotent
 
     public void setSharedEntityManager(boolean sharedEntityManager) {
         this.sharedEntityManager = sharedEntityManager;
+    }
+
+    private static boolean isConstraintViolation(Exception ex) {
+        Throwable cause = ex;
+        while (cause != null) {
+            if (cause instanceof java.sql.SQLIntegrityConstraintViolationException) {
+                return true;
+            }
+            if (cause instanceof jakarta.persistence.EntityExistsException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes 5 of 6 medium-severity findings from the July 2026 camel-jpa component review ([CAMEL-24132](https://issues.apache.org/jira/browse/CAMEL-24132)):

- **M1**: `receiveNoWait()` no longer delegates to `receive()` with pessimistic locking — refactored into `doReceive(boolean useLocking)` so `receiveNoWait()` runs without locks
- **M2**: `receive(timeout)` now calls `future.cancel(true)` on `TimeoutException` so abandoned tasks don't accumulate holding DB locks
- **M3**: `setLockMode()` is skipped for native queries, which throw `IllegalStateException` per JPA spec
- **M4**: Concurrent insert race in `JpaMessageIdRepository.add()` now catches constraint violations and maps them to `return false` (duplicate detected) instead of failing the exchange. Also removed premature `entityManager.close()` inside the transaction lambda
- **M6**: `isUseExecuteUpdate()` now trims query strings and detects update keywords (`INSERT`/`UPDATE`/`DELETE`) instead of select, so queries with leading whitespace or CTEs are correctly classified

M5 (parallel EntityManager fix missing from Multicast/RecipientList/WireTap) is tracked separately in [CAMEL-24174](https://issues.apache.org/jira/browse/CAMEL-24174).

## Test plan

- [x] All 96 existing camel-jpa tests pass (0 failures)
- [ ] Manual verification of M3 with `nativeQuery` + default `consumeLockEntity=true`
- [ ] Manual verification of M6 with leading-whitespace and CTE queries

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>