### PR TITLE
CAMEL-24165: camel-soap - Fix ignoreUnmarshalledHeaders builder recursion and reifier omission

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/SoapDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/SoapDataFormat.java
@@ -295,7 +295,7 @@ public class SoapDataFormat extends DataFormatDefinition {
          * problematic header.
          */
         public Builder ignoreUnmarshalledHeaders(boolean ignoreUnmarshalledHeaders) {
-            return ignoreUnmarshalledHeaders(Boolean.valueOf(ignoreUnmarshalledHeaders));
+            return ignoreUnmarshalledHeaders(Boolean.toString(ignoreUnmarshalledHeaders));
         }
 
         /**

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/SoapDataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/SoapDataFormatReifier.java
@@ -37,6 +37,7 @@ public class SoapDataFormatReifier extends DataFormatReifier<SoapDataFormat> {
         properties.put("namespacePrefix", asRef(definition.getNamespacePrefix()));
         properties.put("schema", definition.getSchema());
         properties.put("contextPath", definition.getContextPath());
+        properties.put("ignoreUnmarshalledHeaders", definition.getIgnoreUnmarshalledHeaders());
     }
 
 }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Croway_

Fixes [CAMEL-24165](https://issues.apache.org/jira/browse/CAMEL-24165) — the `ignoreUnmarshalledHeaders` option on `SoapDataFormat` is completely unusable due to two bugs introduced with CAMEL-22354:

- **Problem A — StackOverflowError**: The builder's `boolean` overload at `SoapDataFormat.Builder.ignoreUnmarshalledHeaders(boolean)` calls `Boolean.valueOf(boolean)` which returns a `Boolean` that auto-unboxes back to `boolean`, hitting the same overload recursively. Fixed by using `Boolean.toString(boolean)` to route to the `String` overload, matching the pattern used by every other builder in the package.

- **Problem B — Reifier silently drops the option**: `SoapDataFormatReifier.prepareDataFormatConfig()` never maps `ignoreUnmarshalledHeaders` into the properties map, so the setting never reaches the runtime data format regardless of DSL. Fixed by adding the missing `properties.put(...)` call, following the same pattern as `JaxbDataFormatReifier` and `JsonDataFormatReifier`.

## Test plan

- [x] `mvn verify` on `components/camel-soap` passes — existing tests `SoapToSoapIgnoreTest` and `SoapToSoapDontIgnoreTest` exercise the runtime behavior of `ignoreUnmarshalledHeaders`
- [x] `mvn install` on `core/camel-core-model` and `core/camel-core-reifier` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)