### PR TITLE
CAMEL-24170: Fix remaining HIGH findings from data format review

### DIFF
--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyKeyValuePairFactory.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/BindyKeyValuePairFactory.java
@@ -141,7 +141,7 @@ public class BindyKeyValuePairFactory extends BindyAbstractFactory implements Bi
         for (String s : data) {
 
             // Get KeyValuePair
-            String[] keyValuePair = s.split(getKeyValuePairSeparator());
+            String[] keyValuePair = s.split(getKeyValuePairSeparator(), 2);
 
             // Extract only if value is populated in key:value pair in incoming message.
             if (keyValuePair.length > 1) {

--- a/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/UnicodeHelper.java
+++ b/components/camel-bindy/src/main/java/org/apache/camel/dataformat/bindy/UnicodeHelper.java
@@ -124,7 +124,7 @@ public class UnicodeHelper implements Serializable {
 
         final int len = new UnicodeHelper(str, method).length();
 
-        for (int index = fromIndex; index + len < length(); index++) {
+        for (int index = fromIndex; index + len <= length(); index++) {
             if (str.equals(input.substring(splitted.get(index), splitted.get(index + len)))) {
                 return index;
             }

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/UnicodeHelperTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/UnicodeHelperTest.java
@@ -206,6 +206,21 @@ public class UnicodeHelperTest {
         assertEquals(3, lh3.indexOf("m̂", 2));
     }
 
+    @Test
+    public void testIndexOfAtEndOfString() {
+        UnicodeHelper lh = new UnicodeHelper("ab|", Method.CODEPOINTS);
+        assertEquals(2, lh.indexOf("|"));
+
+        UnicodeHelper lh2 = new UnicodeHelper("abc|", Method.CODEPOINTS);
+        assertEquals(3, lh2.indexOf("|"));
+
+        UnicodeHelper lh3 = new UnicodeHelper("|", Method.CODEPOINTS);
+        assertEquals(0, lh3.indexOf("|"));
+
+        UnicodeHelper lh4 = new UnicodeHelper("ab|", Method.GRAPHEME);
+        assertEquals(2, lh4.indexOf("|"));
+    }
+
     private static String cps2String(final int... cps) {
         final StringBuilder buf = new StringBuilder();
         for (int cp : cps) {

--- a/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/fix/BindyKeyValuePairSeparatorInValueTest.java
+++ b/components/camel-bindy/src/test/java/org/apache/camel/dataformat/bindy/fix/BindyKeyValuePairSeparatorInValueTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.bindy.fix;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.dataformat.bindy.BindyAbstractFactory;
+import org.apache.camel.dataformat.bindy.kvp.BindyKeyValuePairDataFormat;
+import org.apache.camel.dataformat.bindy.model.fix.simple.Order;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BindyKeyValuePairSeparatorInValueTest {
+
+    @Test
+    public void testValueContainingKeyValueSeparator() throws Exception {
+        BindyKeyValuePairDataFormat dataFormat = new BindyKeyValuePairDataFormat(Order.class);
+        BindyAbstractFactory factory = dataFormat.getFactory();
+
+        // tag 58 (free text) contains '=' which is also the key-value separator
+        String message = "8=FIX.4.1" + "" + "58=a=b=c" + "" + "10=220";
+        List<String> data = Arrays.asList(message.split("\\u0001"));
+
+        Map<String, Object> model = new HashMap<>();
+        model.put(Order.class.getName(), new Order());
+
+        CamelContext camelContext = new DefaultCamelContext();
+        factory.bind(camelContext, data, model, 1);
+
+        Order order = (Order) model.get(Order.class.getName());
+        assertEquals("a=b=c", order.getText());
+    }
+}

--- a/components/camel-protobuf/src/main/java/org/apache/camel/dataformat/protobuf/ProtobufDataFormat.java
+++ b/components/camel-protobuf/src/main/java/org/apache/camel/dataformat/protobuf/ProtobufDataFormat.java
@@ -182,7 +182,8 @@ public class ProtobufDataFormat extends ServiceSupport
         Builder builder = defaultInstance.newBuilderForType();
 
         if (contentTypeFormat.equals(CONTENT_TYPE_FORMAT_JSON)) {
-            JsonFormat.parser().ignoringUnknownFields().merge(new InputStreamReader(inputStream), builder);
+            JsonFormat.parser().ignoringUnknownFields().merge(new InputStreamReader(inputStream, StandardCharsets.UTF_8),
+                    builder);
         } else if (contentTypeFormat.equals(CONTENT_TYPE_FORMAT_NATIVE)) {
             builder = defaultInstance.newBuilderForType().mergeFrom(inputStream);
         } else {

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/AvroDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/AvroDataFormat.java
@@ -33,7 +33,7 @@ import org.apache.camel.spi.Metadata;
           description = "Serialize and deserialize messages using Apache Avro binary data format")
 @XmlRootElement(name = "avro")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class AvroDataFormat extends DataFormatDefinition {
+public class AvroDataFormat extends DataFormatDefinition implements ContentTypeHeaderAware {
 
     @XmlTransient
     private Class<?> unmarshalType;

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/dataformat/YAMLDataFormat.java
@@ -408,7 +408,7 @@ public class YAMLDataFormat extends DataFormatDefinition {
          * Set the types SnakeYAML is allowed to un-marshall.
          */
         public Builder typeFilter(Class<?>... typeFilter) {
-            StringJoiner sj = new StringJoiner(".");
+            StringJoiner sj = new StringJoiner(",");
             for (Class<?> c : typeFilter) {
                 sj.add(c.getName());
             }

--- a/core/camel-core-model/src/test/java/org/apache/camel/model/dataformat/YAMLDataFormatTest.java
+++ b/core/camel-core-model/src/test/java/org/apache/camel/model/dataformat/YAMLDataFormatTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.model.dataformat;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class YAMLDataFormatTest {
+
+    @Test
+    public void testTypeFilterWithMultipleClasses() {
+        YAMLDataFormat df = new YAMLDataFormat.Builder()
+                .typeFilter(String.class, Integer.class)
+                .end();
+        assertEquals("java.lang.String,java.lang.Integer", df.getTypeFilter());
+    }
+
+    @Test
+    public void testTypeFilterWithSingleClass() {
+        YAMLDataFormat df = new YAMLDataFormat.Builder()
+                .typeFilter(String.class)
+                .end();
+        assertEquals("java.lang.String", df.getTypeFilter());
+    }
+
+    @Test
+    public void testTypeFilterWithString() {
+        YAMLDataFormat df = new YAMLDataFormat.Builder()
+                .typeFilter("com.example.Foo,com.example.Bar")
+                .end();
+        assertEquals("com.example.Foo,com.example.Bar", df.getTypeFilter());
+    }
+}

--- a/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JacksonXMLDataFormatReifier.java
+++ b/core/camel-core-reifier/src/main/java/org/apache/camel/reifier/dataformat/JacksonXMLDataFormatReifier.java
@@ -30,7 +30,7 @@ public class JacksonXMLDataFormatReifier extends DataFormatReifier<JacksonXMLDat
 
     @Override
     protected void prepareDataFormatConfig(Map<String, Object> properties) {
-        properties.put("xmlMapper", definition.getXmlMapper());
+        properties.put("xmlMapper", asRef(definition.getXmlMapper()));
         properties.put("unmarshalType", or(definition.getUnmarshalType(), definition.getUnmarshalTypeName()));
         properties.put("jsonView", or(definition.getJsonView(), definition.getJsonViewTypeName()));
         properties.put("prettyPrint", definition.getPrettyPrint());


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes 6 remaining HIGH findings from the July 2026 data format review ([CAMEL-24170](https://issues.apache.org/jira/browse/CAMEL-24170)), excluding H9/H10 (univocity lazy-load architectural issues, to be addressed separately).

### Fixes

- **H2** — `JacksonXMLDataFormatReifier`: `xmlMapper` property missing `asRef()`, causing `NoTypeConversionAvailableException` when referencing a registry bean by name without `#` prefix
- **H11** — `BindyKeyValuePairFactory`: `split(separator)` without limit truncates values containing the key-value separator (e.g. FIX tag `58=a=b=c` → `a` instead of `a=b=c`). Fixed with `split(separator, 2)`
- **H13** — `UnicodeHelper.indexOf`: off-by-one in loop condition (`<` → `<=`) misses delimiter at end-of-record, causing `IndexOutOfBoundsException` from `substring(0, -1)`
- **H15** — `ProtobufDataFormat`: JSON unmarshal uses `new InputStreamReader(inputStream)` (platform default charset) while marshal writes UTF-8. Fixed to explicitly use `StandardCharsets.UTF_8`
- **H16** — `AvroDataFormat` model: missing `implements ContentTypeHeaderAware`, so `contentTypeHeader=false` option is silently ignored by the generic reifier
- **H17** — `YAMLDataFormat.Builder.typeFilter(Class...)`: `StringJoiner(".")` joins class names with `.` instead of `,`, producing a bogus single pattern that matches nothing (CAMEL-22354 regression)

## Test plan

- [x] New test: `UnicodeHelperTest.testIndexOfAtEndOfString` — verifies delimiter found at end-of-string (H13)
- [x] New test: `BindyKeyValuePairSeparatorInValueTest` — verifies KVP unmarshal preserves values containing `=` (H11)
- [x] New test: `YAMLDataFormatTest` — verifies `typeFilter(Class...)` joins with `,` (H17)
- [x] Full `camel-bindy` test suite passes
- [x] Full `camel-protobuf` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)