### PR TITLE
CAMEL-24167: camel-csv - Fix format option silently ignored

### DIFF
--- a/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvDataFormat.java
+++ b/components/camel-csv/src/main/java/org/apache/camel/dataformat/csv/CsvDataFormat.java
@@ -105,8 +105,8 @@ public class CsvDataFormat extends ServiceSupport implements DataFormat, DataFor
     protected void doInit() throws Exception {
         super.doInit();
 
-        if (csvFormat == null && format != null) {
-            csvFormat = CSVFormat.valueOf(format);
+        if (format != null) {
+            csvFormat = resolveFormat(format);
         }
         if (csvFormat == null) {
             csvFormat = CSVFormat.DEFAULT;
@@ -119,6 +119,19 @@ public class CsvDataFormat extends ServiceSupport implements DataFormat, DataFor
     @Override
     protected void doStop() throws Exception {
         // noop
+    }
+
+    private static CSVFormat resolveFormat(String name) {
+        // The model advertises uppercase names (EXCEL, INFORMIX_UNLOAD) but
+        // commons-csv Predefined uses CamelCase (Excel, InformixUnload).
+        // Match by stripping underscores and comparing case-insensitively.
+        String normalized = name.replace("_", "");
+        for (CSVFormat.Predefined p : CSVFormat.Predefined.values()) {
+            if (p.name().equalsIgnoreCase(normalized)) {
+                return p.getFormat();
+            }
+        }
+        throw new IllegalArgumentException("Unknown CSV format: " + name);
     }
 
     CSVFormat getActiveFormat() {

--- a/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatTest.java
+++ b/components/camel-csv/src/test/java/org/apache/camel/dataformat/csv/CsvDataFormatTest.java
@@ -81,6 +81,26 @@ public class CsvDataFormatTest {
     }
 
     @Test
+    void shouldResolveFormatByName() throws IOException {
+        try (CsvDataFormat dataFormat = new CsvDataFormat()) {
+            dataFormat.setFormat("MYSQL");
+            dataFormat.start();
+            assertEquals(CSVFormat.MYSQL, dataFormat.getCsvFormat());
+            assertEquals("\t", dataFormat.getActiveFormat().getDelimiterString());
+        }
+    }
+
+    @Test
+    void shouldResolveFormatByNameCaseInsensitive() throws IOException {
+        try (CsvDataFormat dataFormat = new CsvDataFormat()) {
+            dataFormat.setFormat("EXCEL");
+            dataFormat.start();
+            assertEquals(CSVFormat.EXCEL, dataFormat.getCsvFormat());
+            assertEquals(CSVFormat.EXCEL, dataFormat.getActiveFormat());
+        }
+    }
+
+    @Test
     void shouldDisableCommentMarker() throws IOException {
         try (CsvDataFormat defDataFormat = new CsvDataFormat(); CsvDataFormat dataFormat = defDataFormat
                 .setCommentMarkerDisabled(true)


### PR DESCRIPTION
## Summary

_Claude Code on behalf of Croway_

Fixes two stacked bugs in `CsvDataFormat` that cause the `format` option (e.g., `<csv format="MYSQL"/>`) to be silently ignored:

- **Dead guard:** The `csvFormat` field is eagerly initialized to `CSVFormat.DEFAULT`, making the `doInit()` condition `if (csvFormat == null && format != null)` unreachable. Removed the `csvFormat == null` guard so the `format` string is resolved when set via DSL/XML/YAML.
- **Name mismatch:** `CSVFormat.valueOf(format)` delegates to `CSVFormat.Predefined.valueOf()` which uses CamelCase names (`Excel`, `InformixUnload`) while Camel's model advertises uppercase names (`EXCEL`, `INFORMIX_UNLOAD`). Replaced with a case-insensitive, underscore-stripped lookup.

**Regression history:** Introduced in CAMEL-22354 (getter/setter alignment), partially addressed in CAMEL-23031 (init ordering) but the dead guard and name mismatch remained.

**Failure scenario:** `setFormat("MYSQL")` (which should produce TAB-delimited output) silently produces comma-delimited DEFAULT output instead.

## Test plan

- [x] Added `shouldResolveFormatByName` — verifies `setFormat("MYSQL")` produces TAB delimiter
- [x] Added `shouldResolveFormatByNameCaseInsensitive` — verifies `setFormat("EXCEL")` resolves despite CamelCase enum mismatch
- [x] Existing Spring XML tests (`CsvMarshalAutogenColumnsSpringTest`, `CsvMarshalAutogenColumnsSpringQuoteModeTest`) that use `format="EXCEL"` now exercise the fix path and pass
- [x] Full `mvn verify` on `camel-csv` module passes (92 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)