### PR TITLE
CAMEL-23955: Fix conversation memory user turns and history reset

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
@@ -207,6 +207,8 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         Message in = exchange.getIn();
         List<ChatCompletionMessageParam> messages = new ArrayList<>();
 
+        exchange.removeProperty(PENDING_USER_MESSAGE);
+
         // If a system message is configured and conversation memory is enabled, reset
         // history
         if (ObjectHelper.isNotEmpty(config.getSystemMessage()) && config.isConversationMemory()) {

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
@@ -72,6 +72,7 @@ public class OpenAIProducer extends DefaultAsyncProducer {
     private static final Logger LOG = LoggerFactory.getLogger(OpenAIProducer.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Pattern THINK_PATTERN = Pattern.compile("^\\s*<think>(.*?)</think>\\s*", Pattern.DOTALL);
+    private static final String PENDING_USER_MESSAGE = "CamelOpenAIPendingUserMessage";
 
     public OpenAIProducer(OpenAIEndpoint endpoint) {
         super(endpoint);
@@ -209,7 +210,7 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         // If a system message is configured and conversation memory is enabled, reset
         // history
         if (ObjectHelper.isNotEmpty(config.getSystemMessage()) && config.isConversationMemory()) {
-            in.removeHeader(config.getConversationHistoryProperty());
+            exchange.removeProperty(config.getConversationHistoryProperty());
         }
 
         String systemPrompt = in.getHeader(OpenAIConstants.SYSTEM_MESSAGE, String.class);
@@ -235,6 +236,9 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         ChatCompletionMessageParam userMessage = buildUserMessage(in, config);
         if (userMessage != null) {
             messages.add(userMessage);
+            if (config.isConversationMemory()) {
+                exchange.setProperty(PENDING_USER_MESSAGE, userMessage);
+            }
         }
 
         if (messages.isEmpty()) {
@@ -658,6 +662,15 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         }
     }
 
+    private void appendPendingUserMessageToHistory(Exchange exchange, List<ChatCompletionMessageParam> history) {
+        ChatCompletionMessageParam pendingUserMessage
+                = exchange.getProperty(PENDING_USER_MESSAGE, ChatCompletionMessageParam.class);
+        if (pendingUserMessage != null) {
+            history.add(pendingUserMessage);
+            exchange.removeProperty(PENDING_USER_MESSAGE);
+        }
+    }
+
     private void updateConversationHistory(
             Exchange exchange, ChatCompletionCreateParams params,
             ChatCompletion response) {
@@ -673,6 +686,8 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         if (history == null) {
             history = new ArrayList<>();
         }
+
+        appendPendingUserMessageToHistory(exchange, history);
 
         // Add assistant response to history
         String assistantContent = response.choices().get(0).message().content().orElse("");
@@ -700,6 +715,8 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         if (history == null) {
             history = new ArrayList<>();
         }
+
+        appendPendingUserMessageToHistory(exchange, history);
 
         // Add all intermediate agentic messages (assistant+toolCalls, tool responses)
         history.addAll(agenticMessages);
@@ -732,6 +749,8 @@ public class OpenAIProducer extends DefaultAsyncProducer {
         if (history == null) {
             history = new ArrayList<>();
         }
+
+        appendPendingUserMessageToHistory(exchange, history);
 
         // Add all intermediate agentic messages
         history.addAll(agenticMessages);

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryResetTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryResetTest.java
@@ -31,19 +31,11 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Reproducer for the documented conversation history reset: "When systemMessage is set and conversationMemory is
- * enabled, the conversation history is reset" (openai-mcp.adoc, and the systemMessage option description in
- * OpenAIConfiguration).
- *
- * <p>
- * The reset in {@code OpenAIProducer.buildMessages} calls {@code in.removeHeader(conversationHistoryProperty)}, but the
- * conversation history is stored as an exchange <b>property</b>, not a header — so the reset never has any effect and
- * stale history keeps being sent to the model.
+ * Verifies the documented conversation history reset: "When systemMessage is set and conversationMemory is enabled, the
+ * conversation history is reset" (openai-mcp.adoc, and the systemMessage option description in OpenAIConfiguration).
  */
 public class OpenAIConversationMemoryResetTest extends CamelTestSupport {
 
@@ -84,24 +76,19 @@ public class OpenAIConversationMemoryResetTest extends CamelTestSupport {
             e.getIn().setBody("hello");
         });
 
-        assertNull(result.getException());
+        assertThat(result.getException()).isNull();
 
         String request = requestBody.get();
-        assertNotNull(request, "The mock should have captured the chat completion request");
+        assertThat(request)
+                .as("The mock should have captured the chat completion request")
+                .isNotNull();
 
         JsonNode messages = MAPPER.readTree(request).get("messages");
-        assertNotNull(messages);
+        assertThat(messages).isNotNull();
 
-        boolean staleEntryPresent = false;
-        for (JsonNode message : messages) {
-            if ("stale-history-entry".equals(message.path("content").asText())) {
-                staleEntryPresent = true;
-            }
-        }
-
-        assertFalse(staleEntryPresent,
-                "systemMessage + conversationMemory=true is documented to reset the conversation history, "
-                                       + "so the stale history entry must not be sent to the model. Request was: "
-                                       + request);
+        assertThat(messages)
+                .as("systemMessage + conversationMemory=true is documented to reset the conversation history, "
+                    + "so the stale history entry must not be sent to the model. Request was: %s", request)
+                .noneMatch(message -> "stale-history-entry".equals(message.path("content").asText()));
     }
 }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryResetTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryResetTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.models.chat.completions.ChatCompletionMessageParam;
+import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Reproducer for the documented conversation history reset: "When systemMessage is set and conversationMemory is
+ * enabled, the conversation history is reset" (openai-mcp.adoc, and the systemMessage option description in
+ * OpenAIConfiguration).
+ *
+ * <p>
+ * The reset in {@code OpenAIProducer.buildMessages} calls {@code in.removeHeader(conversationHistoryProperty)}, but the
+ * conversation history is stored as an exchange <b>property</b>, not a header — so the reset never has any effect and
+ * stale history keeps being sent to the model.
+ */
+public class OpenAIConversationMemoryResetTest extends CamelTestSupport {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final AtomicReference<String> requestBody = new AtomicReference<>();
+
+    @RegisterExtension
+    public OpenAIMock openAIMock = new OpenAIMock().builder()
+            .when("hello")
+            .assertRequest(requestBody::set)
+            .replyWith("hi")
+            .end()
+            .build();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:chat")
+                        .to("openai:chat-completion?model=gpt-5&apiKey=dummy&conversationMemory=true"
+                            + "&systemMessage=You are a helpful assistant&baseUrl=" + openAIMock.getBaseUrl() + "/v1");
+            }
+        };
+    }
+
+    @Test
+    void systemMessageWithConversationMemoryMustResetHistory() throws Exception {
+        List<ChatCompletionMessageParam> staleHistory = new ArrayList<>();
+        staleHistory.add(ChatCompletionMessageParam.ofUser(
+                ChatCompletionUserMessageParam.builder()
+                        .content(ChatCompletionUserMessageParam.Content.ofText("stale-history-entry"))
+                        .build()));
+
+        Exchange result = template.request("direct:chat", e -> {
+            e.setProperty("CamelOpenAIConversationHistory", staleHistory);
+            e.getIn().setBody("hello");
+        });
+
+        assertNull(result.getException());
+
+        String request = requestBody.get();
+        assertNotNull(request, "The mock should have captured the chat completion request");
+
+        JsonNode messages = MAPPER.readTree(request).get("messages");
+        assertNotNull(messages);
+
+        boolean staleEntryPresent = false;
+        for (JsonNode message : messages) {
+            if ("stale-history-entry".equals(message.path("content").asText())) {
+                staleEntryPresent = true;
+            }
+        }
+
+        assertFalse(staleEntryPresent,
+                "systemMessage + conversationMemory=true is documented to reset the conversation history, "
+                                       + "so the stale history entry must not be sent to the model. Request was: "
+                                       + request);
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryUserMessageTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryUserMessageTest.java
@@ -27,19 +27,12 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Reproducer for the conversation memory contract documented in openai-component.adoc ("Conversation Memory (Per
- * Exchange)"): with {@code conversationMemory=true}, a second call on the same Exchange must send the previous
- * <b>user</b> turn to the model, not only the previous assistant turn.
- *
- * <p>
- * Currently {@code OpenAIProducer.updateConversationHistory} only appends the assistant response to the history
- * property, so user messages are silently dropped from the conversation sent on subsequent turns.
+ * Verifies the conversation memory contract documented in openai-component.adoc ("Conversation Memory (Per Exchange)"):
+ * with {@code conversationMemory=true}, a second call on the same Exchange must send the previous <b>user</b> turn to
+ * the model, not only the previous assistant turn.
  */
 public class OpenAIConversationMemoryUserMessageTest extends CamelTestSupport {
 
@@ -77,33 +70,26 @@ public class OpenAIConversationMemoryUserMessageTest extends CamelTestSupport {
     void conversationHistoryMustIncludePreviousUserMessage() throws Exception {
         Exchange result = template.request("direct:conversation", e -> e.getIn().setBody("My name is Alice"));
 
-        assertNull(result.getException());
-        assertEquals("Your name is Alice.", result.getMessage().getBody(String.class));
+        assertThat(result.getException()).isNull();
+        assertThat(result.getMessage().getBody(String.class)).isEqualTo("Your name is Alice.");
 
         String request = secondRequestBody.get();
-        assertNotNull(request, "The mock should have captured the second chat completion request");
+        assertThat(request)
+                .as("The mock should have captured the second chat completion request")
+                .isNotNull();
 
         JsonNode messages = MAPPER.readTree(request).get("messages");
-        assertNotNull(messages);
+        assertThat(messages).isNotNull();
 
-        boolean previousUserTurnPresent = false;
-        boolean previousAssistantTurnPresent = false;
-        for (JsonNode message : messages) {
-            String role = message.path("role").asText();
-            String content = message.path("content").asText();
-            if ("user".equals(role) && "My name is Alice".equals(content)) {
-                previousUserTurnPresent = true;
-            }
-            if ("assistant".equals(role) && "Nice to meet you!".equals(content)) {
-                previousAssistantTurnPresent = true;
-            }
-        }
-
-        assertTrue(previousAssistantTurnPresent,
-                "The previous assistant turn must be part of the conversation history sent to the model");
-        assertTrue(previousUserTurnPresent,
-                "The previous user turn must be part of the conversation history sent to the model, "
-                                            + "otherwise the model sees assistant answers without the questions that produced them. Request was: "
-                                            + request);
+        assertThat(messages)
+                .as("The previous assistant turn must be part of the conversation history sent to the model")
+                .anyMatch(message -> "assistant".equals(message.path("role").asText())
+                        && "Nice to meet you!".equals(message.path("content").asText()));
+        assertThat(messages)
+                .as("The previous user turn must be part of the conversation history sent to the model, "
+                    + "otherwise the model sees assistant answers without the questions that produced them. Request was: %s",
+                        request)
+                .anyMatch(message -> "user".equals(message.path("role").asText())
+                        && "My name is Alice".equals(message.path("content").asText()));
     }
 }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryUserMessageTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIConversationMemoryUserMessageTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproducer for the conversation memory contract documented in openai-component.adoc ("Conversation Memory (Per
+ * Exchange)"): with {@code conversationMemory=true}, a second call on the same Exchange must send the previous
+ * <b>user</b> turn to the model, not only the previous assistant turn.
+ *
+ * <p>
+ * Currently {@code OpenAIProducer.updateConversationHistory} only appends the assistant response to the history
+ * property, so user messages are silently dropped from the conversation sent on subsequent turns.
+ */
+public class OpenAIConversationMemoryUserMessageTest extends CamelTestSupport {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final AtomicReference<String> secondRequestBody = new AtomicReference<>();
+
+    @RegisterExtension
+    public OpenAIMock openAIMock = new OpenAIMock().builder()
+            .when("My name is Alice")
+            .replyWith("Nice to meet you!")
+            .end()
+            .when("What is my name?")
+            .assertRequest(secondRequestBody::set)
+            .replyWith("Your name is Alice.")
+            .end()
+            .build();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:conversation")
+                        .to("openai:chat-completion?model=gpt-5&apiKey=dummy&conversationMemory=true&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1")
+                        .setBody(constant("What is my name?"))
+                        .to("openai:chat-completion?model=gpt-5&apiKey=dummy&conversationMemory=true&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+            }
+        };
+    }
+
+    @Test
+    void conversationHistoryMustIncludePreviousUserMessage() throws Exception {
+        Exchange result = template.request("direct:conversation", e -> e.getIn().setBody("My name is Alice"));
+
+        assertNull(result.getException());
+        assertEquals("Your name is Alice.", result.getMessage().getBody(String.class));
+
+        String request = secondRequestBody.get();
+        assertNotNull(request, "The mock should have captured the second chat completion request");
+
+        JsonNode messages = MAPPER.readTree(request).get("messages");
+        assertNotNull(messages);
+
+        boolean previousUserTurnPresent = false;
+        boolean previousAssistantTurnPresent = false;
+        for (JsonNode message : messages) {
+            String role = message.path("role").asText();
+            String content = message.path("content").asText();
+            if ("user".equals(role) && "My name is Alice".equals(content)) {
+                previousUserTurnPresent = true;
+            }
+            if ("assistant".equals(role) && "Nice to meet you!".equals(content)) {
+                previousAssistantTurnPresent = true;
+            }
+        }
+
+        assertTrue(previousAssistantTurnPresent,
+                "The previous assistant turn must be part of the conversation history sent to the model");
+        assertTrue(previousUserTurnPresent,
+                "The previous user turn must be part of the conversation history sent to the model, "
+                                            + "otherwise the model sees assistant answers without the questions that produced them. Request was: "
+                                            + request);
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -122,6 +122,18 @@ String chat(AiAgentBody<?> aiAgentBody, ToolProvider toolProvider);
 Result<String> chat(AiAgentBody<?> aiAgentBody, ToolProvider toolProvider);
 ----
 
+=== camel-openai
+
+The `conversationMemory` feature on the `chat-completion` operation has two behavior fixes:
+
+* User messages are now stored in the `CamelOpenAIConversationHistory` exchange property (configurable via
+  `conversationHistoryProperty`) alongside assistant responses. Previously only assistant turns were appended,
+  so code that reads the history property directly will see roughly twice as many entries (alternating user
+  and assistant messages) compared to Camel 4.21 and earlier.
+* When `systemMessage` is set together with `conversationMemory=true`, the conversation history is now
+  correctly cleared via `exchange.removeProperty()`. Previously `removeHeader()` was used on a property that
+  is stored as an exchange property, so the documented reset had no effect and stale history was kept.
+
 === camel-management - Throughput MBean attribute uses EWMA smoothing
 
 The `Throughput` attribute on the `ManagedPerformanceCounter` JMX MBean now reports an EWMA


### PR DESCRIPTION
## CAMEL-23955 — Summary

**Branch:** `CAMEL-23955-conversation-memory-fix`  
**Commit:** `95e5ee478a7`  
**Module:** `camel-openai`

---

### Bugs Fixed

| # | Problem | Root Cause |
|---|---------|------------|
| 1 | User turns missing from conversation history | Only assistant responses were saved |
| 2 | `systemMessage` reset had no effect | `removeHeader()` used instead of `removeProperty()` |

---

### Code Changes

**File modified:** `OpenAIProducer.java` (+20 lines)

| Area | Before | After |
|------|--------|-------|
| History reset | `in.removeHeader(...)` | `exchange.removeProperty(...)` |
| User message tracking | Not stored | Saved as `PENDING_USER_MESSAGE` in `buildMessages()` |
| History update | Assistant only | New helper `appendPendingUserMessageToHistory()` runs in all 3 update paths |

**Files added (from Jira reproducers):**
- `OpenAIConversationMemoryUserMessageTest.java`
- `OpenAIConversationMemoryResetTest.java`

---

### Tests Passed

| Test Class | What It Verifies | Result |
|------------|------------------|--------|
| `OpenAIConversationMemoryUserMessageTest` | Second turn includes previous user message (`"My name is Alice"`) | **PASSED** |
| `OpenAIConversationMemoryResetTest` | `systemMessage` + `conversationMemory=true` clears stale history | **PASSED** |
| `OpenAIProducerMcpMockTest#conversationMemoryIncludesToolCallChain` | Agentic MCP path still builds full tool-call history | **PASSED** |

**Build:** `BUILD SUCCESS` — 3 tests, 0 failures

---

### Flow After Fix

```
Turn 1:  user → API → history = [user, assistant]
Turn 2:  history + new user → API → history = [user, assistant, user, assistant]
Reset: systemMessage set → exchange property cleared → fresh history
```