### PR TITLE
CAMEL-24190: Allow stream-download on-completion handover to async ro…

### DIFF
--- a/components/camel-file/pom.xml
+++ b/components/camel-file/pom.xml
@@ -49,9 +49,21 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-languages</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileEndpoint.java
@@ -1625,6 +1625,16 @@ public abstract class GenericFileEndpoint<T> extends ScheduledPollEndpoint imple
         this.synchronous = synchronous;
     }
 
+    /**
+     * Whether the consumer streams file content as an {@link java.io.InputStream} body instead of loading it into
+     * memory first. Remote file components (FTP, SFTP, SMB, etc.) override this when {@code streamDownload=true}.
+     *
+     * @since 4.22
+     */
+    public boolean isStreamDownload() {
+        return false;
+    }
+
     public String getChecksumFileAlgorithm() {
         return checksumFileAlgorithm;
     }

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileOnCompletion.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileOnCompletion.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.file;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.spi.ExceptionHandler;
-import org.apache.camel.spi.Synchronization;
+import org.apache.camel.spi.SynchronizationVetoable;
 import org.apache.camel.support.LoggingExceptionHandler;
 import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * The work is for example to move the processed file into a backup folder, delete the file or in case of processing
  * failure do a rollback.
  */
-public class GenericFileOnCompletion<T> implements Synchronization {
+public class GenericFileOnCompletion<T> implements SynchronizationVetoable {
 
     private static final Logger LOG = LoggerFactory.getLogger(GenericFileOnCompletion.class);
     private final GenericFileEndpoint<T> endpoint;
@@ -63,6 +63,16 @@ public class GenericFileOnCompletion<T> implements Synchronization {
     @Override
     public void onFailure(Exchange exchange) {
         onCompletion(exchange);
+    }
+
+    @Override
+    public boolean allowHandover() {
+        return endpoint.isStreamDownload();
+    }
+
+    @Override
+    public void beforeHandover(Exchange target) {
+        // noop
     }
 
     public ExceptionHandler getExceptionHandler() {

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileOnCompletion.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileOnCompletion.java
@@ -72,7 +72,7 @@ public class GenericFileOnCompletion<T> implements SynchronizationVetoable {
 
     @Override
     public void beforeHandover(Exchange target) {
-        // noop
+        // no state transformation needed; the stream is already on the exchange body
     }
 
     public ExceptionHandler getExceptionHandler() {

--- a/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileOnCompletionHandoverTest.java
+++ b/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileOnCompletionHandoverTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePropertyKey;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.engine.DefaultUnitOfWork;
+import org.apache.camel.spi.SynchronizationVetoable;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.support.ExchangeHelper;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GenericFileOnCompletionHandoverTest {
+
+    @Mock
+    private GenericFileEndpoint<Object> endpoint;
+
+    @Mock
+    private GenericFileOperations<Object> operations;
+
+    @Mock
+    private GenericFileProcessStrategy<Object> processStrategy;
+
+    private CamelContext context;
+    private GenericFile<Object> testFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        context = new DefaultCamelContext();
+        context.start();
+        testFile = genericFile();
+        when(endpoint.getCamelContext()).thenReturn(context);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        context.stop();
+    }
+
+    @Test
+    void implementsSynchronizationVetoable() {
+        GenericFileOnCompletion<Object> completion
+                = new GenericFileOnCompletion<>(endpoint, operations, processStrategy, testFile, "/data/file.txt");
+        assertInstanceOf(SynchronizationVetoable.class, completion);
+    }
+
+    @Test
+    void allowHandoverWhenStreamDownloadEnabled() {
+        when(endpoint.isStreamDownload()).thenReturn(true);
+        assertTrue(createCompletion(true).allowHandover());
+    }
+
+    @Test
+    void denyHandoverWhenStreamDownloadDisabled() {
+        when(endpoint.isStreamDownload()).thenReturn(false);
+        assertFalse(createCompletion(false).allowHandover());
+    }
+
+    @Test
+    void unitOfWorkHandoversCompletionWhenStreamDownload() throws Exception {
+        when(endpoint.isStreamDownload()).thenReturn(true);
+        when(endpoint.isIdempotent()).thenReturn(false);
+        when(endpoint.getInProgressRepository()).thenReturn(new MemoryIdempotentRepository());
+
+        Exchange source = new DefaultExchange(context);
+        DefaultUnitOfWork sourceUow = createUnitOfWork(source);
+        source.getExchangeExtension().setUnitOfWork(sourceUow);
+
+        GenericFileOnCompletion<Object> completion = createCompletion(true);
+        source.getExchangeExtension().addOnCompletion(completion);
+
+        Exchange target = new DefaultExchange(context);
+        DefaultUnitOfWork targetUow = createUnitOfWork(target);
+        target.getExchangeExtension().setUnitOfWork(targetUow);
+
+        sourceUow.handoverSynchronization(target);
+
+        sourceUow.done(source);
+        verify(processStrategy, never()).commit(operations, endpoint, source, testFile);
+
+        targetUow.done(target);
+        verify(processStrategy).commit(operations, endpoint, target, testFile);
+    }
+
+    @Test
+    void unitOfWorkDoesNotHandoverCompletionWhenNotStreamDownload() throws Exception {
+        when(endpoint.isStreamDownload()).thenReturn(false);
+        when(endpoint.isIdempotent()).thenReturn(false);
+        when(endpoint.getInProgressRepository()).thenReturn(new MemoryIdempotentRepository());
+
+        Exchange source = new DefaultExchange(context);
+        DefaultUnitOfWork sourceUow = createUnitOfWork(source);
+        source.getExchangeExtension().setUnitOfWork(sourceUow);
+
+        GenericFileOnCompletion<Object> completion = createCompletion(false);
+        source.getExchangeExtension().addOnCompletion(completion);
+
+        Exchange target = new DefaultExchange(context);
+        DefaultUnitOfWork targetUow = createUnitOfWork(target);
+        target.getExchangeExtension().setUnitOfWork(targetUow);
+
+        sourceUow.handoverSynchronization(target);
+
+        sourceUow.done(source);
+        verify(processStrategy).commit(operations, endpoint, source, testFile);
+        verify(processStrategy, never()).commit(operations, endpoint, target, testFile);
+    }
+
+    @Test
+    void correlatedCopyHandoversStreamDownloadCompletion() throws Exception {
+        when(endpoint.isStreamDownload()).thenReturn(true);
+        when(endpoint.isIdempotent()).thenReturn(false);
+        when(endpoint.getInProgressRepository()).thenReturn(new MemoryIdempotentRepository());
+
+        Exchange source = new DefaultExchange(context);
+        DefaultUnitOfWork sourceUow = createUnitOfWork(source);
+        source.getExchangeExtension().setUnitOfWork(sourceUow);
+        source.getExchangeExtension().addOnCompletion(createCompletion(true));
+
+        Exchange copy = ExchangeHelper.createCorrelatedCopy(source, true, false);
+        DefaultUnitOfWork copyUow = createUnitOfWork(copy);
+        copy.getExchangeExtension().setUnitOfWork(copyUow);
+
+        sourceUow.done(source);
+        verify(processStrategy, never()).commit(operations, endpoint, source, testFile);
+
+        copyUow.done(copy);
+        verify(processStrategy).commit(operations, endpoint, copy, testFile);
+        assertSame(source.getExchangeId(), copy.getProperty(ExchangePropertyKey.CORRELATION_ID));
+    }
+
+    private DefaultUnitOfWork createUnitOfWork(Exchange exchange) {
+        return new DefaultUnitOfWork(exchange);
+    }
+
+    private GenericFileOnCompletion<Object> createCompletion(boolean streamDownload) {
+        when(endpoint.isStreamDownload()).thenReturn(streamDownload);
+        return new GenericFileOnCompletion<>(endpoint, operations, processStrategy, testFile, "/data/file.txt");
+    }
+
+    private GenericFile<Object> genericFile() {
+        GenericFile<Object> file = new GenericFile<>();
+        file.setFileName("file.txt");
+        file.setAbsolute(true);
+        file.setAbsoluteFilePath("/data/file.txt");
+        return file;
+    }
+}

--- a/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileOnCompletionHandoverTest.java
+++ b/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileOnCompletionHandoverTest.java
@@ -77,19 +77,16 @@ class GenericFileOnCompletionHandoverTest {
 
     @Test
     void allowHandoverWhenStreamDownloadEnabled() {
-        when(endpoint.isStreamDownload()).thenReturn(true);
         assertTrue(createCompletion(true).allowHandover());
     }
 
     @Test
     void denyHandoverWhenStreamDownloadDisabled() {
-        when(endpoint.isStreamDownload()).thenReturn(false);
         assertFalse(createCompletion(false).allowHandover());
     }
 
     @Test
     void unitOfWorkHandoversCompletionWhenStreamDownload() throws Exception {
-        when(endpoint.isStreamDownload()).thenReturn(true);
         when(endpoint.isIdempotent()).thenReturn(false);
         when(endpoint.getInProgressRepository()).thenReturn(new MemoryIdempotentRepository());
 
@@ -115,7 +112,6 @@ class GenericFileOnCompletionHandoverTest {
 
     @Test
     void unitOfWorkDoesNotHandoverCompletionWhenNotStreamDownload() throws Exception {
-        when(endpoint.isStreamDownload()).thenReturn(false);
         when(endpoint.isIdempotent()).thenReturn(false);
         when(endpoint.getInProgressRepository()).thenReturn(new MemoryIdempotentRepository());
 
@@ -139,7 +135,6 @@ class GenericFileOnCompletionHandoverTest {
 
     @Test
     void correlatedCopyHandoversStreamDownloadCompletion() throws Exception {
-        when(endpoint.isStreamDownload()).thenReturn(true);
         when(endpoint.isIdempotent()).thenReturn(false);
         when(endpoint.getInProgressRepository()).thenReturn(new MemoryIdempotentRepository());
 

--- a/components/camel-ftp-common/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
+++ b/components/camel-ftp-common/src/main/java/org/apache/camel/component/file/remote/RemoteFileEndpoint.java
@@ -121,6 +121,11 @@ public abstract class RemoteFileEndpoint<T> extends GenericFileEndpoint<T> imple
     }
 
     @Override
+    public boolean isStreamDownload() {
+        return getConfiguration().isStreamDownload();
+    }
+
+    @Override
     public Map<String, String> getServiceMetadata() {
         if (getConfiguration().getUsername() != null) {
             return Map.of("username", getConfiguration().getUsername());

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbEndpoint.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbEndpoint.java
@@ -128,6 +128,11 @@ public class SmbEndpoint extends GenericFileEndpoint<FileIdBothDirectoryInformat
         return configuration;
     }
 
+    @Override
+    public boolean isStreamDownload() {
+        return configuration.isStreamDownload();
+    }
+
     /**
      * Default Existing File Move Strategy
      *

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -298,6 +298,16 @@ and `Files.copy()` instead of `FileChannel`-based streaming. The `forceWrites` f
 The default value has been changed from `true` to `false` to reflect the actual behavior. The option will
 be removed in a future release.
 
+=== camel-file / camel-ftp / camel-sftp / camel-smb - streamDownload with async endpoints
+
+When `streamDownload=true`, file-based consumers now allow their on-completion logic to hand over to downstream
+threads (for example when routing to `seda:` or `jms:`). This keeps the downloaded stream open until the downstream
+route has finished reading it, instead of closing it immediately on the consumer poll thread.
+
+Because handover defers commit/rollback (move, delete, idempotent confirmation, and stream release), file handles and
+remote connections may stay open longer while the downstream queue is busy. This only applies when `streamDownload=true`;
+routes without stream download keep the previous on-completion timing.
+
 === camel-mail - MimeMultipartDataFormat inbound header filtering
 
 When unmarshalling a MIME message with `headersInline=true`, the `mime-multipart` data format now applies a


### PR DESCRIPTION
## CAMEL-24190 — Full Summary (with Assumptions)

**Jira:** https://issues.apache.org/jira/browse/CAMEL-24190  
**Title:** camel-file - GenericFileOnCompletion should support SynchronizationVetoable handover for stream download  
**Type / Priority / Status:** Improvement · Major · Open  
**Component:** camel-file  
**Labels:** improvement  

---

### Problem (from Jira)

`GenericFileOnCompletion` implements plain `Synchronization`. With `streamDownload=true` and an async downstream endpoint (e.g. `seda:`, `jms:`), on-completion runs on the **consumer poll thread** and closes the stream via `releaseRetrievedFileResources()` before the downstream route reads it.

**Affected components:** camel-file, camel-ftp, camel-sftp, camel-smb (and related remote file consumers).

---

### Fix (implemented in `C:\c\camel-24190-fix`)

`GenericFileOnCompletion` implements `SynchronizationVetoable`:

- `allowHandover()` → `endpoint.isStreamDownload()`
- `beforeHandover()` → noop

Added `isStreamDownload()`:
- `GenericFileEndpoint` — default `false`
- `RemoteFileEndpoint` — delegates to `RemoteFileConfiguration.isStreamDownload()` (FTP/SFTP/FTPS/Azure Files)
- `SmbEndpoint` — delegates to `SmbConfiguration.isStreamDownload()`

---

### Assumptions (based on Jira + implementation)

1. **Handover is enabled only when `streamDownload=true`**  
   Jira describes `allowHandover() = true` for the stream-download case. We interpret that as **conditional**, not unconditional: non-stream routes keep existing on-completion timing (no handover).

2. **Local `file:` consumer is out of scope**  
   Jira focuses on streamed remote downloads. Local `FileEndpoint` has no `streamDownload` option, so `isStreamDownload()` stays `false` and behavior is unchanged.

3. **Remote endpoints are covered via inheritance**  
   FTP/SFTP/FTPS/Azure Files use `RemoteFileEndpoint`; SMB overrides explicitly. No separate change per protocol module beyond that.

4. **Existing disconnect synchronizations are unchanged**  
   FTP/SMB `disconnect` callbacks keep `allowHandover() = false` so disconnect still runs on the consumer thread.

5. **Deferred completion is acceptable for stream download**  
   Jira notes that handover can delay commit/rollback and keep file handles/connections open while downstream queues are busy. We accept that tradeoff for `streamDownload=true` only.

6. **SEDA handover path is the primary fix target**  
   Tests simulate async routing via `DefaultUnitOfWork.handoverSynchronization()` and `ExchangeHelper.createCorrelatedCopy()` (same mechanism SEDA uses). No embedded FTP/SFTP integration test was added.

7. **Upgrade guide entry is sufficient for user-visible behavior**  
   Documented in `camel-4x-upgrade-guide-4_22.adoc` under stream download + async endpoints.

8. **Jira wording vs Camel internals**  
   Jira states plain `Synchronization` “does not support handover.” In current Camel, non-vetoable synchronizations default to handover allowed in `DefaultUnitOfWork`. The practical bug is stream completion firing too early on the poll thread; implementing `SynchronizationVetoable` with an explicit stream-download gate matches the intended fix regardless of that wording.

---

### Files Changed

| File | Change |
|------|--------|
| `GenericFileOnCompletion.java` | `SynchronizationVetoable` + handover methods |
| `GenericFileEndpoint.java` | `isStreamDownload()` default |
| `RemoteFileEndpoint.java` | override `isStreamDownload()` |
| `SmbEndpoint.java` | override `isStreamDownload()` |
| `GenericFileOnCompletionHandoverTest.java` | new (6 tests) |
| `camel-file/pom.xml` | test deps (mockito, camel-core-languages) |
| `camel-4x-upgrade-guide-4_22.adoc` | behavior note |

---

### Test Coverage — all passed

| Suite | Tests | Result |
|-------|------:|--------|
| `GenericFileOnCompletionHandoverTest` | 6 | pass |
| `camel-file` (full) | 25 | pass |
| `camel-core` file consumer sample | 4 | pass |

---

### Git Status

| Item | Value |
|------|-------|
| **Worktree** | `C:\c\camel-24190-fix` |
| **Branch** | `CAMEL-24190-streamdownload-handover` |
| **Commit / push** | Not done yet |