### PR TITLE
CAMEL-24183: Fix Spring rsClient producer to apply endpoint URI options

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
@@ -66,11 +66,21 @@ public class CxfRsSpringEndpoint extends CxfRsEndpoint implements BeanIdAware {
 
     @Override
     protected void setupJAXRSClientFactoryBean(JAXRSClientFactoryBean cfb, String address) {
+        // apply Spring bean config first so URI options can override
         configurer.configureBean(beanId, cfb);
-        // support to call the configurer here
-        getNullSafeCxfRsEndpointConfigurer().configure(cfb);
-        cfb.setAddress(address);
+        if (getModelRef() != null) {
+            cfb.setModelRef(getModelRef());
+        }
+        if (getResourceClasses() != null && !getResourceClasses().isEmpty()) {
+            cfb.setResourceClass(getResourceClasses().get(0));
+            cfb.getServiceFactory().setResourceClasses(getResourceClasses());
+        }
+        setupCommonFactoryProperties(cfb);
         cfb.setThreadSafe(true);
+        getNullSafeCxfRsEndpointConfigurer().configure(cfb);
+        if (address != null) {
+            cfb.setAddress(address);
+        }
     }
 
     @Override


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Fix `CxfRsSpringEndpoint.setupJAXRSClientFactoryBean` to call `setupCommonFactoryProperties(cfb)`, matching the parent `CxfRsEndpoint` implementation
- Previously, the Spring override completely replaced the parent method without applying providers, features, interceptors, properties, logging feature, or skip-fault-logging — all silently ignored for Spring-based cxfrs producers
- Also adds the missing `modelRef` and `resourceClasses` setup from the parent
- Spring bean config is applied first (`configurer.configureBean`) so URI options correctly override XML config

## Details

The ordering now matches the parent: Spring configurer -> modelRef/resourceClasses -> common properties -> threadSafe -> endpoint configurer -> address. The server side was already correct (uses inherited `setupJAXRSServerFactoryBean`).

## Test plan

- [x] All existing tests in camel-cxf-spring-rest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>