### PR TITLE
Fix flaky Quartz tests: widen timing windows and fix latch timeout

### DIFF
--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzAddDynamicRouteTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzAddDynamicRouteTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.quartz;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
@@ -39,12 +41,15 @@ public class QuartzAddDynamicRouteTest extends BaseQuartzTest {
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
-                from("quartz://myGroup/myTimerName?trigger.repeatInterval=2&trigger.repeatCount=1").routeId("myRoute")
+                // use a reasonable interval (200ms) so that the Quartz
+                // scheduler can reliably fire both triggers on loaded CI
+                // machines (2ms was far too tight for reliable scheduling)
+                from("quartz://myGroup/myTimerName?trigger.repeatInterval=200&trigger.repeatCount=1").routeId("myRoute")
                         .to("direct:foo");
             }
         });
 
-        resultEndpoint.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override

--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzAddRoutesAfterCamelContextStartedTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzAddRoutesAfterCamelContextStartedTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.quartz;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
@@ -36,12 +38,15 @@ public class QuartzAddRoutesAfterCamelContextStartedTest extends BaseQuartzTest 
         context.addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
-                from("quartz://myGroup/myTimerName?trigger.repeatInterval=100&trigger.repeatCount=1").to("mock:result");
+                // use a generous interval (500ms) so that the Quartz scheduler
+                // can reliably fire both the initial and repeat triggers even
+                // on heavily-loaded CI machines (100ms was too tight)
+                from("quartz://myGroup/myTimerName?trigger.repeatInterval=500&trigger.repeatCount=1").to("mock:result");
             }
         });
 
-        // it should also work
-        MockEndpoint.assertIsSatisfied(context);
+        // it should also work — use timed assertion for CI resilience
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
 }

--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzCronRouteWithStartDateEndDateTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzCronRouteWithStartDateEndDateTest.java
@@ -38,10 +38,11 @@ public class QuartzCronRouteWithStartDateEndDateTest extends BaseQuartzTest {
     public void testQuartzCronRouteWithStartDateEndDateTest() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMinimumMessageCount(2);
-        mock.await(5, TimeUnit.SECONDS);
 
-        MockEndpoint.assertIsSatisfied(context);
-        assertThat(mock.getReceivedExchanges().size() <= 3, CoreMatchers.is(true));
+        // use timed assertion — the trigger starts 5s in the future and
+        // fires for 4 seconds, so messages arrive between ~5s and ~9s
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        assertThat(mock.getReceivedExchanges().size() <= 5, CoreMatchers.is(true));
     }
 
     @Override
@@ -51,13 +52,14 @@ public class QuartzCronRouteWithStartDateEndDateTest extends BaseQuartzTest {
                 SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
                 Calendar calendar = Calendar.getInstance();
                 calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-                calendar.add(Calendar.SECOND, 3);
+                calendar.add(Calendar.SECOND, 5);
                 Date startDate = calendar.getTime();
-                calendar.add(Calendar.SECOND, 2);
+                calendar.add(Calendar.SECOND, 4);
                 Date endDate = calendar.getTime();
 
-                // triggers every 1th second at precise 00,01,02,03..59 with startAt and endAt exactly 2 second apart.
-                // configuration will create a maximum of three messages
+                // triggers every 1th second at precise 00,01,02,03..59 with startAt and endAt 4 seconds apart.
+                // give plenty of headroom (5s) for route setup before the trigger window opens,
+                // so that Quartz scheduler initialization doesn't eat into the firing window on loaded CI
                 fromF("quartz://myGroup/myTimerName?cron=0/1 * * * * ?&trigger.startAt=%s&trigger.endAt=%s",
                         dateFormat.format(startDate), dateFormat.format(endDate)).to("mock:result");
             }

--- a/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/CronScheduledRoutePolicyTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/routepolicy/quartz/CronScheduledRoutePolicyTest.java
@@ -227,13 +227,15 @@ public class CronScheduledRoutePolicyTest {
             });
             context.start();
 
-            startedLatch.await(5000, TimeUnit.SECONDS);
+            // wait for the */3 cron to start the route (was 5000 SECONDS — a typo)
+            assertTrue(startedLatch.await(30, TimeUnit.SECONDS), "Route should have been started by cron");
 
             ServiceStatus startedStatus = context.getRouteController().getRouteStatus("test");
             assertTrue(startedStatus == ServiceStatus.Started || startedStatus == ServiceStatus.Starting);
             template.sendBody("direct:start", "Ready or not, Here, I come");
 
-            stoppedLatch.await(5000, TimeUnit.SECONDS);
+            // wait for the */6 cron to stop the route
+            assertTrue(stoppedLatch.await(30, TimeUnit.SECONDS), "Route should have been stopped by cron");
 
             ServiceStatus stoppedStatus = context.getRouteController().getRouteStatus("test");
             assertTrue(stoppedStatus == ServiceStatus.Stopped || stoppedStatus == ServiceStatus.Stopping);


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix 4 flaky tests in `camel-quartz` identified by [Develocity analytics](https://develocity.apache.org):

| Test | Flaky rate | Root cause | Fix |
|---|---|---|---|
| `QuartzAddRoutesAfterCamelContextStartedTest` | 3.2% (48/1483) | `repeatInterval=100ms` too tight for loaded CI | Increased to 500ms, added timed assertion |
| `QuartzCronRouteWithStartDateEndDateTest` | 2.5% (37/1483) | Narrow 2s trigger window with only 3s setup headroom | Widened to 4s window with 5s headroom, proper timed assertion |
| `QuartzAddDynamicRouteTest` | 1.7% (25/1483) | `repeatInterval=2ms` — absurdly tight for any scheduler | Increased to 200ms, added timed assertion |
| `CronScheduledRoutePolicyTest$CronTest5` | 0.3% (5/1483) | `await(5000, TimeUnit.SECONDS)` — 83 minutes! (typo) | Fixed to `await(30, TimeUnit.SECONDS)`, assert result |

### Details

**QuartzAddRoutesAfterCamelContextStartedTest**: The Quartz scheduler thread pool can be starved on loaded CI machines. A 100ms repeat interval with `repeatCount=1` means two firings must happen within ~200ms — too tight. Increased to 500ms.

**QuartzCronRouteWithStartDateEndDateTest**: The cron trigger starts 3 seconds in the future and fires for only 2 seconds. On loaded CI, Quartz scheduler initialization can take >1 second, eating into the headroom. Increased start offset to 5s and window to 4s. Also replaced the redundant `mock.await()` + `assertIsSatisfied()` chain with a single timed `assertIsSatisfied`.

**QuartzAddDynamicRouteTest**: A 2ms repeat interval is far below Quartz's scheduling granularity. Both firings can happen before the mock is ready, or the scheduler may miss them entirely. Increased to 200ms.

**CronScheduledRoutePolicyTest$CronTest5**: `startedLatch.await(5000, TimeUnit.SECONDS)` is clearly a typo — 5000 seconds = 83 minutes. Fixed to 30 seconds with proper assertion of the latch result for fail-fast behavior.

## Test plan

- [x] All 4 fixed tests pass locally (5 consecutive runs)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)