### PR TITLE
CAMEL-24174: Strip JPA EntityManager property in parallel multicast, recipientList and wireTap

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -1020,6 +1020,10 @@ public class MulticastProcessor extends BaseProcessorSupport
             // copy exchange, and do not share the unit of work
             Exchange copy = processorExchangeFactory.createCorrelatedCopy(exchange, false);
             copy.getExchangeExtension().setTransacted(exchange.isTransacted());
+            if (isParallelProcessing()) {
+                // do not share JPA EntityManager in parallel mode as it is not thread-safe (CAMEL-22534)
+                copy.removeProperty(Exchange.JPA_ENTITY_MANAGER);
+            }
             // If we are in a transaction, set TRANSACTION_CONTEXT_DATA property for new exchanges to share txData
             // during the transaction.
             if (exchange.isTransacted() && copy.getProperty(Exchange.TRANSACTION_CONTEXT_DATA) == null) {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/RecipientListProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/RecipientListProcessor.java
@@ -287,6 +287,10 @@ public class RecipientListProcessor extends MulticastProcessor {
         // copy exchange, and do not share the unit of work
         Exchange copy = processorExchangeFactory.createCorrelatedCopy(exchange, false);
         copy.getExchangeExtension().setTransacted(exchange.isTransacted());
+        if (isParallelProcessing()) {
+            // do not share JPA EntityManager in parallel mode as it is not thread-safe (CAMEL-22534)
+            copy.removeProperty(Exchange.JPA_ENTITY_MANAGER);
+        }
 
         // If we are in a transaction, set TRANSACTION_CONTEXT_DATA property for new exchanges to share txData
         // during the transaction.

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/WireTapProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/WireTapProcessor.java
@@ -264,6 +264,8 @@ public class WireTapProcessor extends BaseProcessorSupport
         Exchange target = processorExchangeFactory.createCorrelatedCopy(exchange, false);
         // should not be correlated, but we needed to copy without handover
         target.removeProperty(ExchangePropertyKey.CORRELATION_ID);
+        // do not share JPA EntityManager as wire tap runs asynchronously and EM is not thread-safe (CAMEL-22534)
+        target.removeProperty(Exchange.JPA_ENTITY_MANAGER);
         // set MEP to InOnly as this wire tap is a fire and forget
         target.setPattern(ExchangePattern.InOnly);
         // move OUT to IN if needed


### PR DESCRIPTION
## Summary

CAMEL-22534 fixed a concurrency issue where the Splitter shared the non-thread-safe JPA `EntityManager` map across parallel sub-exchanges. The same fix was missing from three other EIPs:

- **MulticastProcessor** — strip `CamelEntityManager` when `parallelProcessing` is enabled
- **RecipientListProcessor** — strip `CamelEntityManager` when `parallelProcessing` is enabled
- **WireTapProcessor** — always strip `CamelEntityManager` since wire tap runs asynchronously

When the property is removed, the JPA component creates a fresh dedicated EntityManager for each branch, avoiding concurrent access to a non-thread-safe EM and HashMap corruption.

No JPA dependency is introduced in `camel-core-processor` — the property key is just a string constant from `Exchange`.

## Test plan

- [x] `camel-core-processor` builds successfully
- [x] 78 parallel multicast / recipient list / wire tap tests pass
- [x] camel-jpa `JpaWireTapTest` passes

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>