### PR TITLE
CAMEL-24085: Apply header filter strategy to IronMQ message envelope headers (4.18.x backport)

### DIFF
--- a/components/camel-ironmq/src/main/java/org/apache/camel/component/ironmq/GsonUtil.java
+++ b/components/camel-ironmq/src/main/java/org/apache/camel/component/ironmq/GsonUtil.java
@@ -20,11 +20,25 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 import org.apache.camel.Message;
+import org.apache.camel.spi.HeaderFilterStrategy;
+import org.apache.camel.support.DefaultHeaderFilterStrategy;
 
 public final class GsonUtil {
     private static final Gson GSON = new Gson();
 
+    // Filters internal Camel headers (Camel*/camel*) embedded in the IronMQ message envelope, consistent with how
+    // other consumers apply a HeaderFilterStrategy to externally supplied headers. On this branch the in-direction
+    // Camel* filter must be set explicitly, since DefaultHeaderFilterStrategy does not filter Camel* inbound by
+    // default.
+    private static final HeaderFilterStrategy HEADER_FILTER_STRATEGY = createHeaderFilterStrategy();
+
     private GsonUtil() {
+    }
+
+    private static HeaderFilterStrategy createHeaderFilterStrategy() {
+        DefaultHeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
+        strategy.setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
+        return strategy;
     }
 
     static class IronMqMessage {
@@ -57,7 +71,8 @@ public final class GsonUtil {
             for (Map.Entry<String, Object> entry : ironMqMessage.getHeaders().entrySet()) {
                 String key = entry.getKey();
                 Object value = entry.getValue();
-                if (target.getHeader(key) == null) {
+                if (target.getHeader(key) == null
+                        && !HEADER_FILTER_STRATEGY.applyFilterToExternalHeaders(key, value, target.getExchange())) {
                     target.setHeader(key, value);
                 }
             }

--- a/components/camel-ironmq/src/test/java/org/apache/camel/component/ironmq/IronMQConsumerHeaderFilterTest.java
+++ b/components/camel-ironmq/src/test/java/org/apache/camel/component/ironmq/IronMQConsumerHeaderFilterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ironmq;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Message;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class IronMQConsumerHeaderFilterTest extends CamelTestSupport {
+
+    private IronMQEndpoint endpoint;
+    private IronMQClientMock clientMock;
+
+    @EndpointInject("mock:result")
+    private MockEndpoint result;
+
+    @Test
+    public void testCamelHeadersInMessageEnvelopeAreFiltered() throws Exception {
+        result.expectedMessageCount(1);
+        result.expectedBodiesReceived("some payload");
+        // a regular header embedded in the envelope must still be mapped onto the message
+        result.expectedHeaderReceived("MyHeader", "HeaderValue");
+
+        // message envelope as crafted by a sender: internal Camel headers embedded in the envelope must not be
+        // mapped onto the Camel message (matched case-insensitively)
+        String envelope = "{\"headers\":{\"MyHeader\":\"HeaderValue\",\"CamelFileName\":\"injected.txt\","
+                          + "\"camelExecCommandExecutable\":\"injected\"},\"body\":\"some payload\"}";
+        clientMock.queue("TestQueue").push(envelope, 0);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        Message received = result.getExchanges().get(0).getIn();
+        assertNull(received.getHeader("CamelFileName"));
+        assertNull(received.getHeader("camelExecCommandExecutable"));
+        assertNotNull(received.getHeader(IronMQConstants.MESSAGE_ID));
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        IronMQComponent component = new IronMQComponent(context);
+        component.init();
+        endpoint = (IronMQEndpoint) component
+                .createEndpoint("ironmq://TestQueue?projectId=xxx&token=yyy&preserveHeaders=true");
+        clientMock = new IronMQClientMock("dummy", "dummy");
+        endpoint.setClient(clientMock);
+        context.addComponent("ironmq", component);
+        return context;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from(endpoint).to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Backport of #24828 (merged on main, CAMEL-24085) to `camel-4.18.x`.

Branch adaptations, mirroring the CAMEL-24084 knative backport (#24753):
- `DefaultHeaderFilterStrategy` on this branch does not filter `Camel*` inbound by default (pre-CAMEL-23543), so the strategy sets `setInFilterStartsWith(CAMEL_FILTER_STARTS_WITH)` explicitly. The new `IronMQConsumerHeaderFilterTest` passes on this branch, verifying the filter is effective.
- Test support import switched to `org.apache.camel.test.junit5` (this branch is not on junit6).
- No upgrade-guide change here: per convention the 4.18.4 entry is added to `camel-4x-upgrade-guide-4_18.adoc` on `main` via a doc-sync PR.

Testing: `mvn clean install` in `components/camel-ironmq` (all tests pass, including the new filter test); full reactor `mvn clean install -DskipTests` from the branch root: success, no stale generated files.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)