### PR TITLE
CAMEL-23440: Replace usage of net.javacrumbs:spring-ws-test in camel-spring-ws

### DIFF
--- a/components/camel-spring-parent/camel-spring-ws/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ws/pom.xml
@@ -151,12 +151,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.javacrumbs</groupId>
-            <artifactId>smock-springws</artifactId>
-            <version>0.9.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -164,18 +158,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.javacrumbs</groupId>
-            <artifactId>spring-ws-test</artifactId>
-            <version>${javacrumbs-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>xmlunit</groupId>
-                    <artifactId>xmlunit</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-spring-parent/camel-spring-ws/src/test/java/net/javacrumbs/springws/test/helper/DefaultStrategiesHelperFactory.java
+++ b/components/camel-spring-parent/camel-spring-ws/src/test/java/net/javacrumbs/springws/test/helper/DefaultStrategiesHelperFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.springws.test.helper;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.ws.WebServiceMessageFactory;
+import org.springframework.ws.support.DefaultStrategiesHelper;
+import org.springframework.ws.transport.http.HttpTransportException;
+import org.springframework.ws.transport.http.MessageDispatcherServlet;
+
+/**
+ * Creates default Spring WS strategies (message factory / message receiver).
+ * <p>
+ * Re-homed into Camel from the abandoned {@code net.javacrumbs:spring-ws-test} library (last released 2011, Apache
+ * License 2.0) so camel-spring-ws no longer depends on it. See CAMEL-23440.
+ */
+final class DefaultStrategiesHelperFactory {
+
+    private static final String DEFAULT_STRATEGIES_PATH = "MessageDispatcherServlet.properties";
+
+    private static final Log LOGGER = LogFactory.getLog(DefaultStrategiesHelperFactory.class);
+
+    private static final String DEFAULT_MESSAGE_FACTORY_BEAN_NAME
+            = MessageDispatcherServlet.DEFAULT_MESSAGE_FACTORY_BEAN_NAME;
+
+    private DefaultStrategiesHelperFactory() {
+    }
+
+    static DefaultStrategiesHelper getDefaultStrategiesHelper() {
+        // should be MessageDispatcherServlet.class but it would require servlet-api in the classpath, so we use
+        // HttpTransportException instead (same package/jar location)
+        return new DefaultStrategiesHelper(new ClassPathResource(DEFAULT_STRATEGIES_PATH, HttpTransportException.class));
+    }
+
+    static WebServiceMessageFactory createMessageFactory(ApplicationContext applicationContext) {
+        if (applicationContext != null && applicationContext.containsBean(DEFAULT_MESSAGE_FACTORY_BEAN_NAME)) {
+            return applicationContext.getBean(DEFAULT_MESSAGE_FACTORY_BEAN_NAME, WebServiceMessageFactory.class);
+        } else {
+            LOGGER.debug("No WebServiceMessageFactory found, using default");
+            return (WebServiceMessageFactory) getDefaultStrategiesHelper()
+                    .getDefaultStrategy(WebServiceMessageFactory.class, applicationContext);
+        }
+    }
+}

--- a/components/camel-spring-parent/camel-spring-ws/src/test/java/net/javacrumbs/springws/test/helper/InMemoryWebServiceConnection.java
+++ b/components/camel-spring-parent/camel-spring-ws/src/test/java/net/javacrumbs/springws/test/helper/InMemoryWebServiceConnection.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.springws.test.helper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.WebServiceMessageFactory;
+import org.springframework.ws.context.DefaultMessageContext;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.transport.WebServiceConnection;
+import org.springframework.ws.transport.WebServiceMessageReceiver;
+
+/**
+ * Connection that calls a {@link WebServiceMessageReceiver} in memory.
+ * <p>
+ * Re-homed into Camel from the abandoned {@code net.javacrumbs:spring-ws-test} library (last released 2011, Apache
+ * License 2.0) so camel-spring-ws no longer depends on it. See CAMEL-23440.
+ */
+class InMemoryWebServiceConnection implements WebServiceConnection {
+
+    private final URI uri;
+
+    private final WebServiceMessageFactory messageFactory;
+
+    private final WebServiceMessageReceiver webServiceMessageReceiver;
+
+    private MessageContext context;
+
+    InMemoryWebServiceConnection(URI uri, WebServiceMessageFactory messageFactory,
+                                 WebServiceMessageReceiver messageReceiver) {
+        this.uri = uri;
+        this.messageFactory = messageFactory;
+        this.webServiceMessageReceiver = messageReceiver;
+    }
+
+    @Override
+    public void send(WebServiceMessage message) throws IOException {
+        context = createMessageContext(message);
+        try {
+            getWebServiceMessageReceiver().receive(context);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public WebServiceMessage receive(WebServiceMessageFactory messageFactory) throws IOException {
+        return context.getResponse();
+    }
+
+    protected DefaultMessageContext createMessageContext(WebServiceMessage message) {
+        return new DefaultMessageContext(message, messageFactory);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public String getErrorMessage() throws IOException {
+        return null;
+    }
+
+    @Override
+    public URI getUri() throws URISyntaxException {
+        return uri;
+    }
+
+    @Override
+    public boolean hasError() throws IOException {
+        return false;
+    }
+
+    public WebServiceMessageFactory getMessageFactory() {
+        return messageFactory;
+    }
+
+    public WebServiceMessageReceiver getWebServiceMessageReceiver() {
+        return webServiceMessageReceiver;
+    }
+
+    public MessageContext getContext() {
+        return context;
+    }
+}

--- a/components/camel-spring-parent/camel-spring-ws/src/test/java/net/javacrumbs/springws/test/helper/InMemoryWebServiceMessageSender.java
+++ b/components/camel-spring-parent/camel-spring-ws/src/test/java/net/javacrumbs/springws/test/helper/InMemoryWebServiceMessageSender.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.springws.test.helper;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.ws.WebServiceMessageFactory;
+import org.springframework.ws.transport.WebServiceMessageReceiver;
+import org.springframework.ws.transport.WebServiceMessageSender;
+import org.springframework.ws.transport.http.MessageDispatcherServlet;
+
+/**
+ * Sends messages locally in memory. Creates an {@link InMemoryWebServiceConnection} that sends the message directly to
+ * a {@link WebServiceMessageReceiver}. Used for server-side tests.
+ * <p>
+ * Re-homed into Camel from the abandoned {@code net.javacrumbs:spring-ws-test} library (last released 2011, Apache
+ * License 2.0) so camel-spring-ws no longer depends on it. See CAMEL-23440.
+ */
+public class InMemoryWebServiceMessageSender
+        implements WebServiceMessageSender, ApplicationContextAware, InitializingBean {
+
+    private static final String DEFAULT_MESSAGE_RECEIVER_BEAN_NAME
+            = MessageDispatcherServlet.DEFAULT_MESSAGE_RECEIVER_BEAN_NAME;
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private WebServiceMessageFactory messageFactory;
+
+    private WebServiceMessageReceiver webServiceMessageReceiver;
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public InMemoryWebServiceConnection createConnection(URI uri) throws IOException {
+        return new InMemoryWebServiceConnection(uri, messageFactory, webServiceMessageReceiver);
+    }
+
+    @Override
+    public boolean supports(URI uri) {
+        return true;
+    }
+
+    @Override
+    public boolean supports(URI uri, WebServiceMessageSender.UriSource uriSource) {
+        return supports(uri);
+    }
+
+    public WebServiceMessageFactory getMessageFactory() {
+        return messageFactory;
+    }
+
+    public WebServiceMessageReceiver getWebServiceMessageReceiver() {
+        return webServiceMessageReceiver;
+    }
+
+    /**
+     * Creates a {@link WebServiceMessageReceiver}. If it's not in the applicationContext, uses the default strategies
+     * to create it.
+     */
+    protected WebServiceMessageReceiver createWebServiceMessageReceiver() {
+        if (applicationContext != null && applicationContext.containsBean(DEFAULT_MESSAGE_RECEIVER_BEAN_NAME)) {
+            return applicationContext.getBean(DEFAULT_MESSAGE_RECEIVER_BEAN_NAME, WebServiceMessageReceiver.class);
+        } else {
+            logger.debug("No WebServiceMessageReceiver found, using default");
+            return (WebServiceMessageReceiver) DefaultStrategiesHelperFactory.getDefaultStrategiesHelper()
+                    .getDefaultStrategy(WebServiceMessageReceiver.class, applicationContext);
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        initializeMessageReceiver();
+        initializeMessageFactory();
+    }
+
+    protected void initializeMessageReceiver() {
+        if (webServiceMessageReceiver == null) {
+            webServiceMessageReceiver = createWebServiceMessageReceiver();
+        }
+    }
+
+    protected void initializeMessageFactory() {
+        if (messageFactory == null) {
+            messageFactory = DefaultStrategiesHelperFactory.createMessageFactory(applicationContext);
+        }
+    }
+
+    void setWebServiceMessageReceiver(WebServiceMessageReceiver webServiceMessageReceiver) {
+        this.webServiceMessageReceiver = webServiceMessageReceiver;
+    }
+
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    void setMessageFactory(WebServiceMessageFactory messageFactory) {
+        this.messageFactory = messageFactory;
+    }
+}

--- a/components/camel-spring-parent/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/MessageFilterResolvingDefaultsTest.java
+++ b/components/camel-spring-parent/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/MessageFilterResolvingDefaultsTest.java
@@ -21,7 +21,6 @@ import java.net.URI;
 
 import javax.xml.namespace.QName;
 
-import net.javacrumbs.smock.springws.client.AbstractSmockClientTest;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.test.spring.junit6.CamelSpringTest;
 import org.junit.jupiter.api.AfterEach;
@@ -30,30 +29,41 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.test.client.MockWebServiceServer;
 import org.springframework.ws.test.client.RequestMatcher;
+import org.springframework.xml.transform.StringSource;
+
+import static org.springframework.ws.test.client.RequestMatchers.soapHeader;
+import static org.springframework.ws.test.client.ResponseCreators.withPayload;
 
 /**
  * Check if the MessageFilter is used and resolved from endpoint uri or global context configuration.
  */
 @CamelSpringTest
 @ContextConfiguration(locations = { "classpath:org/apache/camel/component/spring/ws/DefaultMessageFilter-context.xml" })
-public class MessageFilterResolvingDefaultsTest extends AbstractSmockClientTest {
+public class MessageFilterResolvingDefaultsTest {
+
+    private static final String RESPONSE
+            = "<customerCountResponse xmlns='http://springframework.org/spring-ws'>"
+              + "<customerCount>1</customerCount></customerCountResponse>";
 
     @Autowired
     private ProducerTemplate template;
 
-    private String body = "<customerCountRequest xmlns='http://springframework.org/spring-ws'>"
-                          + "<customerName>John Doe</customerName>" + "</customerCountRequest>";
+    private MockWebServiceServer mockServer;
+
+    private final String body = "<customerCountRequest xmlns='http://springframework.org/spring-ws'>"
+                                + "<customerName>John Doe</customerName>" + "</customerCountRequest>";
 
     @Test
     public void isUsedDefaultFilter() {
-        expect(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1")))
+        mockServer.expect(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1")))
                 .andExpect(doesntContains(soapHeader(new QName("http://virtualCheck/", "localFilter"))))
-                .andExpect(doesntContains(soapHeader(new QName("http://virtualCheck/", "globalFilter"))));
+                .andExpect(doesntContains(soapHeader(new QName("http://virtualCheck/", "globalFilter"))))
+                .andRespond(withPayload(new StringSource(RESPONSE)));
 
         template.sendBodyAndHeader("direct:sendDefault", body, "headerKey",
                 new QName("http://newHeaderSupport/", "testHeaderValue1"));
-
     }
 
     private RequestMatcher doesntContains(final RequestMatcher soapHeader) {
@@ -61,7 +71,6 @@ public class MessageFilterResolvingDefaultsTest extends AbstractSmockClientTest 
             public void match(URI uri, WebServiceMessage request) throws IOException, AssertionError {
                 try {
                     soapHeader.match(uri, request);
-
                 } catch (AssertionError e) {
                     // ok
                     return;
@@ -73,12 +82,11 @@ public class MessageFilterResolvingDefaultsTest extends AbstractSmockClientTest 
 
     @Autowired
     public void setApplicationContext(ApplicationContext applicationContext) {
-        createServer(applicationContext);
+        mockServer = MockWebServiceServer.createServer(applicationContext);
     }
 
-    @Override
     @AfterEach
     public void verify() {
-        super.verify();
+        mockServer.verify();
     }
 }

--- a/components/camel-spring-parent/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/MessageFilterResolvingTest.java
+++ b/components/camel-spring-parent/camel-spring-ws/src/test/java/org/apache/camel/component/spring/ws/MessageFilterResolvingTest.java
@@ -21,7 +21,6 @@ import java.net.URI;
 
 import javax.xml.namespace.QName;
 
-import net.javacrumbs.smock.springws.client.AbstractSmockClientTest;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.test.spring.junit6.CamelSpringTest;
 import org.junit.jupiter.api.AfterEach;
@@ -30,24 +29,37 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.test.client.MockWebServiceServer;
 import org.springframework.ws.test.client.RequestMatcher;
+import org.springframework.xml.transform.StringSource;
+
+import static org.springframework.ws.test.client.RequestMatchers.soapHeader;
+import static org.springframework.ws.test.client.ResponseCreators.withPayload;
 
 /**
  * Check if the MessageFilter is used and resolved from endpoint uri or global context configuration.
  */
 @CamelSpringTest
 @ContextConfiguration(locations = { "classpath:org/apache/camel/component/spring/ws/MessageFilter-context.xml" })
-public class MessageFilterResolvingTest extends AbstractSmockClientTest {
+public class MessageFilterResolvingTest {
+
+    private static final String RESPONSE
+            = "<customerCountResponse xmlns='http://springframework.org/spring-ws'>"
+              + "<customerCount>1</customerCount></customerCountResponse>";
+
     @Autowired
     private ProducerTemplate template;
 
-    private String body = "<customerCountRequest xmlns='http://springframework.org/spring-ws'>"
-                          + "<customerName>John Doe</customerName>" + "</customerCountRequest>";
+    private MockWebServiceServer mockServer;
+
+    private final String body = "<customerCountRequest xmlns='http://springframework.org/spring-ws'>"
+                                + "<customerName>John Doe</customerName>" + "</customerCountRequest>";
 
     @Test
     public void globalTestHeaderAttribute() {
-        expect(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1")))
-                .andExpect(soapHeader(new QName("http://virtualCheck/", "globalFilter")));
+        mockServer.expect(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1")))
+                .andExpect(soapHeader(new QName("http://virtualCheck/", "globalFilter")))
+                .andRespond(withPayload(new StringSource(RESPONSE)));
 
         template.sendBodyAndHeader("direct:sendWithGlobalFilter", body, "headerKey",
                 new QName("http://newHeaderSupport/", "testHeaderValue1"));
@@ -55,21 +67,21 @@ public class MessageFilterResolvingTest extends AbstractSmockClientTest {
 
     @Test
     public void localTestHeaderAttribute() {
-        expect(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1")))
-                .andExpect(soapHeader(new QName("http://virtualCheck/", "localFilter")));
+        mockServer.expect(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1")))
+                .andExpect(soapHeader(new QName("http://virtualCheck/", "localFilter")))
+                .andRespond(withPayload(new StringSource(RESPONSE)));
 
         template.sendBodyAndHeader("direct:sendWithLocalFilter", body, "headerKey",
                 new QName("http://newHeaderSupport/", "testHeaderValue1"));
-
     }
 
     @Test
     public void emptyTestHeaderAttribute() {
-        expect(doesntContains(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1"))));
+        mockServer.expect(doesntContains(soapHeader(new QName("http://newHeaderSupport/", "testHeaderValue1"))))
+                .andRespond(withPayload(new StringSource(RESPONSE)));
 
         template.sendBodyAndHeader("direct:sendWithoutFilter", body, "headerKey",
                 new QName("http://newHeaderSupport/", "testHeaderValue1"));
-
     }
 
     private RequestMatcher doesntContains(final RequestMatcher soapHeader) {
@@ -77,7 +89,6 @@ public class MessageFilterResolvingTest extends AbstractSmockClientTest {
             public void match(URI uri, WebServiceMessage request) throws IOException, AssertionError {
                 try {
                     soapHeader.match(uri, request);
-
                 } catch (AssertionError e) {
                     // ok
                     return;
@@ -89,12 +100,11 @@ public class MessageFilterResolvingTest extends AbstractSmockClientTest {
 
     @Autowired
     public void setApplicationContext(ApplicationContext applicationContext) {
-        createServer(applicationContext);
+        mockServer = MockWebServiceServer.createServer(applicationContext);
     }
 
-    @Override
     @AfterEach
     public void verify() {
-        super.verify();
+        mockServer.verify();
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -263,7 +263,6 @@
         <java-util-version>4.108.0</java-util-version>
         <jnats-version>2.26.0</jnats-version>
         <javacc-maven-plugin-version>3.2.0</javacc-maven-plugin-version>
-        <javacrumbs-version>0.22</javacrumbs-version>
         <javapoet-version>0.17.0</javapoet-version>
         <javassist-version>3.32.0-GA</javassist-version>
         <jakarta-el-api-version>6.0.1</jakarta-el-api-version>


### PR DESCRIPTION
# Description

The camel-spring-ws test suite depended on net.javacrumbs:spring-ws-test
  (last released 2011) and the coupled net.javacrumbs:smock-springws. The
  javacrumbs project recommends switching to Spring WS 2.x's built-in test
  support.

  - Migrate MessageFilterResolvingTest and MessageFilterResolvingDefaultsTest
    from smock's AbstractSmockClientTest to the official
    org.springframework.ws.test.client.MockWebServiceServer.
  - Re-home the only still-needed piece of spring-ws-test - the in-memory
    server transport (InMemoryWebServiceMessageSender, InMemoryWebServiceConnection,
    DefaultStrategiesHelperFactory) - into the test sources under Apache-2.0.
    Kept in the original package so the 18 wiring XML contexts are unchanged.
  - Remove both net.javacrumbs test dependencies and the now-unused
    javacrumbs-version property from parent/pom.xml.

AI Usage: Co-authored-by: Claude Opus 4.8

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

