### PR TITLE
CAMEL-24119: Fix thread-safety in camel-openapi-java global state

### DIFF
--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestModelConverters.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestModelConverters.java
@@ -44,14 +44,14 @@ public class RestModelConverters {
     private static final ModelConverters MODEL31_CONVERTERS;
 
     static {
-        MODEL31_CONVERTERS = ModelConverters.getInstance(true);
+        MODEL31_CONVERTERS = new ModelConverters(true);
         MODEL31_CONVERTERS.addConverter(new ClassNameExtensionModelResolver(new FqnModelResolver(true)));
     }
 
     private static final ModelConverters MODEL30_CONVERTERS;
 
     static {
-        MODEL30_CONVERTERS = ModelConverters.getInstance();
+        MODEL30_CONVERTERS = new ModelConverters();
         MODEL30_CONVERTERS.addConverter(new ClassNameExtensionModelResolver(new FqnModelResolver()));
     }
 

--- a/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
+++ b/components/camel-openapi-java/src/main/java/org/apache/camel/openapi/RestOpenApiSupport.java
@@ -376,14 +376,12 @@ public class RestOpenApiSupport {
     }
 
     private static String getFromOpenAPI3(OpenAPI openAPI3, ObjectMapper mapper) {
-        DateFormat origin = mapper.getDateFormat();
         try {
-            mapper.setDateFormat(DEFAULT_DATE_FORMAT);
-            return mapper.writer(new DefaultPrettyPrinter()).writeValueAsString(openAPI3);
+            return mapper.writer(new DefaultPrettyPrinter())
+                    .with(DEFAULT_DATE_FORMAT)
+                    .writeValueAsString(openAPI3);
         } catch (Exception e) {
             return null;
-        } finally {
-            mapper.setDateFormat(origin);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **RestModelConverters**: use `new ModelConverters()` instead of `ModelConverters.getInstance()` to create Camel-private instances, preventing Camel's custom converters from polluting the JVM-global swagger-core singleton shared by other libraries in the same process.
- **RestOpenApiSupport**: use `ObjectWriter.with(DateFormat)` instead of temporarily mutating the global `ObjectMapper`'s date format (save → set → serialize → restore), eliminating a race condition when concurrent HTTP requests serialize OpenAPI specs via `getFromOpenAPI3`.

Part of the [CAMEL-24119](https://issues.apache.org/jira/browse/CAMEL-24119) umbrella (thread-safety category).

## Test plan

- [x] All 97 existing tests in `camel-openapi-java` pass (model conversion, reader, support, complex types, security schemes)
- [ ] Verify no regressions in downstream consumers (`camel-rest-openapi`, Spring Boot / Quarkus OpenAPI integration tests)

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)