### PR TITLE
CAMEL-24200: camel-aws2-timestream - createScheduledQuery sets the time column correctly

### DIFF
--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
@@ -199,11 +199,6 @@ public class Timestream2QueryProducer extends DefaultProducer {
                         = ErrorReportConfiguration.builder().s3Configuration(s3Configuration.build()).build();
                 builder.errorReportConfiguration(errorReportConfiguration);
             }
-            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.SCHEDULED_QUERY_EXECUTION_ROLE_ARN))) {
-                String roleArn
-                        = exchange.getIn().getHeader(Timestream2Constants.SCHEDULED_QUERY_EXECUTION_ROLE_ARN, String.class);
-                builder.scheduledQueryExecutionRoleArn(roleArn);
-            }
 
             TargetConfiguration.Builder targetConfiguration = TargetConfiguration.builder();
             TimestreamConfiguration.Builder timestreamConfigBuilder = TimestreamConfiguration.builder();
@@ -217,7 +212,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.TIME_COLUMN))) {
                 String timeColumn = exchange.getIn().getHeader(Timestream2Constants.TIME_COLUMN, String.class);
-                timestreamConfigBuilder.tableName(timeColumn);
+                timestreamConfigBuilder.timeColumn(timeColumn);
             }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.MEASURE_NAME_COLUMN))) {
                 String measureNameColumn = exchange.getIn().getHeader(Timestream2Constants.MEASURE_NAME_COLUMN, String.class);

--- a/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/AmazonTimestreamQueryClientMock.java
+++ b/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/AmazonTimestreamQueryClientMock.java
@@ -24,7 +24,16 @@ import software.amazon.awssdk.services.timestreamquery.model.*;
 
 public class AmazonTimestreamQueryClientMock implements TimestreamQueryClient {
 
+    private CreateScheduledQueryRequest lastCreateScheduledQueryRequest;
+
     public AmazonTimestreamQueryClientMock() {
+    }
+
+    /**
+     * The last request passed to {@link #createScheduledQuery}, so tests can assert how it was built.
+     */
+    public CreateScheduledQueryRequest getLastCreateScheduledQueryRequest() {
+        return lastCreateScheduledQueryRequest;
     }
 
     @Override
@@ -47,6 +56,7 @@ public class AmazonTimestreamQueryClientMock implements TimestreamQueryClient {
 
     @Override
     public CreateScheduledQueryResponse createScheduledQuery(CreateScheduledQueryRequest createScheduledQueryRequest) {
+        this.lastCreateScheduledQueryRequest = createScheduledQueryRequest;
         CreateScheduledQueryResponse.Builder result = CreateScheduledQueryResponse.builder();
         result.arn("aws-timestream:test:scheduled-query:arn");
         return result.build();

--- a/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerTest.java
+++ b/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerTest.java
@@ -107,6 +107,13 @@ public class Timestream2QueryProducerTest extends CamelTestSupport {
 
         CreateScheduledQueryResponse resultGet = (CreateScheduledQueryResponse) exchange.getIn().getBody();
         assertEquals("aws-timestream:test:scheduled-query:arn", resultGet.arn());
+
+        // The time-column header must land in timeColumn and must not overwrite the table name.
+        TimestreamConfiguration timestreamConfiguration
+                = clientMock.getLastCreateScheduledQueryRequest().targetConfiguration().timestreamConfiguration();
+        assertEquals("TESTDB", timestreamConfiguration.databaseName());
+        assertEquals("TESTTABLE", timestreamConfiguration.tableName());
+        assertEquals("time", timestreamConfiguration.timeColumn());
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes [CAMEL-24200](https://issues.apache.org/jira/browse/CAMEL-24200). In `Timestream2QueryProducer.createScheduledQuery` the time-column header was written into the target configuration's **table name**:

```java
if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.TIME_COLUMN))) {
    String timeColumn = exchange.getIn().getHeader(Timestream2Constants.TIME_COLUMN, String.class);
    timestreamConfigBuilder.tableName(timeColumn);   // should be .timeColumn(...)
}
```

So the `timeColumn` (required on a scheduled-query target) was never set, and when `CamelAwsTimestreamTableName` was also supplied the time-column value silently **overwrote the table name** — creating the scheduled query against the wrong table, or having AWS reject it.

Also removes a duplicated block that set `scheduledQueryExecutionRoleArn` twice from the same header.

## Tests

Extends the existing `Timestream2QueryProducerTest.timestreamCreateScheduledQueryTest` (which already sent all three headers but only asserted the response ARN) to capture the `CreateScheduledQueryRequest` via the client mock and assert `databaseName`, `tableName` and `timeColumn` each come from their own header. Against the old code the table name would be `"time"` and the time column `null`, so the test fails without the fix.

## Backport

Same code on `camel-4.18.x` and `camel-4.14.x`; will be backported after merge (fixVersions 4.22.0 / 4.18.4 / 4.14.9).

---
_Claude Code on behalf of oscerd_