### PR TITLE
CAMEL-23962: Preserve all MCP inputSchema keywords in tool conversion

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/McpToolConverter.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/McpToolConverter.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.openai;
 
 import java.util.List;
+import java.util.Map;
 
 import com.openai.core.JsonValue;
 import com.openai.models.FunctionDefinition;
@@ -48,17 +49,13 @@ final class McpToolConverter {
 
         if (tool.inputSchema() != null) {
             FunctionParameters.Builder paramsBuilder = FunctionParameters.builder();
-            paramsBuilder.putAdditionalProperty("type",
-                    JsonValue.from(tool.inputSchema().getOrDefault("type", "object")));
+            Map<String, Object> inputSchema = tool.inputSchema();
 
-            Object properties = tool.inputSchema().get("properties");
-            if (properties != null) {
-                paramsBuilder.putAdditionalProperty("properties", JsonValue.from(properties));
+            if (!inputSchema.containsKey("type")) {
+                paramsBuilder.putAdditionalProperty("type", JsonValue.from("object"));
             }
-
-            Object required = tool.inputSchema().get("required");
-            if (required != null) {
-                paramsBuilder.putAdditionalProperty("required", JsonValue.from(required));
+            for (Map.Entry<String, Object> entry : inputSchema.entrySet()) {
+                paramsBuilder.putAdditionalProperty(entry.getKey(), JsonValue.from(entry.getValue()));
             }
 
             funcBuilder.parameters(paramsBuilder.build());

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/McpToolConverterTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/McpToolConverterTest.java
@@ -20,10 +20,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.openai.core.JsonValue;
+import com.openai.models.FunctionParameters;
 import com.openai.models.chat.completions.ChatCompletionFunctionTool;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -97,5 +100,47 @@ class McpToolConverterTest {
         List<ChatCompletionFunctionTool> result = McpToolConverter.convert(List.of());
         assertNotNull(result);
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void convertPreservesAllInputSchemaKeywords() {
+        Map<String, Object> addressDef = Map.of("type", "object", "properties", Map.of("city", Map.of("type", "string")));
+        Map<String, Object> inputSchema = Map.of(
+                "type", "object",
+                "description", "Search parameters",
+                "additionalProperties", false,
+                "$defs", Map.of("Address", addressDef),
+                "properties", Map.of("query", Map.of("type", "string"), "address", Map.of("$ref", "#/$defs/Address")),
+                "required", List.of("query"));
+
+        McpSchema.Tool tool = McpSchema.Tool.builder("search", inputSchema)
+                .description("Search tool")
+                .build();
+
+        FunctionParameters parameters = McpToolConverter.convert(List.of(tool)).get(0).function().parameters().get();
+        Map<String, JsonValue> converted = parameters._additionalProperties();
+
+        assertThat(converted).containsKeys("type", "description", "additionalProperties", "$defs", "properties", "required");
+        assertThat(converted.get("type").asString()).contains("object");
+        assertThat(converted.get("description").asString()).contains("Search parameters");
+        assertThat(converted.get("additionalProperties").asBoolean()).contains(false);
+        @SuppressWarnings("unchecked")
+        Map<String, JsonValue> defs = (Map<String, JsonValue>) converted.get("$defs").asObject().orElse(Map.of());
+        @SuppressWarnings("unchecked")
+        Map<String, JsonValue> properties = (Map<String, JsonValue>) converted.get("properties").asObject().orElse(Map.of());
+        assertThat(defs).containsKey("Address");
+        assertThat(properties).containsKey("address");
+        assertThat(converted.get("required").asArray()).isNotEmpty();
+    }
+
+    @Test
+    void convertDefaultsTypeToObjectWhenMissing() {
+        McpSchema.Tool tool = McpSchema.Tool.builder("bare_schema", Map.of("properties", Map.of("x", Map.of("type", "string"))))
+                .build();
+
+        FunctionParameters parameters = McpToolConverter.convert(List.of(tool)).get(0).function().parameters().get();
+
+        assertThat(parameters._additionalProperties().get("type").asString()).contains("object");
+        assertThat(parameters._additionalProperties()).containsKey("properties");
     }
 }


### PR DESCRIPTION
---

## Summary

Fixes [CAMEL-23962](https://issues.apache.org/jira/browse/CAMEL-23962).

`McpToolConverter.convertTool()` previously copied only three keys from the MCP tool `inputSchema` into OpenAI `FunctionParameters`: `type`, `properties`, and `required`. All other JSON Schema keywords were dropped silently.

That broke schemas from MCP servers using non-trivial definitions — for example `$defs`/`definitions` referenced by `$ref`, `additionalProperties` (needed for strict function calling), root-level `description`, and compositional keywords like `oneOf`/`anyOf`.

This change copies the full `inputSchema` map into `FunctionParameters`, defaulting `type` to `"object"` when absent (preserving previous behavior).

## Changes

- **`McpToolConverter.java`** — Replace allow-list with a full copy of all `inputSchema` entries
- **`McpToolConverterTest.java`** — Add tests for:
  - `$defs`, `additionalProperties`, `description`, `$ref`, and `required` preservation
  - Default `type: object` when `type` is missing

## Test plan

- [x] `McpToolConverterTest` — all 7 tests pass locally
- [x] `convertPreservesAllInputSchemaKeywords` — verifies full schema keywords are forwarded
- [x] `convertDefaultsTypeToObjectWhenMissing` — verifies backward-compatible type default

---