### PR TITLE
CAMEL-24184: Fix 19 medium-severity findings from camel-cxf code review

### DIFF
--- a/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelper.java
+++ b/components/camel-cxf/camel-cxf-common/src/main/java/org/apache/camel/component/cxf/common/header/CxfHeaderHelper.java
@@ -104,7 +104,12 @@ public final class CxfHeaderHelper {
 
             LOG.trace("Propagate Camel header: {}={} as {}", entry.getKey(), entry.getValue(), cxfHeaderName);
 
-            requestHeaders.put(cxfHeaderName, Arrays.asList(entry.getValue().toString()));
+            Object values = entry.getValue();
+            if (values instanceof List<?>) {
+                requestHeaders.put(cxfHeaderName, CastUtils.cast((List<?>) values, String.class));
+            } else {
+                requestHeaders.put(cxfHeaderName, Arrays.asList(values.toString()));
+            }
         });
     }
 
@@ -191,8 +196,8 @@ public final class CxfHeaderHelper {
 
             LOG.trace("Populate external header: {}={} as {}", entry.getKey(), entry.getValue(), camelHeaderName);
             if (!camelHeaderName.startsWith(":")) {
-                ///* Ignore HTTP/2 pseudo headers such as :status */
-                camelHeaders.put(camelHeaderName, entry.getValue().get(0));
+                List<Object> values = entry.getValue();
+                camelHeaders.put(camelHeaderName, values.size() == 1 ? values.get(0) : values);
             }
         });
     }

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfConverter.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfConverter.java
@@ -223,6 +223,10 @@ public final class CxfConverter {
             Response response = (Response) value;
             Object entity = response.getEntity();
 
+            if (entity == null) {
+                return (T) MISS_VALUE;
+            }
+
             TypeConverter tc = registry.lookup(type, entity.getClass());
             if (tc != null) {
                 return tc.convertTo(type, exchange, entity);

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsInvoker.java
@@ -182,7 +182,7 @@ public class CxfRsInvoker extends JAXRSInvoker {
             Exchange cxfExchange, Method method,
             Object[] paramArray, Object response) {
         ExchangePattern ep = ExchangePattern.InOut;
-        if (method.getReturnType() == Void.class) {
+        if (method.getReturnType() == Void.TYPE || method.getReturnType() == Void.class) {
             ep = ExchangePattern.InOnly;
         }
         final org.apache.camel.Exchange camelExchange = endpoint.createExchange(ep);

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
@@ -647,7 +647,19 @@ public class CxfRsProducer extends DefaultAsyncProducer {
 
             for (Map.Entry<String, List<Object>> entry : resp.getMetadata().entrySet()) {
                 LOG.trace("Parse external header {}={}", entry.getKey(), entry.getValue());
-                answer.put(entry.getKey(), entry.getValue().get(0).toString());
+                List<Object> values = entry.getValue();
+                if (values.size() == 1) {
+                    answer.put(entry.getKey(), values.get(0).toString());
+                } else {
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < values.size(); i++) {
+                        if (i > 0) {
+                            sb.append(", ");
+                        }
+                        sb.append(values.get(i));
+                    }
+                    answer.put(entry.getKey(), sb.toString());
+                }
             }
         }
 
@@ -701,6 +713,7 @@ public class CxfRsProducer extends DefaultAsyncProducer {
                 // handle cookies
                 saveCookies(exchange, client, cxfRsEndpoint.getCookieHandler());
                 if (!exchange.getPattern().isOutCapable()) {
+                    response.close();
                     return;
                 }
 
@@ -806,6 +819,9 @@ public class CxfRsProducer extends DefaultAsyncProducer {
                     return;
                 }
                 if (!exchange.getPattern().isOutCapable()) {
+                    if (response != null) {
+                        response.close();
+                    }
                     return;
                 }
 

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBinding.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBinding.java
@@ -123,10 +123,11 @@ public class DefaultCxfRsBinding implements CxfRsBinding, HeaderFilterStrategyAw
     private static void setProtocolHeaders(org.apache.cxf.message.Exchange cxfExchange, Message response) {
         Map<String, Object> headers
                 = CastUtils.cast((Map<?, ?>) response.getHeader(CxfConstants.PROTOCOL_HEADERS));
-        if (!ObjectHelper.isEmpty(cxfExchange) && !ObjectHelper.isEmpty(cxfExchange.getOutMessage())) {
-            cxfExchange.getOutMessage().putIfAbsent(CxfConstants.PROTOCOL_HEADERS,
-                    new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+        if (cxfExchange == null || cxfExchange.getOutMessage() == null) {
+            return;
         }
+        cxfExchange.getOutMessage().putIfAbsent(CxfConstants.PROTOCOL_HEADERS,
+                new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
         final Map<String, List<String>> cxfHeaders = CastUtils
                 .cast((Map<?, ?>) cxfExchange.getOutMessage().get(CxfConstants.PROTOCOL_HEADERS));
 
@@ -310,8 +311,8 @@ public class DefaultCxfRsBinding implements CxfRsBinding, HeaderFilterStrategyAw
                 /* Ignore HTTP/2 pseudo headers such as :status */
                 continue;
             } else {
-                // just put the first String element, as the complex one is filtered
-                camelMessage.setHeader(entry.getKey(), entry.getValue().get(0));
+                List<String> values = entry.getValue();
+                camelMessage.setHeader(entry.getKey(), values.size() == 1 ? values.get(0) : values);
             }
             continue;
         }

--- a/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/SubResourceClassInvocationHandler.java
+++ b/components/camel-cxf/camel-cxf-rest/src/main/java/org/apache/camel/component/cxf/jaxrs/SubResourceClassInvocationHandler.java
@@ -30,7 +30,7 @@ public class SubResourceClassInvocationHandler implements InvocationHandler {
     public Object invoke(Object proxy, Method method, Object[] parameters) throws Throwable {
         Object result = null;
         Class<?> returnType = method.getReturnType();
-        if (!returnType.isAssignableFrom(Void.class)) {
+        if (returnType != Void.TYPE && returnType != Void.class) {
             // create a instance to return
             if (returnType.isInterface()) {
                 // create a new proxy for it

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfClientCallback.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfClientCallback.java
@@ -88,7 +88,9 @@ public class CxfClientCallback extends ClientCallback {
             ConduitSelector conduitSelector = cxfExchange.get(ConduitSelector.class);
             if (conduitSelector != null) {
                 conduitSelector.complete(cxfExchange);
-                ex = cxfExchange.getOutMessage().getContent(Exception.class);
+                if (cxfExchange.getOutMessage() != null) {
+                    ex = cxfExchange.getOutMessage().getContent(Exception.class);
+                }
                 if (ex == null && cxfExchange.getInMessage() != null) {
                     ex = cxfExchange.getInMessage().getContent(Exception.class);
                 }

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfEndpoint.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/CxfEndpoint.java
@@ -137,7 +137,7 @@ public class CxfEndpoint extends DefaultEndpoint implements AsyncEndpoint, Heade
     private static final Logger LOG = LoggerFactory.getLogger(CxfEndpoint.class);
 
     @UriParam(label = "advanced")
-    protected Bus bus;
+    protected volatile Bus bus;
     @UriParam(label = "advanced")
     protected boolean defaultBus;
     protected volatile boolean createBus;

--- a/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBinding.java
+++ b/components/camel-cxf/camel-cxf-soap/src/main/java/org/apache/camel/component/cxf/jaxws/DefaultCxfBinding.java
@@ -473,8 +473,14 @@ public class DefaultCxfBinding implements CxfBinding, HeaderFilterStrategyAware 
 
         propagateHeadersFromCamelToCxf(camelExchange, camelHeaders, cxfExchange,
                 responseContext);
-        if (cxfExchange.getOutMessage() != null) {
-            cxfExchange.getOutMessage().put(CxfConstants.PROTOCOL_HEADERS, responseContext.get(CxfConstants.PROTOCOL_HEADERS));
+        Object protocolHeaders = responseContext.get(CxfConstants.PROTOCOL_HEADERS);
+        if (protocolHeaders != null) {
+            // Store on the CXF exchange so headers survive into the fault path
+            // (the out message does not exist yet at this point)
+            cxfExchange.put(CxfConstants.PROTOCOL_HEADERS, protocolHeaders);
+            if (cxfExchange.getOutMessage() != null) {
+                cxfExchange.getOutMessage().put(CxfConstants.PROTOCOL_HEADERS, protocolHeaders);
+            }
         }
     }
 
@@ -866,7 +872,7 @@ public class DefaultCxfBinding implements CxfBinding, HeaderFilterStrategyAware 
                 if (part.charAt(0) == '\"') {
                     result = part.substring(1, part.length() - 1);
                 } else {
-                    result = part.substring(5);
+                    result = part;
                 }
                 break;
             }

--- a/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
@@ -48,14 +48,24 @@ public class CxfRsSpringEndpoint extends CxfRsEndpoint implements BeanIdAware {
             setBeanId(beanIdAware.getBeanId());
         }
 
-        ApplicationContext applicationContext = ((SpringCamelContext) getCamelContext()).getApplicationContext();
-        configurer = new ConfigurerImpl(applicationContext);
+        if (getCamelContext() instanceof SpringCamelContext springCamelContext) {
+            ApplicationContext applicationContext = springCamelContext.getApplicationContext();
+            configurer = new ConfigurerImpl(applicationContext);
+        }
     }
 
     @Override
     protected JAXRSServerFactoryBean newJAXRSServerFactoryBean() {
         checkBeanType(bean, JAXRSServerFactoryBean.class);
         return (JAXRSServerFactoryBean) bean;
+    }
+
+    @Override
+    protected void setupJAXRSServerFactoryBean(JAXRSServerFactoryBean sfb) {
+        if (sfb instanceof SpringJAXRSServerFactoryBean springBean) {
+            springBean.setPerformInvocation(isPerformInvocation());
+        }
+        super.setupJAXRSServerFactoryBean(sfb);
     }
 
     @Override
@@ -67,7 +77,9 @@ public class CxfRsSpringEndpoint extends CxfRsEndpoint implements BeanIdAware {
     @Override
     protected void setupJAXRSClientFactoryBean(JAXRSClientFactoryBean cfb, String address) {
         // apply Spring bean config first so URI options can override
-        configurer.configureBean(beanId, cfb);
+        if (configurer != null) {
+            configurer.configureBean(beanId, cfb);
+        }
         if (getModelRef() != null) {
             cfb.setModelRef(getModelRef());
         }

--- a/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/SpringJAXRSServerFactoryBean.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/SpringJAXRSServerFactoryBean.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.cxf.spring.jaxrs;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.camel.component.cxf.common.NullFaultListener;
 import org.apache.camel.component.cxf.jaxrs.BeanIdAware;
@@ -104,6 +105,15 @@ public class SpringJAXRSServerFactoryBean extends JAXRSServerFactoryBean
                 loggingFeature = new LoggingFeature();
             }
             getFeatures().add(loggingFeature);
+        }
+    }
+
+    @Override
+    public void setProperties(Map<String, Object> properties) {
+        if (this.getProperties() != null && properties != null) {
+            this.getProperties().putAll(properties);
+        } else {
+            super.setProperties(properties);
         }
     }
 

--- a/components/camel-cxf/camel-cxf-spring-soap/src/main/java/org/apache/camel/component/cxf/spring/jaxws/CxfSpringEndpoint.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/main/java/org/apache/camel/component/cxf/spring/jaxws/CxfSpringEndpoint.java
@@ -274,6 +274,7 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
 
         if (bus == null) {
             bus = BusWiringBeanFactoryPostProcessor.addDefaultBus(ctx);
+            enableSpringBusShutdownGracefully(bus);
         }
     }
 
@@ -312,10 +313,14 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
                 && applicationContext instanceof AbstractApplicationContext abstractApplicationContext) {
             ApplicationListener cxfSpringBusListener = null;
             for (ApplicationListener listener : abstractApplicationContext.getApplicationListeners()) {
-
-                if (listener.getClass().getName().indexOf("org.apache.cxf.bus.spring.SpringBus") >= 0) {
+                // match by identity to ensure we remove the listener for this specific bus
+                if (listener == springBus) {
                     cxfSpringBusListener = listener;
+                    break;
                 }
+            }
+            if (cxfSpringBusListener == null) {
+                return;
             }
             ApplicationEventMulticaster aem = applicationContext
                     .getBean(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
@@ -323,35 +328,32 @@ public class CxfSpringEndpoint extends CxfEndpoint implements ApplicationContext
             aem.removeApplicationListener(cxfSpringBusListener);
 
             abstractApplicationContext.addApplicationListener((final ApplicationEvent event) -> {
-                new Thread() {
-                    @Override
-                    public void run() {
-                        if (event instanceof ContextClosedEvent && bus.getState() == BusState.RUNNING) {
-
-                            try {
-                                boolean done = false;
-                                ShutdownStrategy shutdownStrategy = ((DefaultCamelContext) getCamelContext())
-                                        .getShutdownStrategy();
-                                while (!done && !shutdownStrategy.hasTimeoutOccurred()) {
-                                    int inflight = getCamelContext().getInflightRepository().size();
-                                    if (inflight != 0) {
-                                        Thread.sleep(1000);
-                                    } else {
-                                        done = true;
-                                    }
+                if (event instanceof ContextClosedEvent && bus.getState() == BusState.RUNNING) {
+                    // only spawn a thread for shutdown to wait for in-flight exchanges
+                    new Thread(() -> {
+                        try {
+                            boolean done = false;
+                            ShutdownStrategy shutdownStrategy = ((DefaultCamelContext) getCamelContext())
+                                    .getShutdownStrategy();
+                            while (!done && !shutdownStrategy.hasTimeoutOccurred()) {
+                                int inflight = getCamelContext().getInflightRepository().size();
+                                if (inflight != 0) {
+                                    Thread.sleep(1000);
+                                } else {
+                                    done = true;
                                 }
-                            } catch (InterruptedException e) {
-                                LOG.info("Interrupted while enabling graceful SpringBus shutdown");
-                                Thread.currentThread().interrupt();
-                            } catch (Exception e) {
-                                LOG.debug("Error when enabling SpringBus shutdown gracefully", e);
                             }
-                            springBus.onApplicationEvent(event);
-                        } else {
-                            springBus.onApplicationEvent(event);
+                        } catch (InterruptedException e) {
+                            LOG.info("Interrupted while enabling graceful SpringBus shutdown");
+                            Thread.currentThread().interrupt();
+                        } catch (Exception e) {
+                            LOG.debug("Error when enabling SpringBus shutdown gracefully", e);
                         }
-                    }
-                }.start();
+                        springBus.onApplicationEvent(event);
+                    }).start();
+                } else {
+                    springBus.onApplicationEvent(event);
+                }
             });
         }
 

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelConduit.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelConduit.java
@@ -47,6 +47,7 @@ public class CamelConduit extends AbstractConduit implements Configurable {
     private final EndpointInfo endpointInfo;
     private String targetCamelEndpointUri;
     private final Producer producer;
+    private volatile boolean closed;
     private ProducerTemplate camelTemplate;
     private final Bus bus;
     private final HeaderFilterStrategy headerFilterStrategy;
@@ -92,9 +93,11 @@ public class CamelConduit extends AbstractConduit implements Configurable {
         return camelContext;
     }
 
-    // prepare the message for send out , not actually send out the message
     @Override
     public void prepare(Message message) throws IOException {
+        if (closed) {
+            throw new IOException("CamelConduit is already closed");
+        }
         LOG.trace("CamelConduit send message");
         CamelOutputStream os = new CamelOutputStream(
                 this.targetCamelEndpointUri,
@@ -107,8 +110,8 @@ public class CamelConduit extends AbstractConduit implements Configurable {
 
     @Override
     public void close() {
+        closed = true;
         LOG.trace("CamelConduit closed ");
-        // shutdown the producer
         try {
             producer.stop();
         } catch (Exception e) {

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelOutputStream.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/CamelOutputStream.java
@@ -130,14 +130,22 @@ class CamelOutputStream extends CachedOutputStream {
             try {
                 syncInvoke(exchange);
             } catch (Exception e) {
-                ((PhaseInterceptorChain) outMessage.getInterceptorChain()).abort();
                 outMessage.setContent(Exception.class, e);
-                ((PhaseInterceptorChain) outMessage.getInterceptorChain()).unwind(outMessage);
-                MessageObserver mo = outMessage.getInterceptorChain().getFaultObserver();
+                if (outMessage.getInterceptorChain() instanceof PhaseInterceptorChain chain) {
+                    chain.abort();
+                    chain.unwind(outMessage);
+                }
+                MessageObserver mo = outMessage.getInterceptorChain() != null
+                        ? outMessage.getInterceptorChain().getFaultObserver()
+                        : null;
                 if (mo == null) {
                     mo = outMessage.getExchange().get(MessageObserver.class);
                 }
-                mo.onMessage(outMessage);
+                if (mo != null) {
+                    mo.onMessage(outMessage);
+                } else {
+                    LOG.error("No fault observer available to handle transport error", e);
+                }
             }
         };
 

--- a/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/message/DefaultCxfMessageMapper.java
+++ b/components/camel-cxf/camel-cxf-transport/src/main/java/org/apache/camel/component/cxf/transport/message/DefaultCxfMessageMapper.java
@@ -152,8 +152,7 @@ public class DefaultCxfMessageMapper implements CxfMessageMapper {
         if (answer == null) {
             answer = camelExchange.getFromEndpoint().getEndpointUri();
             // remove leading scheme before the http(s) transport so we build a correct base path
-            answer = answer.replaceFirst("^\\w+:http", "http");
-            answer = answer.replaceFirst("^\\w+:https", "https");
+            answer = answer.replaceFirst("^\\w+:(https?)", "$1");
         }
 
         return answer;


### PR DESCRIPTION
## Summary

Fixes all 19 medium-severity findings from the July 2026 AI-assisted code review of the `components/camel-cxf/` component family ([CAMEL-24184](https://issues.apache.org/jira/browse/CAMEL-24184)).

The high-severity findings (CAMEL-24176 through CAMEL-24183) were already fixed in separate PRs. This PR addresses the remaining medium-severity items across 6 CXF sub-modules (15 files changed).

### camel-cxf-soap / camel-cxf-common
- **#1** `replaceMultiPartContentType` double-strips `type=` prefix, corrupting Content-Type for unquoted MTOM/multipart
- **#2** `CxfClientCallback` NPE when out message is absent during failover
- **#3** `populateCxfHeaderFromCamelExchangeBeforeCheckError` protocol headers never reach fault response (dead code)
- **#4** `CxfEndpoint.bus` field made `volatile` to prevent visibility issues in lazy init

### camel-cxf-rest
- **#5** `CxfRsInvoker` checks `Void.class` instead of `Void.TYPE` for `void` methods — InOnly MEP never selected
- **#6** `SubResourceClassInvocationHandler` same `Void.class` vs `Void.TYPE` confusion — NPE on void methods
- **#7** Async `completed()` callbacks leak JAX-RS `Response` for InOnly exchanges (connection pinned until GC)
- **#8** Multi-valued Camel headers flattened to literal `"[a, b]"` via `toString()` in `CxfHeaderHelper`
- **#9** Inbound protocol headers truncated to first value (`get(0)`) in 3 locations
- **#10** `setProtocolHeaders` NPE when CXF out message is absent (oneway/fault paths)
- **#11** `CxfConverter` fallback NPE when `Response.getEntity()` returns null (204/empty responses)

### camel-cxf-transport
- **#12** `CamelConduit` producer leak on abandoned conduit + use-after-stop race
- **#13** `asyncInvokeFromWorkQueue` NPE when no fault observer is registered; unsafe `PhaseInterceptorChain` cast
- **#14** `getBasePath` regex: second `replaceFirst` unreachable; combined into single pattern

### camel-cxf-spring-*
- **#15-16** `enableSpringBusShutdownGracefully` was dead code (never called in standard path), spawned a thread for every `ApplicationEvent`, and matched listeners unreliably. Fixed: call from `setApplicationContext`, match by identity, only spawn thread for `ContextClosedEvent`
- **#17** `performInvocation` not propagated to `SpringJAXRSServerFactoryBean` — interface-model resources not filtered in Spring variant
- **#18** `SpringJAXRSServerFactoryBean` missing `setProperties` merge override — `<cxf:properties>` wipes `NullFaultListener`
- **#19** `CxfRsSpringEndpoint` hard-casts `CamelContext` to `SpringCamelContext` — `ClassCastException` in camel-main

## Test plan
- [x] `mvn test` in camel-cxf-common — passed
- [x] `mvn test` in camel-cxf-soap — passed
- [x] `mvn test` in camel-cxf-rest — passed
- [x] `mvn test` in camel-cxf-transport — passed
- [x] `mvn test` in camel-cxf-spring-soap — passed
- [x] `mvn test` in camel-cxf-spring-rest — passed

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>