### PR TITLE
CAMEL-23562: camel-xmpp - upgrade Smack from 4.3.5 to 4.4.8

### DIFF
--- a/components/camel-xmpp/pom.xml
+++ b/components/camel-xmpp/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
-            <artifactId>smack-java7</artifactId>
+            <artifactId>smack-java8</artifactId>
             <version>${smack-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppBinding.java
@@ -24,9 +24,9 @@ import org.apache.camel.Exchange;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.util.ObjectHelper;
-import org.jivesoftware.smack.packet.DefaultExtensionElement;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.StandardExtensionElement;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 import org.jivesoftware.smackx.jiveproperties.packet.JivePropertiesExtension;
@@ -135,8 +135,8 @@ public class XmppBinding {
         if (jpe instanceof JivePropertiesExtension) {
             extractHeadersFrom((JivePropertiesExtension) jpe, exchange, answer);
         }
-        if (jpe instanceof DefaultExtensionElement) {
-            extractHeadersFrom((DefaultExtensionElement) jpe, exchange, answer);
+        if (jpe instanceof StandardExtensionElement) {
+            extractHeadersFrom((StandardExtensionElement) jpe, exchange, answer);
         }
 
         if (stanza instanceof Message) {
@@ -165,9 +165,10 @@ public class XmppBinding {
         }
     }
 
-    private void extractHeadersFrom(DefaultExtensionElement jpe, Exchange exchange, Map<String, Object> answer) {
-        for (String name : jpe.getNames()) {
-            Object value = jpe.getValue(name);
+    private void extractHeadersFrom(StandardExtensionElement jpe, Exchange exchange, Map<String, Object> answer) {
+        for (StandardExtensionElement element : jpe.getElements()) {
+            String name = element.getElementName();
+            Object value = element.getText();
             if (!headerFilterStrategy.applyFilterToExternalHeaders(name, value, exchange)) {
                 answer.put(name, value);
             }

--- a/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppLogger.java
+++ b/components/camel-xmpp/src/main/java/org/apache/camel/component/xmpp/XmppLogger.java
@@ -33,7 +33,7 @@ public class XmppLogger implements StanzaListener {
     @Override
     public void processStanza(Stanza stanza) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("{} : {}", direction, stanza.toXML(null));
+            LOG.debug("{} : {}", direction, stanza.toXML());
         }
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -497,6 +497,16 @@ by the file-based consumers (see the `localWorkDirectory` note in the 4.21 upgra
 Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
 `IllegalArgumentException`.
 
+=== camel-xmpp - Smack upgraded to 4.4
+
+The camel-xmpp component has upgraded Smack from 4.3.5 to 4.4.8. The `smack-java7` module no longer exists in
+Smack 4.4 and has been replaced by `smack-java8` (relevant if you declared it explicitly alongside camel-xmpp).
+When extracting headers from a stanza whose JiveProperties extension is not parsed by a registered provider,
+the unparsed extension is now represented by Smack's `StandardExtensionElement` (the replacement for the removed
+`DefaultExtensionElement`); flat child elements are mapped to headers as before. See the
+https://github.com/igniterealtime/Smack/wiki/Smack-4.4-Readme[Smack 4.4 readme] for behavioral changes in the
+Smack library itself.
+
 === camel-weaviate - potential breaking change
 
 The Weaviate Java client has been upgraded from v5 (`io.weaviate:client`) to v6 (`io.weaviate:client6`).

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -467,7 +467,7 @@
         <slack-api-model-version>1.49.0</slack-api-model-version>
         <slf4j-api-version>2.0.18</slf4j-api-version>
         <slf4j-version>2.0.17</slf4j-version>
-        <smack-version>4.3.5</smack-version>
+        <smack-version>4.4.8</smack-version>
         <smallrye-config-version>3.18.1</smallrye-config-version>
         <smallrye-health-version>4.3.0</smallrye-health-version>
         <smallrye-fault-tolerance-version>6.11.2</smallrye-fault-tolerance-version>


### PR DESCRIPTION
### Motivation

[CAMEL-23562](https://issues.apache.org/jira/browse/CAMEL-23562): upgrade Smack to the 4.4.x line (4.4.8 is the latest stable on Maven Central; 4.5 is still in beta). We were on 4.3.5, released in 2019.

### Changes

- `smack-version` 4.3.5 → 4.4.8; `smack-java7` (gone in 4.4) replaced by `smack-java8` in the camel-xmpp pom.
- `XmppBinding`: `DefaultExtensionElement` was removed in Smack 4.4 — the fallback branch for an unparsed JiveProperties extension now uses its replacement `StandardExtensionElement`, mapping flat child elements to headers with the same header-filter application as before. (The primary `JivePropertiesExtension` path is unchanged.)
- `XmppLogger`: `stanza.toXML(null)` is ambiguous against the 4.4 `Element` overloads (`toXML(XmlEnvironment)` vs `toXML(String)`) — switched to the no-arg `toXML()`.
- Upgrade-guide entry (4.22) noting the upgrade, the module rename, and linking the Smack 4.4 readme for library-level behavioral changes.

### Testing

- Unit tests: all pass.
- The module's container-based integration tests (`*IT`, XMPP server via test-infra) fail in my environment with `SSLHandshakeException: Remote host terminated the handshake` — **identically on current main with Smack 4.3.5** (verified by running the baseline first: same 1 failure + 6 errors, same exception). So their outcome is unchanged by this upgrade; the pre-existing test-server TLS issue can be looked at separately.
- Full reactor `mvn clean install -DskipTests` from root: success, no stale generated files.

No backport: dependency upgrade, main/4.22.0 only.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)