### PR TITLE
CAMEL-24159: camel-azure-eventhubs - fix medium-severity bugs from code review

### DIFF
--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTask.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsCheckpointUpdaterTask.java
@@ -29,7 +29,7 @@ public class EventHubsCheckpointUpdaterTask implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventHubsCheckpointUpdaterTask.class);
 
-    private EventContext eventContext;
+    private volatile EventContext eventContext;
     private final AtomicInteger processedEvents;
     private volatile long scheduledTime;
 
@@ -44,7 +44,7 @@ public class EventHubsCheckpointUpdaterTask implements Runnable {
             LOG.debug("checkpointing offset after reaching timeout, with a batch of {}", processedEvents.get());
             eventContext.updateCheckpointAsync()
                     .subscribe(unused -> LOG.debug("Processed one event..."),
-                            error -> LOG.debug("Error when updating Checkpoint: {}", error.getMessage()),
+                            error -> LOG.warn("Error when updating Checkpoint: {}", error.getMessage(), error),
                             () -> {
                                 LOG.debug("Checkpoint updated.");
                                 processedEvents.set(0);

--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsComponent.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsComponent.java
@@ -60,9 +60,11 @@ public class EventHubsComponent extends DefaultComponent {
                 endpoint.getConfiguration().setCredentialType(CredentialType.CONNECTION_STRING);
             }
         } else {
-            boolean azure = endpoint.getConfiguration().getTokenCredential() instanceof DefaultAzureCredential;
-            endpoint.getConfiguration()
-                    .setCredentialType(azure ? CredentialType.AZURE_IDENTITY : CredentialType.TOKEN_CREDENTIAL);
+            if (endpoint.getConfiguration().getCredentialType() == null) {
+                boolean azure = endpoint.getConfiguration().getTokenCredential() instanceof DefaultAzureCredential;
+                endpoint.getConfiguration()
+                        .setCredentialType(azure ? CredentialType.AZURE_IDENTITY : CredentialType.TOKEN_CREDENTIAL);
+            }
         }
 
         validateConfigurations(configuration);

--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsConsumer.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsConsumer.java
@@ -207,7 +207,7 @@ public class EventHubsConsumer extends DefaultConsumer implements ShutdownAware 
      *
      * @param exchange the exchange
      */
-    private void processCommit(final Exchange exchange, final EventContext eventContext) {
+    private synchronized void processCommit(final Exchange exchange, final EventContext eventContext) {
         if (lastTask == null || lastTask.isExpired()) {
             lastTask = new EventHubsCheckpointUpdaterTask(eventContext, processedEvents);
             // delegate the checkpoint update to a dedicated Thread
@@ -230,7 +230,7 @@ public class EventHubsConsumer extends DefaultConsumer implements ShutdownAware 
                 }
                 eventContext.updateCheckpointAsync()
                         .subscribe(unused -> LOG.debug("Processed one event..."),
-                                error -> LOG.debug("Error when updating Checkpoint: {}", error.getMessage()),
+                                error -> LOG.warn("Error when updating Checkpoint: {}", error.getMessage(), error),
                                 () -> {
                                     LOG.debug("Checkpoint updated.");
                                 });

--- a/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsProducer.java
+++ b/components/camel-azure/camel-azure-eventhubs/src/main/java/org/apache/camel/component/azure/eventhubs/EventHubsProducer.java
@@ -27,6 +27,7 @@ import org.apache.camel.support.DefaultAsyncProducer;
 public class EventHubsProducer extends DefaultAsyncProducer {
 
     private EventHubProducerAsyncClient producerAsyncClient;
+    private boolean clientCloseable;
     private EventHubsProducerOperations producerOperations;
 
     public EventHubsProducer(final Endpoint endpoint) {
@@ -40,8 +41,10 @@ public class EventHubsProducer extends DefaultAsyncProducer {
         EventHubsConfiguration configuration = getConfiguration();
         producerAsyncClient = configuration.getProducerAsyncClient();
         if (producerAsyncClient == null) {
-            // create the client
             producerAsyncClient = EventHubsClientFactory.createEventHubProducerAsyncClient(configuration);
+            clientCloseable = true;
+        } else {
+            clientCloseable = false;
         }
 
         // create our operations
@@ -62,8 +65,7 @@ public class EventHubsProducer extends DefaultAsyncProducer {
 
     @Override
     protected void doStop() throws Exception {
-        if (producerAsyncClient != null) {
-            // shutdown async client
+        if (clientCloseable && producerAsyncClient != null) {
             producerAsyncClient.close();
             producerAsyncClient = null;
         }


### PR DESCRIPTION
## Summary

Fixes 4 medium-severity findings in camel-azure-eventhubs from the July 2026 code review ([CAMEL-24159](https://issues.apache.org/jira/browse/CAMEL-24159)). This is PR 2 of 5 (one per azure component).

- **Credential override guard** — autowired `TokenCredential` no longer silently overrides an explicitly configured `credentialType` (regression from CAMEL-21871)
- **Checkpoint task race condition** — `processCommit()` is now `synchronized` to prevent concurrent partition threads from racing on `lastTask`/`lastScheduledTask`; `eventContext` field in `EventHubsCheckpointUpdaterTask` is now `volatile` for cross-thread visibility
- **Silent checkpoint failures** — checkpoint update errors are now logged at WARN (with stack trace) instead of DEBUG, so operators get visibility when the checkpoint store breaks and unbounded replay would otherwise occur silently
- **User-provided producer client lifecycle** — user-provided (autowired) `EventHubProducerAsyncClient` is no longer closed by the component on stop; only internally-created clients are managed

## Test plan

- [x] `mvn clean install` passes in camel-azure-eventhubs module
- [x] No existing tests broken

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>