### PR TITLE
[backport camel-4.18.x] CAMEL-24200: camel-aws2-timestream - createScheduledQuery sets the time column correctly

### DIFF
--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
@@ -199,11 +199,6 @@ public class Timestream2QueryProducer extends DefaultProducer {
                         = ErrorReportConfiguration.builder().s3Configuration(s3Configuration.build()).build();
                 builder.errorReportConfiguration(errorReportConfiguration);
             }
-            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.SCHEDULED_QUERY_EXECUTION_ROLE_ARN))) {
-                String roleArn
-                        = exchange.getIn().getHeader(Timestream2Constants.SCHEDULED_QUERY_EXECUTION_ROLE_ARN, String.class);
-                builder.scheduledQueryExecutionRoleArn(roleArn);
-            }
 
             TargetConfiguration.Builder targetConfiguration = TargetConfiguration.builder();
             TimestreamConfiguration.Builder timestreamConfigBuilder = TimestreamConfiguration.builder();
@@ -217,7 +212,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.TIME_COLUMN))) {
                 String timeColumn = exchange.getIn().getHeader(Timestream2Constants.TIME_COLUMN, String.class);
-                timestreamConfigBuilder.tableName(timeColumn);
+                timestreamConfigBuilder.timeColumn(timeColumn);
             }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Timestream2Constants.MEASURE_NAME_COLUMN))) {
                 String measureNameColumn = exchange.getIn().getHeader(Timestream2Constants.MEASURE_NAME_COLUMN, String.class);

--- a/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/AmazonTimestreamQueryClientMock.java
+++ b/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/AmazonTimestreamQueryClientMock.java
@@ -24,7 +24,16 @@ import software.amazon.awssdk.services.timestreamquery.model.*;
 
 public class AmazonTimestreamQueryClientMock implements TimestreamQueryClient {
 
+    private CreateScheduledQueryRequest lastCreateScheduledQueryRequest;
+
     public AmazonTimestreamQueryClientMock() {
+    }
+
+    /**
+     * The last request passed to {@link #createScheduledQuery}, so tests can assert how it was built.
+     */
+    public CreateScheduledQueryRequest getLastCreateScheduledQueryRequest() {
+        return lastCreateScheduledQueryRequest;
     }
 
     @Override
@@ -47,6 +56,7 @@ public class AmazonTimestreamQueryClientMock implements TimestreamQueryClient {
 
     @Override
     public CreateScheduledQueryResponse createScheduledQuery(CreateScheduledQueryRequest createScheduledQueryRequest) {
+        this.lastCreateScheduledQueryRequest = createScheduledQueryRequest;
         CreateScheduledQueryResponse.Builder result = CreateScheduledQueryResponse.builder();
         result.arn("aws-timestream:test:scheduled-query:arn");
         return result.build();

--- a/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerTest.java
+++ b/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerTest.java
@@ -107,6 +107,13 @@ public class Timestream2QueryProducerTest extends CamelTestSupport {
 
         CreateScheduledQueryResponse resultGet = (CreateScheduledQueryResponse) exchange.getIn().getBody();
         assertEquals("aws-timestream:test:scheduled-query:arn", resultGet.arn());
+
+        // The time-column header must land in timeColumn and must not overwrite the table name.
+        TimestreamConfiguration timestreamConfiguration
+                = clientMock.getLastCreateScheduledQueryRequest().targetConfiguration().timestreamConfiguration();
+        assertEquals("TESTDB", timestreamConfiguration.databaseName());
+        assertEquals("TESTTABLE", timestreamConfiguration.tableName());
+        assertEquals("time", timestreamConfiguration.timeColumn());
     }
 
     @Test


### PR DESCRIPTION
Backport of #24909 to `camel-4.18.x`. Fixes [CAMEL-24200](https://issues.apache.org/jira/browse/CAMEL-24200) on the 4.18.x line.

The time-column header was written into the target TimestreamConfiguration's `tableName` instead of `timeColumn`, so the required time column was never set and a supplied table name was silently overwritten. Also removes a duplicated `scheduledQueryExecutionRoleArn` block.

Existing module tests extended in the original PR pass on this branch.

---
_Claude Code on behalf of oscerd_