### PR TITLE
CAMEL-24195: camel-aws2-s3 - Fix StreamUploadProducer race condition and timeout task exception handling

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/stream/AWS2S3StreamUploadProducer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/stream/AWS2S3StreamUploadProducer.java
@@ -137,8 +137,12 @@ public class AWS2S3StreamUploadProducer extends DefaultProducer {
             lock.lock();
             try {
                 if (ObjectHelper.isNotEmpty(uploadAggregate)) {
-                    uploadPart(uploadAggregate);
-                    completeUpload(uploadAggregate);
+                    try {
+                        uploadPart(uploadAggregate);
+                        completeUpload(uploadAggregate);
+                    } catch (Exception e) {
+                        LOG.warn("Error during timeout-triggered upload flush for {}", uploadAggregate.dynamicKeyName, e);
+                    }
                     uploadAggregate = null;
                 }
 
@@ -148,8 +152,12 @@ public class AWS2S3StreamUploadProducer extends DefaultProducer {
                     for (Map.Entry<Long, UploadState> entry : timestampBasedUploads.entrySet()) {
                         UploadState state = entry.getValue();
                         if (ObjectHelper.isNotEmpty(state) && state.buffer.size() > 0) {
-                            uploadPart(state);
-                            completeUpload(state);
+                            try {
+                                uploadPart(state);
+                                completeUpload(state);
+                            } catch (Exception e) {
+                                LOG.warn("Error during timeout-triggered upload flush for {}", state.dynamicKeyName, e);
+                            }
                             keysToRemove.add(entry.getKey());
                         }
                     }
@@ -178,10 +186,15 @@ public class AWS2S3StreamUploadProducer extends DefaultProducer {
         byte[] b;
         int maxRead = (getConfiguration().isMultiPartUpload()
                 ? Math.toIntExact(getConfiguration().getPartSize()) : getConfiguration().getBufferSize());
-        if (uploadAggregate != null) {
-            uploadAggregate.index++;
-            maxRead -= uploadAggregate.buffer.size();
-            maxRead = Math.max(1, maxRead);
+        lock.lock();
+        try {
+            if (uploadAggregate != null) {
+                uploadAggregate.index++;
+                maxRead -= uploadAggregate.buffer.size();
+                maxRead = Math.max(1, maxRead);
+            }
+        } finally {
+            lock.unlock();
         }
 
         while ((b = AWS2S3Utils.toByteArray(is, maxRead)) != null && b.length > 0) {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes two concurrency bugs in `AWS2S3StreamUploadProducer`:

- **Race condition**: `uploadAggregate` was read and mutated outside the lock in `processWithoutTimestampGrouping()` (lines 181-184). The timeout task acquires the lock and can set `uploadAggregate = null`, so the main thread could dereference a null reference (NPE). Fix: moved the reads inside a lock block.

- **Timeout task exception handling**: `StreamingUploadTimeoutTask.run()` did not catch exceptions from `uploadPart()`/`completeUpload()`. Since `ScheduledExecutorService.scheduleAtFixedRate` silently cancels all future executions when the task throws an uncaught exception, any S3 API error would permanently disable the timeout flush mechanism. Fix: wrapped the upload calls in try-catch to log and continue.

## Test plan

- [x] Module builds successfully (`mvn install -DskipTests`)
- [ ] Existing integration tests still pass
- [ ] Race condition fix verified by code inspection — the unprotected read window is now under the lock
- [ ] Exception handling verified by code inspection — timeout task catches and logs errors instead of propagating

🤖 Generated with [Claude Code](https://claude.com/claude-code)