### PR TITLE
CAMEL-24085: Apply header filter strategy to IronMQ message envelope headers

### DIFF
--- a/components/camel-ironmq/src/main/java/org/apache/camel/component/ironmq/GsonUtil.java
+++ b/components/camel-ironmq/src/main/java/org/apache/camel/component/ironmq/GsonUtil.java
@@ -20,10 +20,16 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 import org.apache.camel.Message;
+import org.apache.camel.spi.HeaderFilterStrategy;
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
 
 @Deprecated(since = "4.21")
 public final class GsonUtil {
     private static final Gson GSON = new Gson();
+
+    // Filters internal Camel headers (Camel*/camel*) embedded in the IronMQ message envelope, consistent with how
+    // other consumers apply a HeaderFilterStrategy to externally supplied headers.
+    private static final HeaderFilterStrategy HEADER_FILTER_STRATEGY = new DefaultHeaderFilterStrategy();
 
     private GsonUtil() {
     }
@@ -58,7 +64,8 @@ public final class GsonUtil {
             for (Map.Entry<String, Object> entry : ironMqMessage.getHeaders().entrySet()) {
                 String key = entry.getKey();
                 Object value = entry.getValue();
-                if (target.getHeader(key) == null) {
+                if (target.getHeader(key) == null
+                        && !HEADER_FILTER_STRATEGY.applyFilterToExternalHeaders(key, value, target.getExchange())) {
                     target.setHeader(key, value);
                 }
             }

--- a/components/camel-ironmq/src/test/java/org/apache/camel/component/ironmq/IronMQConsumerHeaderFilterTest.java
+++ b/components/camel-ironmq/src/test/java/org/apache/camel/component/ironmq/IronMQConsumerHeaderFilterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ironmq;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Message;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class IronMQConsumerHeaderFilterTest extends CamelTestSupport {
+
+    private IronMQEndpoint endpoint;
+    private IronMQClientMock clientMock;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void testCamelHeadersInMessageEnvelopeAreFiltered() throws Exception {
+        result.expectedMessageCount(1);
+        result.expectedBodiesReceived("some payload");
+        // a regular header embedded in the envelope must still be mapped onto the message
+        result.expectedHeaderReceived("MyHeader", "HeaderValue");
+
+        // message envelope as crafted by a sender: internal Camel headers embedded in the envelope must not be
+        // mapped onto the Camel message (matched case-insensitively)
+        String envelope = "{\"headers\":{\"MyHeader\":\"HeaderValue\",\"CamelFileName\":\"injected.txt\","
+                          + "\"camelExecCommandExecutable\":\"injected\"},\"body\":\"some payload\"}";
+        clientMock.queue("TestQueue").push(envelope, 0);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        Message received = result.getExchanges().get(0).getIn();
+        assertNull(received.getHeader("CamelFileName"));
+        assertNull(received.getHeader("camelExecCommandExecutable"));
+        assertNotNull(received.getHeader(IronMQConstants.MESSAGE_ID));
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        IronMQComponent component = new IronMQComponent(context);
+        component.init();
+        endpoint = (IronMQEndpoint) component
+                .createEndpoint("ironmq://TestQueue?projectId=xxx&token=yyy&preserveHeaders=true");
+        clientMock = new IronMQClientMock("dummy", "dummy");
+        endpoint.setClient(clientMock);
+        context.addComponent("ironmq", component);
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from(endpoint).to("mock:result");
+            }
+        };
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -252,6 +252,16 @@ content-mode / HTTP header path.
 Ordinary CloudEvent extension attributes are unaffected. If a route relied on `Camel*`-named fields being
 propagated from the structured payload, set them explicitly after consuming the event.
 
+=== camel-ironmq - message envelope header filtering
+
+When consuming a message with `preserveHeaders=true`, the IronMQ consumer now applies a `HeaderFilterStrategy` to
+the header entries embedded in the JSON message envelope before mapping them onto the Camel message. Camel-internal
+headers (the `Camel*` namespace, matched case-insensitively) present in the envelope are no longer mapped onto the
+message, consistent with the inbound header filtering performed by other consumers.
+
+Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the
+message envelope, set them explicitly after consuming the message.
+
 === camel-pinecone
 
 The `tls` endpoint option now correctly documents its default as `false` (previously the catalog


### PR DESCRIPTION
### Motivation

When receiving a message with `preserveHeaders=true`, the IronMQ consumer deserializes a JSON envelope (a headers map and a body) and copies the embedded header entries onto the Camel message (`GsonUtil.copyFrom`, called from `IronMQConsumer`) without applying a `HeaderFilterStrategy`. The envelope is fully sender-controlled, so a sender can inject Camel-internal control headers (the `Camel*` namespace) onto the exchange.

### Changes

- `GsonUtil.copyFrom` now routes the embedded envelope headers through a `DefaultHeaderFilterStrategy` (`applyFilterToExternalHeaders`), so `Camel*` headers (matched case-insensitively) are no longer mapped onto the Camel message — consistent with the inbound header filtering performed by other consumers, and with the same approach as the structured-mode CloudEvent fix in CAMEL-24084 (#24724).
- New `IronMQConsumerHeaderFilterTest` pushing a crafted envelope through the existing `MockQueue`: ordinary headers still propagate, `Camel*` entries are filtered.
- Upgrade-guide entry in `camel-4x-upgrade-guide-4_22.adoc`.

Note: camel-ironmq is deprecated since 4.21, but still ships; the same envelope mapping exists on the 4.18.x/4.14.x maintenance branches, so this is a backport candidate (those branches need the explicit `setInFilterStartsWith` variant, pre-CAMEL-23543).

### Testing

- `mvn clean install` in `components/camel-ironmq`: all tests pass (new test + existing preserve-headers round-trip).
- Full reactor `mvn clean install -DskipTests` from root: success, no stale generated files.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)