### PR TITLE
CAMEL-24188: Promote camel-jbang to stable

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -15,6 +15,9 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 === camel-jbang
 
+The Camel JBang CLI (Camel CLI) and TUI have been promoted from _Preview_ to _Stable_ support level.
+The MCP Server has also been promoted to _Stable_.
+
 The Camel JBang CLI now automatic resolves quarkus version to use,
 instead of hardcoded `3.33.1.1` (https://github.com/apache/camel/commit/d1f4713ebdf787ab04a31c50a6f07e3ca66f0c2b).
 

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-mcp.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-mcp.adoc
@@ -13,8 +13,6 @@ Camel applications — without you having to copy-paste anything.
 Built on https://quarkus.io/[Quarkus] with the
 https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html[quarkus-mcp-server] extension.
 
-NOTE: This module is in *Preview* status since Camel 4.18.
-
 == Getting Started
 
 The quickest way to get started:

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-tui.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-tui.adoc
@@ -9,9 +9,6 @@ with your routes. No more black box.
 
 image::jbang/camel-tui-topology-overview.svg[TUI Overview showing multiple routes]
 
-NOTE: This module is in *Preview* status. The TUI is designed for development and prototyping,
-not production monitoring.
-
 == Getting Started
 
 You can start using the TUI in two ways: with your own route, or by running one of the built-in examples.

--- a/dsl/camel-jbang/camel-jbang-console/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-console/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <firstVersion>3.21.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
     </properties>
 
     <dependencies>

--- a/dsl/camel-jbang/camel-jbang-console/src/generated/resources/jbang-console.json
+++ b/dsl/camel-jbang/camel-jbang-console/src/generated/resources/jbang-console.json
@@ -7,7 +7,7 @@
     "deprecated": false,
     "firstVersion": "3.21.0",
     "label": "jbang",
-    "supportLevel": "Preview",
+    "supportLevel": "Stable",
     "groupId": "org.apache.camel",
     "artifactId": "camel-jbang-console",
     "version": "4.22.0-SNAPSHOT"

--- a/dsl/camel-jbang/camel-jbang-core/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-core/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <firstVersion>3.12.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
         <camel.surefire.reuseForks>false</camel.surefire.reuseForks>
     </properties>

--- a/dsl/camel-jbang/camel-jbang-main/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-main/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <firstVersion>3.12.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <dist.dir>dist</dist.dir>
         <camel-prepare-component>false</camel-prepare-component>
     </properties>

--- a/dsl/camel-jbang/camel-jbang-mcp/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-mcp/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <firstVersion>4.18.0</firstVersion>
         <label>jbang,mcp,ai</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
         <!-- Build uber-jar for easy JBang execution -->
         <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>

--- a/dsl/camel-jbang/camel-jbang-plugin-generate/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-generate/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.8.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
     </properties>
 

--- a/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-kubernetes/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.8.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
         <camel.surefire.parallel>false</camel.surefire.parallel>
     </properties>

--- a/dsl/camel-jbang/camel-jbang-plugin-mcp/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-mcp/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.21.0</firstVersion>
         <label>jbang,mcp,ai</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
     </properties>
 

--- a/dsl/camel-jbang/camel-jbang-plugin-route-parser/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-route-parser/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.17.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
     </properties>
 

--- a/dsl/camel-jbang/camel-jbang-plugin-test/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-test/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.14.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
         <camel.surefire.parallel>false</camel.surefire.parallel>
     </properties>

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.20.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Experimental</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
     </properties>
 

--- a/dsl/camel-jbang/camel-jbang-plugin-validate/pom.xml
+++ b/dsl/camel-jbang/camel-jbang-plugin-validate/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <firstVersion>4.18.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
     </properties>
 

--- a/dsl/camel-jbang/camel-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-launcher/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <firstVersion>4.13.0</firstVersion>
         <label>jbang</label>
-        <supportLevel>Preview</supportLevel>
+        <supportLevel>Stable</supportLevel>
         <camel-prepare-component>false</camel-prepare-component>
 
         <!-- Dependency versions -->


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Promotes camel-jbang and TUI from Preview/Experimental to Stable support level. The MCP Server modules are also promoted to Stable.

### Changes

- Changed `supportLevel` from `Preview` to `Stable` in 11 camel-jbang modules
- Changed `supportLevel` from `Experimental` to `Stable` in `camel-jbang-plugin-tui`
- Removed Preview status notices from `camel-jbang-tui.adoc` and `camel-jbang-mcp.adoc`
- Added upgrade guide entry documenting the promotion

**Note:** `camel-jbang-plugin-edit` intentionally remains at `Preview`.

## Test plan

- [x] Verify all 12 pom.xml files have `<supportLevel>Stable</supportLevel>`
- [x] Verify `camel-jbang-plugin-edit` remains at `Preview`
- [ ] Build passes (metadata regeneration picks up new support level)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>