### PR TITLE
CAMEL-24189: camel-smb - Fix SmbStreamDownloadIT reading stream after close

### DIFF
--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbStreamDownloadIT.java
@@ -22,10 +22,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.IOHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class SmbStreamDownloadIT extends SmbServerTestSupport {
 
@@ -43,19 +43,13 @@ public class SmbStreamDownloadIT extends SmbServerTestSupport {
     @Test
     public void testStreamDownload() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:received_send");
-        mock.message(0).body().isInstanceOf(SmbFile.class);
-        mock.message(0).predicate(e -> {
-            Object b = e.getMessage().getBody(SmbFile.class).getBody();
-            return b instanceof InputStream;
-        });
         mock.expectedMessageCount(1);
 
         mock.assertIsSatisfied();
 
-        InputStream is = mock.getExchanges().get(0).getIn().getBody(InputStream.class);
-        assertNotNull(is);
-        String text = IOHelper.loadText(is);
-        Assertions.assertEquals("World\n", text);
+        Exchange exchange = mock.getExchanges().get(0);
+        String text = exchange.getIn().getHeader("StreamContent", String.class);
+        assertEquals("World\n", text);
     }
 
     private void prepareSmbServer() {
@@ -67,6 +61,14 @@ public class SmbStreamDownloadIT extends SmbServerTestSupport {
         return new RouteBuilder() {
             public void configure() {
                 from(getSmbUrl()).streamCache("false")
+                        .process(e -> {
+                            Object body = e.getMessage().getBody(SmbFile.class);
+                            assertInstanceOf(SmbFile.class, body);
+                            Object inner = ((SmbFile) body).getBody();
+                            assertInstanceOf(InputStream.class, inner);
+                            String text = IOHelper.loadText((InputStream) inner);
+                            e.getMessage().setHeader("StreamContent", text);
+                        })
                         .to("mock:received_send");
             }
         };


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

The `SmbStreamDownloadIT.testStreamDownload` test was reading the `InputStream` body *after* `mock.assertIsSatisfied()`, but by that point `GenericFileOnCompletion` has already fired `processStrategy.commit()` which calls `releaseRetrievedFileResources()` — closing the `SmbFileClosingInputStream` and its underlying SMB file handle. Reading a closed stream returns empty content.

Fix: move the stream reading and assertions into a `process()` step inside the route where the stream is still open. The content is stashed in a header and verified after `assertIsSatisfied()`.

## Test plan

- [x] `SmbStreamDownloadIT` passes (was failing consistently with `expected: <World\n> but was: <>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)