### PR TITLE
CAMEL-23215: Prevent SpringAiImageOllamaIT from blocking on retries

### DIFF
--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-image/src/test/java/org/apache/camel/component/springai/image/SpringAiImageOllamaIT.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-image/src/test/java/org/apache/camel/component/springai/image/SpringAiImageOllamaIT.java
@@ -28,6 +28,7 @@ import org.apache.camel.test.infra.ollama.services.OllamaService;
 import org.apache.camel.test.infra.ollama.services.OllamaServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -38,9 +39,9 @@ import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.OpenAiImageOptions;
 import org.springframework.ai.openai.api.OpenAiImageApi;
-import org.springframework.ai.retry.RetryUtils;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * converter that supports this media type.
  */
 @DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Disabled unless running in CI")
+@Timeout(180)
 public class SpringAiImageOllamaIT extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringAiImageOllamaIT.class);
@@ -100,7 +102,13 @@ public class SpringAiImageOllamaIT extends CamelTestSupport {
                 .model(IMAGE_MODEL_NAME)
                 .build();
 
-        imageModel = new OpenAiImageModel(imageApi, defaultOptions, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+        // Disable Spring AI default exponential backoff retries in ITs: a failing Ollama call would
+        // otherwise block CI for many minutes (see CAMEL-23215).
+        RetryTemplate noRetryTemplate = RetryTemplate.builder()
+                .maxAttempts(1)
+                .build();
+
+        imageModel = new OpenAiImageModel(imageApi, defaultOptions, noRetryTemplate);
         LOG.info("ImageModel initialized successfully");
     }
 


### PR DESCRIPTION
## CAMEL-23215 Summary

**Issue:** [CAMEL-23215](https://issues.apache.org/jira/browse/CAMEL-23215) — `SpringAiImageOllamaIT` stays blocked in CI  
**Component:** `camel-spring-ai-image`  
**Branch:** `CAMEL-23215-spring-ai-image-ollama-it-retry`  
**Commit:** `fb60f894321`

---

### Problem

When Ollama image generation fails, `OpenAiImageModel` uses `RetryUtils.DEFAULT_RETRY_TEMPLATE`, which retries with exponential backoff. CI hung for **~16 minutes** (`testImageGenerationWithOptions` stuck in `ThreadWaitSleeper.sleep`).

---

### Fix (`SpringAiImageOllamaIT.java`)

| Change | Purpose |
|--------|---------|
| `RetryTemplate.builder().maxAttempts(1)` | Fail fast instead of long retry loops |
| `@Timeout(180)` | 3-minute class-level safety net for CI |

Same pattern as `SpringAiChatWrappedFileIT`.

---

### Local Verification

| Step | Result |
|------|--------|
| Ollama 0.32.1 installed | Done |
| `x/flux2-klein:4b` pulled | Done (5.7 GB) |
| IT runtime | **~19 seconds** (no hang) |
| Tests passed | **No** on Windows — MLX model not supported natively |

The fix works: failures surface quickly. Full green runs need **Linux** (WSL2, Docker, or CI).