### PR TITLE
CAMEL-24175: Remove incorrect option counts from documentation page headers

### DIFF
--- a/core/camel-core-engine/src/main/docs/modules/eips/partials/eip-exchangeProperties.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/partials/eip-exchangeProperties.adoc
@@ -10,7 +10,7 @@ ifeval::[{optioncount} == 0]
 The {doctitle} eip has no exchange properties.
 endif::[]
 ifeval::[{optioncount} != 0]
-The {doctitle} eip supports {optioncount} exchange properties, which are listed below.
+The {doctitle} eip supports the following exchange properties which are listed below.
 
 The exchange properties are set on the `Exchange` by the EIP, unless otherwise specified in the description.
 This means those properties are available after this EIP has completed processing the `Exchange`.

--- a/core/camel-core-engine/src/main/docs/modules/eips/partials/eip-options.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/partials/eip-options.adoc
@@ -4,13 +4,8 @@
 |util.valueAsString(value.defaultValue) \
 |util.javaSimpleName(value.javaType)'
 :requires: 'util=util/jsonpath-util.js'
-include::jsonpathcount$example$json/{shortname}.json[queries='optioncount=nodes$.properties[?(@.displayName!="Id" && @.displayName!="Description" && @.displayName!="Expression" && @.displayName!="Outputs")]']
 
-ifeval::[{optioncount} == 0]
-The {doctitle} eip has no options.
-endif::[]
-ifeval::[{optioncount} != 0]
-The {doctitle} eip supports {optioncount} options, which are listed below.
+The {doctitle} eip supports the following options which are listed below.
 
 
 [{tablespec}]
@@ -19,5 +14,3 @@ The {doctitle} eip supports {optioncount} options, which are listed below.
 |===
 
 jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.displayName!="Id")]',{cellformats},{requires}]
-endif::[]
-

--- a/docs/components/modules/ROOT/partials/component-endpoint-headers.adoc
+++ b/docs/components/modules/ROOT/partials/component-endpoint-headers.adoc
@@ -10,7 +10,7 @@ include::jsonpathcount$example$json/{shortname}.json[queries='headercount=nodes$
 ifeval::[{headercount} != 0]
 == Message Headers
 
-The {doctitle} component supports {headercount} message header(s), which is/are listed below:
+The {doctitle} component supports the following message header(s), which is/are listed below:
 
 [{tablespec}]
 |===

--- a/docs/components/modules/ROOT/partials/component-endpoint-options.adoc
+++ b/docs/components/modules/ROOT/partials/component-endpoint-options.adoc
@@ -8,11 +8,11 @@
 |util.valueAsString(value.defaultValue) \
 |util.javaSimpleName(value.javaType)
 include::jsonpath$example$json/{shortname}.json[query='$.component',formats='name,scheme,pascalcasescheme=util.pascalCase(scheme),syntax,apiSyntax', requires={requires}]
-include::jsonpathcount$example$json/{shortname}.json[queries='propertycount=nodes$.componentProperties.*,pathparametercount=nodes$.properties[?(@.kind=="path")],queryparametercount=nodes$.properties[?(@.kind=="parameter")],apicount=nodes$.apis.*']
+include::jsonpathcount$example$json/{shortname}.json[queries='pathparametercount=nodes$.properties[?(@.kind=="path")],queryparametercount=nodes$.properties[?(@.kind=="parameter")],apicount=nodes$.apis.*']
 
 == Component Options
 
-The {doctitle} component supports {propertycount} options, which are listed below.
+The {doctitle} component supports the following options which are listed below.
 
 [{tablespec}]
 |===
@@ -34,7 +34,7 @@ The {doctitle} endpoint is configured using URI syntax:
 
 With the following _path_ and _query_ parameters:
 
-=== Path Parameters ({pathparametercount} parameters)
+=== Path Parameters
 
 ifeval::[{pathparametercount} == 0]
 The {doctitle} endpoint has no path parameters.
@@ -51,7 +51,7 @@ jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.kind=="path"
 endif::[]
 
 [#_query_parameters]
-=== Query Parameters ({queryparametercount} parameters)
+=== Query Parameters
 
 ifeval::[{queryparametercount} == 0]
 The {doctitle} endpoint has no _query_ parameters.

--- a/docs/components/modules/dataformats/partials/dataformat-options.adoc
+++ b/docs/components/modules/dataformats/partials/dataformat-options.adoc
@@ -3,13 +3,8 @@
 |util.valueAsString(value.defaultValue) \
 |util.pascalCase(value.type) \
 |util.description(value)'
-include::jsonpathcount$example$json/{shortname}.json[queries='optioncount=nodes$.properties[?(@.displayName!="Id")]']
 
-ifeval::[{optioncount} == 0]
-The {doctitle} dataformat has no options.
-endif::[]
-ifeval::[{optioncount} != 0]
-The {doctitle} dataformat supports {optioncount} options, which are listed below.
+The {doctitle} dataformat supports the following options which are listed below.
 
 
 [{tablespec}]
@@ -18,5 +13,4 @@ The {doctitle} dataformat supports {optioncount} options, which are listed below
 |===
 
 jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.displayName!="Id")]',{cellformats},{requires}]
-endif::[]
 

--- a/docs/components/modules/languages/partials/language-options.adoc
+++ b/docs/components/modules/languages/partials/language-options.adoc
@@ -3,13 +3,8 @@
 |util.valueAsString(value.defaultValue) \
 |util.pascalCase(value.type) \
 |util.description(value)'
-include::jsonpathcount$example$json/{shortname}.json[queries='optioncount=nodes$.properties[?(@.kind=="attribute" && @.displayName!="Id")]']
 
-ifeval::[{optioncount} == 0]
-The {doctitle} language has no options.
-endif::[]
-ifeval::[{optioncount} != 0]
-The {doctitle} language supports {optioncount} options, which are listed below.
+The {doctitle} language supports the following options which are listed below.
 
 
 [{tablespec}]
@@ -18,5 +13,4 @@ The {doctitle} language supports {optioncount} options, which are listed below.
 |===
 
 jsonpathTable::example$json/{shortname}.json['nodes$.properties[?(@.kind=="attribute" && @.displayName!="Id")]',{cellformats},{requires}]
-endif::[]
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Removes incorrect option count numbers from EIP, component, language, and dataformat documentation page headers
- Replaces "supports N options" with generic "supports the following options" text
- Removes broken `jsonpathcount$` include directives that produced wrong counts on the website

## Problem

The `jsonpathcount$` Asciidoctor include processor (from `@djencks/asciidoctor-jsonpath`) produces incorrect option counts during the Antora website build:
- **87 out of 106 EIPs** show wrong counts (e.g., Saga shows "0 options" while 11 are listed in the table)
- The count filter in `eip-options.adoc` excluded `Description`, `Expression`, and `Outputs` from the count but the table showed them — a filter mismatch
- On top of that, the `jsonpathcount$` processor itself produces wildly incorrect results during the Antora build (counts don't match what the jsonpath library returns locally)

## Changes

| File | Change |
|---|---|
| `eip-options.adoc` | Remove `jsonpathcount$`, `ifeval` conditionals, and count from header |
| `eip-exchangeProperties.adoc` | Remove count from header text (keep `ifeval` for hiding empty sections) |
| `language-options.adoc` | Remove `jsonpathcount$`, `ifeval` conditionals, and count from header |
| `dataformat-options.adoc` | Remove `jsonpathcount$`, `ifeval` conditionals, and count from header |
| `component-endpoint-options.adoc` | Remove `propertycount` and counts from section headers (keep `pathparametercount`/`queryparametercount`/`apicount` for `ifeval` conditionals) |
| `component-endpoint-headers.adoc` | Remove count from header text (keep `ifeval` for hiding empty sections) |

## Test plan

- [ ] Verify the website builds without errors after this change
- [ ] Spot-check EIP pages (e.g., saga-eip, stickyLoadBalancer-eip, aggregate-eip) to confirm they no longer show incorrect "supports 0 options"
- [ ] Verify component pages still correctly hide empty path/query parameter sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>