### PR TITLE
CAMEL-24169: Schema resolver latches first resolved schema forever (4.14.x)

### DIFF
--- a/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/transform/AvroSchemaResolver.java
+++ b/components/camel-jackson-avro/src/main/java/org/apache/camel/component/jackson/avro/transform/AvroSchemaResolver.java
@@ -161,10 +161,6 @@ public class AvroSchemaResolver implements SchemaResolver, Processor {
             }
         }
 
-        if (answer != null) {
-            this.schema = answer;
-        }
-
         return answer;
     }
 }

--- a/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/transform/ProtobufSchemaResolver.java
+++ b/components/camel-jackson-protobuf/src/main/java/org/apache/camel/component/jackson/protobuf/transform/ProtobufSchemaResolver.java
@@ -159,10 +159,6 @@ public class ProtobufSchemaResolver implements SchemaResolver, Processor {
             }
         }
 
-        if (answer != null) {
-            this.schema = answer;
-        }
-
         return answer;
     }
 }


### PR DESCRIPTION
## Summary
Backport of #24921 to 4.14.x.

- Fix `AvroSchemaResolver` and `ProtobufSchemaResolver` unconditionally promoting dynamically resolved schemas into the `this.schema` instance field
- After the first exchange resolves a schema, the per-type `schemes` ConcurrentMap becomes dead code — every subsequent exchange short-circuits to the latched schema regardless of body type or per-exchange properties
- The fix removes the `this.schema = answer` latch from `computeIfAbsent()` so `this.schema` is only authoritative when explicitly set via `setSchema()`
- jackson3 variants don't exist on 4.14.x

## Test plan
- [x] Cherry-picked cleanly (jackson3 files excluded — not present on this branch)
- [ ] `mvn verify` in `camel-jackson-avro` and `camel-jackson-protobuf`

_Claude Code on behalf of davsclaus_