### PR TITLE
CAMEL-23959: camel-openai - Honor storeFullResponse in embeddings producer

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
@@ -103,6 +103,10 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
         CreateEmbeddingResponse response = getEndpoint().getClient()
                 .embeddings().create(params);
 
+        if (config.isStoreFullResponse()) {
+            exchange.setProperty(OpenAIConstants.RESPONSE, response);
+        }
+
         // Extract embeddings
         List<List<Float>> embeddings = new ArrayList<>();
         for (Embedding embedding : response.data()) {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmbeddingsMockTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmbeddingsMockTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenAIEmbeddingsMockTest extends CamelTestSupport {
@@ -56,6 +57,10 @@ public class OpenAIEmbeddingsMockTest extends CamelTestSupport {
             public void configure() {
                 from("direct:embedding")
                         .to("openai:embeddings?embeddingModel=text-embedding-ada-002&apiKey=dummy&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+
+                from("direct:embedding-store-response")
+                        .to("openai:embeddings?embeddingModel=text-embedding-ada-002&apiKey=dummy&storeFullResponse=true&baseUrl="
                             + openAIMock.getBaseUrl() + "/v1");
             }
         };
@@ -172,5 +177,23 @@ public class OpenAIEmbeddingsMockTest extends CamelTestSupport {
         assertEquals(4, result.getMessage().getHeader(OpenAIConstants.EMBEDDING_VECTOR_SIZE));
         assertTrue(result.getMessage().getHeader(OpenAIConstants.PROMPT_TOKENS, Integer.class) > 0);
         assertTrue(result.getMessage().getHeader(OpenAIConstants.TOTAL_TOKENS, Integer.class) > 0);
+    }
+
+    @Test
+    void storeFullResponseStoresEmbeddingResponse() {
+        Exchange result = template.request("direct:embedding-store-response",
+                e -> e.getIn().setBody("What is Apache Camel?"));
+
+        assertNotNull(result.getProperty(OpenAIConstants.RESPONSE),
+                "storeFullResponse=true must store the full response in the CamelOpenAIResponse exchange property");
+    }
+
+    @Test
+    void storeFullResponseDefaultDoesNotStoreResponse() {
+        Exchange result = template.request("direct:embedding",
+                e -> e.getIn().setBody("What is Apache Camel?"));
+
+        assertNull(result.getProperty(OpenAIConstants.RESPONSE),
+                "storeFullResponse defaults to false, so CamelOpenAIResponse should not be set");
     }
 }


### PR DESCRIPTION
## Summary

- The `storeFullResponse` option was silently ignored by `OpenAIEmbeddingsProducer`. Now stores the full `CreateEmbeddingResponse` in the `CamelOpenAIResponse` exchange property when enabled, consistent with the chat-completion and audio-transcription producers.

## Test plan

- [x] New test `storeFullResponseStoresEmbeddingResponse` verifies property is set when `storeFullResponse=true`
- [x] New test `storeFullResponseDefaultDoesNotStoreResponse` verifies property is absent by default
- [x] All 6 embeddings tests pass

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>