### PR TITLE
CAMEL-24163: Guard Jackson-only options in JsonDataFormatReifier

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dataformats/fastjson.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dataformats/fastjson.json
@@ -16,7 +16,8 @@
     "modelJavaType": "org.apache.camel.model.dataformat.JsonDataFormat"
   },
   "properties": {
-    "unmarshalType": { "index": 0, "kind": "attribute", "displayName": "Unmarshal Type", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class name of the java type to use when unmarshalling." },
-    "contentTypeHeader": { "index": 1, "kind": "attribute", "displayName": "Content Type Header", "group": "common", "required": false, "type": "boolean", "javaType": "java.lang.Boolean", "deprecated": false, "autowired": false, "secret": false, "defaultValue": true, "description": "Whether the data format should set the Content-Type header with the type from the data format. For example application\/xml for data formats marshalling to XML, or application\/json for data formats marshalling to JSON" }
+    "prettyPrint": { "index": 0, "kind": "attribute", "displayName": "Pretty Print", "group": "common", "required": false, "type": "boolean", "javaType": "java.lang.Boolean", "deprecated": false, "autowired": false, "secret": false, "defaultValue": false, "description": "To enable pretty printing output nicely formatted. Is by default false." },
+    "unmarshalType": { "index": 1, "kind": "attribute", "displayName": "Unmarshal Type", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class name of the java type to use when unmarshalling." },
+    "contentTypeHeader": { "index": 2, "kind": "attribute", "displayName": "Content Type Header", "group": "common", "required": false, "type": "boolean", "javaType": "java.lang.Boolean", "deprecated": false, "autowired": false, "secret": false, "defaultValue": true, "description": "Whether the data format should set the Content-Type header with the type from the data format. For example application\/xml for data formats marshalling to XML, or application\/json for data formats marshalling to JSON" }
   }
 }

--- a/components/camel-fastjson/src/generated/java/org/apache/camel/component/fastjson/FastjsonDataFormatConfigurer.java
+++ b/components/camel-fastjson/src/generated/java/org/apache/camel/component/fastjson/FastjsonDataFormatConfigurer.java
@@ -23,6 +23,7 @@ public class FastjsonDataFormatConfigurer extends org.apache.camel.support.compo
     static {
         Map<String, Object> map = new CaseInsensitiveMap();
         map.put("ContentTypeHeader", boolean.class);
+        map.put("PrettyPrint", boolean.class);
         map.put("UnmarshalType", java.lang.Class.class);
         ALL_OPTIONS = map;
     }
@@ -33,6 +34,8 @@ public class FastjsonDataFormatConfigurer extends org.apache.camel.support.compo
         switch (ignoreCase ? name.toLowerCase() : name) {
         case "contenttypeheader":
         case "contentTypeHeader": target.setContentTypeHeader(property(camelContext, boolean.class, value)); return true;
+        case "prettyprint":
+        case "prettyPrint": target.setPrettyPrint(property(camelContext, boolean.class, value)); return true;
         case "unmarshaltype":
         case "unmarshalType": target.setUnmarshalType(property(camelContext, java.lang.Class.class, value)); return true;
         default: return false;
@@ -49,6 +52,8 @@ public class FastjsonDataFormatConfigurer extends org.apache.camel.support.compo
         switch (ignoreCase ? name.toLowerCase() : name) {
         case "contenttypeheader":
         case "contentTypeHeader": return boolean.class;
+        case "prettyprint":
+        case "prettyPrint": return boolean.class;
         case "unmarshaltype":
         case "unmarshalType": return java.lang.Class.class;
         default: return null;
@@ -61,6 +66,8 @@ public class FastjsonDataFormatConfigurer extends org.apache.camel.support.compo
         switch (ignoreCase ? name.toLowerCase() : name) {
         case "contenttypeheader":
         case "contentTypeHeader": return target.isContentTypeHeader();
+        case "prettyprint":
+        case "prettyPrint": return target.isPrettyPrint();
         case "unmarshaltype":
         case "unmarshalType": return target.getUnmarshalType();
         default: return null;

--- a/components/camel-fastjson/src/generated/resources/META-INF/org/apache/camel/component/fastjson/fastjson.json
+++ b/components/camel-fastjson/src/generated/resources/META-INF/org/apache/camel/component/fastjson/fastjson.json
@@ -16,7 +16,8 @@
     "modelJavaType": "org.apache.camel.model.dataformat.JsonDataFormat"
   },
   "properties": {
-    "unmarshalType": { "index": 0, "kind": "attribute", "displayName": "Unmarshal Type", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class name of the java type to use when unmarshalling." },
-    "contentTypeHeader": { "index": 1, "kind": "attribute", "displayName": "Content Type Header", "group": "common", "required": false, "type": "boolean", "javaType": "java.lang.Boolean", "deprecated": false, "autowired": false, "secret": false, "defaultValue": true, "description": "Whether the data format should set the Content-Type header with the type from the data format. For example application\/xml for data formats marshalling to XML, or application\/json for data formats marshalling to JSON" }
+    "prettyPrint": { "index": 0, "kind": "attribute", "displayName": "Pretty Print", "group": "common", "required": false, "type": "boolean", "javaType": "java.lang.Boolean", "deprecated": false, "autowired": false, "secret": false, "defaultValue": false, "description": "To enable pretty printing output nicely formatted. Is by default false." },
+    "unmarshalType": { "index": 1, "kind": "attribute", "displayName": "Unmarshal Type", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "autowired": false, "secret": false, "description": "Class name of the java type to use when unmarshalling." },
+    "contentTypeHeader": { "index": 2, "kind": "attribute", "displayName": "Content Type Header", "group": "common", "required": false, "type": "boolean", "javaType": "java.lang.Boolean", "deprecated": false, "autowired": false, "secret": false, "defaultValue": true, "description": "Whether the data format should set the Content-Type header with the type from the data format. For example application\/xml for data formats marshalling to XML, or application\/json for data formats marshalling to JSON" }
   }
 }

--- a/components/camel-fastjson/src/main/java/org/apache/camel/component/fastjson/FastjsonDataFormat.java
+++ b/components/camel-fastjson/src/main/java/org/apache/camel/component/fastjson/FastjsonDataFormat.java
@@ -39,7 +39,7 @@ import org.apache.camel.support.service.ServiceSupport;
  * Marshal POJOs to JSON and back using <a href="https://github.com/alibaba/fastjson">Fastjson</a>
  */
 @Dataformat("fastjson")
-@Metadata(includeProperties = "unmarshalType,unmarshalTypeName,prettyprint,contentTypeHeader")
+@Metadata(includeProperties = "unmarshalType,unmarshalTypeName,prettyPrint,contentTypeHeader")
 public class FastjsonDataFormat extends ServiceSupport
         implements DataFormat, DataFormatName, DataFormatContentTypeHeader, CamelContextAware {
 

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JsonDataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JsonDataFormatReifier.java
@@ -31,8 +31,10 @@ public class JsonDataFormatReifier extends DataFormatReifier<JsonDataFormat> {
 
     @Override
     protected void prepareDataFormatConfig(Map<String, Object> properties) {
-        properties.put("objectMapper", asRef(definition.getObjectMapper()));
+        properties.put("unmarshalType", or(definition.getUnmarshalType(), definition.getUnmarshalTypeName()));
+        properties.put("prettyPrint", definition.getPrettyPrint());
         if (definition.getLibrary() == JsonLibrary.Jackson) {
+            properties.put("objectMapper", asRef(definition.getObjectMapper()));
             if (definition.getUseDefaultObjectMapper() == null) {
                 // default true
                 properties.put("useDefaultObjectMapper", "true");
@@ -41,27 +43,26 @@ public class JsonDataFormatReifier extends DataFormatReifier<JsonDataFormat> {
             }
             properties.put("autoDiscoverObjectMapper", definition.getAutoDiscoverObjectMapper());
             properties.put("jsonView", or(definition.getJsonView(), definition.getJsonViewTypeName()));
-        } else {
-            properties.put("jsonView", definition.getJsonView());
-        }
-        properties.put("unmarshalType", or(definition.getUnmarshalType(), definition.getUnmarshalTypeName()));
-        properties.put("prettyPrint", definition.getPrettyPrint());
-        properties.put("include", definition.getInclude());
-        properties.put("allowJmsType", definition.getAllowJmsType());
-        properties.put("collectionType", or(definition.getCollectionType(), definition.getCollectionTypeName()));
-        properties.put("useList", definition.getUseList());
-        properties.put("combineUnicodeSurrogates", definition.getCombineUnicodeSurrogates());
-        properties.put("moduleClassNames", definition.getModuleClassNames());
-        properties.put("moduleRefs", definition.getModuleRefs());
-        properties.put("enableFeatures", definition.getEnableFeatures());
-        properties.put("disableFeatures", definition.getDisableFeatures());
-        properties.put("allowUnmarshallType", definition.getAllowUnmarshallType());
-        if (definition.getLibrary() == JsonLibrary.Jackson) {
+            properties.put("include", definition.getInclude());
+            properties.put("allowJmsType", definition.getAllowJmsType());
+            properties.put("collectionType", or(definition.getCollectionType(), definition.getCollectionTypeName()));
+            properties.put("useList", definition.getUseList());
+            properties.put("combineUnicodeSurrogates", definition.getCombineUnicodeSurrogates());
+            properties.put("moduleClassNames", definition.getModuleClassNames());
+            properties.put("moduleRefs", definition.getModuleRefs());
+            properties.put("enableFeatures", definition.getEnableFeatures());
+            properties.put("disableFeatures", definition.getDisableFeatures());
+            properties.put("allowUnmarshallType", definition.getAllowUnmarshallType());
             properties.put("schemaResolver", asRef(definition.getSchemaResolver()));
             properties.put("autoDiscoverSchemaResolver", definition.getAutoDiscoverSchemaResolver());
             properties.put("namingStrategy", definition.getNamingStrategy());
             properties.put("timezone", definition.getTimezone());
             properties.put("maxStringLength", definition.getMaxStringLength());
+        } else {
+            properties.put("jsonView", definition.getJsonView());
+        }
+        if (definition.getLibrary() == JsonLibrary.Jsonb) {
+            properties.put("objectMapper", asRef(definition.getObjectMapper()));
         }
         if (definition.getLibrary() == JsonLibrary.Fastjson || definition.getLibrary() == JsonLibrary.Gson) {
             properties.put("dateFormatPattern", definition.getDateFormatPattern());

--- a/core/camel-core/src/test/java/org/apache/camel/reifier/dataformat/JsonDataFormatReifierTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/reifier/dataformat/JsonDataFormatReifierTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.reifier.dataformat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.model.dataformat.JsonDataFormat;
+import org.apache.camel.model.dataformat.JsonLibrary;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JsonDataFormatReifierTest {
+
+    private static final Set<String> JACKSON_ONLY_OPTIONS = Set.of(
+            "objectMapper", "useDefaultObjectMapper", "autoDiscoverObjectMapper",
+            "include", "allowJmsType", "collectionType", "useList",
+            "combineUnicodeSurrogates", "moduleClassNames", "moduleRefs",
+            "enableFeatures", "disableFeatures", "allowUnmarshallType",
+            "schemaResolver", "autoDiscoverSchemaResolver", "namingStrategy",
+            "timezone", "maxStringLength");
+
+    @Test
+    public void testGsonDoesNotIncludeJacksonOnlyOptions() {
+        assertNoJacksonOptions(JsonLibrary.Gson);
+    }
+
+    @Test
+    public void testFastjsonDoesNotIncludeJacksonOnlyOptions() {
+        assertNoJacksonOptions(JsonLibrary.Fastjson);
+    }
+
+    @Test
+    public void testJsonbDoesNotIncludeJacksonOnlyOptions() {
+        Map<String, Object> properties = getProperties(JsonLibrary.Jsonb);
+        // Jsonb supports objectMapper, so only check the rest
+        Set<String> jsonbExcluded = Set.of(
+                "useDefaultObjectMapper", "autoDiscoverObjectMapper",
+                "include", "allowJmsType", "collectionType", "useList",
+                "combineUnicodeSurrogates", "moduleClassNames", "moduleRefs",
+                "enableFeatures", "disableFeatures", "allowUnmarshallType",
+                "schemaResolver", "autoDiscoverSchemaResolver", "namingStrategy",
+                "timezone", "maxStringLength");
+        for (String option : jsonbExcluded) {
+            assertFalse(properties.containsKey(option),
+                    "Jsonb should not include Jackson-only option: " + option);
+        }
+        assertTrue(properties.containsKey("objectMapper"),
+                "Jsonb should include objectMapper");
+    }
+
+    @Test
+    public void testJacksonIncludesAllOptions() {
+        Map<String, Object> properties = getProperties(JsonLibrary.Jackson);
+        for (String option : JACKSON_ONLY_OPTIONS) {
+            assertTrue(properties.containsKey(option),
+                    "Jackson should include option: " + option);
+        }
+    }
+
+    private void assertNoJacksonOptions(JsonLibrary library) {
+        Map<String, Object> properties = getProperties(library);
+        for (String option : JACKSON_ONLY_OPTIONS) {
+            assertFalse(properties.containsKey(option),
+                    library.name() + " should not include Jackson-only option: " + option);
+        }
+    }
+
+    private Map<String, Object> getProperties(JsonLibrary library) {
+        DefaultCamelContext context = new DefaultCamelContext();
+        JsonDataFormat definition = new JsonDataFormat();
+        definition.setLibrary(library);
+        JsonDataFormatReifier reifier = new JsonDataFormatReifier(context, definition);
+        Map<String, Object> properties = new LinkedHashMap<>();
+        reifier.prepareDataFormatConfig(properties);
+        return properties;
+    }
+}


### PR DESCRIPTION
## Summary

`JsonDataFormatReifier.prepareDataFormatConfig` unconditionally put 10 Jackson-only options (`include`, `allowJmsType`, `collectionType`, `useList`, `combineUnicodeSurrogates`, `moduleClassNames`, `moduleRefs`, `enableFeatures`, `disableFeatures`, `allowUnmarshallType`) plus `objectMapper` into the property map for all JSON libraries. When any of these was non-null and the library was Gson, Fastjson, or Jsonb, `PropertyBindingSupport` with `withMandatory(true)` threw a `PropertyBindingException` at route startup.

- Moved the 10 Jackson-only options and `objectMapper` into the `library == Jackson` guard block
- Added a separate `library == Jsonb` guard for `objectMapper` (the only non-Jackson library that supports it)
- Fixed pre-existing `@Metadata(includeProperties)` casing bug in `FastjsonDataFormat`: `prettyprint` → `prettyPrint` so the generated configurer recognizes the property
- Regenerated Fastjson configurer and metadata

## Test plan

- [x] Added `JsonDataFormatReifierTest` with 4 tests verifying Gson/Fastjson/Jsonb don't get Jackson-only options, and Jackson still gets all of them
- [ ] CI green

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>