### PR TITLE
CAMEL-24145: camel-saga - InMemorySagaCoordinator compensate/complete now propagate finalization outcome

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/SagaFailuresTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SagaFailuresTest.java
@@ -19,10 +19,13 @@ package org.apache.camel.processor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.saga.InMemorySagaService;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SagaFailuresTest extends ContextTestSupport {
 
@@ -84,6 +87,24 @@ public class SagaFailuresTest extends ContextTestSupport {
 
         complete.assertIsNotSatisfied();
         end.assertIsSatisfied();
+    }
+
+    @Test
+    public void testCompletionFailurePropagates() throws Exception {
+        maxFailures = new AtomicInteger(3);
+
+        Exchange result = template.send("direct:saga-complete", e -> e.getMessage().setBody("hello"));
+
+        assertNotNull(result.getException(), "Completion failure should propagate to exchange");
+    }
+
+    @Test
+    public void testCompensationFailurePropagates() throws Exception {
+        maxFailures = new AtomicInteger(3);
+
+        Exchange result = template.send("direct:saga-compensate", e -> e.getMessage().setBody("hello"));
+
+        assertNotNull(result.getException(), "Compensation failure should propagate to exchange");
     }
 
     @Override

--- a/core/camel-support/src/main/java/org/apache/camel/saga/InMemorySagaCoordinator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/saga/InMemorySagaCoordinator.java
@@ -123,14 +123,20 @@ public class InMemorySagaCoordinator implements CamelSagaCoordinator {
         boolean doAction = currentStatus.compareAndSet(Status.RUNNING, Status.COMPENSATING);
 
         if (doAction) {
-            doCompensate(exchange);
-        } else {
-            Status status = currentStatus.get();
-            if (status != Status.COMPENSATING && status != Status.COMPENSATED) {
-                CompletableFuture<Void> res = new CompletableFuture<>();
-                res.completeExceptionally(new IllegalStateException("Cannot compensate: status is " + status));
-                return res;
-            }
+            return doCompensate(exchange).thenApply(res -> {
+                if (!res) {
+                    throw new RuntimeCamelException(
+                            "Unable to compensate all required steps of the saga " + sagaId);
+                }
+                return null;
+            });
+        }
+
+        Status status = currentStatus.get();
+        if (status != Status.COMPENSATING && status != Status.COMPENSATED) {
+            CompletableFuture<Void> res = new CompletableFuture<>();
+            res.completeExceptionally(new IllegalStateException("Cannot compensate: status is " + status));
+            return res;
         }
 
         return CompletableFuture.completedFuture(null);
@@ -141,14 +147,20 @@ public class InMemorySagaCoordinator implements CamelSagaCoordinator {
         boolean doAction = currentStatus.compareAndSet(Status.RUNNING, Status.COMPLETING);
 
         if (doAction) {
-            doComplete(exchange);
-        } else {
-            Status status = currentStatus.get();
-            if (status != Status.COMPLETING && status != Status.COMPLETED) {
-                CompletableFuture<Void> res = new CompletableFuture<>();
-                res.completeExceptionally(new IllegalStateException("Cannot complete: status is " + status));
-                return res;
-            }
+            return doComplete(exchange).thenApply(res -> {
+                if (!res) {
+                    throw new RuntimeCamelException(
+                            "Unable to complete all required steps of the saga " + sagaId);
+                }
+                return null;
+            });
+        }
+
+        Status status = currentStatus.get();
+        if (status != Status.COMPLETING && status != Status.COMPLETED) {
+            CompletableFuture<Void> res = new CompletableFuture<>();
+            res.completeExceptionally(new IllegalStateException("Cannot complete: status is " + status));
+            return res;
         }
 
         return CompletableFuture.completedFuture(null);

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -553,6 +553,23 @@ stylesheet-driven external fetches.
 Users of Saxon Professional or Enterprise editions who rely on Java extension functions
 called from XSLT stylesheets must now explicitly set `secureProcessing=false` on the endpoint.
 
+=== camel-core - InMemorySagaCoordinator now propagates finalization outcome
+
+The `InMemorySagaCoordinator` used for the Saga EIP (when no external LRA coordinator is configured)
+previously returned an already-completed future from `compensate()` and `complete()`, meaning the
+exchange finished before any compensation or completion endpoints had been invoked. Finalization
+failures were only logged as warnings and never propagated to the caller.
+
+The coordinator now returns the actual finalization future, so the exchange waits for the
+compensation or completion callbacks to finish (including retries). If all retry attempts fail,
+the failure is propagated as an exception on the exchange, consistent with the `camel-lra`
+coordinator behavior.
+
+This is a behavior change: routes that previously completed immediately regardless of
+compensation/completion outcome will now wait for finalization and may see exceptions
+that were previously swallowed. If your route relies on fire-and-forget saga finalization,
+consider using `MANUAL` completion mode instead.
+
 === camel-xslt / camel-xslt-saxon - transformerFactoryConfigurationStrategy now honored
 
 The `transformerFactoryConfigurationStrategy` option is now applied on all factory creation paths.


### PR DESCRIPTION
## Summary

`InMemorySagaCoordinator.compensate()` and `complete()` returned `CompletableFuture.completedFuture(null)` unconditionally, meaning the exchange finished before any compensation/completion endpoint was invoked and finalization failures never propagated to the caller.

- `compensate()` and `complete()` now return the actual future from `doCompensate()`/`doComplete()` so the exchange waits for finalization (including retries) to finish
- When all retry attempts fail, the failure is propagated as a `RuntimeCamelException` on the exchange, consistent with the `camel-lra` coordinator behavior
- Added 2 new tests verifying failure propagation
- Added upgrade guide note for the behavior change

Fixes: [CAMEL-24145](https://issues.apache.org/jira/browse/CAMEL-24145)

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>