### PR TITLE
CAMEL-24156: Fix high-severity findings across camel-aws2 components

### DIFF
--- a/components/camel-aws/camel-aws2-ddb/src/main/java/org/apache/camel/component/aws2/ddb/transform/Ddb2JsonDataTypeTransformer.java
+++ b/components/camel-aws/camel-aws2-ddb/src/main/java/org/apache/camel/component/aws2/ddb/transform/Ddb2JsonDataTypeTransformer.java
@@ -194,11 +194,7 @@ public class Ddb2JsonDataTypeTransformer extends Transformer {
             return AttributeValue.builder().s(value.toString()).build();
         }
 
-        if (value instanceof Integer) {
-            return AttributeValue.builder().n(value.toString()).build();
-        }
-
-        if (value instanceof Double) {
+        if (value instanceof Number) {
             return AttributeValue.builder().n(value.toString()).build();
         }
 

--- a/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-component.adoc
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/docs/aws2-kinesis-component.adoc
@@ -66,6 +66,17 @@ all available shards (multiple shards consumption) of Amazon Kinesis, therefore,
 property in the DSL configuration empty, then it'll consume all available shards
 otherwise only the specified shard corresponding to the shardId will be consumed.
 
+=== Custom Resume Action
+
+The consumer supports a custom `KinesisResumeAction` for controlling where each shard starts reading
+(e.g., resuming from a persisted sequence number). Register a subclass in the Camel registry under the
+key `CamelKinesisDbResumeAction`.
+
+The consumer creates a separate instance per shard via reflection to avoid concurrent mutation when
+multiple shards are processed in parallel. Because of this, custom subclasses *must* provide a
+public no-arg constructor. Per-shard state (`builder`, `shardId`, `streamName`) is injected via
+setters after construction.
+
 === Batch Producer
 
 This component implements the Batch Producer.

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Configuration.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Configuration.java
@@ -68,7 +68,7 @@ public class Kinesis2Configuration implements Cloneable, AwsCommonConfiguration 
                             + " In case of ignore a WARN message will be logged once and the consumer will not process new messages until restarted,"
                             + "in case of silent there will be no logging and the consumer will not process new messages until restarted,"
                             + "in case of fail a ReachedClosedStateException will be thrown")
-    private Kinesis2ShardClosedStrategyEnum shardClosed;
+    private Kinesis2ShardClosedStrategyEnum shardClosed = Kinesis2ShardClosedStrategyEnum.ignore;
     @UriParam(label = "proxy", enums = "HTTP,HTTPS", defaultValue = "HTTPS",
               description = "To define a proxy protocol when instantiating the Kinesis client")
     private Protocol proxyProtocol = Protocol.HTTPS;

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
@@ -347,11 +347,8 @@ public class Kinesis2Consumer extends ScheduledBatchPollingConsumer implements R
         if (ObjectHelper.isEmpty(template)) {
             action = new KinesisResumeAction(req);
         } else {
-            try {
-                action = template.getClass().getDeclaredConstructor().newInstance();
-            } catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
-            }
+            action = (KinesisResumeAction) getEndpoint().getCamelContext().getInjector()
+                    .newInstance(template.getClass());
             action.setBuilder(req);
         }
         action.setShardId(shardId);

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
@@ -341,7 +341,19 @@ public class Kinesis2Consumer extends ScheduledBatchPollingConsumer implements R
     }
 
     private KinesisResumeAction resolveResumeAction(String shardId, GetShardIteratorRequest.Builder req) {
-        KinesisResumeAction action = new KinesisResumeAction(req);
+        KinesisResumeAction template = getEndpoint().getCamelContext().getRegistry()
+                .lookupByNameAndType(Kinesis2Constants.RESUME_ACTION, KinesisResumeAction.class);
+        KinesisResumeAction action;
+        if (ObjectHelper.isEmpty(template)) {
+            action = new KinesisResumeAction(req);
+        } else {
+            try {
+                action = template.getClass().getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+            action.setBuilder(req);
+        }
         action.setShardId(shardId);
         action.setStreamName(getEndpoint().getConfiguration().getStreamName());
         return action;

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
@@ -341,15 +341,7 @@ public class Kinesis2Consumer extends ScheduledBatchPollingConsumer implements R
     }
 
     private KinesisResumeAction resolveResumeAction(String shardId, GetShardIteratorRequest.Builder req) {
-        KinesisResumeAction action
-                = getEndpoint().getCamelContext().getRegistry().lookupByNameAndType(Kinesis2Constants.RESUME_ACTION,
-                        KinesisResumeAction.class);
-        if (ObjectHelper.isEmpty(action)) {
-            action = new KinesisResumeAction(req);
-        } else {
-            action.setBuilder(req);
-        }
-
+        KinesisResumeAction action = new KinesisResumeAction(req);
         action.setShardId(shardId);
         action.setStreamName(getEndpoint().getConfiguration().getStreamName());
         return action;

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/Kinesis2Consumer.java
@@ -43,6 +43,7 @@ import org.apache.camel.util.CastUtils;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
@@ -152,31 +153,25 @@ public class Kinesis2Consumer extends ScheduledBatchPollingConsumer implements R
             return;
         }
 
-        GetRecordsRequest req = GetRecordsRequest
-                .builder()
-                .shardIterator(shardIterator)
-                .limit(getEndpoint()
-                        .getConfiguration()
-                        .getMaxResultsPerRequest())
-                .build();
-
         GetRecordsResponse result;
-        if (getEndpoint().getConfiguration().isAsyncClient()) {
+        try {
+            result = getRecords(shardIterator, kinesisConnection);
+        } catch (ExpiredIteratorException e) {
+            LOG.warn("Shard iterator expired for shard {} on stream {}, requesting a fresh one",
+                    shard.shardId(), getEndpoint().getConfiguration().getStreamName());
+            currentShardIterators.remove(shard.shardId());
             try {
-                result = kinesisConnection
-                        .getAsyncClient(getEndpoint())
-                        .getRecords(req)
-                        .get();
-            } catch (InterruptedException e) {
+                shardIterator = getShardIterator(shard, kinesisConnection);
+            } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            } catch (ExecutionException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException(ie);
+            } catch (ExecutionException ee) {
+                throw new RuntimeException(ee);
             }
-        } else {
-            result = kinesisConnection
-                    .getClient(getEndpoint())
-                    .getRecords(req);
+            if (ObjectHelper.isEmpty(shardIterator)) {
+                return;
+            }
+            result = getRecords(shardIterator, kinesisConnection);
         }
 
         try {
@@ -191,6 +186,37 @@ public class Kinesis2Consumer extends ScheduledBatchPollingConsumer implements R
         // we left off, however, I don't know what happens to subsequent
         // exchanges when an earlier exchange fails.
         updateShardIterator(shard, result.nextShardIterator());
+    }
+
+    private GetRecordsResponse getRecords(String shardIterator, KinesisConnection kinesisConnection) {
+        GetRecordsRequest req = GetRecordsRequest
+                .builder()
+                .shardIterator(shardIterator)
+                .limit(getEndpoint()
+                        .getConfiguration()
+                        .getMaxResultsPerRequest())
+                .build();
+
+        if (getEndpoint().getConfiguration().isAsyncClient()) {
+            try {
+                return kinesisConnection
+                        .getAsyncClient(getEndpoint())
+                        .getRecords(req)
+                        .get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof ExpiredIteratorException ex) {
+                    throw ex;
+                }
+                throw new RuntimeException(e);
+            }
+        } else {
+            return kinesisConnection
+                    .getClient(getEndpoint())
+                    .getRecords(req);
+        }
     }
 
     private void updateShardIterator(Shard shard, String nextShardIterator) {

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/KinesisConnection.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/KinesisConnection.java
@@ -73,11 +73,18 @@ public class KinesisConnection implements Closeable {
 
     @Override
     public void close() throws IOException {
-        if (ObjectHelper.isNotEmpty(kinesisClient)) {
-            kinesisClient.close();
-        }
-        if (ObjectHelper.isNotEmpty(kinesisAsyncClient)) {
-            kinesisAsyncClient.close();
+        lock.lock();
+        try {
+            if (ObjectHelper.isNotEmpty(kinesisClient)) {
+                kinesisClient.close();
+                kinesisClient = null;
+            }
+            if (ObjectHelper.isNotEmpty(kinesisAsyncClient)) {
+                kinesisAsyncClient.close();
+                kinesisAsyncClient = null;
+            }
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/consumer/KinesisResumeAction.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/kinesis/consumer/KinesisResumeAction.java
@@ -21,6 +21,9 @@ import org.apache.camel.resume.ResumeAction;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
+/**
+ * Subclasses must provide a public no-arg constructor — the consumer creates per-shard instances via reflection.
+ */
 public class KinesisResumeAction implements ResumeAction {
 
     private GetShardIteratorRequest.Builder builder;

--- a/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/integration/KinesisConsumerResumeIT.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/integration/KinesisConsumerResumeIT.java
@@ -77,11 +77,11 @@ public class KinesisConsumerResumeIT extends CamelTestSupport {
         }
     }
 
-    static class TestResumeAction extends KinesisResumeAction {
+    public static class TestResumeAction extends KinesisResumeAction {
         private static volatile List<PutRecordsResponse> previousRecords;
         private static volatile int expectedCount;
 
-        TestResumeAction() {
+        public TestResumeAction() {
         }
 
         public static void setPreviousRecords(List<PutRecordsResponse> records) {

--- a/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/integration/KinesisConsumerResumeIT.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/integration/KinesisConsumerResumeIT.java
@@ -77,7 +77,7 @@ public class KinesisConsumerResumeIT extends CamelTestSupport {
         }
     }
 
-    private static final class TestResumeAction extends KinesisResumeAction {
+    static class TestResumeAction extends KinesisResumeAction {
         private static volatile List<PutRecordsResponse> previousRecords;
         private static volatile int expectedCount;
 

--- a/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/integration/KinesisConsumerResumeIT.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/test/java/org/apache/camel/component/aws2/kinesis/integration/KinesisConsumerResumeIT.java
@@ -78,19 +78,18 @@ public class KinesisConsumerResumeIT extends CamelTestSupport {
     }
 
     private static final class TestResumeAction extends KinesisResumeAction {
-        private List<PutRecordsResponse> previousRecords;
-        private final int expectedCount;
+        private static volatile List<PutRecordsResponse> previousRecords;
+        private static volatile int expectedCount;
 
-        private TestResumeAction(int expectedCount) {
-            this.expectedCount = expectedCount;
+        TestResumeAction() {
         }
 
-        public void setPreviousRecords(List<PutRecordsResponse> previousRecords) {
-            this.previousRecords = previousRecords;
+        public static void setPreviousRecords(List<PutRecordsResponse> records) {
+            previousRecords = records;
         }
 
-        public int getExpectedCount() {
-            return expectedCount;
+        public static void setExpectedCount(int count) {
+            expectedCount = count;
         }
 
         @Override
@@ -125,7 +124,7 @@ public class KinesisConsumerResumeIT extends CamelTestSupport {
     private final int expectedCount = messageCount / 2;
     private List<KinesisData> receivedMessages = new CopyOnWriteArrayList<>();
     private List<PutRecordsResponse> previousRecords;
-    private TestResumeAction action = new TestResumeAction(expectedCount);
+    private TestResumeAction action = new TestResumeAction();
 
     @Override
     protected RouteBuilder createRouteBuilder() {
@@ -176,7 +175,8 @@ public class KinesisConsumerResumeIT extends CamelTestSupport {
             }
         }
 
-        action.setPreviousRecords(previousRecords);
+        TestResumeAction.setExpectedCount(expectedCount);
+        TestResumeAction.setPreviousRecords(previousRecords);
     }
 
     @AfterEach

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -214,7 +214,11 @@ public class AWS2S3Producer extends DefaultProducer {
         if (contentLength == 0 || contentLength < partSize) {
             // optimize to do a single op if content length is known and < part size
             LOG.debug("Payload size < partSize ({} > {}). Uploading payload in single operation", contentLength, partSize);
-            doPutObject(exchange, objectMetadata, filePayload, inputStream, contentLength);
+            try {
+                doPutObject(exchange, objectMetadata, filePayload, inputStream, contentLength);
+            } finally {
+                IOHelper.close(inputStream);
+            }
             return;
         }
 
@@ -224,7 +228,7 @@ public class AWS2S3Producer extends DefaultProducer {
         final String keyName = AWS2S3Utils.determineKey(exchange, getConfiguration());
         final String bucketName = AWS2S3Utils.determineBucketName(exchange, getConfiguration());
         CreateMultipartUploadRequest.Builder createMultipartUploadRequest
-                = CreateMultipartUploadRequest.builder().bucket(getConfiguration().getBucketName()).key(keyName);
+                = CreateMultipartUploadRequest.builder().bucket(bucketName).key(keyName);
 
         String storageClass = AWS2S3Utils.determineStorageClass(exchange, getConfiguration());
         if (ObjectHelper.isNotEmpty(storageClass)) {
@@ -279,7 +283,7 @@ public class AWS2S3Producer extends DefaultProducer {
             for (int part = 1; position < contentLength; part++) {
                 partSize = Math.min(partSize, contentLength - position);
 
-                UploadPartRequest uploadRequest = UploadPartRequest.builder().bucket(getConfiguration().getBucketName())
+                UploadPartRequest uploadRequest = UploadPartRequest.builder().bucket(bucketName)
                         .key(keyName).uploadId(initResponse.uploadId())
                         .partNumber(part).build();
 
@@ -295,7 +299,7 @@ public class AWS2S3Producer extends DefaultProducer {
             LOG.debug("Completing multi-part upload for {}", keyName);
             CompletedMultipartUpload completeMultipartUpload = CompletedMultipartUpload.builder().parts(completedParts).build();
             CompleteMultipartUploadRequest.Builder compRequestBuilder = CompleteMultipartUploadRequest.builder()
-                    .multipartUpload(completeMultipartUpload).bucket(getConfiguration().getBucketName()).key(keyName)
+                    .multipartUpload(completeMultipartUpload).bucket(bucketName).key(keyName)
                     .uploadId(initResponse.uploadId());
             if (getConfiguration().isConditionalWritesEnabled()) {
                 compRequestBuilder.ifNoneMatch("*");
@@ -304,7 +308,7 @@ public class AWS2S3Producer extends DefaultProducer {
 
         } catch (Exception e) {
             getEndpoint().getS3Client()
-                    .abortMultipartUpload(AbortMultipartUploadRequest.builder().bucket(getConfiguration().getBucketName())
+                    .abortMultipartUpload(AbortMultipartUploadRequest.builder().bucket(bucketName)
                             .key(keyName).uploadId(initResponse.uploadId()).build());
             throw e;
         } finally {
@@ -616,7 +620,9 @@ public class AWS2S3Producer extends DefaultProducer {
                 ResponseInputStream<GetObjectResponse> res
                         = s3Client.getObject(req, ResponseTransformer.toInputStream());
                 Message message = getMessageForResponse(exchange);
-                if (!getConfiguration().isIgnoreBody()) {
+                if (getConfiguration().isIgnoreBody()) {
+                    IOHelper.close(res);
+                } else {
                     message.setBody(res);
                 }
                 populateMetadata(res, message);
@@ -658,7 +664,9 @@ public class AWS2S3Producer extends DefaultProducer {
             ResponseInputStream<GetObjectResponse> res = s3Client.getObject(req.build(), ResponseTransformer.toInputStream());
 
             Message message = getMessageForResponse(exchange);
-            if (!getConfiguration().isIgnoreBody()) {
+            if (getConfiguration().isIgnoreBody()) {
+                IOHelper.close(res);
+            } else {
                 message.setBody(res);
             }
             populateMetadata(res, message);

--- a/components/camel-aws/camel-aws2-sns/src/main/java/org/apache/camel/component/aws2/sns/Sns2Endpoint.java
+++ b/components/camel-aws/camel-aws2-sns/src/main/java/org/apache/camel/component/aws2/sns/Sns2Endpoint.java
@@ -149,6 +149,9 @@ public class Sns2Endpoint extends DefaultEndpoint implements HeaderFilterStrateg
 
             if (configuration.isFifoTopic()) {
                 attributes.put("FifoTopic", "true");
+                if (configuration.getMessageDeduplicationIdStrategy() instanceof NullMessageDeduplicationIdStrategy) {
+                    attributes.put("ContentBasedDeduplication", "true");
+                }
                 builder.attributes(attributes);
             }
 

--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Producer.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Producer.java
@@ -281,6 +281,9 @@ public class Sqs2Producer extends DefaultProducer {
     }
 
     private void addDelay(SendMessageRequest.Builder request, Exchange exchange) {
+        if (getEndpoint().getConfiguration().isDelayQueue() || getEndpoint().getConfiguration().isFifoQueue()) {
+            return;
+        }
         Integer headerValue = exchange.getIn().getHeader(Sqs2Constants.DELAY_HEADER, Integer.class);
         Integer delayValue;
         if (ObjectHelper.isEmpty(headerValue)) {
@@ -297,6 +300,9 @@ public class Sqs2Producer extends DefaultProducer {
     }
 
     private void addDelay(SendMessageBatchRequestEntry.Builder request, Exchange exchange) {
+        if (getEndpoint().getConfiguration().isDelayQueue() || getEndpoint().getConfiguration().isFifoQueue()) {
+            return;
+        }
         Integer headerValue = exchange.getIn().getHeader(Sqs2Constants.DELAY_HEADER, Integer.class);
         Integer delayValue;
         if (ObjectHelper.isEmpty(headerValue)) {

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -611,6 +611,14 @@ Two behavior changes follow:
 * On startup the consumer tails events from the moment it starts, rather than first replaying the
   single most-recent historical event.
 
+=== camel-aws2-sqs - per-message delay skipped for delay queues and FIFO queues
+
+The SQS producer no longer sets per-message `DelaySeconds` when `delayQueue=true` (delay is queue-level)
+or when the queue is FIFO (AWS rejects per-message delay with `InvalidParameterValue`). Previously the
+`CamelAwsSqsDelayHeader` header was applied unconditionally, which could cause AWS errors on FIFO queues
+and was redundant on delay queues. If your route relied on per-message delay overrides on a delay queue,
+the override will now be silently ignored.
+
 === camel-xslt-saxon - secure processing now applied unconditionally
 
 The `secureProcessing` option (default `true`) is now applied to the Saxon `TransformerFactory`

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -611,6 +611,15 @@ Two behavior changes follow:
 * On startup the consumer tails events from the moment it starts, rather than first replaying the
   single most-recent historical event.
 
+=== camel-aws2-kinesis - Custom KinesisResumeAction requires a public no-arg constructor
+
+Custom `KinesisResumeAction` subclasses registered in the Camel registry under the
+`CamelKinesisDbResumeAction` key must now provide a public no-arg constructor. The consumer creates
+a separate instance per shard via reflection to avoid concurrent mutation when multiple shards are
+processed in parallel. Per-shard state (`builder`, `shardId`, `streamName`) is injected via setters
+after construction. Any initialization that was previously done in a parameterized constructor should
+be moved to setters or to the `evalEntry` method.
+
 === camel-aws2-sqs - per-message delay skipped for delay queues and FIFO queues
 
 The SQS producer no longer sets per-message `DelaySeconds` when `delayQueue=true` (delay is queue-level)


### PR DESCRIPTION
## Summary

Fixes high-severity findings from the July 2026 deep code review of camel-aws2-s3, -sqs, -sns, -kinesis, and -ddb (umbrella issue CAMEL-24156). Three additional findings (KCL checkpoint/session credentials, Kinesis shard thread-safety) were already fixed by CAMEL-24191 and CAMEL-24080. DDB stream fixes (pagination, CME, expired iterator) were already merged separately via PR #24861 (CAMEL-24154).

### camel-aws2-s3
- Close `ResponseInputStream` when `ignoreBody=true` to prevent connection pool exhaustion after ~50 exchanges
- Use dynamic bucket name (from header/expression) in all multipart upload API calls instead of raw configured bucket
- Close `FileInputStream` on the `contentLength < partSize` shortcut path where `doPutObject` uses `RequestBody.fromFile()` and the stream is never consumed

### camel-aws2-sqs
- Skip per-message `DelaySeconds` when `delayQueue=true` (delay is queue-level) or when the queue is FIFO (AWS rejects per-message delay with `InvalidParameterValue`)

### camel-aws2-sns
- Set `ContentBasedDeduplication` attribute on auto-created FIFO topics when `useContentBasedDeduplication` strategy is configured

### camel-aws2-kinesis
- Initialize `shardClosed` field to its documented default (`ignore`) — was null, causing NPE on first shard rotation
- Handle `ExpiredIteratorException` by invalidating the cached iterator and requesting a fresh one, preventing permanent consumer stall
- Reset client fields to null in `KinesisConnection.close()` so subsequent calls create a fresh client instead of returning a closed one
- Fix `resolveResumeAction` thread-safety: create per-shard instances via reflection while preserving registry-based customization for user-registered subclasses

### camel-aws2-ddb (transformer)
- Use `Number` instead of separate `Integer`/`Double` checks so `Long`, `BigInteger`, `BigDecimal`, and `Float` values are stored as DynamoDB Number (`N`) type instead of String (`S`). Also fixes `List<Long>`/`List<Double>` to become NumberSet (`NS`) instead of StringSet (`SS`).

## Review feedback addressed

- Rebased onto `main` after PR #24861 merge — dropped overlapping ShardIteratorHandler hunks
- Restored KinesisResumeAction registry lookup with per-shard reflection-based instantiation
- Added upgrade guide note for SQS delay behavior change (`camel-4x-upgrade-guide-4_22.adoc`)

## Test plan

- [x] camel-aws2-ddb module tests pass (62 tests)
- [x] camel-aws2-kinesis module tests pass
- [x] All affected modules compile successfully
- [ ] Verify S3 getObject with `ignoreBody=true` no longer leaks connections
- [ ] Verify S3 multipart upload uses override bucket name when header is set
- [ ] Verify SQS FIFO sends succeed without per-message DelaySeconds
- [ ] Verify SNS FIFO topic auto-creation with content-based deduplication
- [ ] Verify Kinesis consumer recovers from expired shard iterators
- [ ] Verify Kinesis resume action registry customization still works with multi-shard streams

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
**Update:** Fixed `KinesisConsumerResumeIT` to work with the per-shard resume action instances — `TestResumeAction` now uses a no-arg constructor and static fields so reflection-created instances can access test state.

_Claude Code on behalf of davsclaus_