### PR TITLE
[backport camel-4.18.x] CAMEL-24187: CamelContext.getEndpoint() never caches a uri containing a % character

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/AbstractCamelContext.java
@@ -860,8 +860,8 @@ public abstract class AbstractCamelContext extends BaseService
                 if (answer != null) {
                     if (!prototype) {
                         addService(answer);
-                        // register in registry
-                        answer = addEndpointToRegistry(uri, answer);
+                        // register in registry (uri is already normalized above, so avoid normalizing it again)
+                        answer = addEndpointToRegistry(uri, answer, true);
                     } else {
                         addPrototypeService(answer);
                         // if there is endpoint strategies, then use the endpoints they return
@@ -912,6 +912,21 @@ public abstract class AbstractCamelContext extends BaseService
      * @return          the added endpoint
      */
     protected Endpoint addEndpointToRegistry(String uri, Endpoint endpoint) {
+        return addEndpointToRegistry(uri, endpoint, false);
+    }
+
+    /**
+     * Strategy to add the given endpoint to the internal endpoint registry
+     *
+     * @param  uri        uri of the endpoint
+     * @param  endpoint   the endpoint to add
+     * @param  normalized whether the uri is already normalized (for example because it was normalized earlier to do the
+     *                    cache lookup that preceded this call). Re-normalizing an already normalized uri is not
+     *                    idempotent for uris containing a literal {@code %} character, so callers must not normalize
+     *                    twice or the stored key will never match a later lookup key (CAMEL-24171).
+     * @return            the added endpoint
+     */
+    protected Endpoint addEndpointToRegistry(String uri, Endpoint endpoint, boolean normalized) {
         StringHelper.notEmpty(uri, "uri");
         ObjectHelper.notNull(endpoint, "endpoint");
 
@@ -920,7 +935,7 @@ public abstract class AbstractCamelContext extends BaseService
         for (EndpointStrategy strategy : getEndpointStrategies()) {
             endpoint = strategy.registerEndpoint(uri, endpoint);
         }
-        endpoints.put(getEndpointKey(uri, endpoint), endpoint);
+        endpoints.put(getEndpointKey(uri, endpoint, normalized), endpoint);
         return endpoint;
     }
 
@@ -942,11 +957,24 @@ public abstract class AbstractCamelContext extends BaseService
      * @return          the key
      */
     protected NormalizedUri getEndpointKey(String uri, Endpoint endpoint) {
+        return getEndpointKey(uri, endpoint, false);
+    }
+
+    /**
+     * Gets the endpoint key to use for lookup or whe adding endpoints to the {@link DefaultEndpointRegistry}
+     *
+     * @param  uri        the endpoint uri
+     * @param  endpoint   the endpoint
+     * @param  normalized whether the uri is already normalized; see
+     *                    {@link #addEndpointToRegistry(String, Endpoint, boolean)}
+     * @return            the key
+     */
+    protected NormalizedUri getEndpointKey(String uri, Endpoint endpoint, boolean normalized) {
         if (endpoint != null && !endpoint.isSingleton()) {
             int counter = endpointKeyCounter.incrementAndGet();
-            return NormalizedUri.newNormalizedUri(uri + ":" + counter, false);
+            return NormalizedUri.newNormalizedUri(uri + ":" + counter, normalized);
         } else {
-            return NormalizedUri.newNormalizedUri(uri, false);
+            return NormalizedUri.newNormalizedUri(uri, normalized);
         }
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/impl/DefaultEndpointRegistryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/DefaultEndpointRegistryTest.java
@@ -102,6 +102,32 @@ public class DefaultEndpointRegistryTest {
         ctx.stop();
     }
 
+    // Testing the issue https://issues.apache.org/jira/browse/CAMEL-24171
+    @Test
+    public void testGetEndpointIsCachedForUriContainingPercentCharacter() {
+        DefaultCamelContext ctx = new DefaultCamelContext();
+        ctx.start();
+
+        // A % anywhere in the query string makes EndpointHelper.normalizeEndpointUri() non-idempotent:
+        // running it twice turns %41 into %2541 instead of leaving it alone. doGetEndpoint() normalizes
+        // the uri once for the cache lookup (NormalizedUri.newNormalizedUri(uri, true) - "already normalized").
+        // But on a cache miss it hands that *already normalized* uri to addEndpointToRegistry(), which calls
+        // getEndpointKey(uri, endpoint) -> NormalizedUri.newNormalizedUri(uri, false) - "not normalized yet,
+        // please normalize" - normalizing it a second time before storing it. The stored key (double
+        // normalized) then never matches the lookup key computed on a later call (single normalized), so a
+        // brand-new Endpoint (with its own doStart()) gets created on every single call instead of the
+        // cached singleton being reused.
+        String uri = "controlbus:route?routeId=RAW(%41)&action=status";
+
+        Endpoint first = ctx.getEndpoint(uri);
+        Endpoint second = ctx.getEndpoint(uri);
+
+        Assertions.assertSame(first, second,
+                "getEndpoint(uri) must return the cached singleton instance on a second call with the identical uri");
+        Assertions.assertEquals(1, ctx.getEndpoints().size(),
+                "the endpoint registry must not accumulate a new entry on every call for the same uri");
+    }
+
     @Test
     public void testMigration() {
         DefaultCamelContext ctx = new DefaultCamelContext();


### PR DESCRIPTION
## Summary

Backport of #24805 to `camel-4.18.x` (excludes the camel-plc4x test).

- `AbstractCamelContext.doGetEndpoint()` normalizes the URI once for cache lookup, but on a cache miss passes the already-normalized URI to `addEndpointToRegistry()`, which normalizes it a **second** time. Since `EndpointHelper.normalizeEndpointUri()` is not idempotent for URIs containing `%` (each pass encodes `%41` → `%2541`), the stored registry key never matches a later lookup key — causing `getEndpoint()` to create a brand-new `Endpoint` on every call instead of reusing the cached singleton.
- Adds a `normalized`-aware overload of `getEndpointKey()`/`addEndpointToRegistry()` so the `doGetEndpoint()` call site skips redundant re-normalization. Public APIs (`hasEndpoint`, `addEndpoint`, `removeEndpoints`) are unchanged.
- Affects any component whose endpoint URI contains a literal `%` and is re-resolved by string (`pollEnrich`/`toD`/`recipientList`).

## Test plan

- [x] New test `DefaultEndpointRegistryTest#testGetEndpointIsCachedForUriContainingPercentCharacter` verifies the fix using `controlbus:route?routeId=RAW(%41)&action=status`.

_Claude Opus 4.6 on behalf of Croway_