### PR TITLE
CAMEL-23382: camel-ai-tool - align spring-ai-chat with camel-ai-tool …

### DIFF
--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/pom.xml
@@ -40,10 +40,10 @@
             <artifactId>camel-support</artifactId>
         </dependency>
 
-        <!-- Camel Spring AI Tools for function calling -->
+        <!-- Camel AI Tool for unified AiToolRegistry -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-spring-ai-tools</artifactId>
+            <artifactId>camel-ai-tool</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
@@ -96,6 +96,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/docs/spring-ai-chat-component.adoc
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/docs/spring-ai-chat-component.adoc
@@ -501,9 +501,9 @@ NOTE: The component automatically configures conversation isolation using metada
 
 === Function Calling / Tool Integration
 
-The component integrates with the xref:spring-ai-tools-component.adoc[Spring AI Tools Component] to enable LLMs to call Camel routes as functions/tools. This extends the LLM's capabilities with custom logic, external APIs, database queries, and more.
+The component integrates with the xref:ai-tool-component.adoc[AI Tool Component] to enable LLMs to call Camel routes as functions/tools. This extends the LLM's capabilities with custom logic, external APIs, database queries, and more.
 
-When you configure the `tags` parameter, the chat component discovers all matching tools from `spring-ai-tools` routes, registers them with Spring AI's ChatClient, and allows the LLM to call them during conversation.
+When you configure the `tags` parameter, the chat component discovers all matching tools from `ai-tool` routes, registers them with Spring AI's ChatClient, and allows the LLM to call them during conversation.
 
 [tabs]
 ====
@@ -512,13 +512,13 @@ Java::
 [source,java]
 ----
 // Define tools
-from("spring-ai-tools:weather?tags=weather&description=Get current weather for a location")
+from("ai-tool:weather?tags=weather&description=Get current weather for a location")
     .setBody(constant("Sunny"));
 
-from("spring-ai-tools:calculator?tags=math&description=Evaluate mathematical expressions")
+from("ai-tool:calculator?tags=math&description=Evaluate mathematical expressions")
     .setBody(constant("42"));
 
-from("spring-ai-tools:stock?tags=finance&description=Get current stock price")
+from("ai-tool:stock?tags=finance&description=Get current stock price")
     .setBody(constant("42"));
 
 // Chat endpoints with different tool combinations
@@ -538,17 +538,17 @@ XML::
 ----
 <!-- Define tools -->
 <route>
-  <from uri="spring-ai-tools:weather?tags=weather&amp;description=Get current weather for a location"/>
+  <from uri="ai-tool:weather?tags=weather&amp;description=Get current weather for a location"/>
   <setBody><constant>Sunny</constant></setBody>
 </route>
 
 <route>
-  <from uri="spring-ai-tools:calculator?tags=math&amp;description=Evaluate mathematical expressions"/>
+  <from uri="ai-tool:calculator?tags=math&amp;description=Evaluate mathematical expressions"/>
   <setBody><constant>42</constant></setBody>
 </route>
 
 <route>
-  <from uri="spring-ai-tools:stock?tags=finance&amp;description=Get current stock price"/>
+  <from uri="ai-tool:stock?tags=finance&amp;description=Get current stock price"/>
   <setBody><constant>42</constant></setBody>
 </route>
 
@@ -576,7 +576,7 @@ YAML::
 # Define tools
 - route:
     from:
-      uri: spring-ai-tools:weather
+      uri: ai-tool:weather
       parameters:
         tags: weather
         description: Get current weather for a location
@@ -586,7 +586,7 @@ YAML::
 
 - route:
     from:
-      uri: spring-ai-tools:calculator
+      uri: ai-tool:calculator
       parameters:
         tags: math
         description: Evaluate mathematical expressions
@@ -596,7 +596,7 @@ YAML::
 
 - route:
     from:
-      uri: spring-ai-tools:stock
+      uri: ai-tool:stock
       parameters:
         tags: finance
         description: Get current stock price
@@ -1028,7 +1028,7 @@ template.request("direct:chat", e -> {
 ----
 
 NOTE: Tool context works with Spring AI `@Tool` methods and MCP tools.
-Camel route tools (defined via `spring-ai-tools` consumer) do not receive the `ToolContext`.
+Camel route tools (defined via `ai-tool` consumer) do not receive the `ToolContext`.
 
 === Structured Output Validation
 
@@ -1384,7 +1384,7 @@ logging.level.org.springframework.ai.chat.client.advisor=DEBUG
 
 * https://docs.spring.io/spring-ai/reference/[Spring AI Documentation]
 * https://docs.spring.io/spring-ai/reference/api/tools.html[Spring AI Function Calling]
-* xref:spring-ai-tools-component.adoc[Spring AI Tools Component]
+* xref:ai-tool-component.adoc[AI Tool Component]
 * xref:spring-ai-embeddings-component.adoc[Spring AI Embeddings Component]
 * xref:spring-ai-vector-store-component.adoc[Spring AI VectorStore Component]
 * xref:spring-ai-image-component.adoc[Spring AI Image Component]

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/java/org/apache/camel/component/springai/chat/AiToolSpecToSpringAi.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/java/org/apache/camel/component/springai/chat/AiToolSpecToSpringAi.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.springai.chat;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.ai.tool.AiToolExecutor;
+import org.apache.camel.component.ai.tool.AiToolResult;
+import org.apache.camel.component.ai.tool.AiToolSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+/**
+ * Converts a framework-agnostic {@link AiToolSpec} into a Spring AI {@link ToolCallback}. Delegates tool execution to
+ * {@link AiToolExecutor} so that argument filtering, required-parameter validation, and route invocation are handled
+ * uniformly across all AI framework adapters.
+ */
+final class AiToolSpecToSpringAi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AiToolSpecToSpringAi.class);
+
+    private AiToolSpecToSpringAi() {
+    }
+
+    static ToolCallback toToolCallback(AiToolSpec spec) {
+        Function<Map<String, Object>, String> function = args -> {
+            Exchange toolExchange = spec.getConsumer().getEndpoint().createExchange();
+            try {
+                AiToolResult result = AiToolExecutor.execute(spec, args, toolExchange);
+                if (result instanceof AiToolResult.Success success) {
+                    return success.value();
+                } else if (result instanceof AiToolResult.ArgumentError argErr) {
+                    return "Tool execution failed: " + argErr.message();
+                } else if (result instanceof AiToolResult.ExecutionError execErr) {
+                    LOG.warn("Tool '{}' execution failed: {}", spec.getName(), execErr.message(), execErr.cause());
+                    return "Tool execution failed";
+                }
+                return "Tool execution failed";
+            } finally {
+                spec.getConsumer().releaseExchange(toolExchange, false);
+            }
+        };
+
+        FunctionToolCallback.Builder builder = FunctionToolCallback
+                .builder(spec.getName(), function)
+                .description(spec.getDescription())
+                .inputType(Map.class);
+
+        if (spec.getParametersJsonSchema() != null) {
+            builder.inputSchema(spec.getParametersJsonSchema());
+        }
+
+        return builder.build();
+    }
+}

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/java/org/apache/camel/component/springai/chat/SpringAiChatConfiguration.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/java/org/apache/camel/component/springai/chat/SpringAiChatConfiguration.java
@@ -360,7 +360,7 @@ public class SpringAiChatConfiguration implements Cloneable {
 
     /**
      * Tags for discovering and calling Camel route tools. When provided, the chat component will automatically register
-     * tools from camel-spring-ai-tools routes matching these tags.
+     * tools from ai-tool routes matching these tags.
      */
     public void setTags(String tags) {
         this.tags = tags;

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/java/org/apache/camel/component/springai/chat/SpringAiChatProducer.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/main/java/org/apache/camel/component/springai/chat/SpringAiChatProducer.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,10 +32,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.NoSuchHeaderException;
 import org.apache.camel.WrappedFile;
+import org.apache.camel.component.ai.tool.AiToolParameterHelper;
+import org.apache.camel.component.ai.tool.AiToolRegistry;
+import org.apache.camel.component.ai.tool.AiToolSpec;
 import org.apache.camel.component.springai.chat.mcp.SpringAiChatMcpManager;
-import org.apache.camel.component.springai.tools.TagsHelper;
-import org.apache.camel.component.springai.tools.spec.CamelToolExecutorCache;
-import org.apache.camel.component.springai.tools.spec.CamelToolSpecification;
 import org.apache.camel.support.DefaultProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -958,7 +959,7 @@ public class SpringAiChatProducer extends DefaultProducer {
     }
 
     /**
-     * Register tools from camel-spring-ai-tools routes based on configured tags
+     * Register tools from ai-tool routes based on configured tags
      *
      * Tools are registered via ChatOptions.toolCallbacks() which is the correct way to pass ToolCallback instances in
      * Spring AI. The tools() method expects objects with @Tool annotated methods, not ToolCallback instances.
@@ -969,8 +970,8 @@ public class SpringAiChatProducer extends DefaultProducer {
             return List.of();
         }
 
-        // Discover tools from Camel Spring AI Tools routes
-        List<ToolCallback> toolCallbacks = discoverTools(tags);
+        // Discover tools from the unified AiToolRegistry
+        List<ToolCallback> toolCallbacks = discoverAiRegistryTools(tags);
 
         if (!toolCallbacks.isEmpty()) {
             // Collect tool names for enhanced logging
@@ -994,21 +995,22 @@ public class SpringAiChatProducer extends DefaultProducer {
     }
 
     /**
-     * Discover tools by tags and return a list of ToolCallback instances
+     * Discover tools registered via {@code ai-tool:} consumer endpoints in the shared {@link AiToolRegistry}. Converts
+     * each {@link AiToolSpec} to a Spring AI {@link ToolCallback} via {@link AiToolSpecToSpringAi}.
      */
-    private List<ToolCallback> discoverTools(String tags) {
-        final CamelToolExecutorCache toolCache = CamelToolExecutorCache.getInstance();
-        final Map<String, Set<CamelToolSpecification>> tools = toolCache.getTools();
-        final String[] tagArray = TagsHelper.splitTags(tags);
+    private List<ToolCallback> discoverAiRegistryTools(String tags) {
+        final AiToolRegistry registry = AiToolRegistry.getOrCreate(getEndpoint().getCamelContext());
+        final String[] tagArray = AiToolParameterHelper.splitTags(tags);
 
-        final List<ToolCallback> toolCallbacks = Arrays.stream(tagArray)
-                .flatMap(tag -> tools.entrySet().stream()
-                        .filter(entry -> entry.getKey().equals(tag))
-                        .flatMap(entry -> entry.getValue().stream()))
-                .map(CamelToolSpecification::getToolCallback)
+        final Set<AiToolSpec> uniqueSpecs = new LinkedHashSet<>();
+        for (String tag : tagArray) {
+            uniqueSpecs.addAll(registry.getToolsByTag(tag));
+        }
+        final List<ToolCallback> toolCallbacks = uniqueSpecs.stream()
+                .map(AiToolSpecToSpringAi::toToolCallback)
                 .collect(Collectors.toList());
 
-        LOG.debug("Discovered {} unique tools for tags: {}", toolCallbacks.size(), tags);
+        LOG.debug("Discovered {} tools from AiToolRegistry for tags: {}", toolCallbacks.size(), tags);
         return toolCallbacks;
     }
 

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/test/java/org/apache/camel/component/springai/chat/SpringAiChatToolsDiscoveryTest.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/test/java/org/apache/camel/component/springai/chat/SpringAiChatToolsDiscoveryTest.java
@@ -16,60 +16,53 @@
  */
 package org.apache.camel.component.springai.chat;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.springai.tools.spec.CamelToolExecutorCache;
+import org.apache.camel.component.ai.tool.AiToolRegistry;
 import org.apache.camel.test.junit6.CamelTestSupport;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Unit test for tool discovery mechanism in camel-spring-ai-chat component.
  *
- * This test verifies that tools are properly registered in the cache when defined using the spring-ai-tools component.
+ * This test verifies that tools are properly registered in the AiToolRegistry when defined using the ai-tool component.
  */
 public class SpringAiChatToolsDiscoveryTest extends CamelTestSupport {
 
-    @AfterEach
-    public void cleanupToolCache() {
-        // Clean up the tool cache after each test
-        CamelToolExecutorCache.getInstance().getTools().clear();
-    }
-
     @Test
-    public void testToolsAreRegisteredWithCache() throws Exception {
-        // Wait for routes to start and tools to be registered
-        Thread.sleep(500);
+    public void testToolsAreRegisteredWithRegistry() throws Exception {
+        var registry = AiToolRegistry.getOrCreate(context);
 
-        var toolCache = CamelToolExecutorCache.getInstance();
-        var tools = toolCache.getTools();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            var tools = registry.getTools();
 
-        // Verify that tools are registered with correct tags
-        assertThat(tools).isNotEmpty();
-        assertThat(tools).containsKey("weather");
-        assertThat(tools).containsKey("math");
-        assertThat(tools).containsKey("database");
+            assertThat(tools).isNotEmpty();
+            assertThat(tools).containsKey("weather");
+            assertThat(tools).containsKey("math");
+            assertThat(tools).containsKey("database");
 
-        // Verify weather tools
-        assertThat(tools.get("weather")).isNotEmpty();
-        assertThat(tools.get("weather")).hasSize(1);
+            assertThat(tools.get("weather")).isNotEmpty();
+            assertThat(tools.get("weather")).hasSize(1);
 
-        // Verify math tools
-        assertThat(tools.get("math")).isNotEmpty();
-        assertThat(tools.get("math")).hasSize(1);
+            assertThat(tools.get("math")).isNotEmpty();
+            assertThat(tools.get("math")).hasSize(1);
 
-        // Verify database tools
-        assertThat(tools.get("database")).isNotEmpty();
-        assertThat(tools.get("database")).hasSize(1);
+            assertThat(tools.get("database")).isNotEmpty();
+            assertThat(tools.get("database")).hasSize(1);
+        });
     }
 
     @Test
     public void testToolExecutionWithParameters() throws Exception {
-        // Wait for routes to start
-        Thread.sleep(500);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            var registry = AiToolRegistry.getOrCreate(context);
+            assertThat(registry.getTools()).isNotEmpty();
+        });
 
-        // Test that a tool can be executed directly via the tool route
         var exchange = template().request("direct:testWeatherTool", e -> {
             e.getIn().setHeader("city", "Paris");
         });
@@ -80,18 +73,15 @@ public class SpringAiChatToolsDiscoveryTest extends CamelTestSupport {
     }
 
     @Test
-    public void testMultipleToolsWithSameTag() throws Exception {
-        // Wait for routes to start
-        Thread.sleep(500);
+    public void testToolExecutionWithDifferentInput() throws Exception {
+        var registry = AiToolRegistry.getOrCreate(context);
 
-        var toolCache = CamelToolExecutorCache.getInstance();
-        var tools = toolCache.getTools();
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            var tools = registry.getTools();
+            assertThat(tools.get("weather")).isNotNull();
+            assertThat(tools.get("weather")).hasSize(1);
+        });
 
-        // Verify that the weather tag has exactly one tool
-        assertThat(tools.get("weather")).isNotNull();
-        assertThat(tools.get("weather")).hasSize(1);
-
-        // Verify the tool can be executed
         var exchange = template().request("direct:testWeatherTool", e -> {
             e.getIn().setHeader("city", "London");
         });
@@ -107,7 +97,7 @@ public class SpringAiChatToolsDiscoveryTest extends CamelTestSupport {
             @Override
             public void configure() throws Exception {
                 // Define weather tool
-                from("spring-ai-tools:weather?tags=weather&description=Get weather for a city")
+                from("ai-tool:weather?tags=weather&description=Get weather for a city")
                         .process(exchange -> {
                             String city = exchange.getIn().getHeader("city", String.class);
                             String weather = "The weather in " + city + " is sunny";
@@ -115,14 +105,14 @@ public class SpringAiChatToolsDiscoveryTest extends CamelTestSupport {
                         });
 
                 // Define calculator tool
-                from("spring-ai-tools:calculator?tags=math&description=Calculate expressions")
+                from("ai-tool:calculator?tags=math&description=Calculate expressions")
                         .process(exchange -> {
                             String expression = exchange.getIn().getHeader("expression", String.class);
                             exchange.getIn().setBody("Result: " + expression);
                         });
 
                 // Define database tool
-                from("spring-ai-tools:queryDb?tags=database&description=Query database")
+                from("ai-tool:queryDb?tags=database&description=Query database")
                         .process(exchange -> {
                             String query = exchange.getIn().getHeader("query", String.class);
                             exchange.getIn().setBody("Query result: " + query);

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/test/java/org/apache/camel/component/springai/chat/SpringAiChatToolsIntegrationIT.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-chat/src/test/java/org/apache/camel/component/springai/chat/SpringAiChatToolsIntegrationIT.java
@@ -16,16 +16,19 @@
  */
 package org.apache.camel.component.springai.chat;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.ai.tool.AiToolRegistry;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.component.springai.tools.spec.CamelToolExecutorCache;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
- * Integration test demonstrating interaction between camel-spring-ai-chat and camel-spring-ai-tools components.
+ * Integration test demonstrating interaction between camel-spring-ai-chat and ai-tool components.
  *
  * This test shows how Camel routes can be exposed as tools/functions that LLMs can call during conversations.
  *
@@ -42,18 +45,17 @@ public class SpringAiChatToolsIntegrationIT extends OllamaTestSupport {
 
     @Test
     public void testToolsAreRegistered() throws Exception {
-        // Verify that tools are registered in the cache before testing
-        var toolCache = CamelToolExecutorCache.getInstance();
-        var tools = toolCache.getTools();
+        var registry = AiToolRegistry.getOrCreate(context);
 
-        // Give routes time to start and register tools
-        Thread.sleep(1000);
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            var tools = registry.getTools();
 
-        assertThat(tools).isNotEmpty();
-        assertThat(tools).containsKey("weather");
-        assertThat(tools).containsKey("math");
-        assertThat(tools.get("weather")).hasSize(1);
-        assertThat(tools.get("math")).hasSize(1);
+            assertThat(tools).isNotEmpty();
+            assertThat(tools).containsKey("weather");
+            assertThat(tools).containsKey("math");
+            assertThat(tools.get("weather")).hasSize(1);
+            assertThat(tools.get("math")).hasSize(1);
+        });
     }
 
     @Test
@@ -190,7 +192,7 @@ public class SpringAiChatToolsIntegrationIT extends OllamaTestSupport {
                 bindChatModel(getCamelContext());
 
                 // Define weather tool - gets weather for a specified city
-                from("spring-ai-tools:weather?tags=weather&description=Get current weather for a city&parameter.city=string")
+                from("ai-tool:weather?tags=weather&description=Get current weather for a city&parameter.city=string")
                         .log("Weather tool called with city: ${header.city}")
                         .process(exchange -> {
                             String city = exchange.getIn().getHeader("city", String.class);
@@ -210,7 +212,7 @@ public class SpringAiChatToolsIntegrationIT extends OllamaTestSupport {
                         .to("mock:weather");
 
                 // Define calculator tool - performs simple calculations
-                from("spring-ai-tools:calculator?tags=math&description=Calculate mathematical expressions&parameter.expression=string")
+                from("ai-tool:calculator?tags=math&description=Calculate mathematical expressions&parameter.expression=string")
                         .process(exchange -> {
                             String expression = exchange.getIn().getHeader("expression", String.class);
                             String result;

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -210,6 +210,47 @@ The following 10 Oracle connector options have been removed by Debezium 3.6.0 an
 
 If you use any of these options, remove them from your configuration as they will cause errors.
 
+=== camel-spring-ai-chat
+
+==== Camel route tools now use ai-tool
+
+The `spring-ai-chat` producer now discovers Camel route tools from the `ai-tool` component
+(`AiToolRegistry`) instead of the `spring-ai-tools` component (`CamelToolExecutorCache`).
+
+Migrate your tool definition routes from `spring-ai-tools:` to `ai-tool:`:
+
+[source,java]
+----
+// Before (no longer works with spring-ai-chat)
+from("spring-ai-tools:weather?tags=weather&description=Get current weather for a city&parameter.city=string")
+    .setBody(constant("{\"city\": \"Paris\", \"temp\": \"22°C\"}"));
+
+// After
+from("ai-tool:weather?tags=weather&description=Get current weather for a city&parameter.city=string")
+    .setBody(constant("{\"city\": \"Paris\", \"temp\": \"22°C\"}"));
+----
+
+The `spring-ai-chat` producer endpoint is unchanged — only the tool consumer routes need
+to be migrated:
+
+[source,java]
+----
+from("direct:chat")
+    .to("spring-ai-chat:weatherChat?tags=weather&chatModel=#chatModel");
+----
+
+Add the `camel-ai-tool` dependency to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>camel-ai-tool</artifactId>
+</dependency>
+----
+
+The `camel-spring-ai-tools` dependency is no longer required by `camel-spring-ai-chat`.
+
 === camel-fory with JDK 25+ - Breaking change
 
 Due to new requirements from Apache Fory, when using Apache Fory Dataformat, the JVM parameter `--add-opens java.base/java.lang.invoke=ALL-UNNAMED` must be provided.


### PR DESCRIPTION
…component

# Description

Step 3: Wire camel-spring-ai-chat producer to discover tools from AiToolRegistry

## Summary
Migrate the `camel-spring-ai-chat` producer from `camel-spring-ai-tools` (`CamelToolExecutorCache`) to the unified `camel-ai-tool` module (`AiToolRegistry`).

  - **Bridge adapter**: new `AiToolSpecToSpringAi` converts `AiToolSpec` → Spring AI `ToolCallback`, with explicit handling of all `AiToolResult` subtypes and WARN logging on execution errors
  - **Tool deduplication**: uses `LinkedHashSet` to prevent duplicate tools when tags overlap
  - **Dependency swap**: `camel-spring-ai-tools` → `camel-ai-tool` in pom.xml
  - **Tests**: migrated to `AiToolRegistry`, replaced `Thread.sleep()` with Awaitility
  - **Docs**: updated component docs and upgrade guide with migration instructions

  No changes to other modules.

  ## Roadmap

  - [x] Step 1: Create the new `camel-ai-tool` module - https://github.com/apache/camel/pull/24473
  - [ ] Step 2: Wire `camel-langchain4j-agent` producer to `AiToolRegistry`
  - [x] **Step 3 (this PR): Wire `camel-spring-ai-chat` producer to `AiToolRegistry`**
  - [ ] Step 4: Wire `camel-langchain4j-tools` producer to `AiToolRegistry`
  - [ ] Step 5: Deprecate `camel-langchain4j-tools` consumer, remove `camel-spring-ai-tools`
  - [ ] Step 6: Add tool support to `camel-openai`

