### PR TITLE
CAMEL-24140: Fix UseOriginalAggregationStrategy not honored when shareUnitOfWork enabled

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -332,6 +332,9 @@ public class MulticastProcessor extends BaseProcessorSupport
                 clone = new ShareUnitOfWorkAggregationStrategy(clone);
             }
             setAggregationStrategyOnExchange(exchange, clone);
+        } else if (isShareUnitOfWork() && strategy != null
+                && !(strategy instanceof ShareUnitOfWorkAggregationStrategy)) {
+            setAggregationStrategyOnExchange(exchange, new ShareUnitOfWorkAggregationStrategy(strategy));
         }
 
         if (synchronous) {

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -333,6 +333,7 @@ public class MulticastProcessor extends BaseProcessorSupport
             }
             setAggregationStrategyOnExchange(exchange, clone);
         } else if (isShareUnitOfWork() && strategy != null
+                // wrap here (not in the reifier) so the UseOriginal instanceof check above sees the unwrapped strategy
                 && !(strategy instanceof ShareUnitOfWorkAggregationStrategy)) {
             setAggregationStrategyOnExchange(exchange, new ShareUnitOfWorkAggregationStrategy(strategy));
         }

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/MulticastProcessor.java
@@ -333,7 +333,7 @@ public class MulticastProcessor extends BaseProcessorSupport
             }
             setAggregationStrategyOnExchange(exchange, clone);
         } else if (isShareUnitOfWork() && strategy != null
-                // wrap here (not in the reifier) so the UseOriginal instanceof check above sees the unwrapped strategy
+        // wrap here (not in the reifier) so the UseOriginal instanceof check above sees the unwrapped strategy
                 && !(strategy instanceof ShareUnitOfWorkAggregationStrategy)) {
             setAggregationStrategyOnExchange(exchange, new ShareUnitOfWorkAggregationStrategy(strategy));
         }

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/MulticastReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/MulticastReifier.java
@@ -31,7 +31,6 @@ import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.processor.MulticastProcessor;
 import org.apache.camel.processor.aggregate.AggregationStrategyBeanAdapter;
 import org.apache.camel.processor.aggregate.AggregationStrategyBiFunctionAdapter;
-import org.apache.camel.processor.aggregate.ShareUnitOfWorkAggregationStrategy;
 import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
 
 public class MulticastReifier extends ProcessorReifier<MulticastDefinition> {
@@ -127,11 +126,6 @@ public class MulticastReifier extends ProcessorReifier<MulticastDefinition> {
             strategy = new UseLatestAggregationStrategy();
         }
         CamelContextAware.trySetCamelContext(strategy, camelContext);
-
-        if (parseBoolean(definition.getShareUnitOfWork(), false)) {
-            // wrap strategy in share unit of work
-            strategy = new ShareUnitOfWorkAggregationStrategy(strategy);
-        }
 
         return strategy;
     }

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/RecipientListReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/RecipientListReifier.java
@@ -32,7 +32,6 @@ import org.apache.camel.processor.EvaluateExpressionProcessor;
 import org.apache.camel.processor.RecipientList;
 import org.apache.camel.processor.aggregate.AggregationStrategyBeanAdapter;
 import org.apache.camel.processor.aggregate.AggregationStrategyBiFunctionAdapter;
-import org.apache.camel.processor.aggregate.ShareUnitOfWorkAggregationStrategy;
 import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
 
 public class RecipientListReifier extends ProcessorReifier<RecipientListDefinition<?>> {
@@ -153,11 +152,6 @@ public class RecipientListReifier extends ProcessorReifier<RecipientListDefiniti
             strategy = new UseLatestAggregationStrategy();
         }
         CamelContextAware.trySetCamelContext(strategy, camelContext);
-
-        if (parseBoolean(definition.getShareUnitOfWork(), false)) {
-            // wrap strategy in share unit of work
-            strategy = new ShareUnitOfWorkAggregationStrategy(strategy);
-        }
 
         return strategy;
     }

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/SplitReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/SplitReifier.java
@@ -29,7 +29,6 @@ import org.apache.camel.model.SplitDefinition;
 import org.apache.camel.processor.Splitter;
 import org.apache.camel.processor.aggregate.AggregationStrategyBeanAdapter;
 import org.apache.camel.processor.aggregate.AggregationStrategyBiFunctionAdapter;
-import org.apache.camel.processor.aggregate.ShareUnitOfWorkAggregationStrategy;
 import org.apache.camel.resume.ResumeStrategy;
 
 public class SplitReifier extends ExpressionReifier<SplitDefinition> {
@@ -182,10 +181,6 @@ public class SplitReifier extends ExpressionReifier<SplitDefinition> {
         }
 
         CamelContextAware.trySetCamelContext(strategy, camelContext);
-        if (strategy != null && parseBoolean(definition.getShareUnitOfWork(), false)) {
-            // wrap strategy in share unit of work
-            strategy = new ShareUnitOfWorkAggregationStrategy(strategy);
-        }
 
         return strategy;
     }

--- a/core/camel-core/src/test/java/org/apache/camel/processor/MulticastUseOriginalShareUnitOfWorkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/MulticastUseOriginalShareUnitOfWorkTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.processor.aggregate.UseOriginalAggregationStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MulticastUseOriginalShareUnitOfWorkTest extends ContextTestSupport {
+
+    @Test
+    public void testWithoutShareUnitOfWork() throws Exception {
+        getMockEndpoint("mock:a").expectedMessageCount(1);
+        getMockEndpoint("mock:b").expectedMessageCount(1);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:noShare", "original");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange out = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        assertEquals("original", out.getIn().getBody(String.class));
+    }
+
+    @Test
+    public void testWithShareUnitOfWork() throws Exception {
+        getMockEndpoint("mock:a").expectedMessageCount(1);
+        getMockEndpoint("mock:b").expectedMessageCount(1);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:share", "original");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange out = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        assertEquals("original", out.getIn().getBody(String.class));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:noShare")
+                        .multicast(new UseOriginalAggregationStrategy())
+                            .to("direct:a")
+                            .to("direct:b")
+                        .end()
+                        .to("mock:result");
+
+                from("direct:share")
+                        .multicast(new UseOriginalAggregationStrategy()).shareUnitOfWork()
+                            .to("direct:a")
+                            .to("direct:b")
+                        .end()
+                        .to("mock:result");
+
+                from("direct:a")
+                        .setBody(constant("A"))
+                        .to("mock:a");
+
+                from("direct:b")
+                        .setBody(constant("B"))
+                        .to("mock:b");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/processor/RecipientListUseOriginalShareUnitOfWorkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RecipientListUseOriginalShareUnitOfWorkTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.processor.aggregate.UseOriginalAggregationStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecipientListUseOriginalShareUnitOfWorkTest extends ContextTestSupport {
+
+    @Test
+    public void testWithoutShareUnitOfWork() throws Exception {
+        getMockEndpoint("mock:a").expectedMessageCount(1);
+        getMockEndpoint("mock:b").expectedMessageCount(1);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:noShare", "original");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange out = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        assertEquals("original", out.getIn().getBody(String.class));
+    }
+
+    @Test
+    public void testWithShareUnitOfWork() throws Exception {
+        getMockEndpoint("mock:a").expectedMessageCount(1);
+        getMockEndpoint("mock:b").expectedMessageCount(1);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:share", "original");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange out = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        assertEquals("original", out.getIn().getBody(String.class));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:noShare")
+                        .recipientList(constant("direct:a,direct:b"))
+                            .aggregationStrategy(new UseOriginalAggregationStrategy())
+                        .end()
+                        .to("mock:result");
+
+                from("direct:share")
+                        .recipientList(constant("direct:a,direct:b"))
+                            .aggregationStrategy(new UseOriginalAggregationStrategy())
+                            .shareUnitOfWork()
+                        .end()
+                        .to("mock:result");
+
+                from("direct:a")
+                        .setBody(constant("A"))
+                        .to("mock:a");
+
+                from("direct:b")
+                        .setBody(constant("B"))
+                        .to("mock:b");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitUseOriginalShareUnitOfWorkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitUseOriginalShareUnitOfWorkTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.processor.aggregate.UseOriginalAggregationStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SplitUseOriginalShareUnitOfWorkTest extends ContextTestSupport {
+
+    @Test
+    public void testWithoutShareUnitOfWork() throws Exception {
+        getMockEndpoint("mock:split").expectedMessageCount(2);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:noShare", "A,B");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange out = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        assertEquals("A,B", out.getIn().getBody(String.class));
+    }
+
+    @Test
+    public void testWithShareUnitOfWork() throws Exception {
+        getMockEndpoint("mock:split").expectedMessageCount(2);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:share", "A,B");
+
+        assertMockEndpointsSatisfied();
+
+        Exchange out = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        assertEquals("A,B", out.getIn().getBody(String.class));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:noShare")
+                        .split(body().tokenize(","), new UseOriginalAggregationStrategy())
+                            .to("mock:split")
+                        .end()
+                        .to("mock:result");
+
+                from("direct:share")
+                        .split(body().tokenize(","), new UseOriginalAggregationStrategy()).shareUnitOfWork()
+                            .to("mock:split")
+                        .end()
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `UseOriginalAggregationStrategy` being silently ignored when `shareUnitOfWork=true` on Multicast, Split, and RecipientList EIPs
- Remove `ShareUnitOfWorkAggregationStrategy` wrapping from the three reifiers (MulticastReifier, SplitReifier, RecipientListReifier), centralizing all wrapping logic in `MulticastProcessor.process()`
- Add tests covering `UseOriginalAggregationStrategy` with and without `shareUnitOfWork` for all three EIPs

The root cause: the reifiers wrapped the strategy in `ShareUnitOfWorkAggregationStrategy` at route-build time, so the `instanceof UseOriginalAggregationStrategy` check in `MulticastProcessor.process()` (added by CAMEL-24062) never matched, and `newInstance(exchange)` was never called — the original body was lost.

_Claude Code on behalf of davsclaus_

## Test plan

- [x] `MulticastUseOriginalShareUnitOfWorkTest` — multicast with and without `shareUnitOfWork`
- [x] `SplitUseOriginalShareUnitOfWorkTest` — split with and without `shareUnitOfWork`
- [x] `RecipientListUseOriginalShareUnitOfWorkTest` — recipient list with and without `shareUnitOfWork`
- [x] `MulticastUseOriginalPropagateExceptionCaughtTest` — existing regression test
- [x] `MulticastShareUnitOfWorkOnExceptionHandledFalseIssueTest` — existing regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)