### PR TITLE
CAMEL-24149: camel-saga - SagaProducer reads ExchangeExtension first, survives removeHeaders

### DIFF
--- a/components/camel-saga/src/main/java/org/apache/camel/component/saga/SagaProducer.java
+++ b/components/camel-saga/src/main/java/org/apache/camel/component/saga/SagaProducer.java
@@ -44,14 +44,19 @@ public class SagaProducer extends DefaultAsyncProducer {
 
     @Override
     public boolean process(Exchange exchange, AsyncCallback callback) {
-        String currentSaga = exchange.getIn().getHeader(SagaConstants.SAGA_LONG_RUNNING_ACTION, String.class);
-        if (currentSaga == null) {
+        String sagaId = exchange.getExchangeExtension().getSagaLongRunningAction();
+        if (sagaId == null) {
+            sagaId = exchange.getIn().getHeader(SagaConstants.SAGA_LONG_RUNNING_ACTION, String.class);
+        }
+        if (sagaId == null) {
+            String action = success ? "complete" : "compensate";
             exchange.setException(
-                    new IllegalStateException("Current exchange is not bound to a saga context: cannot complete"));
+                    new IllegalStateException("Current exchange is not bound to a saga context: cannot " + action));
             callback.done(true);
             return true;
         }
 
+        final String currentSaga = sagaId;
         camelSagaService.getSaga(currentSaga).thenApply(coordinator -> {
             if (coordinator == null) {
                 throw new IllegalStateException("No coordinator found for saga id " + currentSaga);

--- a/core/camel-core/src/test/java/org/apache/camel/component/saga/SagaProducerRemoveHeadersTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/saga/SagaProducerRemoveHeadersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.saga;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.SagaCompletionMode;
+import org.apache.camel.saga.InMemorySagaService;
+import org.junit.jupiter.api.Test;
+
+public class SagaProducerRemoveHeadersTest extends ContextTestSupport {
+
+    @Test
+    public void testManualCompleteAfterRemoveHeaders() throws InterruptedException {
+        MockEndpoint completed = getMockEndpoint("mock:completed");
+        completed.expectedMessageCount(1);
+
+        template.sendBody("direct:manual-workflow", "manual-complete");
+
+        completed.assertIsSatisfied();
+    }
+
+    @Test
+    public void testManualCompensateAfterRemoveHeaders() throws InterruptedException {
+        MockEndpoint compensated = getMockEndpoint("mock:compensated");
+        compensated.expectedMessageCount(1);
+
+        template.sendBody("direct:manual-workflow", "manual-compensate");
+
+        compensated.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                context.addService(new InMemorySagaService());
+
+                from("direct:manual-workflow")
+                        .saga().compensation("mock:compensated").completion("mock:completed")
+                        .completionMode(SagaCompletionMode.MANUAL)
+                        .removeHeaders("*")
+                        .choice()
+                        .when(body().isEqualTo(constant("manual-complete")))
+                        .to("saga:complete")
+                        .when(body().isEqualTo(constant("manual-compensate")))
+                        .to("saga:compensate")
+                        .end();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

`SagaProducer` (the `saga:complete` / `saga:compensate` component) read the saga ID exclusively from the message header. CAMEL-23469 fixed `SagaProcessor` to dual-read from `ExchangeExtension` first (surviving `removeHeaders("*")`), but `SagaProducer` was not updated — so MANUAL-completion saga routes that strip headers got `IllegalStateException`.

### Changes

- `SagaProducer.process()`: read `ExchangeExtension.getSagaLongRunningAction()` first, fall back to header — mirrors the pattern in `SagaProcessor.getCurrentSagaCoordinator()`
- Fixed error message to distinguish "cannot complete" vs "cannot compensate"
- Added `SagaProducerRemoveHeadersTest` covering both `saga:complete` and `saga:compensate` after `removeHeaders("*")`

## Test plan

- [x] New `SagaProducerRemoveHeadersTest` — 2 tests: manual complete and manual compensate after `removeHeaders("*")`
- [x] Existing `SagaComponentTest` — 5 tests still pass (no regression)
- [x] All 7 tests pass in `mvn verify`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>