### PR TITLE
CAMEL-24159: camel-azure-servicebus - fix medium-severity bugs from code review

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusComponent.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusComponent.java
@@ -62,9 +62,11 @@ public class ServiceBusComponent extends DefaultComponent {
                 endpoint.getConfiguration().setCredentialType(CredentialType.CONNECTION_STRING);
             }
         } else {
-            boolean azure = endpoint.getConfiguration().getTokenCredential() instanceof DefaultAzureCredential;
-            endpoint.getConfiguration()
-                    .setCredentialType(azure ? CredentialType.AZURE_IDENTITY : CredentialType.TOKEN_CREDENTIAL);
+            if (endpoint.getConfiguration().getCredentialType() == null) {
+                boolean azure = endpoint.getConfiguration().getTokenCredential() instanceof DefaultAzureCredential;
+                endpoint.getConfiguration()
+                        .setCredentialType(azure ? CredentialType.AZURE_IDENTITY : CredentialType.TOKEN_CREDENTIAL);
+            }
         }
 
         return endpoint;

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -55,6 +55,7 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
     private static final int LOCK_RENEW_INTERVAL_SECONDS = 10;
 
     private ServiceBusProcessorClient client;
+    private boolean clientCloseable;
     private ServiceBusReceiverAsyncClient renewalClient;
     private LockRenewer lockRenewer;
     private final AtomicInteger pendingExchanges = new AtomicInteger();
@@ -75,8 +76,15 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
 
         LOG.debug("Creating connection to Azure ServiceBus");
 
+        // close any previously created client (e.g. on route restart after doStop)
+        if (clientCloseable && client != null) {
+            client.close();
+            client = null;
+        }
+
         client = getConfiguration().getProcessorClient();
         if (client == null) {
+            clientCloseable = true;
             // create client as per sessions
             if (Boolean.FALSE.equals(getConfiguration().isSessionEnabled())) {
                 client = getEndpoint().getServiceBusClientFactory().createServiceBusProcessorClient(getConfiguration(),
@@ -85,6 +93,8 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
                 client = getEndpoint().getServiceBusClientFactory().createServiceBusSessionProcessorClient(getConfiguration(),
                         this::processMessage, this::processError);
             }
+        } else {
+            clientCloseable = false;
         }
 
         client.start();
@@ -144,9 +154,13 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
             renewalClient = null;
         }
         if (client != null) {
-            // stop accepting new messages but keep the connection open
-            // so that in-flight exchanges can still complete/abandon messages
-            client.stop();
+            if (clientCloseable) {
+                client.close();
+                client = null;
+            } else {
+                // user-provided client: stop accepting messages but don't close
+                client.stop();
+            }
         }
 
         // shutdown camel consumer
@@ -164,9 +178,9 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
             renewalClient.close();
             renewalClient = null;
         }
-        if (client != null) {
-            // close the client after all in-flight exchanges have completed
+        if (clientCloseable && client != null) {
             client.close();
+            client = null;
         }
 
         super.doShutdown();

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusProducer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusProducer.java
@@ -43,6 +43,7 @@ public class ServiceBusProducer extends DefaultProducer {
     private final Map<ServiceBusProducerOperationDefinition, Consumer<Exchange>> operationsToExecute
             = new EnumMap<>(ServiceBusProducerOperationDefinition.class);
     private ServiceBusSenderClient client;
+    private boolean clientCloseable;
     private ServiceBusConfigurationOptionsProxy configurationOptionsProxy;
     private ServiceBusSenderOperations serviceBusSenderOperations;
 
@@ -67,9 +68,13 @@ public class ServiceBusProducer extends DefaultProducer {
         super.doStart();
 
         // create the senderClient
-        client = getConfiguration().getSenderClient() != null
-                ? getConfiguration().getSenderClient()
-                : getEndpoint().getServiceBusClientFactory().createServiceBusSenderClient(getConfiguration());
+        if (getConfiguration().getSenderClient() != null) {
+            client = getConfiguration().getSenderClient();
+            clientCloseable = false;
+        } else {
+            client = getEndpoint().getServiceBusClientFactory().createServiceBusSenderClient(getConfiguration());
+            clientCloseable = true;
+        }
 
         // create the operations
         serviceBusSenderOperations = new ServiceBusSenderOperations(client);
@@ -99,9 +104,9 @@ public class ServiceBusProducer extends DefaultProducer {
 
     @Override
     protected void doStop() throws Exception {
-        if (client != null) {
-            // shutdown client
+        if (clientCloseable && client != null) {
             client.close();
+            client = null;
         }
 
         super.doStop();
@@ -128,6 +133,8 @@ public class ServiceBusProducer extends DefaultProducer {
                     = exchange.getMessage().getHeader(ServiceBusConstants.APPLICATION_PROPERTIES, Map.class);
             if (applicationProperties == null) {
                 applicationProperties = new HashMap<>();
+            } else {
+                applicationProperties = new HashMap<>(applicationProperties);
             }
             propagateHeaders(exchange, applicationProperties);
             final String correlationId = exchange.getMessage().getHeader(ServiceBusConstants.CORRELATION_ID, String.class);
@@ -159,6 +166,8 @@ public class ServiceBusProducer extends DefaultProducer {
                     = exchange.getMessage().getHeader(ServiceBusConstants.APPLICATION_PROPERTIES, Map.class);
             if (applicationProperties == null) {
                 applicationProperties = new HashMap<>();
+            } else {
+                applicationProperties = new HashMap<>(applicationProperties);
             }
             propagateHeaders(exchange, applicationProperties);
             final String correlationId = exchange.getMessage().getHeader(ServiceBusConstants.CORRELATION_ID, String.class);

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/transform/ServicebusCloudEventDataTypeTransformer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/transform/ServicebusCloudEventDataTypeTransformer.java
@@ -53,7 +53,7 @@ public class ServicebusCloudEventDataTypeTransformer extends Transformer {
         headers.put(CloudEvent.CAMEL_CLOUD_EVENT_TIME, cloudEvent.getEventTime(message.getExchange()));
         if (message.getHeaders().containsKey(ServiceBusConstants.CONTENT_TYPE)) {
             headers.put(CloudEvent.CAMEL_CLOUD_EVENT_CONTENT_TYPE,
-                    message.getHeaders().containsKey(ServiceBusConstants.CONTENT_TYPE));
+                    message.getHeader(ServiceBusConstants.CONTENT_TYPE));
         } else {
             headers.put(CloudEvent.CAMEL_CLOUD_EVENT_CONTENT_TYPE, CloudEvent.APPLICATION_OCTET_STREAM_MIME_TYPE);
         }

--- a/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumerTest.java
+++ b/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumerTest.java
@@ -612,8 +612,7 @@ public class ServiceBusConsumerTest {
         consumer.doStop();
 
         verify(renewalClient).close();
-        verify(client).stop();
-        verify(client, never()).close();
+        verify(client).close();
     }
 
     @Test
@@ -703,7 +702,18 @@ public class ServiceBusConsumerTest {
     }
 
     @Test
-    void doStopStopsClientWithoutClosing() throws Exception {
+    void doStopClosesInternallyCreatedClient() throws Exception {
+        ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor);
+        consumer.doStart();
+
+        consumer.doStop();
+
+        verify(client).close();
+    }
+
+    @Test
+    void doStopStopsUserProvidedClientWithoutClosing() throws Exception {
+        when(configuration.getProcessorClient()).thenReturn(client);
         ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor);
         consumer.doStart();
 
@@ -714,13 +724,24 @@ public class ServiceBusConsumerTest {
     }
 
     @Test
-    void doShutdownClosesClient() throws Exception {
+    void doShutdownClosesInternallyCreatedClient() throws Exception {
         ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor);
         consumer.doStart();
 
         consumer.doShutdown();
 
         verify(client).close();
+    }
+
+    @Test
+    void doShutdownDoesNotCloseUserProvidedClient() throws Exception {
+        when(configuration.getProcessorClient()).thenReturn(client);
+        ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor);
+        consumer.doStart();
+
+        consumer.doShutdown();
+
+        verify(client, never()).close();
     }
 
     private void configureMockMessage() {


### PR DESCRIPTION
## Summary

Fixes 5 medium-severity findings in camel-azure-servicebus from the July 2026 code review ([CAMEL-24159](https://issues.apache.org/jira/browse/CAMEL-24159)). This is PR 1 of 5 (one per azure component).

- **Credential override guard** — autowired `TokenCredential` no longer silently overrides an explicitly configured `credentialType` (regression from CAMEL-21871)
- **Client leak on route restart** — internally-created `ServiceBusProcessorClient` is now properly closed in `doStop()`, preventing AMQP connection leaks on stop/start cycles
- **User-provided client lifecycle** — user-provided (autowired) sender/processor clients are no longer closed by the component; only internally-created clients are managed
- **CloudEvent content type** — fixed `containsKey()` (returns Boolean) to `getHeader()` (returns the actual content type string) in the CloudEvent transformer (bug since CAMEL-20450)
- **APPLICATION_PROPERTIES mutation** — producer now defensive-copies the user-supplied `APPLICATION_PROPERTIES` map before adding propagated headers, preventing `UnsupportedOperationException` on immutable maps

The 6th finding (maxConcurrentCalls backpressure for async routes) is a design limitation and will be addressed in a separate follow-up issue.

## Test plan

- [x] Updated existing lifecycle tests to match new close/stop behavior
- [x] Added `doStopStopsUserProvidedClientWithoutClosing` test
- [x] Added `doShutdownDoesNotCloseUserProvidedClient` test
- [x] `mvn clean install` passes (72 tests, 0 failures)

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>