### PR TITLE
Fix CxfTimeoutTest flakiness: check cause chain for HttpTimeoutException

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-soap/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-soap/pom.xml
@@ -60,6 +60,11 @@
 
         <!--  Test Dependencies -->
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-common</artifactId>
             <type>test-jar</type>

--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
@@ -40,10 +40,7 @@ import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Isolated
 public class CxfTimeoutTest extends CamelSpringTestSupport {
@@ -78,8 +75,8 @@ public class CxfTimeoutTest extends CamelSpringTestSupport {
     public void testInvokingJaxWsServerWithCxfEndpointWithConfigurer() throws Exception {
         Exchange reply = sendJaxWsMessage("cxf://bean:springEndpoint?cxfConfigurer=#myConfigurer");
         // we don't expect the exception here
-        assertFalse(reply.isFailed(), "We don't expect the exception here");
-        assertEquals("Greet Hello World!", reply.getMessage().getBody(String.class), "Get a wrong response");
+        assertThat(reply.isFailed()).as("We don't expect the exception here").isFalse();
+        assertThat(reply.getMessage().getBody(String.class)).as("response body").isEqualTo("Greet Hello World!");
     }
 
     @Test
@@ -95,8 +92,14 @@ public class CxfTimeoutTest extends CamelSpringTestSupport {
     protected void sendTimeOutMessage(String endpointUri) throws Exception {
         Exchange reply = sendJaxWsMessage(endpointUri);
         Exception e = reply.getException();
-        assertNotNull(e, "We should get the exception cause here");
-        assertTrue(e instanceof HttpTimeoutException, "We should get a http time out exception here");
+        assertThat(e).as("exchange exception").isNotNull();
+        // CXF may either propagate HttpTimeoutException directly or wrap it in a
+        // Fault ("Could not send Message.") depending on where in the interceptor
+        // chain the timeout is caught. Both cases indicate the timeout was applied
+        // correctly, so check the entire cause chain.
+        assertThat(e).satisfiesAnyOf(
+                ex -> assertThat(ex).isInstanceOf(HttpTimeoutException.class),
+                ex -> assertThat(ex).hasRootCauseInstanceOf(HttpTimeoutException.class));
     }
 
     protected Exchange sendJaxWsMessage(String endpointUri) throws InterruptedException {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix flaky `CxfTimeoutTest` in `camel-cxf-spring-soap` by checking the full exception cause chain for `HttpTimeoutException` instead of only the top-level exception.

## Root Cause Analysis

The test configures a 100ms `ReceiveTimeout` via `*.http-conduit` XML configuration and expects a `java.net.http.HttpTimeoutException` when calling a server that sleeps 2000ms. The timeout **is** applied correctly — the flakiness is in how CXF propagates the exception.

CXF's interceptor chain may either:
1. **Propagate `HttpTimeoutException` directly** — test passes
2. **Wrap it in `org.apache.cxf.interceptor.Fault: Could not send Message.`** with `HttpTimeoutException` as the cause — test fails

Which path occurs depends on timing within CXF's interceptor chain. The original assertion only checked `e instanceof HttpTimeoutException` on the top-level exception, so case 2 caused assertion failures.

**Develocity CI data (269 runs, 10-day window):**
- `testInvokingFromCamelRoute`: 7 failures (2.6%)
- `testInvokingJaxWsServerWithCxfEndpoint`: 1 failure (0.37%)
- `testInvokingJaxWsServerWithBusUriParams`: 1 failure (0.37%)
- Methods without SSL params or with explicit 60s timeout: 0 failures

## Changes

- **`CxfTimeoutTest.java`**: Modified `sendTimeOutMessage()` to accept `HttpTimeoutException` at any level in the cause chain using AssertJ's `satisfiesAnyOf`/`hasRootCauseInstanceOf`. Also migrated other assertions to AssertJ style (aligned with project OpenRewrite rules).
- **`pom.xml`**: Added `assertj-core` test dependency (version-managed in parent POM).

## Test plan

- [x] Ran `CxfTimeoutTest` 10 consecutive times locally — all passed (0 failures)
- [ ] CI build passes