### PR TITLE
CAMEL-24112: camel-rest-openapi - Fix path parameters leaking into query string with multi-param operations

### DIFF
--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpoint.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpoint.java
@@ -683,13 +683,12 @@ public final class RestOpenApiEndpoint extends DefaultEndpoint {
         if (this.parameters != null) {
             if (operation.getParameters() != null) {
                 for (Map.Entry<String, Object> entry : this.parameters.entrySet()) {
-                    for (Parameter param : operation.getParameters()) {
-                        // skip parameters that are part of the operation as path as otherwise
-                        // it will be duplicated as query parameter as well
-                        boolean clash = "path".equals(param.getIn()) && entry.getKey().equals(param.getName());
-                        if (!clash) {
-                            nestedParameters.put(entry.getKey(), entry.getValue());
-                        }
+                    // skip parameters that are part of the operation as path as otherwise
+                    // it will be duplicated as query parameter as well
+                    boolean clash = operation.getParameters().stream()
+                            .anyMatch(p -> "path".equals(p.getIn()) && entry.getKey().equals(p.getName()));
+                    if (!clash) {
+                        nestedParameters.put(entry.getKey(), entry.getValue());
                     }
                 }
             } else {

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpointV3Test.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpointV3Test.java
@@ -288,6 +288,70 @@ public class RestOpenApiEndpointV3Test {
     }
 
     @Test
+    public void shouldNotLeakPathParametersAsQueryParameters() {
+        final CamelContext camelContext = mock(CamelContext.class);
+
+        final RestOpenApiComponent component = new RestOpenApiComponent();
+        component.setCamelContext(camelContext);
+
+        // endpoint parameters include two path params and one extra param
+        Map<String, Object> params = new HashMap<>();
+        params.put("userId", "1");
+        params.put("orderId", "2");
+        params.put("format", "json");
+
+        final RestOpenApiEndpoint endpoint = new RestOpenApiEndpoint(
+                "uri", "remaining", component, params);
+        endpoint.setHost("http://petstore.openapi.io");
+
+        final OpenAPI openapi = new OpenAPI();
+        final Operation operation = new Operation().operationId("getOrder");
+        operation.addParametersItem(new Parameter().name("userId").in("path").required(true));
+        operation.addParametersItem(new Parameter().name("orderId").in("path").required(true));
+
+        Map<String, Object> result = endpoint.determineEndpointParameters(openapi, operation);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nested = (Map<String, Object>) result.get("parameters");
+
+        // path params must not leak into nested parameters
+        assertThat(nested).doesNotContainKey("userId");
+        assertThat(nested).doesNotContainKey("orderId");
+        // non-path param must be preserved
+        assertThat(nested).containsEntry("format", "json");
+    }
+
+    @Test
+    public void shouldKeepEndpointParametersWhenNoPathParamClash() {
+        final CamelContext camelContext = mock(CamelContext.class);
+
+        final RestOpenApiComponent component = new RestOpenApiComponent();
+        component.setCamelContext(camelContext);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("verbose", "true");
+        params.put("timeout", "5000");
+
+        final RestOpenApiEndpoint endpoint = new RestOpenApiEndpoint(
+                "uri", "remaining", component, params);
+        endpoint.setHost("http://petstore.openapi.io");
+
+        final OpenAPI openapi = new OpenAPI();
+        final Operation operation = new Operation().operationId("listUsers");
+        operation.addParametersItem(new Parameter().name("page").in("query"));
+        operation.addParametersItem(new Parameter().name("limit").in("query"));
+
+        Map<String, Object> result = endpoint.determineEndpointParameters(openapi, operation);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nested = (Map<String, Object>) result.get("parameters");
+
+        // no path params in the operation, so all endpoint params should be preserved
+        assertThat(nested).containsEntry("verbose", "true");
+        assertThat(nested).containsEntry("timeout", "5000");
+    }
+
+    @Test
     public void shouldDetermineHostFromRestConfiguration() {
         assertThat(RestOpenApiEndpoint.hostFrom(null)).isNull();
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes a logic bug in `RestOpenApiEndpoint.determineEndpointParameters()` where path parameters leak into the query string when an operation has more than one parameter.

The inner loop was logically inverted: an endpoint parameter entry was added to `nestedParameters` inside the inner per-operation-parameter loop whenever *any* operation parameter did not clash, instead of only when *no* parameter clashed. This meant the path-param filtering only worked for single-parameter operations.

**Example:** `GET /users/{userId}/orders/{orderId}` with `userId=1&orderId=2` would produce a request to `GET /users/1/orders/2?userId=1&orderId=2` — the path params leaked as query params.

**Fix:** Replace the nested loop with a stream `anyMatch` check so the clash is evaluated across all operation parameters before deciding whether to include the entry.

Introduced in commit 94847d8c4a84 (CAMEL-17049), unfixed since 2021 due to lack of test coverage for the multi-parameter case.

## Test plan

- [x] Added `shouldNotLeakPathParametersAsQueryParameters` — two path params, verifies neither leaks and a non-path param is preserved
- [x] Added `shouldKeepEndpointParametersWhenNoPathParamClash` — only query params in operation, verifies all endpoint params are preserved
- [x] All 137 existing tests pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>