### PR TITLE
CAMEL-24176: camel-cxfrs - Fix async producer never mapping HTTP errors to CxfOperationException

### DIFF
--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
@@ -746,17 +746,19 @@ public class CxfRsProducer extends DefaultAsyncProducer {
         }
 
         private void fail(Throwable throwable) {
-            if (throwable.getClass().isInstance(WebApplicationException.class)) {
-                final WebApplicationException cast = WebApplicationException.class.cast(throwable);
-                final Response response = cast.getResponse();
+            if (throwable instanceof WebApplicationException wae) {
+                Response response = wae.getResponse();
                 if (shouldHandleError(response)) {
                     handleError(response);
+                } else {
+                    exchange.setException(throwable);
                 }
-            } else if (throwable.getClass().isInstance(ResponseProcessingException.class)) {
-                final ResponseProcessingException cast = ResponseProcessingException.class.cast(throwable);
-                final Response response = cast.getResponse();
+            } else if (throwable instanceof ResponseProcessingException rpe) {
+                Response response = rpe.getResponse();
                 if (shouldHandleError(response)) {
                     handleError(response);
+                } else {
+                    exchange.setException(throwable);
                 }
             } else {
                 exchange.setException(throwable);
@@ -839,17 +841,19 @@ public class CxfRsProducer extends DefaultAsyncProducer {
         }
 
         private void fail(Throwable throwable) {
-            if (throwable.getClass().isInstance(WebApplicationException.class)) {
-                final WebApplicationException cast = WebApplicationException.class.cast(throwable);
-                final Response response = cast.getResponse();
+            if (throwable instanceof WebApplicationException wae) {
+                Response response = wae.getResponse();
                 if (shouldHandleError(response)) {
                     handleError(response);
+                } else {
+                    exchange.setException(throwable);
                 }
-            } else if (throwable.getClass().isInstance(ResponseProcessingException.class)) {
-                final ResponseProcessingException cast = ResponseProcessingException.class.cast(throwable);
-                final Response response = cast.getResponse();
+            } else if (throwable instanceof ResponseProcessingException rpe) {
+                Response response = rpe.getResponse();
                 if (shouldHandleError(response)) {
                     handleError(response);
+                } else {
+                    exchange.setException(throwable);
                 }
             } else {
                 exchange.setException(throwable);

--- a/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsAsyncProducerTest.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsAsyncProducerTest.java
@@ -44,6 +44,7 @@ import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -505,5 +506,24 @@ public class CxfRsAsyncProducerTest extends CamelSpringTestSupport {
         CxfOperationException cxfOperationException = CxfOperationException.class.cast(exchange.getException());
 
         assertEquals(422, cxfOperationException.getStatusCode(), "CXF operation exception has correct response code");
+    }
+
+    @Test
+    public void testAsyncProxyProducerServerErrorMappedToCxfOperationException() {
+        Exchange exchange = template.send("direct://proxy", newExchange -> {
+            newExchange.setPattern(ExchangePattern.InOut);
+            Message inMessage = newExchange.getIn();
+            inMessage.setHeader(CxfConstants.OPERATION_NAME, "getCustomer");
+            inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, Boolean.FALSE);
+            // pass an invalid id that causes NumberFormatException on the server (500 error),
+            // which the proxy client receives as a WebApplicationException through failed()
+            inMessage.setBody("invalid");
+        });
+
+        assertNotNull(exchange.getException(), "Expect an exception on the exchange");
+        assertInstanceOf(CxfOperationException.class, exchange.getException(),
+                "Async proxy producer should map WebApplicationException to CxfOperationException");
+        CxfOperationException coe = (CxfOperationException) exchange.getException();
+        assertEquals(500, coe.getStatusCode(), "Status code should be 500");
     }
 }


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

Fix two bugs in the async CXF-RS producer's `fail()` callback in both `CxfInvocationCallback` and `CxfProxyInvocationCallback`:

1. **Reversed `isInstance` check** — `throwable.getClass().isInstance(WebApplicationException.class)` always evaluates to `false` because it tests whether the `Class` object is an instance of the throwable's class (which it never is). Both `if` branches were dead code, so every async failure fell through to `exchange.setException(throwable)` with the raw JAX-RS exception instead of wrapping it in `CxfOperationException`. Fixed by replacing with `throwable instanceof WebApplicationException` (same for `ResponseProcessingException`).

2. **Silent exception swallowing** — When `shouldHandleError()` returned `false` (e.g., `throwExceptionOnFailure=false` or status ≤ 207), neither `handleError()` nor `exchange.setException()` was called — the exception was silently dropped. Added `else { exchange.setException(throwable); }` fallback in each branch.

## Impact

With the default `synchronous=false`, a server error (404/500) now correctly yields a `CxfOperationException` (carrying status code, response headers and body) — matching the synchronous path behavior. `onException(CxfOperationException.class)` handlers now work consistently regardless of sync/async mode.

## Test plan

- [x] Added `testAsyncProxyProducerServerErrorMappedToCxfOperationException` — calls via the proxy client API with an invalid ID that triggers a 500 on the server; verifies the exchange exception is `CxfOperationException` with status 500 (not a raw `InternalServerErrorException`)
- [x] All 18 existing `CxfRsAsyncProducerTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>