### PR TITLE
CAMEL-24179: camel-cxf - Fix continuation timeout race with async processing

### DIFF
--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.cxf.jaxrs;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class CxfRsInvoker extends JAXRSInvoker {
     private static final Logger LOG = LoggerFactory.getLogger(CxfRsInvoker.class);
     private static final String SUSPENDED = "org.apache.camel.component.cxf.jaxrs.suspend";
+    private static final String COMPLETED = "org.apache.camel.component.cxf.jaxrs.completed";
     private final CxfRsConsumer cxfRsConsumer;
     private final CxfRsEndpoint endpoint;
 
@@ -91,8 +93,10 @@ public class CxfRsInvoker extends JAXRSInvoker {
                 final org.apache.camel.Exchange camelExchange = prepareExchange(cxfExchange, method, paramArray, response);
                 // we want to handle the UoW
                 cxfRsConsumer.createUoW(camelExchange);
-                // Now we don't set up the timeout value
                 LOG.trace("Suspending continuation of exchangeId: {}", camelExchange.getExchangeId());
+                // guard so exactly one of {timeout, async completion} owns the response and UoW lifecycle
+                final AtomicBoolean completed = new AtomicBoolean(false);
+                cxfExchange.put(COMPLETED, completed);
                 // The continuation could be called before the suspend is called
                 continuation.suspend(endpoint.getContinuationTimeout());
                 cxfExchange.put(SUSPENDED, Boolean.TRUE);
@@ -101,9 +105,16 @@ public class CxfRsInvoker extends JAXRSInvoker {
                     public void done(boolean doneSync) {
                         // make sure the continuation resume will not be called before the suspend method in other thread
                         synchronized (continuation) {
-                            LOG.trace("Resuming continuation of exchangeId: {}", camelExchange.getExchangeId());
-                            // resume processing after both, sync and async callbacks
-                            continuation.resume();
+                            if (completed.compareAndSet(false, true)) {
+                                LOG.trace("Resuming continuation of exchangeId: {}", camelExchange.getExchangeId());
+                                // resume processing after both, sync and async callbacks
+                                continuation.resume();
+                            } else {
+                                // timeout already sent the response; close the UoW now that the worker has finished
+                                LOG.trace("Timeout already handled response for exchangeId: {}; closing UoW",
+                                        camelExchange.getExchangeId());
+                                cxfRsConsumer.doneUoW(camelExchange);
+                            }
                         }
                     }
                 });
@@ -120,14 +131,23 @@ public class CxfRsInvoker extends JAXRSInvoker {
                 }
             } else {
                 if (continuation.isTimeout() || !continuation.isPending()) {
-                    cxfExchange.put(SUSPENDED, Boolean.FALSE);
-                    org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange) continuation.getObject();
-                    camelExchange.setException(new ExchangeTimedOutException(camelExchange, endpoint.getContinuationTimeout()));
-                    try {
-                        return returnResponse(cxfExchange, camelExchange);
-                    } catch (Exception ex) {
-                        cxfRsConsumer.doneUoW(camelExchange);
-                        throw ex;
+                    AtomicBoolean completed = (AtomicBoolean) cxfExchange.get(COMPLETED);
+                    if (completed != null && completed.compareAndSet(false, true)) {
+                        cxfExchange.put(SUSPENDED, Boolean.FALSE);
+                        org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange) continuation.getObject();
+                        camelExchange
+                                .setException(new ExchangeTimedOutException(camelExchange, endpoint.getContinuationTimeout()));
+                        try {
+                            Object result = returnResponse(cxfExchange, camelExchange);
+                            // detach so UnitOfWorkCloserInterceptor won't close UoW;
+                            // the late async callback will close it after the worker finishes
+                            cxfExchange.put(org.apache.camel.Exchange.class, null);
+                            return result;
+                        } catch (Exception ex) {
+                            cxfExchange.put(org.apache.camel.Exchange.class, null);
+                            cxfRsConsumer.doneUoW(camelExchange);
+                            throw ex;
+                        }
                     }
                 }
             }

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfConsumer.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfConsumer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.xml.ws.WebFault;
 
@@ -151,6 +152,8 @@ public class CxfConsumer extends DefaultConsumer implements Suspendable {
 
     private class CxfConsumerInvoker implements Invoker {
 
+        private static final String COMPLETED = "org.apache.camel.component.cxf.jaxws.completed";
+
         private final CxfEndpoint endpoint;
 
         CxfConsumerInvoker(CxfEndpoint endpoint) {
@@ -180,8 +183,11 @@ public class CxfConsumer extends DefaultConsumer implements Suspendable {
                 if (continuation.isNew()) {
                     final org.apache.camel.Exchange camelExchange = prepareCamelExchange(cxfExchange);
 
-                    // Now we don't set up the timeout value
                     LOG.trace("Suspending continuation of exchangeId: {}", camelExchange.getExchangeId());
+
+                    // guard so exactly one of {timeout, async completion} owns the response and UoW lifecycle
+                    final AtomicBoolean completed = new AtomicBoolean(false);
+                    cxfExchange.put(COMPLETED, completed);
 
                     // The continuation could be called before the suspend is called
                     continuation.suspend(cxfEndpoint.getContinuationTimeout());
@@ -193,9 +199,16 @@ public class CxfConsumer extends DefaultConsumer implements Suspendable {
                         public void done(boolean doneSync) {
                             // make sure the continuation resume will not be called before the suspend method in other thread
                             synchronized (continuation) {
-                                LOG.trace("Resuming continuation of exchangeId: {}", camelExchange.getExchangeId());
-                                // resume processing after both, sync and async callbacks
-                                continuation.resume();
+                                if (completed.compareAndSet(false, true)) {
+                                    LOG.trace("Resuming continuation of exchangeId: {}", camelExchange.getExchangeId());
+                                    // resume processing after both, sync and async callbacks
+                                    continuation.resume();
+                                } else {
+                                    // timeout already sent the response; close the UoW now that the worker has finished
+                                    LOG.trace("Timeout already handled response for exchangeId: {}; closing UoW",
+                                            camelExchange.getExchangeId());
+                                    CxfConsumer.this.doneUoW(camelExchange);
+                                }
                             }
                         }
                     });
@@ -210,16 +223,23 @@ public class CxfConsumer extends DefaultConsumer implements Suspendable {
                     }
 
                 } else if (continuation.isTimeout() || !continuation.isResumed() && !continuation.isPending()) {
-                    org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange) continuation.getObject();
-                    try {
-                        if (!continuation.isPending()) {
-                            camelExchange.setException(
-                                    new ExchangeTimedOutException(camelExchange, cxfEndpoint.getContinuationTimeout()));
+                    AtomicBoolean completed = (AtomicBoolean) cxfExchange.get(COMPLETED);
+                    if (completed != null && completed.compareAndSet(false, true)) {
+                        org.apache.camel.Exchange camelExchange = (org.apache.camel.Exchange) continuation.getObject();
+                        try {
+                            if (!continuation.isPending()) {
+                                camelExchange.setException(
+                                        new ExchangeTimedOutException(camelExchange, cxfEndpoint.getContinuationTimeout()));
+                            }
+                            setResponseBack(cxfExchange, camelExchange);
+                            // detach so UnitOfWorkCloserInterceptor won't close UoW;
+                            // the late async callback will close it after the worker finishes
+                            cxfExchange.put(org.apache.camel.Exchange.class, null);
+                        } catch (Exception ex) {
+                            cxfExchange.put(org.apache.camel.Exchange.class, null);
+                            CxfConsumer.this.doneUoW(camelExchange);
+                            throw ex;
                         }
-                        setResponseBack(cxfExchange, camelExchange);
-                    } catch (Exception ex) {
-                        CxfConsumer.this.doneUoW(camelExchange);
-                        throw ex;
                     }
                 }
             }

--- a/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerContinuationTimeoutTest.java
+++ b/components/camel-cxf/camel-cxf-soap/src/test/java/org/apache/camel/component/cxf/jaxws/CxfConsumerContinuationTimeoutTest.java
@@ -114,4 +114,15 @@ public class CxfConsumerContinuationTimeoutTest extends CamelTestSupport {
         assertTrue(out.contains("The OUT message was not received within: 5000 millis."));
     }
 
+    @Test
+    public void testTimeoutThenNormalRequest() throws Exception {
+        // first request times out
+        String out = template.requestBodyAndHeader("direct:start", "Bye World", "priority", "slow", String.class);
+        assertTrue(out.contains("The OUT message was not received within: 5000 millis."));
+
+        // subsequent normal request must succeed without state corruption
+        Object out2 = template.requestBody("direct:start", "Hello World", String.class);
+        assertEquals(ECHO_BOOLEAN_RESPONSE, out2);
+    }
+
 }


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

Fix race condition in `camel-cxf-soap` (`CxfConsumer`) and `camel-cxf-rest` (`CxfRsInvoker`) where a CXF continuation timeout fires while the Camel async processor is still running, leading to:

1. **Double `continuation.resume()`** — the `done()` callback unconditionally called `resume()` even after timeout already produced a response
2. **Double UoW close** — `UnitOfWorkCloserInterceptor` closes UoW on the timeout response path, then the late callback's resume triggers a second close. `DefaultUnitOfWork.done()` is not idempotent — a double-call fires synchronization callbacks twice, double-removes from inflight registry, and with pooled exchanges recycles the Exchange while the worker still holds it
3. **Concurrent Exchange mutation** — timeout thread sets `ExchangeTimedOutException` on the same Exchange the async worker is still processing

### Fix

Introduce an `AtomicBoolean completed` per-request so exactly one of {timeout, async completion} wins the response and UoW lifecycle:

- **`done()` callback**: guard `continuation.resume()` with `completed.compareAndSet(false, true)`. If timeout already won, the callback closes the UoW (safely, since the worker has finished)
- **Timeout branch**: guard with the same `compareAndSet`. If won, write the timeout response and detach the Camel Exchange from the CXF exchange so `UnitOfWorkCloserInterceptor` won't close UoW prematurely. The late `done()` callback closes it after the worker finishes

### Files changed

- `CxfRsInvoker.java` — REST async invoke race guard
- `CxfConsumer.java` — SOAP async invoke race guard (symmetric change)
- `CxfConsumerContinuationTimeoutTest.java` — add test verifying timeout followed by normal request (no state corruption)

## Test plan

- [x] `CxfConsumerContinuationTimeoutTest` — all 3 tests pass (no-timeout, timeout, timeout-then-normal)
- [x] Full `camel-cxf-soap` module test suite passes (161 tests)
- [x] Full `camel-cxf-rest` module test suite passes
- [x] Full root build (`mvn clean install -DskipTests`) passes with no regenerated file changes


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>