### PR TITLE
CAMEL-24159: camel-azure-storage-queue - Fix medium-severity bugs from code review

### DIFF
--- a/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/QueueComponent.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/QueueComponent.java
@@ -73,7 +73,9 @@ public class QueueComponent extends HealthCheckComponent {
                     configuration.setCredentialType(CredentialType.SHARED_ACCOUNT_KEY);
                 }
             } else {
-                configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
+                if (configuration.getCredentialType() == null) {
+                    configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
+                }
             }
         }
 

--- a/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/client/QueueClientWrapper.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/client/QueueClientWrapper.java
@@ -43,6 +43,10 @@ public class QueueClientWrapper {
         return client.createWithResponse(metadata, timeout, Context.NONE);
     }
 
+    public void createIfNotExists(Map<String, String> metadata, Duration timeout) {
+        client.createIfNotExists();
+    }
+
     public Response<Void> delete(Duration timeout) {
         return client.deleteWithResponse(timeout, Context.NONE);
     }

--- a/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/client/QueueClientWrapper.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/client/QueueClientWrapper.java
@@ -44,7 +44,7 @@ public class QueueClientWrapper {
     }
 
     public void createIfNotExists(Map<String, String> metadata, Duration timeout) {
-        client.createIfNotExists();
+        client.createIfNotExistsWithResponse(metadata, timeout, Context.NONE);
     }
 
     public Response<Void> delete(Duration timeout) {

--- a/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/operations/QueueOperations.java
+++ b/components/camel-azure/camel-azure-storage-queue/src/main/java/org/apache/camel/component/azure/storage/queue/operations/QueueOperations.java
@@ -82,7 +82,9 @@ public class QueueOperations {
         final boolean queueCreated = configurationOptionsProxy.isCreateQueue(exchange);
 
         if (queueCreated) {
-            createQueue(exchange);
+            final Map<String, String> metadata = configurationOptionsProxy.getMetadata(exchange);
+            final Duration timeout = configurationOptionsProxy.getTimeout(exchange);
+            client.createIfNotExists(metadata, timeout);
         }
 
         final String text = exchange.getIn().getBody(String.class);


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes 2 medium-severity findings in `camel-azure-storage-queue` from CAMEL-24159 code review:

- **Credential override guard** (`QueueComponent`): wrap the else branch with `if (credentialType == null)` so user-explicit credential type is not overridden when a `StorageSharedKeyCredential` bean is found in the registry.
- **Idempotent queue creation** (`QueueOperations` + `QueueClientWrapper`): when `createQueue=true` on `sendMessage`, use `createIfNotExistsWithResponse()` instead of `create()` so repeated sends don't throw HTTP 409 Conflict when the queue already exists with different metadata.

## Review feedback addressed

- Fixed `createIfNotExists` wrapper to forward `metadata` and `timeout` via `createIfNotExistsWithResponse(metadata, timeout, Context.NONE)` instead of the no-arg `createIfNotExists()` that silently dropped both parameters.

## Test plan

- [x] Module builds successfully: `cd components/camel-azure/camel-azure-storage-queue && mvn clean install`
- [ ] Verify credential override guard preserves user-explicit `credentialType`
- [ ] Verify sendMessage with createQueue=true succeeds on second call when queue already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>