### PR TITLE
CAMEL-24114: camel-rest-openapi - Request validator also checks exchange variables and endpoint literal parameters

### DIFF
--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpoint.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/RestOpenApiEndpoint.java
@@ -864,6 +864,7 @@ public final class RestOpenApiEndpoint extends DefaultEndpoint {
             OpenAPI openAPI, Operation operation, String method, String uriTemplate) {
         DefaultRequestValidator answer = new DefaultRequestValidator();
         answer.setOperation(new RestOpenApiOperation(operation, method, uriTemplate));
+        answer.setEndpointParameters(parameters);
         return answer;
     }
 

--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/validator/DefaultRequestValidator.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/validator/DefaultRequestValidator.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.rest.openapi.validator;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,10 +35,15 @@ import static org.apache.camel.support.http.RestUtil.isValidOrAcceptedContentTyp
 public class DefaultRequestValidator implements RequestValidator {
 
     private RestOpenApiOperation operation;
+    private Map<String, Object> endpointParameters = Collections.emptyMap();
 
     @Override
     public void setOperation(RestOpenApiOperation operation) {
         this.operation = operation;
+    }
+
+    public void setEndpointParameters(Map<String, Object> endpointParameters) {
+        this.endpointParameters = endpointParameters != null ? endpointParameters : Collections.emptyMap();
     }
 
     @Override
@@ -100,9 +106,16 @@ public class DefaultRequestValidator implements RequestValidator {
                 .stream()
                 .filter(parameter -> Objects.nonNull(parameter.getRequired()) && parameter.getRequired())
                 .forEach(parameter -> {
-                    Object header = message.getHeader(parameter.getName());
-                    if (ObjectHelper.isEmpty(header)) {
-                        validationErrors.add("Query parameter '" + parameter.getName() + "' is required but none found.");
+                    String name = parameter.getName();
+                    Object value = message.getHeader(name);
+                    if (ObjectHelper.isEmpty(value)) {
+                        value = exchange.getVariable(name);
+                    }
+                    if (ObjectHelper.isEmpty(value)) {
+                        value = endpointParameters.get(name);
+                    }
+                    if (ObjectHelper.isEmpty(value)) {
+                        validationErrors.add("Query parameter '" + name + "' is required but none found.");
                     }
                 });
 

--- a/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiRequestValidationTest.java
+++ b/components/camel-rest-openapi/src/test/java/org/apache/camel/component/rest/openapi/RestOpenApiRequestValidationTest.java
@@ -308,6 +308,37 @@ public class RestOpenApiRequestValidationTest extends CamelTestSupport {
     }
 
     @ParameterizedTest
+    @MethodSource("petStoreVersions")
+    @SuppressWarnings("unchecked")
+    void requestValidationWithRequiredQueryParameterFromEndpointUri(String petStoreVersion) {
+        Map<String, Object> headers = Map.of("petStoreVersion", petStoreVersion);
+        List<Pet> pets
+                = template.requestBodyAndHeaders("direct:validateQueryParamsFromEndpoint", null, headers, List.class);
+        assertFalse(pets.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("petStoreVersions")
+    @SuppressWarnings("unchecked")
+    void requestValidationWithRequiredQueryParameterFromVariable(String petStoreVersion) {
+        Exchange exchange = template.request("direct:validateQueryParamsFromVariable", new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                exchange.getMessage().setHeader("petStoreVersion", petStoreVersion);
+                exchange.setVariable("status", "available");
+            }
+        });
+
+        Exception exception = exchange.getException();
+        if (exception != null) {
+            throw new AssertionError("Unexpected validation failure", exception);
+        }
+        List<Pet> pets = exchange.getMessage().getBody(List.class);
+        assertNotNull(pets);
+        assertFalse(pets.isEmpty());
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = { "petStoreV3" })
     void requestValidationWithBinaryBody(String petStoreVersion) throws IOException {
         Map<String, Object> headers = Map.of(
@@ -457,6 +488,14 @@ public class RestOpenApiRequestValidationTest extends CamelTestSupport {
                         .toD("${header.petStoreVersion}:#addPet?requestValidationEnabled=true");
 
                 from("direct:validateOperationForQueryParams")
+                        .toD("${header.petStoreVersion}:findPetsByStatus?requestValidationEnabled=true")
+                        .unmarshal(jacksonDataFormat);
+
+                from("direct:validateQueryParamsFromEndpoint")
+                        .toD("${header.petStoreVersion}:findPetsByStatus?requestValidationEnabled=true&status=available")
+                        .unmarshal(jacksonDataFormat);
+
+                from("direct:validateQueryParamsFromVariable")
                         .toD("${header.petStoreVersion}:findPetsByStatus?requestValidationEnabled=true")
                         .unmarshal(jacksonDataFormat);
 


### PR DESCRIPTION
## Summary

`DefaultRequestValidator` rejected requests whose required query parameters were supplied via endpoint URI literals or exchange variables, because it only checked `message.getHeader()`.

The fix extends the query parameter validation in `DefaultRequestValidator.validate()` to mirror the resolution order used by `RestProducer.createQueryParameters()`:
1. Message header
2. Exchange variable
3. Literal endpoint parameter (from the endpoint URI)

Changes:
- `DefaultRequestValidator` — added `endpointParameters` field and extended the required query parameter check to also consult exchange variables and endpoint literal parameters
- `RestOpenApiEndpoint.configureRequestValidator()` — passes the endpoint's remaining parameters to the validator
- `RestOpenApiRequestValidationTest` — added two new parameterized tests covering literal endpoint URI query params and exchange variables with validation enabled

Fixes: [CAMEL-24114](https://issues.apache.org/jira/browse/CAMEL-24114)

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>