### PR TITLE
CAMEL-24196: camel-aws2-sqs - Fix QueueDoesNotExist swallowed, thread pool leak, and batch chunking

### DIFF
--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Consumer.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Consumer.java
@@ -339,6 +339,28 @@ public class Sqs2Consumer extends ScheduledBatchPollingConsumer {
     }
 
     @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        if (ObjectHelper.isNotEmpty(timeoutExtender)) {
+            timeoutExtender.cancel();
+            timeoutExtender = null;
+        }
+        if (ObjectHelper.isNotEmpty(scheduledFuture)) {
+            scheduledFuture.cancel(true);
+            scheduledFuture = null;
+        }
+        if (ObjectHelper.isNotEmpty(scheduledExecutor)) {
+            getEndpoint().getCamelContext().getExecutorServiceManager().shutdown(scheduledExecutor);
+            scheduledExecutor = null;
+        }
+        if (ObjectHelper.isNotEmpty(pollingTask)) {
+            pollingTask.close();
+            pollingTask = null;
+        }
+    }
+
+    @Override
     protected void doShutdown() throws Exception {
         if (ObjectHelper.isNotEmpty(timeoutExtender)) {
             timeoutExtender.cancel();
@@ -594,6 +616,10 @@ public class Sqs2Consumer extends ScheduledBatchPollingConsumer {
 
             final PollingContext context = new PollingContext();
             final List<software.amazon.awssdk.services.sqs.model.Message> messages = poll(context);
+            if (context.isQueueMissing() && context.hasErrors()) {
+                context.rethrowIfFirstErrorIsRuntimeException();
+                throw new IOException("Queue %s does not exist".formatted(queueName), context.firstError());
+            }
             if (context.errorCount() == numberOfRequestsPerPoll) {
                 if (context.errorCount() == 1) {
                     context.rethrowIfFirstErrorIsRuntimeException();

--- a/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Producer.java
+++ b/components/camel-aws/camel-aws2-sqs/src/main/java/org/apache/camel/component/aws2/sqs/Sqs2Producer.java
@@ -17,8 +17,8 @@
 package org.apache.camel.component.aws2.sqs;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
@@ -56,6 +56,7 @@ public class Sqs2Producer extends DefaultProducer {
     private static final Logger LOG = LoggerFactory.getLogger(Sqs2Producer.class);
 
     private static final int MAX_ATTRIBUTES = 10;
+    private static final int MAX_BATCH_ENTRIES = 10;
     private static final String MAX_MESSAGE
             = "Number of message headers exceeded. At most " + MAX_ATTRIBUTES + " headers is allowed when sending to AWS SQS.";
 
@@ -121,32 +122,24 @@ public class Sqs2Producer extends DefaultProducer {
                 && ObjectHelper.isEmpty(getEndpoint().getConfiguration().getMessageGroupIdStrategy())) {
             throw new IllegalArgumentException("messageGroupIdStrategy must be set for FIFO queues.");
         }
-        SendMessageBatchRequest.Builder request = SendMessageBatchRequest.builder().queueUrl(getQueueUrl());
-        Collection<SendMessageBatchRequestEntry> entries = new ArrayList<>();
         if (exchange.getIn().getBody() instanceof Iterable) {
-            Iterable c = exchange.getIn().getBody(Iterable.class);
+            Iterable<?> c = exchange.getIn().getBody(Iterable.class);
+            List<SendMessageBatchRequestEntry> entries = new ArrayList<>();
             int index = 0;
             for (Object o : c) {
-                String object = (String) o;
                 SendMessageBatchRequestEntry.Builder entry = SendMessageBatchRequestEntry.builder();
                 entry.id(UUID.randomUUID().toString());
                 entry.messageAttributes(translateAttributes(exchange.getIn().getHeaders(), exchange));
-                entry.messageBody(object);
+                entry.messageBody((String) o);
                 addDelay(entry, exchange);
                 configureFifoAttributes(entry, exchange, index++);
                 entries.add(entry.build());
             }
-            request.entries(entries);
-            SendMessageBatchResponse result = amazonSQS.sendMessageBatch(request.build());
-            Message message = getMessageForResponse(exchange);
-            message.setBody(result);
-            message.setHeader(Sqs2Constants.FAILED_MESSAGE_COUNT,
-                    ObjectHelper.isNotEmpty(result.failed()) ? result.failed().size() : 0);
-            message.setHeader(Sqs2Constants.SUCCESSFUL_MESSAGE_COUNT,
-                    ObjectHelper.isNotEmpty(result.successful()) ? result.successful().size() : 0);
+            sendBatchEntries(amazonSQS, exchange, entries);
         } else if (exchange.getIn().getBody() instanceof String) {
             String c = exchange.getIn().getBody(String.class);
             String[] elements = c.split(getConfiguration().getBatchSeparator());
+            List<SendMessageBatchRequestEntry> entries = new ArrayList<>();
             int index = 0;
             for (String o : elements) {
                 SendMessageBatchRequestEntry.Builder entry = SendMessageBatchRequestEntry.builder();
@@ -157,14 +150,7 @@ public class Sqs2Producer extends DefaultProducer {
                 configureFifoAttributes(entry, exchange, index++);
                 entries.add(entry.build());
             }
-            request.entries(entries);
-            SendMessageBatchResponse result = amazonSQS.sendMessageBatch(request.build());
-            Message message = getMessageForResponse(exchange);
-            message.setBody(result);
-            message.setHeader(Sqs2Constants.FAILED_MESSAGE_COUNT,
-                    ObjectHelper.isNotEmpty(result.failed()) ? result.failed().size() : 0);
-            message.setHeader(Sqs2Constants.SUCCESSFUL_MESSAGE_COUNT,
-                    ObjectHelper.isNotEmpty(result.successful()) ? result.successful().size() : 0);
+            sendBatchEntries(amazonSQS, exchange, entries);
         } else {
             SendMessageBatchRequest req = exchange.getIn().getBody(SendMessageBatchRequest.class);
             SendMessageBatchResponse result = amazonSQS.sendMessageBatch(req);
@@ -175,6 +161,29 @@ public class Sqs2Producer extends DefaultProducer {
             message.setHeader(Sqs2Constants.SUCCESSFUL_MESSAGE_COUNT,
                     ObjectHelper.isNotEmpty(result.successful()) ? result.successful().size() : 0);
         }
+    }
+
+    private void sendBatchEntries(SqsClient amazonSQS, Exchange exchange, List<SendMessageBatchRequestEntry> entries) {
+        if (entries.isEmpty()) {
+            return;
+        }
+        int totalFailed = 0;
+        int totalSuccessful = 0;
+        SendMessageBatchResponse lastResult = null;
+        for (int i = 0; i < entries.size(); i += MAX_BATCH_ENTRIES) {
+            List<SendMessageBatchRequestEntry> chunk = entries.subList(i, Math.min(i + MAX_BATCH_ENTRIES, entries.size()));
+            SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+                    .queueUrl(getQueueUrl())
+                    .entries(chunk)
+                    .build();
+            lastResult = amazonSQS.sendMessageBatch(request);
+            totalFailed += ObjectHelper.isNotEmpty(lastResult.failed()) ? lastResult.failed().size() : 0;
+            totalSuccessful += ObjectHelper.isNotEmpty(lastResult.successful()) ? lastResult.successful().size() : 0;
+        }
+        Message message = getMessageForResponse(exchange);
+        message.setBody(lastResult);
+        message.setHeader(Sqs2Constants.FAILED_MESSAGE_COUNT, totalFailed);
+        message.setHeader(Sqs2Constants.SUCCESSFUL_MESSAGE_COUNT, totalSuccessful);
     }
 
     private void deleteMessage(SqsClient amazonSQS, Exchange exchange) {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes three bugs in camel-aws2-sqs:

- **QueueDoesNotExistException silently swallowed** (`Sqs2Consumer`): When `maxMessagesPerPoll > 10`, parallel polling sends N requests. Only the first thread to catch `QueueDoesNotExistException` fires an error (errorCount=1), but the error propagation check requires `errorCount == N`, which never matches. Fix: added explicit check for `isQueueMissing() && hasErrors()` before the all-errors check.

- **Thread pool leak on stop/start** (`Sqs2Consumer`): `doStart()` unconditionally creates a new `PollingTask` with a new thread pool, but cleanup only happened in `doShutdown()`, not `doStop()`. Each route stop/start cycle leaked the previous thread pool. Fix: added `doStop()` override that cleans up the PollingTask, TimeoutExtender, and scheduled executor.

- **sendBatchMessage missing 10-entry chunking** (`Sqs2Producer`): All entries were collected into a single `sendMessageBatch()` call. SQS hard-limits batches to 10 entries; 11+ throws `TooManyEntriesInBatchRequestException`. Fix: extracted `sendBatchEntries()` helper that chunks entries into groups of 10.

## Test plan

- [x] Module builds successfully (`mvn install -DskipTests`)
- [ ] Existing integration tests still pass
- [ ] Bug 1 verified by code inspection — queue-missing error now propagated regardless of parallel request count
- [ ] Bug 2 verified by code inspection — `doStop()` cleans up all resources that `doStart()` creates
- [ ] Bug 3 verified by code inspection — entries chunked into groups of 10 before SQS API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)