### PR TITLE
CAMEL-24046 - avoid system property leak to other tests from ZXsltTotalOpsTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/ZXsltTotalOpsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/ZXsltTotalOpsTest.java
@@ -20,6 +20,7 @@ import javax.xml.transform.TransformerConfigurationException;
 
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
@@ -32,6 +33,12 @@ public class ZXsltTotalOpsTest extends ContextTestSupport {
     @Override
     public boolean isUseRouteBuilder() {
         return false;
+    }
+
+    @AfterEach
+    void clearXpathLimit() {
+        // Workaround to https://issues.apache.org/jira/browse/CAMEL-24216
+        System.clearProperty("jdk.xml.xpathTotalOpLimit");
     }
 
     @Test


### PR DESCRIPTION

when it is failing, usually the 2nd and 3rd run are failing with:

```
org.apache.camel.FailedToCreateRouteException: Failed to create route:
route8150 at: >>> to[xslt:org/apache/camel/component/xslt/example.xsl]
<<< in route:
Route(route8150)[From[file:/tmp/junit-11867091151342813293?m... because:
Failed to resolve endpoint:
xslt://org/apache/camel/component/xslt/example.xsl due to:
javax.xml.transform.TransformerConfigurationException: JAXP0801003: the
compiler encountered XPath expressions with an accumulated '2' operators
that exceeds the '1' limit set by 'system property'.
```
When I checked on the workspace filesystem of a failed build the file camel-core/target/test-classes/org/apache/camel/component/xslt/example.xsl seems fine.
But maybe the file is locked at that time or modified temporarily by another test, so modified the test to use a specific xsl file for this test class.

Note that it doesn't impact the first flaky failure which is usually another error.

I propose to first try this way to see if we can get rid of the 2nd and 3rd failure, which are causing the build to fail. if there is only the first attempt failing, it is not nice but only flaky and few seconds are lost.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

