### PR TITLE
CAMEL-23895: camel-azure-servicebus - document RAW() usage for connectionString (camel-4.18.x backport)

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/docs/azure-servicebus-component.adoc
+++ b/components/camel-azure/camel-azure-servicebus/src/main/docs/azure-servicebus-component.adoc
@@ -56,6 +56,22 @@ To use this component, you have three options to provide the required Azure auth
 
 - Provide `connectionString` string it is the simplest option to get started.
 
+[IMPORTANT]
+====
+The `SharedAccessKey` part of a connection string is a Base64-encoded value that often contains characters with a
+special meaning in URIs (such as `+`, `/` or `=`). When the `connectionString` is configured directly in an endpoint
+URI (including the Endpoint DSL), wrap the value with `RAW()` so it is not URI-decoded, otherwise authentication
+fails with `status-code: 401 ... InvalidSignature: The token has an invalid signature`:
+
+[source,java]
+----
+from("azure-servicebus:myQueue?connectionString=RAW(Endpoint=sb://myhost.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=aBc+dEf/123=)")
+    .to("mock:result");
+----
+
+See xref:manual::endpoint.adoc#_configuring_parameter_values_using_raw_values_such_as_passwords[Configuring parameter values using raw values] for more details.
+====
+
 *TOKEN_CREDENTIAL*:
 
 - Provide an implementation of `com.azure.core.credential.TokenCredential` into the Camel's Registry, e.g., using the `com.azure.identity.DefaultAzureCredentialBuilder().build();` API.


### PR DESCRIPTION
Docs-only backport of the component-doc part of #24846 (merged on main, CAMEL-23895): IMPORTANT admonition in the CONNECTION_STRING authentication section with a `RAW()` example and the 401 InvalidSignature error signature. The option-description/catalog metadata part of the main fix is intentionally not backported to avoid metadata regeneration churn on the maintenance branch.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)