### PR TITLE
CAMEL-23961: Fail clearly when chat completion has empty choices

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
@@ -54,6 +54,7 @@ import com.openai.models.completions.CompletionUsage;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.camel.AsyncCallback;
+import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.WrappedFile;
@@ -434,14 +435,15 @@ public class OpenAIProducer extends DefaultAsyncProducer {
             exchange.setProperty(OpenAIConstants.RESPONSE, response);
         }
 
-        if (isToolCallsFinishReason(response.choices().get(0))) {
-            exchange.getMessage().setBody(response.choices().get(0).message().toolCalls());
+        ChatCompletion.Choice choice = requireFirstChoice(exchange, response);
+        if (isToolCallsFinishReason(choice)) {
+            exchange.getMessage().setBody(choice.message().toolCalls());
         } else {
-            String content = response.choices().get(0).message().content().orElse("");
+            String content = choice.message().content().orElse("");
             content = processThinkingContent(exchange, content, config);
             exchange.getMessage().setBody(content);
-            extractReasoningContent(exchange, response.choices().get(0).message());
-            extractAdditionalResponseHeaders(exchange, response.choices().get(0).message());
+            extractReasoningContent(exchange, choice.message());
+            extractAdditionalResponseHeaders(exchange, choice.message());
         }
         setResponseHeaders(exchange.getMessage(), response);
         updateConversationHistory(exchange, params, response);
@@ -464,7 +466,7 @@ public class OpenAIProducer extends DefaultAsyncProducer {
 
         while (iteration < maxIterations) {
             ChatCompletion response = getEndpoint().getClient().chat().completions().create(paramsBuilder.build());
-            ChatCompletion.Choice choice = response.choices().get(0);
+            ChatCompletion.Choice choice = requireFirstChoice(exchange, response);
 
             if (!isToolCallsFinishReason(choice)) {
                 // Final LLM response
@@ -625,6 +627,14 @@ public class OpenAIProducer extends DefaultAsyncProducer {
             }
         });
 
+    }
+
+    private static ChatCompletion.Choice requireFirstChoice(Exchange exchange, ChatCompletion response)
+            throws CamelExchangeException {
+        if (response.choices().isEmpty()) {
+            throw new CamelExchangeException("OpenAI response contained no choices", exchange);
+        }
+        return response.choices().get(0);
     }
 
     private static boolean isToolCallsFinishReason(ChatCompletion.Choice choice) {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmptyChoicesResponseTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmptyChoicesResponseTest.java
@@ -29,8 +29,7 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Reproducer for a robustness gap: a chat completion response with an empty {@code choices} array fails the exchange
@@ -79,10 +78,9 @@ public class OpenAIEmptyChoicesResponseTest extends CamelTestSupport {
     void emptyChoicesMustFailWithMeaningfulException() {
         Exchange result = template.request("direct:chat", e -> e.getIn().setBody("hello"));
 
-        assertNotNull(result.getException(), "An empty choices array cannot produce a response body");
-        assertFalse(result.getException() instanceof IndexOutOfBoundsException,
-                "An empty choices array must surface as a meaningful exception describing the malformed "
-                                                                                + "provider response, not a raw IndexOutOfBoundsException. Got: "
-                                                                                + result.getException());
+        assertThat(result.getException())
+                .as("An empty choices array cannot produce a response body")
+                .isNotNull()
+                .isNotInstanceOf(IndexOutOfBoundsException.class);
     }
 }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmptyChoicesResponseTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmptyChoicesResponseTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Reproducer for a robustness gap: a chat completion response with an empty {@code choices} array fails the exchange
+ * with a raw {@code IndexOutOfBoundsException} because {@code OpenAIProducer.processNonStreamingSimple} dereferences
+ * {@code response.choices().get(0)} unguarded — while {@code setResponseHeaders} in the same class does guard against
+ * empty choices. Empty {@code choices} payloads are known in the OpenAI-compatible ecosystem from the streaming side
+ * (Azure OpenAI content-filter chunks, OpenRouter usage-only final chunks); for non-streaming this is defensive
+ * hardening against misbehaving compatible shims/proxies, which should surface as a meaningful exception.
+ */
+public class OpenAIEmptyChoicesResponseTest extends CamelTestSupport {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @RegisterExtension
+    public OpenAIMock openAIMock = new OpenAIMock().builder()
+            .when("hello")
+            .thenRespondWith((exchange, input) -> {
+                try {
+                    Map<String, Object> completion = new HashMap<>();
+                    completion.put("id", UUID.randomUUID().toString());
+                    completion.put("choices", List.of());
+                    completion.put("created", System.currentTimeMillis() / 1000L);
+                    completion.put("model", "openai-mock");
+                    completion.put("object", "chat.completion");
+                    return MAPPER.writeValueAsString(completion);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .end()
+            .build();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:chat")
+                        .to("openai:chat-completion?model=gpt-5&apiKey=dummy&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+            }
+        };
+    }
+
+    @Test
+    void emptyChoicesMustFailWithMeaningfulException() {
+        Exchange result = template.request("direct:chat", e -> e.getIn().setBody("hello"));
+
+        assertNotNull(result.getException(), "An empty choices array cannot produce a response body");
+        assertFalse(result.getException() instanceof IndexOutOfBoundsException,
+                "An empty choices array must surface as a meaningful exception describing the malformed "
+                                                                                + "provider response, not a raw IndexOutOfBoundsException. Got: "
+                                                                                + result.getException());
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmptyChoicesResponseTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmptyChoicesResponseTest.java
@@ -19,9 +19,13 @@ package org.apache.camel.component.openai;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.infra.openai.mock.OpenAIMock;
@@ -30,14 +34,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
- * Reproducer for a robustness gap: a chat completion response with an empty {@code choices} array fails the exchange
- * with a raw {@code IndexOutOfBoundsException} because {@code OpenAIProducer.processNonStreamingSimple} dereferences
- * {@code response.choices().get(0)} unguarded — while {@code setResponseHeaders} in the same class does guard against
- * empty choices. Empty {@code choices} payloads are known in the OpenAI-compatible ecosystem from the streaming side
- * (Azure OpenAI content-filter chunks, OpenRouter usage-only final chunks); for non-streaming this is defensive
- * hardening against misbehaving compatible shims/proxies, which should surface as a meaningful exception.
+ * Verifies that a chat completion response with an empty {@code choices} array fails the exchange with a meaningful
+ * {@link CamelExchangeException} in both the simple and agentic non-streaming paths.
  */
 public class OpenAIEmptyChoicesResponseTest extends CamelTestSupport {
 
@@ -46,19 +49,7 @@ public class OpenAIEmptyChoicesResponseTest extends CamelTestSupport {
     @RegisterExtension
     public OpenAIMock openAIMock = new OpenAIMock().builder()
             .when("hello")
-            .thenRespondWith((exchange, input) -> {
-                try {
-                    Map<String, Object> completion = new HashMap<>();
-                    completion.put("id", UUID.randomUUID().toString());
-                    completion.put("choices", List.of());
-                    completion.put("created", System.currentTimeMillis() / 1000L);
-                    completion.put("model", "openai-mock");
-                    completion.put("object", "chat.completion");
-                    return MAPPER.writeValueAsString(completion);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            })
+            .thenRespondWith((exchange, input) -> emptyChoicesCompletionJson())
             .end()
             .build();
 
@@ -70,6 +61,10 @@ public class OpenAIEmptyChoicesResponseTest extends CamelTestSupport {
                 from("direct:chat")
                         .to("openai:chat-completion?model=gpt-5&apiKey=dummy&baseUrl="
                             + openAIMock.getBaseUrl() + "/v1");
+
+                from("direct:mcp-chat")
+                        .to("openai:chat-completion?model=gpt-5&apiKey=dummy&autoToolExecution=true&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
             }
         };
     }
@@ -80,7 +75,64 @@ public class OpenAIEmptyChoicesResponseTest extends CamelTestSupport {
 
         assertThat(result.getException())
                 .as("An empty choices array cannot produce a response body")
-                .isNotNull()
-                .isNotInstanceOf(IndexOutOfBoundsException.class);
+                .isInstanceOf(CamelExchangeException.class)
+                .hasMessageContaining("no choices");
+    }
+
+    @Test
+    void emptyChoicesInAgenticPathMustFailWithMeaningfulException() {
+        String endpointUri = "openai:chat-completion?model=gpt-5&apiKey=dummy&autoToolExecution=true&baseUrl="
+                             + openAIMock.getBaseUrl() + "/v1";
+
+        Map<String, McpSyncClient> toolClients = new HashMap<>();
+        toolClients.put("get_weather", createMockMcpClient("Sunny, 22°C"));
+        injectMcpTools(endpointUri, toolClients);
+
+        Exchange result = template.request("direct:mcp-chat", e -> e.getIn().setBody("hello"));
+
+        assertThat(result.getException())
+                .as("An empty choices array cannot produce a response body in the agentic path")
+                .isInstanceOf(CamelExchangeException.class)
+                .hasMessageContaining("no choices");
+    }
+
+    private static String emptyChoicesCompletionJson() {
+        try {
+            Map<String, Object> completion = new HashMap<>();
+            completion.put("id", UUID.randomUUID().toString());
+            completion.put("choices", List.of());
+            completion.put("created", System.currentTimeMillis() / 1000L);
+            completion.put("model", "openai-mock");
+            completion.put("object", "chat.completion");
+            return MAPPER.writeValueAsString(completion);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private McpSyncClient createMockMcpClient(String resultText) {
+        McpSyncClient client = mock(McpSyncClient.class);
+        McpSchema.CallToolResult result = McpSchema.CallToolResult.builder()
+                .content(List.of(new McpSchema.TextContent(null, resultText, null)))
+                .isError(false)
+                .build();
+        when(client.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
+        return client;
+    }
+
+    private void injectMcpTools(String endpointKey, Map<String, McpSyncClient> toolClients) {
+        OpenAIEndpoint endpoint = context.getEndpoint(endpointKey, OpenAIEndpoint.class);
+
+        List<McpSchema.Tool> mcpTools = toolClients.keySet().stream()
+                .map(name -> McpSchema.Tool.builder(name, Map.of("type", "object"))
+                        .description("Mock tool: " + name)
+                        .build())
+                .toList();
+
+        endpoint.setMcpToolState(new McpToolState(
+                McpToolConverter.convert(mcpTools),
+                toolClients,
+                Map.of(),
+                Set.of()));
     }
 }


### PR DESCRIPTION
**CAMEL-23961 is done.**

- **Branch:** `CAMEL-23961-empty-choices-response` (pushed)
- **Commit:** `36fc75910d3`
- **Fix:** Empty `choices` arrays now throw `CamelExchangeException` instead of `IndexOutOfBoundsException` in simple and agentic non-streaming paths
- **Test:** `OpenAIEmptyChoicesResponseTest` — **PASSED**
