### PR TITLE
CAMEL-24180: Fix CxfMessageHelper fallback setting null instead of actual body

### DIFF
--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/message/CxfMessageHelper.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/message/CxfMessageHelper.java
@@ -60,7 +60,7 @@ public final class CxfMessageHelper {
             answer.setContent(InputStream.class, body);
         } else if (message.getBody() != null) {
             // fallback and set the body as what it is
-            answer.setContent(Object.class, body);
+            answer.setContent(Object.class, message.getBody());
         }
 
         answer.putAll(message.getHeaders());

--- a/components/camel-cxf/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/common/message/CxfMessageHelperTest.java
+++ b/components/camel-cxf/camel-cxf-transport/src/test/java/org/apache/camel/component/cxf/common/message/CxfMessageHelperTest.java
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CxfMessageHelperTest {
@@ -103,6 +105,33 @@ public class CxfMessageHelperTest {
         List<String> values = headers.get(name);
         assertTrue(values != null && values.size() == 1, "The entry must be available");
         assertEquals(values.get(0), value, "The value must match");
+    }
+
+    @Test
+    public void testGetCxfInMessageWithPojoBody() throws Exception {
+        HeaderFilterStrategy headerFilterStrategy = new CxfHeaderFilterStrategy();
+        Exchange exchange = new DefaultExchange(context);
+
+        Object pojo = List.of("item1", "item2");
+        exchange.getIn().setBody(pojo);
+
+        Message message = CxfMessageHelper.getCxfInMessage(headerFilterStrategy, exchange, false);
+
+        assertNull(message.getContent(InputStream.class), "POJO should not be convertible to InputStream");
+        assertSame(pojo, message.getContent(Object.class), "Fallback must set the original POJO body");
+    }
+
+    @Test
+    public void testGetCxfInMessageWithNullBody() throws Exception {
+        HeaderFilterStrategy headerFilterStrategy = new CxfHeaderFilterStrategy();
+        Exchange exchange = new DefaultExchange(context);
+
+        exchange.getIn().setBody(null);
+
+        Message message = CxfMessageHelper.getCxfInMessage(headerFilterStrategy, exchange, false);
+
+        assertNull(message.getContent(InputStream.class), "Null body should produce no InputStream content");
+        assertNull(message.getContent(Object.class), "Null body should produce no Object content");
     }
 
     private String toString(InputStream is) throws IOException {


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Fix copy-paste bug in `CxfMessageHelper.getCxfInMessage()` where the fallback branch (line 63) passed the null `body` variable instead of `message.getBody()`, causing non-InputStream message bodies (e.g. POJOs) to arrive as null content in downstream CXF interceptors
- Add test coverage for the fallback branch with POJO and null bodies

## Details

The bug has been dormant since 2011 because most Camel bodies have an `InputStream` type converter. The `else if` branch is only reachable when `body` (the `InputStream` variable) is null, so `answer.setContent(Object.class, body)` always set null. The fix changes it to `answer.setContent(Object.class, message.getBody())`.

## Test plan

- [x] `testGetCxfInMessageWithPojoBody` — verifies a `List` body (no InputStream converter) is preserved via the fallback
- [x] `testGetCxfInMessageWithNullBody` — verifies null body produces no content (no NPE)
- [x] Existing `testGetCxfInMessage` — verifies String/DOMSource/File bodies still work via InputStream path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>