### PR TITLE
CAMEL-24173: Change queue durable default to true for RabbitMQ 4.3+ compatibility

### DIFF
--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/docs/spring-rabbitmq-component.adoc
@@ -146,7 +146,7 @@ queue and routing keys.
 
 The elements can be configured using the multivalued `args` option.
 
-For example, to specify the queue as durable and exclusive, you can configure the endpoint uri with `arg.queue.durable=true&arg.queue.exclusive=true`.
+For example, to specify the queue as exclusive, you can configure the endpoint uri with `arg.queue.exclusive=true`.
 
 *Exchanges*
 
@@ -167,7 +167,7 @@ See details in the RabbitMQ documentation.
 |=====================================================================
 |Option |Type |Description|Default
 | autoDelete | boolean | True if the server should delete the queue when it is no longer in use (queue that has had at least one consumer is deleted when last consumer unsubscribes). | false
-| durable | boolean | A durable queue will survive a server restart. | false
+| durable | boolean | A durable queue will survive a server restart. | true
 | exclusive | boolean | Whether the queue is exclusive | false
 | x-dead-letter-exchange | String | The name of the dead letter exchange. If none configured, then the component configured value is used. |
 | x-dead-letter-routing-key | String | The routing key for the dead letter exchange. If none configured, then the component configured value is used. |

--- a/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQEndpoint.java
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/src/main/java/org/apache/camel/component/springrabbit/SpringRabbitMQEndpoint.java
@@ -754,7 +754,7 @@ public class SpringRabbitMQEndpoint extends DefaultEndpoint implements AsyncEndp
                 queue = queue.trim();
                 Map<String, Object> map = getQueueArgs();
                 prepareDeadLetterQueueArgs(map);
-                boolean durable = parseArgsBoolean(map, "durable", "false");
+                boolean durable = parseArgsBoolean(map, "durable", "true");
                 boolean autoDelete = parseArgsBoolean(map, "autoDelete", autoDeleteDefault);
                 boolean exclusive = parseArgsBoolean(map, "exclusive", "false");
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -557,6 +557,17 @@ Previously, the component-level default was still 5 seconds, which would overrid
 endpoint's declared 30-second default. If you were relying on the effective 5-second timeout,
 you can restore it by explicitly setting `replyTimeout=5000` on the component or endpoint.
 
+=== camel-spring-rabbitmq - queue durable default changed to true
+
+The queue `durable` default has been changed from `false` to `true` when using `autoDeclare`.
+This aligns queues with the exchange default (which was already `durable=true`) and with RabbitMQ 4.3+
+which no longer permits non-durable, non-exclusive queues by default (the `transient_nonexcl_queues`
+deprecated feature is now denied by default).
+
+If you were relying on non-durable queues, you can restore the previous behavior by explicitly
+setting `arg.queue.durable=false&arg.queue.exclusive=true` on the endpoint URI. Note that
+RabbitMQ 4.3+ requires non-durable queues to also be exclusive.
+
 === camel-core - Multicast UseOriginalAggregationStrategy fix
 
 The Multicast EIP now correctly honors `UseOriginalAggregationStrategy`, consistent with the Splitter


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Change the `autoDeclare` queue `durable` default from `false` to `true` in `SpringRabbitMQEndpoint`, fixing compatibility with RabbitMQ 4.3+ which rejects non-durable, non-exclusive queues (`transient_nonexcl_queues` feature denied by default)
- Update component documentation to reflect the new default
- Add upgrade guide entry documenting the breaking default change

## Details

RabbitMQ 4.3.0 moved the `transient_nonexcl_queues` deprecated feature from `permitted_by_default` to `denied_by_default` as part of the Khepri storage migration. This means declaring a queue with `durable=false, exclusive=false` is now rejected.

The queue durable default was the only inconsistency — exchanges already defaulted to `durable=true`, and dead letter queues were hardcoded as durable. This change aligns all three.

Users who specifically need non-durable queues can set `arg.queue.durable=false&arg.queue.exclusive=true` (RabbitMQ 4.3+ requires non-durable queues to also be exclusive).

Fixes: [CAMEL-24173](https://issues.apache.org/jira/browse/CAMEL-24173)

## Test plan

- [x] All 6 existing unit tests pass
- [x] Full root build succeeds
- [ ] Integration tests with RabbitMQ 4.3+ (test infra currently uses 4.2.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>