### PR TITLE
CAMEL-24146: Fix FluentProducerTemplate leak in InMemorySagaCoordinator

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/saga/InMemorySagaCoordinator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/saga/InMemorySagaCoordinator.java
@@ -196,7 +196,7 @@ public class InMemorySagaCoordinator implements CamelSagaCoordinator {
         Exchange target = createExchange(exchange, endpoint, step);
 
         return CompletableFuture.supplyAsync(() -> {
-            Exchange res = camelContext.createFluentProducerTemplate().to(endpoint).withExchange(target).send();
+            Exchange res = sagaService.getProducerTemplate().send(endpoint, target);
             Exception ex = res.getException();
             if (ex != null) {
                 throw new RuntimeCamelException(res.getException());

--- a/core/camel-support/src/main/java/org/apache/camel/saga/InMemorySagaService.java
+++ b/core/camel-support/src/main/java/org/apache/camel/saga/InMemorySagaService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.ObjectHelper;
 
@@ -40,6 +41,8 @@ public class InMemorySagaService extends ServiceSupport implements CamelSagaServ
     private final Map<String, CamelSagaCoordinator> coordinators = new ConcurrentHashMap<>();
 
     private ScheduledExecutorService executorService;
+
+    private ProducerTemplate producerTemplate;
 
     private int maxRetryAttempts = DEFAULT_MAX_RETRY_ATTEMPTS;
 
@@ -72,10 +75,17 @@ public class InMemorySagaService extends ServiceSupport implements CamelSagaServ
             this.executorService = camelContext.getExecutorServiceManager()
                     .newDefaultScheduledThreadPool(this, "saga");
         }
+        if (this.producerTemplate == null) {
+            this.producerTemplate = camelContext.createProducerTemplate();
+        }
     }
 
     @Override
     protected void doStop() throws Exception {
+        if (this.producerTemplate != null) {
+            this.producerTemplate.stop();
+            this.producerTemplate = null;
+        }
         if (this.executorService != null) {
             camelContext.getExecutorServiceManager().shutdownGraceful(this.executorService);
             this.executorService = null;
@@ -84,6 +94,10 @@ public class InMemorySagaService extends ServiceSupport implements CamelSagaServ
 
     public ScheduledExecutorService getExecutorService() {
         return executorService;
+    }
+
+    public ProducerTemplate getProducerTemplate() {
+        return producerTemplate;
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

`InMemorySagaCoordinator.doFinalize` created a new `FluentProducerTemplate` per compensation/completion call (including retries) and never stopped it. Each leaked template holds a started `ProducerTemplate` with a producer cache (default max 1000). With the default 5 retry attempts, a single saga finalization could leak up to N*5 templates.

**Fix:** Create a shared `ProducerTemplate` in `InMemorySagaService` (which already has `doStart`/`doStop` lifecycle) and reuse it across all coordinator finalization calls. The `FluentProducerTemplate` was overkill here — the only call was `.to(endpoint).withExchange(target).send()`, which delegates to `ProducerTemplate.send(Endpoint, Exchange)`.

Changes:
- `InMemorySagaService`: add a `ProducerTemplate` field, create in `doStart()`, stop in `doStop()`
- `InMemorySagaCoordinator`: replace per-call `createFluentProducerTemplate()` with the shared `sagaService.getProducerTemplate().send()`

## Test plan

- [x] All 24 existing saga tests pass (`SagaTest`, `SagaFailuresTest`, `SagaOptionsTest`, `SagaPropagationTest`, `SagaRemoveHeadersTest`, `SagaTimeoutTest`, `SagaComponentTest`)
- [x] `SagaFailuresTest` exercises the retry code path where the leak was most severe

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>