### PR TITLE
[backport camel-4.18.x] CAMEL-24201: camel-aws2-step-functions - listExecutions sets the state machine ARN

### DIFF
--- a/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
@@ -633,6 +633,10 @@ public class StepFunctions2Producer extends DefaultProducer {
             }
         } else {
             ListExecutionsRequest.Builder builder = ListExecutionsRequest.builder();
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(StepFunctions2Constants.STATE_MACHINE_ARN))) {
+                String stateMachineArn = exchange.getIn().getHeader(StepFunctions2Constants.STATE_MACHINE_ARN, String.class);
+                builder.stateMachineArn(stateMachineArn);
+            }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(StepFunctions2Constants.EXECUTIONS_MAX_RESULTS))) {
                 int maxRes = exchange.getIn().getHeader(StepFunctions2Constants.EXECUTIONS_MAX_RESULTS, Integer.class);
                 builder.maxResults(maxRes);

--- a/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/AmazonStepFunctionsClientMock.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/AmazonStepFunctionsClientMock.java
@@ -25,7 +25,16 @@ import software.amazon.awssdk.services.sfn.model.*;
 
 public class AmazonStepFunctionsClientMock implements SfnClient {
 
+    private ListExecutionsRequest lastListExecutionsRequest;
+
     public AmazonStepFunctionsClientMock() {
+    }
+
+    /**
+     * The last request passed to {@link #listExecutions}, so tests can assert how it was built.
+     */
+    public ListExecutionsRequest getLastListExecutionsRequest() {
+        return lastListExecutionsRequest;
     }
 
     @Override
@@ -102,6 +111,7 @@ public class AmazonStepFunctionsClientMock implements SfnClient {
 
     @Override
     public ListExecutionsResponse listExecutions(ListExecutionsRequest listExecutionsRequest) {
+        this.lastListExecutionsRequest = listExecutionsRequest;
         ListExecutionsResponse.Builder result = ListExecutionsResponse.builder();
         List<ExecutionListItem> executionListItems = new ArrayList<>();
         executionListItems.add(ExecutionListItem.builder().executionArn("aws:sfn-execution::test-arn").build());

--- a/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerTest.java
@@ -308,6 +308,7 @@ public class StepFunctions2ProducerTest extends CamelTestSupport {
             @Override
             public void process(Exchange exchange) {
                 exchange.getIn().setHeader(StepFunctions2Constants.OPERATION, StepFunctions2Operations.listExecutions);
+                exchange.getIn().setHeader(StepFunctions2Constants.STATE_MACHINE_ARN, "aws:sfn::test-state-machine");
             }
         });
 
@@ -316,6 +317,8 @@ public class StepFunctions2ProducerTest extends CamelTestSupport {
         ListExecutionsResponse resultGet = (ListExecutionsResponse) exchange.getIn().getBody();
         assertEquals(1, resultGet.executions().size());
         assertEquals("aws:sfn-execution::test-arn", resultGet.executions().get(0).executionArn());
+        // ListExecutions requires the state machine ARN; it must be taken from the header.
+        assertEquals("aws:sfn::test-state-machine", clientMock.getLastListExecutionsRequest().stateMachineArn());
     }
 
     @Test


### PR DESCRIPTION
Backport of #24928 to `camel-4.18.x`. Fixes [CAMEL-24201](https://issues.apache.org/jira/browse/CAMEL-24201) on the 4.18.x line.

`listExecutions` never read `CamelAwsStepFunctionsStateMachineArn`, which the AWS ListExecutions API requires, so the operation always failed in header mode.

Existing module tests extended in the original PR pass on this branch.

---
_Claude Code on behalf of oscerd_