### PR TITLE
CAMEL-24159: camel-azure-storage-blob - Fix medium-severity bugs from code review

### DIFF
--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/BlobCommonRequestOptions.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/BlobCommonRequestOptions.java
@@ -54,9 +54,8 @@ public class BlobCommonRequestOptions {
         return accessTier;
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends BlobRequestConditions> T getBlobRequestConditions() {
-        return blobRequestConditions == null ? null : (T) blobRequestConditions;
+    public BlobRequestConditions getBlobRequestConditions() {
+        return blobRequestConditions;
     }
 
     public byte[] getContentMD5() {

--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/BlobComponent.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/BlobComponent.java
@@ -91,7 +91,9 @@ public class BlobComponent extends HealthCheckComponent {
                     configuration.setCredentialType(AZURE_IDENTITY);
                 }
             } else {
-                configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
+                if (configuration.getCredentialType() == null) {
+                    configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
+                }
             }
         }
     }

--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobChangeFeedOperations.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobChangeFeedOperations.java
@@ -43,7 +43,7 @@ public class BlobChangeFeedOperations {
         final OffsetDateTime endTime = configurationOptionsProxy.getChangeFeedEndTime(exchange);
         final Context context = configurationOptionsProxy.getChangeFeedContext(exchange);
 
-        if (ObjectHelper.isEmpty(startTime) || ObjectHelper.isEmpty(endTime)) {
+        if (ObjectHelper.isEmpty(startTime) && ObjectHelper.isEmpty(endTime)) {
             return BlobOperationResponse.create(getEvents());
         } else {
             return BlobOperationResponse.create(getEvents(startTime, endTime, context));

--- a/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperations.java
+++ b/components/camel-azure/camel-azure-storage-blob/src/main/java/org/apache/camel/component/azure/storage/blob/operations/BlobOperations.java
@@ -34,6 +34,7 @@ import com.azure.core.http.rest.ResponseBase;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.AccessTier;
 import com.azure.storage.blob.models.AppendBlobItem;
+import com.azure.storage.blob.models.AppendBlobRequestConditions;
 import com.azure.storage.blob.models.BlobDownloadHeaders;
 import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.models.BlobImmutabilityPolicy;
@@ -49,6 +50,7 @@ import com.azure.storage.blob.models.BlockListType;
 import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
 import com.azure.storage.blob.models.DownloadRetryOptions;
 import com.azure.storage.blob.models.PageBlobItem;
+import com.azure.storage.blob.models.PageBlobRequestConditions;
 import com.azure.storage.blob.models.PageRange;
 import com.azure.storage.blob.models.PageRangeItem;
 import com.azure.storage.blob.models.ParallelTransferOptions;
@@ -155,6 +157,11 @@ public class BlobOperations {
         }
 
         final File fileToDownload = AzureFileNameHelper.resolveWithinDirectory(fileDir, client.getBlobName());
+        File parentDir = fileToDownload.getParentFile();
+        if (parentDir != null) {
+            parentDir.mkdirs();
+        }
+        fileToDownload.delete();
         final BlobCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
         final BlobRange blobRange = configurationProxy.getBlobRange(exchange);
         final ParallelTransferOptions parallelTransferOptions = configurationProxy.getParallelTransferOptions(exchange);
@@ -449,7 +456,7 @@ public class BlobOperations {
             throw new IllegalArgumentException("Source Account Name must be specified for copyBlob Operation");
         }
         String sourceContainerName = exchange.getMessage().getHeader(BlobConstants.SOURCE_BLOB_CONTAINER_NAME, String.class);
-        if (ObjectHelper.isEmpty(sourceAccountName)) {
+        if (ObjectHelper.isEmpty(sourceContainerName)) {
             throw new IllegalArgumentException("Source Container Name must be specified for copyBlob Operation");
         }
         final String response
@@ -476,7 +483,8 @@ public class BlobOperations {
             leaseClient = acquireLeaseIfConfigured(commonRequestOptions.getBlobRequestConditions(), exchange);
             final Response<AppendBlobItem> response
                     = client.appendBlobBlock(streamAndLength.getInputStream(), streamAndLength.getStreamLength(),
-                            commonRequestOptions.getContentMD5(), commonRequestOptions.getBlobRequestConditions(),
+                            commonRequestOptions.getContentMD5(),
+                            toAppendBlobRequestConditions(commonRequestOptions.getBlobRequestConditions()),
                             commonRequestOptions.getTimeout());
 
             return BlobOperationResponse.createWithEmptyBody(response);
@@ -529,7 +537,8 @@ public class BlobOperations {
             leaseClient = acquireLeaseIfConfigured(requestOptions.getBlobRequestConditions(), exchange);
             final Response<PageBlobItem> response
                     = client.uploadPageBlob(pageRange, is, requestOptions.getContentMD5(),
-                            requestOptions.getBlobRequestConditions(), requestOptions.getTimeout());
+                            toPageBlobRequestConditions(requestOptions.getBlobRequestConditions()),
+                            requestOptions.getTimeout());
 
             return BlobOperationResponse.createWithEmptyBody(response);
         } finally {
@@ -570,7 +579,9 @@ public class BlobOperations {
         try {
             leaseClient = acquireLeaseIfConfigured(requestOptions.getBlobRequestConditions(), exchange);
             final Response<PageBlobItem> response
-                    = client.clearPagesBlob(pageRange, requestOptions.getBlobRequestConditions(), requestOptions.getTimeout());
+                    = client.clearPagesBlob(pageRange,
+                            toPageBlobRequestConditions(requestOptions.getBlobRequestConditions()),
+                            requestOptions.getTimeout());
 
             return BlobOperationResponse.createWithEmptyBody(response);
         } finally {
@@ -845,5 +856,39 @@ public class BlobOperations {
         if (leaseClient != null) {
             leaseClient.releaseLease();
         }
+    }
+
+    private static AppendBlobRequestConditions toAppendBlobRequestConditions(BlobRequestConditions conditions) {
+        if (conditions == null) {
+            return null;
+        }
+        if (conditions instanceof AppendBlobRequestConditions abc) {
+            return abc;
+        }
+        AppendBlobRequestConditions result = new AppendBlobRequestConditions();
+        result.setLeaseId(conditions.getLeaseId());
+        result.setIfMatch(conditions.getIfMatch());
+        result.setIfNoneMatch(conditions.getIfNoneMatch());
+        result.setIfModifiedSince(conditions.getIfModifiedSince());
+        result.setIfUnmodifiedSince(conditions.getIfUnmodifiedSince());
+        result.setTagsConditions(conditions.getTagsConditions());
+        return result;
+    }
+
+    private static PageBlobRequestConditions toPageBlobRequestConditions(BlobRequestConditions conditions) {
+        if (conditions == null) {
+            return null;
+        }
+        if (conditions instanceof PageBlobRequestConditions pbc) {
+            return pbc;
+        }
+        PageBlobRequestConditions result = new PageBlobRequestConditions();
+        result.setLeaseId(conditions.getLeaseId());
+        result.setIfMatch(conditions.getIfMatch());
+        result.setIfNoneMatch(conditions.getIfNoneMatch());
+        result.setIfModifiedSince(conditions.getIfModifiedSince());
+        result.setIfUnmodifiedSince(conditions.getIfUnmodifiedSince());
+        result.setTagsConditions(conditions.getTagsConditions());
+        return result;
     }
 }


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes 5 medium-severity findings in `camel-azure-storage-blob` from CAMEL-24159 code review:

- **Credential override guard** (`BlobComponent`): wrap the autowiring branch with `if (credentialType == null)` so user-explicit credential type is not overridden when a `TokenCredential` bean is found in the registry.
- **changeFeed time bounds** (`BlobChangeFeedOperations`): change `||` to `&&` so that setting only `startTime` or only `endTime` correctly calls the time-bounded overload instead of discarding both.
- **copyBlob validation** (`BlobOperations`): fix the second `isEmpty` check — it was re-checking `sourceAccountName` instead of `sourceContainerName`.
- **ClassCastException with BlobRequestConditions** (`BlobCommonRequestOptions` + `BlobOperations`): remove the unsafe generic `(T)` cast from `getBlobRequestConditions()` that would throw ClassCastException at runtime when append/page blob operations need `AppendBlobRequestConditions` or `PageBlobRequestConditions`. Add proper type-safe conversion methods.
- **Consumer fileDir download failures** (`BlobOperations`): create parent directories before downloading (fixes `NoSuchFileException` for nested blob names like `dir/file.txt`) and delete existing file first (fixes `FileAlreadyExistsException` on re-poll).

## Test plan

- [x] Module builds successfully: `cd components/camel-azure/camel-azure-storage-blob && mvn clean install`
- [ ] Verify credential override guard preserves user-explicit `credentialType=SHARED_KEY_CREDENTIAL`
- [ ] Verify changeFeed with only startTime set returns bounded results
- [ ] Verify copyBlob validates sourceContainerName is provided
- [ ] Verify append/page blob operations with request conditions don't throw ClassCastException
- [ ] Verify consumer re-poll downloads successfully without FileAlreadyExistsException

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>