### PR TITLE
CAMEL-24139: Fix Splitter watermark advancing past unrouted items on streaming abort

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
@@ -290,6 +290,10 @@ public class Splitter extends MulticastProcessor {
         private final Exchange original;
         // tracks individual (raw) item count, independent of grouping
         private final AtomicInteger rawItemCount = new AtomicInteger();
+        // tracks whether the primary (processing) iterator has been created;
+        // subsequent iterators (e.g. the drain in MulticastProcessor.doDone)
+        // must not update the watermark count (CAMEL-24139)
+        private boolean primaryIteratorCreated;
 
         private SplitterIterable(Exchange exchange, Object value) {
             this.original = exchange;
@@ -349,6 +353,11 @@ public class Splitter extends MulticastProcessor {
 
         @Override
         public Iterator<ProcessorExchangePair> iterator() {
+            // only the first (primary) iterator tracks watermark count;
+            // subsequent iterators (drain in doDone) must not inflate it (CAMEL-24139)
+            boolean isPrimary = !primaryIteratorCreated;
+            primaryIteratorCreated = true;
+
             return new Iterator<>() {
                 private final Processor processor = getProcessors().iterator().next();
                 private int index;
@@ -365,14 +374,6 @@ public class Splitter extends MulticastProcessor {
                     if (!answer) {
                         // we are now closed
                         closed = true;
-                        // store raw item count for watermark tracking (guard against
-                        // re-iteration in MulticastProcessor.doDone which re-creates
-                        // the iterator to release exchanges).
-                        // Use rawItemCount (individual items) not index (which counts chunks when group > 0)
-                        if (resumeStrategy != null && watermarkKey != null && watermarkExpression == null
-                                && original.getProperty(SPLIT_WATERMARK_COUNT) == null) {
-                            original.setProperty(SPLIT_WATERMARK_COUNT, rawItemCount.get());
-                        }
                         // nothing more so we need to close the expression value in case it needs to be
                         try {
                             close();
@@ -421,6 +422,11 @@ public class Splitter extends MulticastProcessor {
                                 = original.getProperty(SPLIT_FAILURE_TRACKER, SplitFailureTracker.class);
                         if (tracker != null) {
                             tracker.incrementTotalItems();
+                        }
+                        // eagerly update watermark count for items actually routed (primary iterator only)
+                        // so the drain loop in MulticastProcessor.doDone cannot inflate it (CAMEL-24139)
+                        if (isPrimary && resumeStrategy != null && watermarkKey != null && watermarkExpression == null) {
+                            original.setProperty(SPLIT_WATERMARK_COUNT, rawItemCount.get());
                         }
                         return createProcessorExchangePair(index++, processor, newExchange, route);
                     } else {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitterWatermarkTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitterWatermarkTest.java
@@ -286,6 +286,24 @@ class SplitterWatermarkTest extends ContextTestSupport {
                 "Watermark should not be updated when processing is aborted");
     }
 
+    @Test
+    void testIndexBasedWatermarkNoUpdateOnHandledAbort() throws Exception {
+        // CAMEL-24139: streaming split + stopOnException + handled(true) should NOT
+        // advance the watermark past items that were never routed
+        MockEndpoint mock = getMockEndpoint("mock:handled-abort");
+        mock.expectedBodiesReceived("a");
+
+        template.sendBody("direct:handled-abort", Arrays.asList("a", "FAIL", "c", "d", "e"));
+
+        mock.assertIsSatisfied();
+
+        // items "a" (index 0) and "FAIL" (index 1) were both consumed and routed;
+        // watermark must cover them but NOT the unrouted items c, d, e
+        String watermark = store.get("handledAbortJob");
+        assertNotNull(watermark, "Watermark should be set for routed items");
+        assertEquals("1", watermark, "Watermark should cover items 0-1 (routed), not 0-4 (entire stream)");
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -373,6 +391,18 @@ class SplitterWatermarkTest extends ContextTestSupport {
                             }
                         })
                         .to("mock:abort-val-wm");
+
+                from("direct:handled-abort")
+                        .onException(IllegalArgumentException.class).handled(true).end()
+                        .split(body()).streaming().stopOnException()
+                        .resumeStrategy(strategy, "handledAbortJob")
+                        .process(exchange -> {
+                            String body = exchange.getIn().getBody(String.class);
+                            if ("FAIL".equals(body)) {
+                                throw new IllegalArgumentException("Simulated failure");
+                            }
+                        })
+                        .to("mock:handled-abort");
             }
         };
     }


### PR DESCRIPTION
## Summary

- Fix `SplitterIterable` watermark count being inflated when `MulticastProcessor.doDone()` drains remaining stream items after an early abort
- Track whether the primary (processing) iterator has been created; only the primary iterator updates `SPLIT_WATERMARK_COUNT` eagerly on each `next()` call
- Drain iterators (created by `doDone()` to release pooled exchanges) no longer touch the watermark count
- Add test for `streaming()` + `stopOnException()` + `handled(true)` abort path that verifies the watermark covers only items actually routed

**Root cause:** `SplitterIterable.iterator()` creates new wrapper iterators sharing the same counting iterator. When `doDone()` drains remaining items, the shared `rawItemCount` is driven to the full stream size. The old code only set `SPLIT_WATERMARK_COUNT` when the iterator was exhausted (`hasNext()` returning false), so the drain's exhaustion stored the inflated count. With no exception on the exchange (handled or timeout), `updateWatermark()` persisted it — causing silent data loss on resume.

**Fix:** The primary iterator now eagerly sets `SPLIT_WATERMARK_COUNT` on each `next()` call. Subsequent drain iterators are marked non-primary and skip the watermark update.

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>