### PR TITLE
CAMEL-24085: Sync IronMQ envelope header-filtering upgrade notes to 4_18 and 4_14 guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -34,6 +34,16 @@ content-mode / HTTP header path.
 Ordinary CloudEvent extension attributes are unaffected. If a route relied on `Camel*`-named fields being
 propagated from the structured payload, set them explicitly after consuming the event.
 
+=== camel-ironmq - message envelope header filtering
+
+When consuming a message with `preserveHeaders=true`, the IronMQ consumer now applies a `HeaderFilterStrategy` to
+the header entries embedded in the JSON message envelope before mapping them onto the Camel message. Camel-internal
+headers (the `Camel*` namespace, matched case-insensitively) present in the envelope are no longer mapped onto the
+message, consistent with the inbound header filtering performed by other consumers.
+
+Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the
+message envelope, set them explicitly after consuming the message.
+
 === camel-azure-eventhubs - producer now filters Camel-internal headers
 
 The `azure-eventhubs` producer now applies a `DefaultHeaderFilterStrategy` to the headers copied onto

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -61,6 +61,16 @@ content-mode / HTTP header path.
 Ordinary CloudEvent extension attributes are unaffected. If a route relied on `Camel*`-named fields being
 propagated from the structured payload, set them explicitly after consuming the event.
 
+=== camel-ironmq - message envelope header filtering
+
+When consuming a message with `preserveHeaders=true`, the IronMQ consumer now applies a `HeaderFilterStrategy` to
+the header entries embedded in the JSON message envelope before mapping them onto the Camel message. Camel-internal
+headers (the `Camel*` namespace, matched case-insensitively) present in the envelope are no longer mapped onto the
+message, consistent with the inbound header filtering performed by other consumers.
+
+Ordinary application headers are unaffected. If a route relied on `Camel*` headers being propagated from the
+message envelope, set them explicitly after consuming the message.
+
 === camel-azure-eventhubs - producer now filters Camel-internal headers
 
 The `azure-eventhubs` producer now applies a `DefaultHeaderFilterStrategy` to the headers copied onto


### PR DESCRIPTION
The camel-ironmq message envelope header-filtering change (CAMEL-24085, #24828) is backported to 4.18.x (#24905) and 4.14.x (#24907). Per the backport upgrade-guide policy, this adds the matching notes to the `camel-4x-upgrade-guide-4_18.adoc` (4.18.4 section) and `camel-4x-upgrade-guide-4_14.adoc` (4.14.9 section) on `main`, mirroring the knative doc-sync #24768. Docs-only change.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)