### PR TITLE
CAMEL-24169: Schema resolver latches first resolved schema forever

### DIFF
--- a/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/transform/AvroSchemaResolver.java
+++ b/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/transform/AvroSchemaResolver.java
@@ -165,10 +165,6 @@ public class AvroSchemaResolver implements SchemaResolver, Processor {
             }
         }
 
-        if (answer != null) {
-            this.schema = answer;
-        }
-
         return answer;
     }
 }

--- a/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/transform/ProtobufSchemaResolver.java
+++ b/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/transform/ProtobufSchemaResolver.java
@@ -163,10 +163,6 @@ public class ProtobufSchemaResolver implements SchemaResolver, Processor {
             }
         }
 
-        if (answer != null) {
-            this.schema = answer;
-        }
-
         return answer;
     }
 }

--- a/components/camel-jackson3-avro/src/main/java/org/apache/camel/component/jackson3/avro/transform/AvroSchemaResolver.java
+++ b/components/camel-jackson3-avro/src/main/java/org/apache/camel/component/jackson3/avro/transform/AvroSchemaResolver.java
@@ -165,10 +165,6 @@ public class AvroSchemaResolver implements SchemaResolver, Processor {
             }
         }
 
-        if (answer != null) {
-            this.schema = answer;
-        }
-
         return answer;
     }
 }

--- a/components/camel-jackson3-protobuf/src/main/java/org/apache/camel/component/jackson3/protobuf/transform/ProtobufSchemaResolver.java
+++ b/components/camel-jackson3-protobuf/src/main/java/org/apache/camel/component/jackson3/protobuf/transform/ProtobufSchemaResolver.java
@@ -163,10 +163,6 @@ public class ProtobufSchemaResolver implements SchemaResolver, Processor {
             }
         }
 
-        if (answer != null) {
-            this.schema = answer;
-        }
-
         return answer;
     }
 }


### PR DESCRIPTION
## Summary
- Fix `AvroSchemaResolver` and `ProtobufSchemaResolver` (both jackson and jackson3 variants) unconditionally promoting dynamically resolved schemas into the `this.schema` instance field
- After the first exchange resolves a schema, the per-type `schemes` ConcurrentMap becomes dead code — every subsequent exchange short-circuits to the latched schema regardless of body type or per-exchange properties
- The fix removes the `this.schema = answer` latch from `computeIfAbsent()` in all four resolvers, so `this.schema` is only authoritative when explicitly set via `setSchema()`

## Test plan
- [x] `mvn verify` passes in all four modules: `camel-jackson-avro`, `camel-jackson-protobuf`, `camel-jackson3-avro`, `camel-jackson3-protobuf`
- [ ] Verify with attached reproducer from JIRA (multi-type route with distinct inline schemas)

_Claude Code on behalf of davsclaus_