### PR TITLE
CAMEL-24182: Fix SpringBusFactoryBean to shut down bus on context close

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/SpringBusFactoryBean.java
+++ b/components/camel-cxf/camel-cxf-spring-common/src/main/java/org/apache/camel/component/cxf/spring/SpringBusFactoryBean.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.cxf.spring;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.spring.SpringBusFactory;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.SmartFactoryBean;
 
 /**
@@ -29,18 +30,22 @@ import org.springframework.beans.factory.SmartFactoryBean;
  * all the extension in CXF 2.4.x by default. You can still specify the spring extension file in the cfgFiles list and
  * it will override the extensions which is load by CXF bus.
  */
-public class SpringBusFactoryBean implements SmartFactoryBean<Bus> {
+public class SpringBusFactoryBean implements SmartFactoryBean<Bus>, DisposableBean {
     private String[] cfgFiles;
     private boolean includeDefaultBus;
+    private Bus bus;
 
     @Override
     public Bus getObject() throws Exception {
-        SpringBusFactory bf = new SpringBusFactory();
-        if (cfgFiles != null) {
-            return bf.createBus(cfgFiles, includeDefaultBus);
-        } else {
-            return bf.createBus();
+        if (bus == null) {
+            SpringBusFactory bf = new SpringBusFactory();
+            if (cfgFiles != null) {
+                bus = bf.createBus(cfgFiles, includeDefaultBus);
+            } else {
+                bus = bf.createBus();
+            }
         }
+        return bus;
     }
 
     @Override
@@ -49,7 +54,9 @@ public class SpringBusFactoryBean implements SmartFactoryBean<Bus> {
     }
 
     public void setCfgFiles(String cfgFiles) {
-        this.cfgFiles = cfgFiles.split(";");
+        if (cfgFiles != null) {
+            this.cfgFiles = cfgFiles.split(";");
+        }
     }
 
     public void setIncludeDefaultBus(boolean includeDefaultBus) {
@@ -69,6 +76,14 @@ public class SpringBusFactoryBean implements SmartFactoryBean<Bus> {
     @Override
     public boolean isPrototype() {
         return false;
+    }
+
+    @Override
+    public void destroy() {
+        if (bus != null) {
+            bus.shutdown(true);
+            bus = null;
+        }
     }
 
 }

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/spring/SpringBusFactoryBeanTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/spring/SpringBusFactoryBeanTest.java
@@ -17,9 +17,11 @@
 package org.apache.camel.component.cxf.spring;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.Bus.BusState;
 import org.apache.cxf.binding.soap.SoapBindingFactory;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SpringBusFactoryBeanTest extends AbstractSpringBeanTestSupport {
@@ -39,6 +41,23 @@ public class SpringBusFactoryBeanTest extends AbstractSpringBeanTestSupport {
 
         SoapBindingFactory soapBindingFactory = bus.getExtension(SoapBindingFactory.class);
         assertNotNull(soapBindingFactory, "You should find the factory here");
+    }
+
+    @Test
+    public void testBusShutdownOnContextClose() {
+        Bus bus = ctx.getBean("cxfBus", Bus.class);
+        assertNotNull(bus);
+
+        // bus should be running while context is open
+        assertEquals(BusState.RUNNING, bus.getState());
+
+        // closing the context must shut down the bus via DisposableBean.destroy()
+        ctx.close();
+        assertEquals(BusState.SHUTDOWN, bus.getState(),
+                "Bus must be shut down after application context close");
+
+        // prevent tearDown from closing again
+        ctx = null;
     }
 
 }


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Implement `DisposableBean` on `SpringBusFactoryBean` so Spring calls `destroy()` on context close, which calls `bus.shutdown(true)` to release the `BusApplicationContext`, workqueue threads, and classloader references
- Store the created `Bus` as a field (was previously returned as a local and lost), cache it for singleton semantics
- Add null-guard in `setCfgFiles` to prevent NPE on null input

Without this fix, the bus, its internal Spring context, and thread pools leak on every context close/refresh (servlet redeploy, Spring Boot devtools restart, repeated integration tests).

## Test plan

- [x] `testBusShutdownOnContextClose` — verifies bus state transitions to SHUTDOWN after context close
- [x] Existing `getTheBusInstance` test still passes
- [x] All 160 tests in camel-cxf-spring-soap pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>