### PR TITLE
CAMEL-24159: camel-azure-storage-datalake - Fix medium-severity bugs from code review

### DIFF
--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeComponent.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/DataLakeComponent.java
@@ -71,12 +71,14 @@ public class DataLakeComponent extends HealthCheckComponent {
                     configuration.setCredentialType(CredentialType.CLIENT_SECRET);
                 }
             } else {
-                if (configuration.getSharedKeyCredential() != null) {
-                    configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
-                } else if (configuration.getSasCredential() != null) {
-                    configuration.setCredentialType(CredentialType.AZURE_SAS);
-                } else if (configuration.getClientSecretCredential() != null) {
-                    configuration.setCredentialType(CredentialType.CLIENT_SECRET);
+                if (configuration.getCredentialType() == null) {
+                    if (configuration.getSharedKeyCredential() != null) {
+                        configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
+                    } else if (configuration.getSasCredential() != null) {
+                        configuration.setCredentialType(CredentialType.AZURE_SAS);
+                    } else if (configuration.getClientSecretCredential() != null) {
+                        configuration.setCredentialType(CredentialType.CLIENT_SECRET);
+                    }
                 }
             }
         }

--- a/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileOperations.java
+++ b/components/camel-azure/camel-azure-storage-datalake/src/main/java/org/apache/camel/component/azure/storage/datalake/operations/DataLakeFileOperations.java
@@ -108,6 +108,11 @@ public class DataLakeFileOperations {
         }
         final DataLakeFileClientWrapper fileClientWrapper = getFileClientWrapper(exchange);
         final File recieverFile = AzureFileNameHelper.resolveWithinDirectory(fileDir, fileClientWrapper.getFileName());
+        File parentDir = recieverFile.getParentFile();
+        if (parentDir != null) {
+            parentDir.mkdirs();
+        }
+        recieverFile.delete();
         final FileCommonRequestOptions commonRequestOptions = getCommonRequestOptions(exchange);
         final FileRange fileRange = configurationProxy.getFileRange(exchange);
         final ParallelTransferOptions parallelTransferOptions = configurationProxy.getParallelTransferOptions(exchange);
@@ -183,8 +188,9 @@ public class DataLakeFileOperations {
         final Boolean retainUncommitedData = configurationProxy.retainUnCommitedData(exchange);
         final Boolean close = configurationProxy.getClose(exchange);
         final DataLakeFileClientWrapper fileClientWrapper = getFileClientWrapper(exchange);
+        final long flushPosition = (position != null ? position : 0L) + fileClientWrapper.getFileSize();
         final Response<PathInfo> response
-                = fileClientWrapper.flushWithResponse(position + fileClientWrapper.getFileSize(), retainUncommitedData, close,
+                = fileClientWrapper.flushWithResponse(flushPosition, retainUncommitedData, close,
                         commonRequestOptions.getPathHttpHeaders(), commonRequestOptions.getRequestConditions(),
                         commonRequestOptions.getTimeout());
         DataLakeExchangeHeaders exchangeHeaders
@@ -215,7 +221,6 @@ public class DataLakeFileOperations {
                 = new FileParallelUploadOptions(is)
                         .setHeaders(commonRequestOptions.getPathHttpHeaders()).setParallelTransferOptions(transferOptions)
                         .setMetadata(commonRequestOptions.getMetadata()).setPermissions(permission)
-                        .setRequestConditions(commonRequestOptions.getRequestConditions())
                         .setRequestConditions(commonRequestOptions.getRequestConditions()).setUmask(umask);
         final DataLakeFileClientWrapper fileClientWrapper = getFileClientWrapper(exchange);
         final Response<PathInfo> response


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes 4 medium-severity findings in `camel-azure-storage-datalake` from CAMEL-24159 code review:

- **Credential override guard** (`DataLakeComponent`): wrap the auto-detection else branch with `if (credentialType == null)` so user-explicit credential type is not overridden when credential objects are found in the configuration.
- **Duplicate setRequestConditions** (`DataLakeFileOperations.upload()`): remove the duplicate `.setRequestConditions()` call on `FileParallelUploadOptions` (copy-paste error).
- **Null position NPE** (`DataLakeFileOperations.flushToFile()`): guard against null `position` (which is `Long` with no default) before unboxing arithmetic with `fileClientWrapper.getFileSize()`. Defaults to 0 when null.
- **Consumer downloadToFile failures** (`DataLakeFileOperations.downloadToFile()`): create parent directories before downloading (fixes `NoSuchFileException` for nested file names like `dir/file.txt`) and delete existing file first (fixes `FileAlreadyExistsException` on re-poll).

## Test plan

- [x] Module builds successfully: `cd components/camel-azure/camel-azure-storage-datalake && mvn clean install`
- [ ] Verify credential override guard preserves user-explicit `credentialType`
- [ ] Verify upload operation with request conditions succeeds (no duplicate setter)
- [ ] Verify flushToFile with null position doesn't throw NPE
- [ ] Verify consumer re-poll downloads successfully without FileAlreadyExistsException

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>