### PR TITLE
CAMEL-24162: Fix moduleClassNames typo in JacksonXMLDataFormatReifier

### DIFF
--- a/components/camel-jacksonxml/src/test/java/org/apache/camel/component/jacksonxml/JacksonXMLModuleClassNamesReifierTest.java
+++ b/components/camel-jacksonxml/src/test/java/org/apache/camel/component/jacksonxml/JacksonXMLModuleClassNamesReifierTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jacksonxml;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.dataformat.JacksonXMLDataFormat;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+public class JacksonXMLModuleClassNamesReifierTest extends CamelTestSupport {
+
+    @Test
+    public void testModuleClassNamesViaModel() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:marshal");
+        mock.expectedMessageCount(1);
+        mock.message(0).body(String.class)
+                .isEqualTo("<TestOtherPojo><my-name>Camel</my-name><my-country>Denmark</my-country></TestOtherPojo>");
+
+        TestOtherPojo pojo = new TestOtherPojo();
+        pojo.setName("Camel");
+        pojo.setCountry("Denmark");
+
+        template.sendBody("direct:marshal", pojo);
+
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() {
+                JacksonXMLDataFormat format = new JacksonXMLDataFormat();
+                format.setModuleClassNames("org.apache.camel.component.jacksonxml.MyModule");
+                format.setInclude("NON_NULL");
+
+                from("direct:marshal").marshal(format).to("mock:marshal");
+            }
+        };
+    }
+
+}

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JacksonXMLDataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JacksonXMLDataFormatReifier.java
@@ -39,7 +39,7 @@ public class JacksonXMLDataFormatReifier extends DataFormatReifier<JacksonXMLDat
         properties.put("collectionType", or(definition.getCollectionType(), definition.getCollectionTypeName()));
         properties.put("useList", definition.getUseList());
         properties.put("enableJaxbAnnotationModule", definition.getEnableJaxbAnnotationModule());
-        properties.put("modulesClassNames", definition.getModuleClassNames());
+        properties.put("moduleClassNames", definition.getModuleClassNames());
         properties.put("moduleRefs", definition.getModuleRefs());
         properties.put("enableFeatures", definition.getEnableFeatures());
         properties.put("disableFeatures", definition.getDisableFeatures());


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Croway_

- Fix typo in `JacksonXMLDataFormatReifier.prepareDataFormatConfig()`: the property key `"modulesClassNames"` (extra `s`) is corrected to `"moduleClassNames"`, matching the actual field name in `JacksonXMLDataFormat` and its generated configurer.
- Add regression test (`JacksonXMLModuleClassNamesReifierTest`) that exercises the reifier path by configuring `moduleClassNames` through the model class, confirming the route starts and the custom module is applied.

The equivalent bug in camel-jackson (JSON) was fixed in 2016 (commit `eb2f171ff39f`), but the XML reifier was overlooked. The same reifier also serves camel-jackson3xml, which is equally fixed.

## Test plan

- [x] New test `JacksonXMLModuleClassNamesReifierTest` confirmed RED before fix, GREEN after
- [x] Full `mvn verify` on `components/camel-jacksonxml` passes (42 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)