### PR TITLE
CAMEL-24201: camel-aws2-step-functions - listExecutions sets the state machine ARN

### DIFF
--- a/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
@@ -633,6 +633,10 @@ public class StepFunctions2Producer extends DefaultProducer {
             }
         } else {
             ListExecutionsRequest.Builder builder = ListExecutionsRequest.builder();
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(StepFunctions2Constants.STATE_MACHINE_ARN))) {
+                String stateMachineArn = exchange.getIn().getHeader(StepFunctions2Constants.STATE_MACHINE_ARN, String.class);
+                builder.stateMachineArn(stateMachineArn);
+            }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(StepFunctions2Constants.EXECUTIONS_MAX_RESULTS))) {
                 int maxRes = exchange.getIn().getHeader(StepFunctions2Constants.EXECUTIONS_MAX_RESULTS, Integer.class);
                 builder.maxResults(maxRes);

--- a/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/AmazonStepFunctionsClientMock.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/AmazonStepFunctionsClientMock.java
@@ -25,7 +25,16 @@ import software.amazon.awssdk.services.sfn.model.*;
 
 public class AmazonStepFunctionsClientMock implements SfnClient {
 
+    private ListExecutionsRequest lastListExecutionsRequest;
+
     public AmazonStepFunctionsClientMock() {
+    }
+
+    /**
+     * The last request passed to {@link #listExecutions}, so tests can assert how it was built.
+     */
+    public ListExecutionsRequest getLastListExecutionsRequest() {
+        return lastListExecutionsRequest;
     }
 
     @Override
@@ -102,6 +111,7 @@ public class AmazonStepFunctionsClientMock implements SfnClient {
 
     @Override
     public ListExecutionsResponse listExecutions(ListExecutionsRequest listExecutionsRequest) {
+        this.lastListExecutionsRequest = listExecutionsRequest;
         ListExecutionsResponse.Builder result = ListExecutionsResponse.builder();
         List<ExecutionListItem> executionListItems = new ArrayList<>();
         executionListItems.add(ExecutionListItem.builder().executionArn("aws:sfn-execution::test-arn").build());

--- a/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerTest.java
@@ -308,6 +308,7 @@ public class StepFunctions2ProducerTest extends CamelTestSupport {
             @Override
             public void process(Exchange exchange) {
                 exchange.getIn().setHeader(StepFunctions2Constants.OPERATION, StepFunctions2Operations.listExecutions);
+                exchange.getIn().setHeader(StepFunctions2Constants.STATE_MACHINE_ARN, "aws:sfn::test-state-machine");
             }
         });
 
@@ -316,6 +317,8 @@ public class StepFunctions2ProducerTest extends CamelTestSupport {
         ListExecutionsResponse resultGet = (ListExecutionsResponse) exchange.getIn().getBody();
         assertEquals(1, resultGet.executions().size());
         assertEquals("aws:sfn-execution::test-arn", resultGet.executions().get(0).executionArn());
+        // ListExecutions requires the state machine ARN; it must be taken from the header.
+        assertEquals("aws:sfn::test-state-machine", clientMock.getLastListExecutionsRequest().stateMachineArn());
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes [CAMEL-24201](https://issues.apache.org/jira/browse/CAMEL-24201). `StepFunctions2Producer.listExecutions` built the request with only `maxResults`:

```java
ListExecutionsRequest.Builder builder = ListExecutionsRequest.builder();
if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(StepFunctions2Constants.EXECUTIONS_MAX_RESULTS))) {
    builder.maxResults(maxRes);
}
```

The AWS `ListExecutions` API **requires** a `stateMachineArn` (or a `mapRunArn`), so in header (non-POJO) mode the call was always rejected by AWS — the operation was effectively unusable. The `CamelAwsStepFunctionsStateMachineArn` header already exists and is read by the sibling operations (`deleteStateMachine`, `updateStateMachine`, `describeStateMachine`, …), but `listExecutions` never read it.

The ARN is now read from that header using the same optional-header pattern as its siblings.

## Tests

Extends the existing `sfnListExecutionsTest` to set the state-machine-ARN header and assert (via the client mock, which now records the request) that it reaches the `ListExecutionsRequest`. All 17 tests in `StepFunctions2ProducerTest` pass.

## Backport

Same code on `camel-4.18.x` and `camel-4.14.x`; will be backported after merge (fixVersions 4.22.0 / 4.18.4 / 4.14.9).

---
_Claude Code on behalf of oscerd_