### PR TITLE
CAMEL-23958: camel-openai - Skip duplicate MCP tool names from advertised tool list

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEndpoint.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEndpoint.java
@@ -193,18 +193,17 @@ public class OpenAIEndpoint extends DefaultEndpoint {
             McpSchema.ListToolsResult toolsResult = mcpClient.listTools();
             List<McpSchema.Tool> serverTools = toolsResult.tools();
 
-            tools.addAll(McpToolConverter.convert(serverTools));
-
             for (McpSchema.Tool tool : serverTools) {
                 if (toolClientMap.putIfAbsent(tool.name(), mcpClient) != null) {
                     LOG.warn("Duplicate MCP tool name '{}' from server '{}', using first registered", tool.name(),
                             serverName);
                 } else {
                     toolToServerName.put(tool.name(), serverName);
-                }
+                    tools.addAll(McpToolConverter.convert(List.of(tool)));
 
-                if (isReturnDirect(tool)) {
-                    returnDirectTools.add(tool.name());
+                    if (isReturnDirect(tool)) {
+                        returnDirectTools.add(tool.name());
+                    }
                 }
             }
 
@@ -379,12 +378,17 @@ public class OpenAIEndpoint extends DefaultEndpoint {
                 newToolToServer.keySet().removeIf(oldServerTools::contains);
                 newReturnDirect.removeIf(oldServerTools::contains);
 
-                newTools.addAll(McpToolConverter.convert(tools));
                 for (McpSchema.Tool tool : tools) {
-                    newClientMap.put(tool.name(), newClient);
-                    newToolToServer.put(tool.name(), serverName);
-                    if (isReturnDirect(tool)) {
-                        newReturnDirect.add(tool.name());
+                    if (newClientMap.containsKey(tool.name())) {
+                        LOG.warn("Duplicate MCP tool name '{}' from server '{}', using first registered", tool.name(),
+                                serverName);
+                    } else {
+                        newTools.addAll(McpToolConverter.convert(List.of(tool)));
+                        newClientMap.put(tool.name(), newClient);
+                        newToolToServer.put(tool.name(), serverName);
+                        if (isReturnDirect(tool)) {
+                            newReturnDirect.add(tool.name());
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

- When multiple MCP servers expose tools with the same name, only the first-registered tool is now added to the advertised function list sent to the OpenAI API. Previously, duplicates were excluded from the dispatch map (via `putIfAbsent`) but still included in the tool list, causing API rejections or silent cross-server misdispatch.
- Same fix applied to the `doReconnectMcpServer` path which had the same defect.

## Test plan

- [x] All 90 existing tests pass (no regressions)
- [x] Existing `OpenAIEndpointMcpReconnectConcurrencyTest` covers the reconnect path

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>