### PR TITLE
CAMEL-24186: camel-cxf - code-quality cleanup

### DIFF
--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfConverter.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfConverter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -105,7 +106,7 @@ public final class CxfConverter {
 
     @Converter
     public static DataFormat toDataFormat(final String name) {
-        return DataFormat.valueOf(name.toUpperCase());
+        return DataFormat.valueOf(name.toUpperCase(Locale.ROOT));
     }
 
     @Converter(allowNull = true)

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 public class CxfRsInvoker extends JAXRSInvoker {
     private static final Logger LOG = LoggerFactory.getLogger(CxfRsInvoker.class);
-    private static final String SUSPENED = "org.apache.camel.component.cxf.jaxrs.suspend";
+    private static final String SUSPENDED = "org.apache.camel.component.cxf.jaxrs.suspend";
     private final CxfRsConsumer cxfRsConsumer;
     private final CxfRsEndpoint endpoint;
 
@@ -95,7 +95,7 @@ public class CxfRsInvoker extends JAXRSInvoker {
                 LOG.trace("Suspending continuation of exchangeId: {}", camelExchange.getExchangeId());
                 // The continuation could be called before the suspend is called
                 continuation.suspend(endpoint.getContinuationTimeout());
-                cxfExchange.put(SUSPENED, Boolean.TRUE);
+                cxfExchange.put(SUSPENDED, Boolean.TRUE);
                 continuation.setObject(camelExchange);
                 cxfRsConsumer.getAsyncProcessor().process(camelExchange, new AsyncCallback() {
                     public void done(boolean doneSync) {
@@ -110,7 +110,7 @@ public class CxfRsInvoker extends JAXRSInvoker {
                 return null;
             }
             if (!continuation.isTimeout() && continuation.isResumed()) {
-                cxfExchange.put(SUSPENED, Boolean.FALSE);
+                cxfExchange.put(SUSPENDED, Boolean.FALSE);
                 org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange) continuation.getObject();
                 try {
                     return returnResponse(cxfExchange, camelExchange);
@@ -120,7 +120,7 @@ public class CxfRsInvoker extends JAXRSInvoker {
                 }
             } else {
                 if (continuation.isTimeout() || !continuation.isPending()) {
-                    cxfExchange.put(SUSPENED, Boolean.FALSE);
+                    cxfExchange.put(SUSPENDED, Boolean.FALSE);
                     org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange) continuation.getObject();
                     camelExchange.setException(new ExchangeTimedOutException(camelExchange, endpoint.getContinuationTimeout()));
                     try {

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
@@ -212,7 +212,6 @@ public class CxfRsProducer extends DefaultAsyncProducer {
 
         // find out the method which we want to invoke
         JAXRSServiceFactoryBean sfb = cfb.getServiceFactory();
-        sfb.getResourceClasses();
         // check the null body first
         Object[] parameters = null;
         if (inMessage.getBody() != null) {
@@ -465,7 +464,6 @@ public class CxfRsProducer extends DefaultAsyncProducer {
 
         // find out the method which we want to invoke
         JAXRSServiceFactoryBean sfb = cfb.getServiceFactory();
-        sfb.getResourceClasses();
         // check the null body first
         Object[] parameters = null;
         if (inMessage.getBody() != null) {

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfConsumer.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfConsumer.java
@@ -53,7 +53,6 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.service.invoker.Invoker;
 import org.apache.cxf.service.model.BindingOperationInfo;
-import org.apache.cxf.transport.MessageObserver;
 import org.apache.cxf.ws.addressing.ContextUtils;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.slf4j.Logger;
@@ -93,11 +92,6 @@ public class CxfConsumer extends DefaultConsumer implements Suspendable {
         if (ObjectHelper.isNotEmpty(cxfEndpoint.getPublishedEndpointUrl())) {
             ret.getEndpoint().getEndpointInfo().setProperty("publishedEndpointUrl", cxfEndpoint.getPublishedEndpointUrl());
         }
-
-        final MessageObserver originalOutFaultObserver = ret.getEndpoint().getOutFaultObserver();
-        ret.getEndpoint().setOutFaultObserver(message -> {
-            originalOutFaultObserver.onMessage(message);
-        });
 
         // setup the UnitOfWorkCloserInterceptor for OneWayMessageProcessor
         ret.getEndpoint().getInInterceptors().add(new UnitOfWorkCloserInterceptor(Phase.POST_INVOKE, true));

--- a/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/SpringBusFactoryBean.java
+++ b/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/SpringBusFactoryBean.java
@@ -32,11 +32,10 @@ import org.springframework.beans.factory.SmartFactoryBean;
 public class SpringBusFactoryBean implements SmartFactoryBean<Bus> {
     private String[] cfgFiles;
     private boolean includeDefaultBus;
-    private SpringBusFactory bf;
 
     @Override
     public Bus getObject() throws Exception {
-        bf = new SpringBusFactory();
+        SpringBusFactory bf = new SpringBusFactory();
         if (cfgFiles != null) {
             return bf.createBus(cfgFiles, includeDefaultBus);
         } else {

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/message/CxfMessageMapper.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/message/CxfMessageMapper.java
@@ -21,7 +21,7 @@ import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.cxf.message.Message;
 
 /**
- * A Strategy to bind a Camel exchange to a CXF message used by {@link CxfBeanDestination}.
+ * A Strategy to bind a Camel exchange to a CXF message, used by the Camel CXF transport.
  */
 public interface CxfMessageMapper {
 


### PR DESCRIPTION
## CAMEL-24186: camel-cxf — code-quality cleanup

Behaviour-preserving cleanups from an AI-assisted code review of the `camel-cxf` component family. This is the safe, mechanical **batch 1** of the improvements umbrella [CAMEL-24186](https://issues.apache.org/jira/browse/CAMEL-24186); remaining items (refactors, deprecated-API migrations that touch semantics, fail-loud changes) are tracked there as follow-ups.

### Changes
- **CxfConverter** — `toDataFormat` now calls `toUpperCase(Locale.ROOT)` instead of the default-locale `toUpperCase()` (avoids the Turkish-i class of bug when resolving the data-format enum).
- **CxfRsInvoker** — fix the misspelled private constant `SUSPENED` → `SUSPENDED` (internal key; no functional change).
- **CxfRsProducer** — remove two discarded `sfb.getResourceClasses();` calls whose result is thrown away and immediately re-fetched on the next line.
- **CxfConsumer** — remove the no-op out-fault observer wrapper (`setOutFaultObserver(m -> original.onMessage(m))`) that just re-delegated to the original observer, plus the now-unused `MessageObserver` import.
- **SpringBusFactoryBean** — make `bf` a method-local variable instead of an instance field (it was only used within `getObject()`).
- **CxfMessageMapper** — fix a Javadoc `{@link}` pointing at a class that does not exist in the module.

### Testing
- `mvn formatter:format impsort:sort` clean; all six modules build.
- Existing test suites pass for the touched modules (transport, spring-common in full; converter/producer/binding and consumer smoke tests for rest/soap). No behaviour change is intended or observed.

---
_Authored by Claude Code (Claude Fable) on behalf of Federico Mariani (GitHub: @Croway)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
