### PR TITLE
CAMEL-24147: camel-lra - URL-encode callback query parameters and fix parseQuery split

### DIFF
--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaRoutes.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaRoutes.java
@@ -69,8 +69,8 @@ public class LRASagaRoutes extends RouteBuilder {
             // first, split by parameter separator '&'
             // then collect the map with the variable name '[0]' and value '[1]', both url decoded
             result = Arrays.stream(queryStr.split("&")).collect(
-                    Collectors.toMap(element -> decode(saveArrayAccess(element.split("="), 0)),
-                            element -> decode(saveArrayAccess(element.split("="), 1))));
+                    Collectors.toMap(element -> decode(saveArrayAccess(element.split("=", 2), 0)),
+                            element -> decode(saveArrayAccess(element.split("=", 2), 1))));
 
         } else {
             LOG.debug("query param is empty, nothing to parse.");

--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAUrlBuilder.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRAUrlBuilder.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.service.lra;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 
@@ -93,7 +95,7 @@ public class LRAUrlBuilder {
         } else {
             copy.query += "&";
         }
-        copy.query += toNonnullString(key) + "=" + toNonnullString(value);
+        copy.query += encode(toNonnullString(key)) + "=" + encode(toNonnullString(value));
         return copy;
     }
 
@@ -114,6 +116,10 @@ public class LRAUrlBuilder {
             second = second.substring(1);
         }
         return first + "/" + second;
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     private String toNonnullString(Object obj) {

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaRoutesTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRASagaRoutesTest.java
@@ -79,6 +79,36 @@ public class LRASagaRoutesTest {
                 "query parameter value for name 'key2' has unexpected content");
     }
 
+    @DisplayName("Tests parseQuery() preserves values containing '=' characters")
+    @Test
+    void testParseQueryWithEqualsInValue() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+
+        Map<String, String> testResult = (Map<String, String>) getParseQueryMethod()
+                .invoke(new LRASagaRoutes(null),
+                        "key1=value%3Dwith%3Dequals&key2=normal");
+
+        Assertions.assertEquals(2, testResult.size(), "query parameter count must be two");
+        Assertions.assertEquals("value=with=equals", testResult.get("key1"),
+                "value containing '=' characters must be preserved");
+        Assertions.assertEquals("normal", testResult.get("key2"));
+    }
+
+    @DisplayName("Tests parseQuery() decodes URL-encoded special characters correctly")
+    @Test
+    void testParseQueryWithEncodedSpecialChars()
+            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+
+        Map<String, String> testResult = (Map<String, String>) getParseQueryMethod()
+                .invoke(new LRASagaRoutes(null),
+                        "key1=value+with%26ampersand&key2=a%2Bb");
+
+        Assertions.assertEquals(2, testResult.size(), "query parameter count must be two");
+        Assertions.assertEquals("value with&ampersand", testResult.get("key1"),
+                "encoded '&' and '+' must be decoded correctly");
+        Assertions.assertEquals("a+b", testResult.get("key2"),
+                "encoded '+' must be decoded correctly");
+    }
+
     @DisplayName("Tests parseQuery() to handle incorrect query string (no value is given)")
     @Test
     void testParseQuerySuccessEncoded() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {

--- a/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAUrlBuilderTest.java
+++ b/components/camel-lra/src/test/java/org/apache/camel/service/lra/LRAUrlBuilderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.service.lra;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LRAUrlBuilderTest {
+
+    @DisplayName("Tests that query() URL-encodes special characters in values")
+    @Test
+    void testQueryEncodesSpecialCharacters() {
+        String url = new LRAUrlBuilder()
+                .host("http://localhost:8080")
+                .path("lra-participant")
+                .query("key", "value with spaces&and=special+chars#hash")
+                .build();
+
+        assertTrue(url.contains("key=value+with+spaces%26and%3Dspecial%2Bchars%23hash"),
+                "Special characters must be URL-encoded in query values: " + url);
+    }
+
+    @DisplayName("Tests that compensation URI with query params is properly encoded")
+    @Test
+    void testCompensationUriWithQueryParams() {
+        String url = new LRAUrlBuilder()
+                .host("http://localhost:8080")
+                .path("lra-participant")
+                .compensation("seda:cancelOrder?concurrentConsumers=2&size=1000")
+                .build();
+
+        URI uri = URI.create(url);
+        assertNotNull(uri.getQuery(), "URL must have a valid query string");
+
+        String query = uri.getRawQuery();
+        assertTrue(query.contains("Camel-Saga-Compensate="),
+                "Query must contain the compensation key");
+        assertTrue(query.contains("seda%3AcancelOrder%3FconcurrentConsumers%3D2%26size%3D1000"),
+                "Compensation URI must be fully encoded: " + query);
+    }
+
+    @DisplayName("Tests full round-trip: LRAUrlBuilder encodes, parseQuery decodes back to original")
+    @Test
+    void testCallbackUrlRoundTrip() throws Exception {
+        String compensationUri = "seda:cancelOrder?concurrentConsumers=2&size=1000";
+        String completionUri = "direct:complete";
+        String optionValue = "ACME&region=EU";
+
+        String url = new LRAUrlBuilder()
+                .host("http://localhost:8080")
+                .path("lra-participant")
+                .query("myOption", optionValue)
+                .compensation(compensationUri)
+                .completion(completionUri)
+                .path("compensate")
+                .build();
+
+        URI uri = URI.create(url);
+        String rawQuery = uri.getRawQuery();
+
+        Method parseQuery = LRASagaRoutes.class.getDeclaredMethod("parseQuery", String.class);
+        parseQuery.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, String> parsed = (Map<String, String>) parseQuery.invoke(new LRASagaRoutes(null), rawQuery);
+
+        assertEquals(compensationUri, parsed.get("Camel-Saga-Compensate"),
+                "Compensation URI must survive encode/decode round-trip");
+        assertEquals(completionUri, parsed.get("Camel-Saga-Complete"),
+                "Completion URI must survive encode/decode round-trip");
+        assertEquals(optionValue, parsed.get("myOption"),
+                "Option value with special characters must survive encode/decode round-trip");
+    }
+
+    @DisplayName("Tests that simple direct: URIs still work after encoding")
+    @Test
+    void testSimpleDirectUri() {
+        String url = new LRAUrlBuilder()
+                .host("http://localhost:8080")
+                .path("lra-participant")
+                .compensation("direct://saga1_participant1_compensate")
+                .completion("direct://saga1_participant1_complete")
+                .path("compensate")
+                .build();
+
+        URI uri = URI.create(url);
+        assertNotNull(uri.getQuery(), "URL must have a valid query string");
+    }
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Two related defects in camel-lra cause saga compensation/completion to silently fail when endpoint URIs contain query parameters or special characters:

- **`LRAUrlBuilder.query()`** concatenated keys and values raw with no `URLEncoder`. An endpoint URI like `seda:cancelOrder?concurrentConsumers=2&size=1000` corrupts the callback URL registered with the LRA coordinator.
- **`LRASagaRoutes.parseQuery()`** used `split("=")` without a limit, dropping everything after the second `=` in a value.

### Changes

- `LRAUrlBuilder.query()`: URL-encode both key and value with `URLEncoder.encode()`
- `LRASagaRoutes.parseQuery()`: use `split("=", 2)` to preserve values containing `=`
- Added `LRAUrlBuilderTest` with encoding and round-trip tests
- Added new test cases to `LRASagaRoutesTest` for encoded special characters and equals-in-value

## Test plan

- [x] New `LRAUrlBuilderTest` verifies encoding of special characters, round-trip fidelity, and realistic compensation URIs with query parameters
- [x] New `LRASagaRoutesTest` cases verify `parseQuery()` handles encoded `&`, `=`, `+` and preserves values with `=`
- [x] All 9 tests pass in `mvn verify`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>