### PR TITLE
CAMEL-24133: Circuit Breaker EIP - Release correlated copy instead of original exchange in pooled mode

### DIFF
--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceProcessor.java
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceProcessor.java
@@ -458,8 +458,10 @@ public class FaultToleranceProcessor extends BaseProcessorSupport
                 cause = exchange.getException();
             }
 
-            // and release exchange back in pool
-            processorExchangeFactory.release(exchange);
+            // and release correlated copy back in pool
+            if (copy != null) {
+                processorExchangeFactory.release(copy);
+            }
 
             if (cause != null) {
                 // throw exception so fault tolerance knows it was a failure

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/test/java/org/apache/camel/component/microprofile/faulttolerance/FaultTolerancePooledProcessorExchangeFactoryTest.java
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/test/java/org/apache/camel/component/microprofile/faulttolerance/FaultTolerancePooledProcessorExchangeFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.microprofile.faulttolerance;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.engine.PooledExchangeFactory;
+import org.apache.camel.impl.engine.PooledProcessorExchangeFactory;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class FaultTolerancePooledProcessorExchangeFactoryTest extends CamelTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        context.getCamelContextExtension().setExchangeFactory(new PooledExchangeFactory());
+        context.getCamelContextExtension().setProcessorExchangeFactory(new PooledProcessorExchangeFactory());
+        return context;
+    }
+
+    @Test
+    public void testBodySurvivesCircuitBreaker() throws Exception {
+        getMockEndpoint("mock:result").expectedMinimumMessageCount(1);
+        getMockEndpoint("mock:result").allMessages().body().isEqualTo("Bye World");
+
+        context.getRouteController().startAllRoutes();
+
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("timer:foo?repeatCount=1").autoStartup(false)
+                        .setBody(constant("Hello World"))
+                        .circuitBreaker()
+                            .to("direct:foo")
+                        .end()
+                        .to("log:result")
+                        .to("mock:result");
+
+                from("direct:foo")
+                        .transform().constant("Bye World");
+            }
+        };
+    }
+}

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
@@ -611,8 +611,10 @@ public class ResilienceProcessor extends BaseProcessorSupport
             cause = exchange.getException();
         }
 
-        // and release exchange back in pool
-        processorExchangeFactory.release(exchange);
+        // and release correlated copy back in pool
+        if (copy != null) {
+            processorExchangeFactory.release(copy);
+        }
 
         if (cause != null) {
             // throw exception so resilient4j know it was a failure

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResiliencePooledProcessorExchangeFactoryTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResiliencePooledProcessorExchangeFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.resilience4j;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.engine.PooledExchangeFactory;
+import org.apache.camel.impl.engine.PooledProcessorExchangeFactory;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class ResiliencePooledProcessorExchangeFactoryTest extends CamelTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        context.getCamelContextExtension().setExchangeFactory(new PooledExchangeFactory());
+        context.getCamelContextExtension().setProcessorExchangeFactory(new PooledProcessorExchangeFactory());
+        return context;
+    }
+
+    @Test
+    public void testBodySurvivesCircuitBreaker() throws Exception {
+        getMockEndpoint("mock:result").expectedMinimumMessageCount(1);
+        getMockEndpoint("mock:result").allMessages().body().isEqualTo("Bye World");
+
+        context.getRouteController().startAllRoutes();
+
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("timer:foo?repeatCount=1").autoStartup(false)
+                        .setBody(constant("Hello World"))
+                        .circuitBreaker()
+                            .to("direct:foo")
+                        .end()
+                        .to("log:result")
+                        .to("mock:result");
+
+                from("direct:foo")
+                        .transform().constant("Bye World");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24133](https://issues.apache.org/jira/browse/CAMEL-24133)

Both Circuit Breaker EIP implementations (`ResilienceProcessor` and `FaultToleranceProcessor`) release the **original in-flight exchange** back to the processor exchange pool instead of the **correlated copy** when `camel.main.exchange-factory=pooled` is enabled.

- `ResilienceProcessor.processTask()` called `processorExchangeFactory.release(exchange)` — the original
- `FaultToleranceProcessor.CircuitBreakerTask.call()` — same bug

This causes `PooledExchange.done()` to wipe the body, properties, exception, and exchangeId of the still-in-use original exchange, resulting in `null` body downstream and potential cross-exchange corruption under concurrency.

**Fix:** Release the correlated `copy` (with null guard) instead of the original `exchange`, matching the pattern used by Enricher, Splitter, and MulticastProcessor.

## Changes

- `ResilienceProcessor.java` — change `processorExchangeFactory.release(exchange)` to `processorExchangeFactory.release(copy)`
- `FaultToleranceProcessor.java` — same change
- Added `ResiliencePooledProcessorExchangeFactoryTest` — uses `timer:` consumer with both `PooledExchangeFactory` and `PooledProcessorExchangeFactory`, verifies body survives circuit breaker
- Added `FaultTolerancePooledProcessorExchangeFactoryTest` — same test for microprofile-fault-tolerance

## Test plan

- [x] New test `ResiliencePooledProcessorExchangeFactoryTest` passes (fails without fix)
- [x] New test `FaultTolerancePooledProcessorExchangeFactoryTest` passes (fails without fix)
- [x] All 45 existing camel-resilience4j tests pass
- [x] All 21 existing camel-microprofile-fault-tolerance tests pass

_Claude Code on behalf of davsclaus_