### PR TITLE
CAMEL-24143: Fix medium findings in Split & Aggregate EIP processors

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/SplitResult.java
+++ b/core/camel-api/src/main/java/org/apache/camel/SplitResult.java
@@ -40,12 +40,14 @@ public final class SplitResult {
     }
 
     private final int totalItems;
+    private final int processedItems;
     private final int failureCount;
     private final List<Failure> failures;
     private final boolean aborted;
 
-    public SplitResult(int totalItems, int failureCount, List<Failure> failures, boolean aborted) {
+    public SplitResult(int totalItems, int processedItems, int failureCount, List<Failure> failures, boolean aborted) {
         this.totalItems = totalItems;
+        this.processedItems = processedItems;
         this.failureCount = failureCount;
         this.failures = failures != null ? Collections.unmodifiableList(failures) : Collections.emptyList();
         this.aborted = aborted;
@@ -60,10 +62,19 @@ public final class SplitResult {
     }
 
     /**
+     * The number of items that were actually processed. After an abort, this may be less than {@code getTotalItems()}.
+     *
+     * @since 4.22
+     */
+    public int getProcessedItems() {
+        return processedItems;
+    }
+
+    /**
      * The number of items that completed successfully.
      */
     public int getSuccessCount() {
-        return totalItems - failureCount;
+        return processedItems - failureCount;
     }
 
     /**
@@ -90,6 +101,7 @@ public final class SplitResult {
     @Override
     public String toString() {
         return "SplitResult[total=" + totalItems
+               + ", processed=" + processedItems
                + ", success=" + getSuccessCount()
                + ", failures=" + failureCount
                + ", aborted=" + aborted + "]";

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Splitter.java
@@ -55,6 +55,7 @@ import org.apache.camel.support.resume.OffsetKeys;
 import org.apache.camel.support.resume.Offsets;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.IOHelper;
+import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -314,7 +315,15 @@ public class Splitter extends MulticastProcessor {
                     storedIndex = readCurrentWatermark();
                 }
                 if (storedIndex != null) {
-                    int skipTo = Integer.parseInt(storedIndex);
+                    int skipTo;
+                    try {
+                        skipTo = Integer.parseInt(storedIndex);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeCamelException(
+                                "Watermark value '" + storedIndex + "' under key '" + watermarkKey
+                                                        + "' is not a valid integer",
+                                e);
+                    }
                     while (rawIterator.hasNext() && skipCount <= skipTo) {
                         rawIterator.next();
                         skipCount++;
@@ -541,37 +550,58 @@ public class Splitter extends MulticastProcessor {
     }
 
     @Override
+    protected void afterSend(ProcessorExchangePair pair, StopWatch watch) {
+        super.afterSend(pair, watch);
+        SplitFailureTracker tracker = pair.getExchange().getProperty(SPLIT_FAILURE_TRACKER, SplitFailureTracker.class);
+        if (tracker != null) {
+            tracker.incrementProcessedItems();
+        }
+    }
+
+    @Override
     protected boolean shouldContinueOnFailure(Exchange subExchange, Exchange original, int index) {
         SplitFailureTracker tracker = original.getProperty(SPLIT_FAILURE_TRACKER, SplitFailureTracker.class);
         if (tracker == null) {
             return super.shouldContinueOnFailure(subExchange, original, index);
         }
 
-        // record the failure
-        tracker.recordFailure(index, subExchange.getException());
-
-        // check if we've exceeded the max failed records
-        if (maxFailedRecords > 0 && tracker.getFailureCount() >= maxFailedRecords) {
+        // a deliberate .stop() or rollback in the child route is not a failure —
+        // honor the stop/rollback semantics without inflating the failure count
+        if (subExchange.isRouteStop() || subExchange.isRollbackOnly() || subExchange.isRollbackOnlyLast()) {
             return false;
         }
-        // check if we've exceeded the error ratio threshold
-        if (errorThreshold > 0) {
-            double ratio = (double) tracker.getFailureCount() / (index + 1);
-            if (ratio >= errorThreshold) {
+
+        // only record actual unhandled exceptions as failures — error-handler-handled
+        // exceptions should not inflate the failure count
+        boolean hasException = subExchange.getException() != null;
+        if (hasException) {
+            tracker.recordFailure(index, subExchange.getException());
+
+            // check if we've exceeded the max failed records
+            if (maxFailedRecords > 0 && tracker.getFailureCount() >= maxFailedRecords) {
                 return false;
             }
-        }
+            // check if we've exceeded the error ratio threshold
+            if (errorThreshold > 0) {
+                int processed = tracker.getProcessedItems();
+                if (processed > 0) {
+                    double ratio = (double) tracker.getFailureCount() / processed;
+                    if (ratio >= errorThreshold) {
+                        return false;
+                    }
+                }
+            }
 
-        // Continue processing — clear the exception from the sub-exchange so that aggregation
-        // proceeds normally. The failure is already recorded in the tracker above, so the
-        // SplitResult will still contain the failure details even though the exception is cleared.
-        subExchange.setException(null);
+            // continue processing — clear the exception so aggregation proceeds normally
+            subExchange.setException(null);
+        }
         return true;
     }
 
     static final class SplitFailureTracker {
         private final AtomicInteger failureCount = new AtomicInteger();
         private final AtomicInteger totalItems = new AtomicInteger();
+        private final AtomicInteger processedItems = new AtomicInteger();
         private final CopyOnWriteArrayList<SplitResult.Failure> failures = new CopyOnWriteArrayList<>();
 
         void recordFailure(int index, Exception exception) {
@@ -583,8 +613,16 @@ public class Splitter extends MulticastProcessor {
             totalItems.incrementAndGet();
         }
 
+        void incrementProcessedItems() {
+            processedItems.incrementAndGet();
+        }
+
         int getTotalItems() {
             return totalItems.get();
+        }
+
+        int getProcessedItems() {
+            return processedItems.get();
         }
 
         int getFailureCount() {
@@ -708,8 +746,9 @@ public class Splitter extends MulticastProcessor {
         }
 
         boolean aborted = exchange.getException() != null;
-        SplitResult result
-                = new SplitResult(tracker.getTotalItems(), tracker.getFailureCount(), tracker.getFailures(), aborted);
+        SplitResult result = new SplitResult(
+                tracker.getTotalItems(), tracker.getProcessedItems(),
+                tracker.getFailureCount(), tracker.getFailures(), aborted);
         exchange.setProperty(ExchangePropertyKey.SPLIT_RESULT, result);
 
         // remove internal tracker

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/aggregate/AggregateProcessor.java
@@ -212,6 +212,7 @@ public class AggregateProcessor extends BaseProcessorSupport
             completedByStrategy.set(0);
             completedByTimeout.set(0);
             completedByPredicate.set(0);
+            completedByInterval.set(0);
             completedByBatchConsumer.set(0);
             completedByForce.set(0);
             discarded.set(0);
@@ -404,9 +405,14 @@ public class AggregateProcessor extends BaseProcessorSupport
                     long delay = optimisticLockRetryPolicy.getDelay(attempt);
                     if (delay > 0) {
                         int nextAttempt = attempt;
-                        getOptimisticLockingExecutorService().schedule(
-                                () -> doInOptimisticLock(exchange, key, callback, nextAttempt, false), delay,
-                                TimeUnit.MILLISECONDS);
+                        getOptimisticLockingExecutorService().schedule(() -> {
+                            try {
+                                doInOptimisticLock(exchange, key, callback, nextAttempt, false);
+                            } catch (Exception t) {
+                                exchange.setException(t);
+                                callback.done(false);
+                            }
+                        }, delay, TimeUnit.MILLISECONDS);
                         return false;
                     }
                 } else {
@@ -923,6 +929,9 @@ public class AggregateProcessor extends BaseProcessorSupport
 
     private void aggregateCompletionCounter(Exchange exchange) {
         String completedBy = exchange.getProperty(ExchangePropertyKey.AGGREGATED_COMPLETED_BY, String.class);
+        if (completedBy == null) {
+            return;
+        }
         switch (completedBy) {
             case COMPLETED_BY_INTERVAL:
                 completedByInterval.incrementAndGet();

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitterErrorThresholdTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitterErrorThresholdTest.java
@@ -100,8 +100,10 @@ class SplitterErrorThresholdTest extends ContextTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:parallel-split");
         mock.expectedMinimumMessageCount(0);
 
+        // 3 failures out of 5 items = 60% failure rate, exceeds 50% threshold
+        // regardless of parallel completion order
         Exchange result = template.send("direct:parallel",
-                e -> e.getIn().setBody(Arrays.asList("FAIL", "FAIL", "a", "b", "c")));
+                e -> e.getIn().setBody(Arrays.asList("FAIL", "FAIL", "FAIL", "a", "b")));
 
         mock.assertIsSatisfied();
 

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SplitterSplitResultTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SplitterSplitResultTest.java
@@ -136,8 +136,9 @@ class SplitterSplitResultTest extends ContextTestSupport {
 
     @Test
     void testSplitResultConstructorWithNullFailures() {
-        SplitResult result = new SplitResult(5, 0, null, false);
+        SplitResult result = new SplitResult(5, 5, 0, null, false);
         assertEquals(5, result.getTotalItems());
+        assertEquals(5, result.getProcessedItems());
         assertEquals(0, result.getFailureCount());
         assertEquals(5, result.getSuccessCount());
         assertFalse(result.isAborted());


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24143](https://issues.apache.org/jira/browse/CAMEL-24143) — medium-severity findings from code review of the Split and Aggregate EIP processors.

## Changes

### Splitter

- **Processed vs total items**: `SplitResult.getSuccessCount()` now uses actual processed count instead of total items, giving correct results after an abort
- **Stop/rollback semantics**: `shouldContinueOnFailure` no longer counts deliberate `.stop()` or rollback as failures
- **Error threshold accuracy**: ratio calculation now uses processed items (not index+1), avoiding off-by-one in parallel mode
- **Exception-only failures**: only unhandled exceptions are recorded as failures — error-handler-handled exceptions don't inflate the count
- **Watermark validation**: `NumberFormatException` on invalid watermark values is now caught and wrapped with a clear error message

### AggregateProcessor

- **Missing reset**: `completedByInterval` counter was not reset in `resetCounters()`
- **Null-safe stats**: `aggregateCompletionCounter` guards against null `completedBy` property
- **Optimistic lock retry safety**: scheduled retry lambda now catches exceptions and propagates them to the exchange instead of losing them

### SplitResult API

- Added `getProcessedItems()` method (with `@since 4.22` tag) to distinguish processed from total items

## Test plan

- [x] `SplitterErrorThresholdTest` — updated to reliably trigger the threshold regardless of parallel completion order
- [x] `SplitterSplitResultTest` — updated for new `SplitResult` constructor with `processedItems`

_Claude Code on behalf of davsclaus_