### PR TITLE
chore: fix model writer property ordering for *Common classes

### DIFF
--- a/core/camel-java-io/src/generated/java/org/apache/camel/java/out/JavaDslModelWriter.java
+++ b/core/camel-java-io/src/generated/java/org/apache/camel/java/out/JavaDslModelWriter.java
@@ -1906,18 +1906,18 @@ public class JavaDslModelWriter extends JavaDslModelWriterSupport {
     }
     protected void doWriteFaultToleranceConfigurationCommonAttributes(StringBuilder sb, FaultToleranceConfigurationCommon def) {
         doWriteIdentifiedTypeAttributes(sb, def);
-        doWriteAttribute(sb, "delay", def.getDelay(), "5000");
-        doWriteAttribute(sb, "bulkheadWaitingTaskQueue", def.getBulkheadWaitingTaskQueue(), "10");
         doWriteAttribute(sb, "typedGuard", def.getTypedGuard(), null);
-        doWriteAttribute(sb, "failureRatio", def.getFailureRatio(), "50");
-        doWriteAttribute(sb, "timeoutDuration", def.getTimeoutDuration(), "1000");
-        doWriteAttribute(sb, "timeoutEnabled", def.getTimeoutEnabled(), "false");
-        doWriteAttribute(sb, "timeoutPoolSize", def.getTimeoutPoolSize(), "10");
+        doWriteAttribute(sb, "delay", def.getDelay(), "5000");
         doWriteAttribute(sb, "successThreshold", def.getSuccessThreshold(), "1");
         doWriteAttribute(sb, "requestVolumeThreshold", def.getRequestVolumeThreshold(), "20");
-        doWriteAttribute(sb, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "10");
-        doWriteAttribute(sb, "threadOffloadExecutorService", def.getThreadOffloadExecutorService(), null);
+        doWriteAttribute(sb, "failureRatio", def.getFailureRatio(), "50");
+        doWriteAttribute(sb, "timeoutEnabled", def.getTimeoutEnabled(), "false");
+        doWriteAttribute(sb, "timeoutDuration", def.getTimeoutDuration(), "1000");
+        doWriteAttribute(sb, "timeoutPoolSize", def.getTimeoutPoolSize(), "10");
         doWriteAttribute(sb, "bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute(sb, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "10");
+        doWriteAttribute(sb, "bulkheadWaitingTaskQueue", def.getBulkheadWaitingTaskQueue(), "10");
+        doWriteAttribute(sb, "threadOffloadExecutorService", def.getThreadOffloadExecutorService(), null);
     }
     protected void doWriteFaultToleranceConfigurationCommon(StringBuilder sb, FaultToleranceConfigurationCommon def) {
         doWriteFaultToleranceConfigurationCommonAttributes(sb, def);
@@ -2311,27 +2311,27 @@ public class JavaDslModelWriter extends JavaDslModelWriterSupport {
     }
     protected void doWriteResilience4jConfigurationCommonAttributes(StringBuilder sb, Resilience4jConfigurationCommon def) {
         doWriteIdentifiedTypeAttributes(sb, def);
+        doWriteAttribute(sb, "circuitBreaker", def.getCircuitBreaker(), null);
+        doWriteAttribute(sb, "config", def.getConfig(), null);
         doWriteAttribute(sb, "failureRateThreshold", def.getFailureRateThreshold(), "50");
-        doWriteAttribute(sb, "bulkheadMaxWaitDuration", def.getBulkheadMaxWaitDuration(), "0");
-        doWriteAttribute(sb, "slowCallDurationThreshold", def.getSlowCallDurationThreshold(), "60");
-        doWriteAttribute(sb, "timeoutCancelRunningFuture", def.getTimeoutCancelRunningFuture(), "true");
-        doWriteAttribute(sb, "minimumNumberOfCalls", def.getMinimumNumberOfCalls(), "100");
-        doWriteAttribute(sb, "timeoutDuration", def.getTimeoutDuration(), "1000");
-        doWriteAttribute(sb, "timeoutEnabled", def.getTimeoutEnabled(), "false");
-        doWriteAttribute(sb, "timeoutExecutorService", def.getTimeoutExecutorService(), null);
         doWriteAttribute(sb, "permittedNumberOfCallsInHalfOpenState", def.getPermittedNumberOfCallsInHalfOpenState(), "10");
         doWriteAttribute(sb, "throwExceptionWhenHalfOpenOrOpenState", def.getThrowExceptionWhenHalfOpenOrOpenState(), "false");
-        doWriteAttribute(sb, "slowCallRateThreshold", def.getSlowCallRateThreshold(), "100");
-        doWriteAttribute(sb, "micrometerEnabled", def.getMicrometerEnabled(), "false");
-        doWriteAttribute(sb, "writableStackTraceEnabled", def.getWritableStackTraceEnabled(), "true");
-        doWriteAttribute(sb, "automaticTransitionFromOpenToHalfOpenEnabled", def.getAutomaticTransitionFromOpenToHalfOpenEnabled(), "false");
-        doWriteAttribute(sb, "circuitBreaker", def.getCircuitBreaker(), null);
         doWriteAttribute(sb, "slidingWindowSize", def.getSlidingWindowSize(), "100");
-        doWriteAttribute(sb, "config", def.getConfig(), null);
-        doWriteAttribute(sb, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "25");
         doWriteAttribute(sb, "slidingWindowType", def.getSlidingWindowType(), "COUNT_BASED");
-        doWriteAttribute(sb, "bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute(sb, "minimumNumberOfCalls", def.getMinimumNumberOfCalls(), "100");
+        doWriteAttribute(sb, "writableStackTraceEnabled", def.getWritableStackTraceEnabled(), "true");
         doWriteAttribute(sb, "waitDurationInOpenState", def.getWaitDurationInOpenState(), "60");
+        doWriteAttribute(sb, "automaticTransitionFromOpenToHalfOpenEnabled", def.getAutomaticTransitionFromOpenToHalfOpenEnabled(), "false");
+        doWriteAttribute(sb, "slowCallRateThreshold", def.getSlowCallRateThreshold(), "100");
+        doWriteAttribute(sb, "slowCallDurationThreshold", def.getSlowCallDurationThreshold(), "60");
+        doWriteAttribute(sb, "bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute(sb, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "25");
+        doWriteAttribute(sb, "bulkheadMaxWaitDuration", def.getBulkheadMaxWaitDuration(), "0");
+        doWriteAttribute(sb, "timeoutEnabled", def.getTimeoutEnabled(), "false");
+        doWriteAttribute(sb, "timeoutExecutorService", def.getTimeoutExecutorService(), null);
+        doWriteAttribute(sb, "timeoutDuration", def.getTimeoutDuration(), "1000");
+        doWriteAttribute(sb, "timeoutCancelRunningFuture", def.getTimeoutCancelRunningFuture(), "true");
+        doWriteAttribute(sb, "micrometerEnabled", def.getMicrometerEnabled(), "false");
     }
     protected void doWriteResilience4jConfigurationCommonElements(StringBuilder sb, Resilience4jConfigurationCommon def) {
         doWriteStringList(sb, null, "ignoreException", def.getIgnoreExceptions());

--- a/core/camel-xml-io/src/generated/java/org/apache/camel/xml/out/ModelWriter.java
+++ b/core/camel-xml-io/src/generated/java/org/apache/camel/xml/out/ModelWriter.java
@@ -1004,18 +1004,18 @@ public class ModelWriter extends BaseWriter {
     }
     protected void doWriteFaultToleranceConfigurationCommonAttributes(FaultToleranceConfigurationCommon def) throws IOException {
         doWriteIdentifiedTypeAttributes(def);
-        doWriteAttribute("delay", def.getDelay(), "5000");
-        doWriteAttribute("bulkheadWaitingTaskQueue", def.getBulkheadWaitingTaskQueue(), "10");
         doWriteAttribute("typedGuard", def.getTypedGuard(), null);
-        doWriteAttribute("failureRatio", def.getFailureRatio(), "50");
-        doWriteAttribute("timeoutDuration", def.getTimeoutDuration(), "1000");
-        doWriteAttribute("timeoutEnabled", def.getTimeoutEnabled(), "false");
-        doWriteAttribute("timeoutPoolSize", def.getTimeoutPoolSize(), "10");
+        doWriteAttribute("delay", def.getDelay(), "5000");
         doWriteAttribute("successThreshold", def.getSuccessThreshold(), "1");
         doWriteAttribute("requestVolumeThreshold", def.getRequestVolumeThreshold(), "20");
-        doWriteAttribute("bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "10");
-        doWriteAttribute("threadOffloadExecutorService", def.getThreadOffloadExecutorService(), null);
+        doWriteAttribute("failureRatio", def.getFailureRatio(), "50");
+        doWriteAttribute("timeoutEnabled", def.getTimeoutEnabled(), "false");
+        doWriteAttribute("timeoutDuration", def.getTimeoutDuration(), "1000");
+        doWriteAttribute("timeoutPoolSize", def.getTimeoutPoolSize(), "10");
         doWriteAttribute("bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute("bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "10");
+        doWriteAttribute("bulkheadWaitingTaskQueue", def.getBulkheadWaitingTaskQueue(), "10");
+        doWriteAttribute("threadOffloadExecutorService", def.getThreadOffloadExecutorService(), null);
     }
     protected void doWriteFaultToleranceConfigurationCommon(String name, FaultToleranceConfigurationCommon def) throws IOException {
         startElement(name);
@@ -1505,27 +1505,27 @@ public class ModelWriter extends BaseWriter {
     }
     protected void doWriteResilience4jConfigurationCommonAttributes(Resilience4jConfigurationCommon def) throws IOException {
         doWriteIdentifiedTypeAttributes(def);
+        doWriteAttribute("circuitBreaker", def.getCircuitBreaker(), null);
+        doWriteAttribute("config", def.getConfig(), null);
         doWriteAttribute("failureRateThreshold", def.getFailureRateThreshold(), "50");
-        doWriteAttribute("bulkheadMaxWaitDuration", def.getBulkheadMaxWaitDuration(), "0");
-        doWriteAttribute("slowCallDurationThreshold", def.getSlowCallDurationThreshold(), "60");
-        doWriteAttribute("timeoutCancelRunningFuture", def.getTimeoutCancelRunningFuture(), "true");
-        doWriteAttribute("minimumNumberOfCalls", def.getMinimumNumberOfCalls(), "100");
-        doWriteAttribute("timeoutDuration", def.getTimeoutDuration(), "1000");
-        doWriteAttribute("timeoutEnabled", def.getTimeoutEnabled(), "false");
-        doWriteAttribute("timeoutExecutorService", def.getTimeoutExecutorService(), null);
         doWriteAttribute("permittedNumberOfCallsInHalfOpenState", def.getPermittedNumberOfCallsInHalfOpenState(), "10");
         doWriteAttribute("throwExceptionWhenHalfOpenOrOpenState", def.getThrowExceptionWhenHalfOpenOrOpenState(), "false");
-        doWriteAttribute("slowCallRateThreshold", def.getSlowCallRateThreshold(), "100");
-        doWriteAttribute("micrometerEnabled", def.getMicrometerEnabled(), "false");
-        doWriteAttribute("writableStackTraceEnabled", def.getWritableStackTraceEnabled(), "true");
-        doWriteAttribute("automaticTransitionFromOpenToHalfOpenEnabled", def.getAutomaticTransitionFromOpenToHalfOpenEnabled(), "false");
-        doWriteAttribute("circuitBreaker", def.getCircuitBreaker(), null);
         doWriteAttribute("slidingWindowSize", def.getSlidingWindowSize(), "100");
-        doWriteAttribute("config", def.getConfig(), null);
-        doWriteAttribute("bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "25");
         doWriteAttribute("slidingWindowType", def.getSlidingWindowType(), "COUNT_BASED");
-        doWriteAttribute("bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute("minimumNumberOfCalls", def.getMinimumNumberOfCalls(), "100");
+        doWriteAttribute("writableStackTraceEnabled", def.getWritableStackTraceEnabled(), "true");
         doWriteAttribute("waitDurationInOpenState", def.getWaitDurationInOpenState(), "60");
+        doWriteAttribute("automaticTransitionFromOpenToHalfOpenEnabled", def.getAutomaticTransitionFromOpenToHalfOpenEnabled(), "false");
+        doWriteAttribute("slowCallRateThreshold", def.getSlowCallRateThreshold(), "100");
+        doWriteAttribute("slowCallDurationThreshold", def.getSlowCallDurationThreshold(), "60");
+        doWriteAttribute("bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute("bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "25");
+        doWriteAttribute("bulkheadMaxWaitDuration", def.getBulkheadMaxWaitDuration(), "0");
+        doWriteAttribute("timeoutEnabled", def.getTimeoutEnabled(), "false");
+        doWriteAttribute("timeoutExecutorService", def.getTimeoutExecutorService(), null);
+        doWriteAttribute("timeoutDuration", def.getTimeoutDuration(), "1000");
+        doWriteAttribute("timeoutCancelRunningFuture", def.getTimeoutCancelRunningFuture(), "true");
+        doWriteAttribute("micrometerEnabled", def.getMicrometerEnabled(), "false");
     }
     protected void doWriteResilience4jConfigurationCommonElements(Resilience4jConfigurationCommon def) throws IOException {
         doWriteList(null, "ignoreException", def.getIgnoreExceptions(), this::doWriteString);

--- a/core/camel-yaml-io/src/generated/java/org/apache/camel/yaml/out/YamlModelWriter.java
+++ b/core/camel-yaml-io/src/generated/java/org/apache/camel/yaml/out/YamlModelWriter.java
@@ -999,18 +999,18 @@ public class YamlModelWriter extends YamlModelWriterSupport {
     }
     protected void doWriteFaultToleranceConfigurationCommonAttributes(JsonObject jo, FaultToleranceConfigurationCommon def) {
         doWriteIdentifiedTypeAttributes(jo, def);
-        doWriteAttribute(jo, "delay", def.getDelay(), "5000");
-        doWriteAttribute(jo, "bulkheadWaitingTaskQueue", def.getBulkheadWaitingTaskQueue(), "10");
         doWriteAttribute(jo, "typedGuard", def.getTypedGuard(), null);
-        doWriteAttribute(jo, "failureRatio", def.getFailureRatio(), "50");
-        doWriteAttribute(jo, "timeoutDuration", def.getTimeoutDuration(), "1000");
-        doWriteAttribute(jo, "timeoutEnabled", def.getTimeoutEnabled(), "false");
-        doWriteAttribute(jo, "timeoutPoolSize", def.getTimeoutPoolSize(), "10");
+        doWriteAttribute(jo, "delay", def.getDelay(), "5000");
         doWriteAttribute(jo, "successThreshold", def.getSuccessThreshold(), "1");
         doWriteAttribute(jo, "requestVolumeThreshold", def.getRequestVolumeThreshold(), "20");
-        doWriteAttribute(jo, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "10");
-        doWriteAttribute(jo, "threadOffloadExecutorService", def.getThreadOffloadExecutorService(), null);
+        doWriteAttribute(jo, "failureRatio", def.getFailureRatio(), "50");
+        doWriteAttribute(jo, "timeoutEnabled", def.getTimeoutEnabled(), "false");
+        doWriteAttribute(jo, "timeoutDuration", def.getTimeoutDuration(), "1000");
+        doWriteAttribute(jo, "timeoutPoolSize", def.getTimeoutPoolSize(), "10");
         doWriteAttribute(jo, "bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute(jo, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "10");
+        doWriteAttribute(jo, "bulkheadWaitingTaskQueue", def.getBulkheadWaitingTaskQueue(), "10");
+        doWriteAttribute(jo, "threadOffloadExecutorService", def.getThreadOffloadExecutorService(), null);
     }
     protected JsonObject doWriteFaultToleranceConfigurationCommon(FaultToleranceConfigurationCommon def) {
         JsonObject jo = new JsonObject();
@@ -1500,27 +1500,27 @@ public class YamlModelWriter extends YamlModelWriterSupport {
     }
     protected void doWriteResilience4jConfigurationCommonAttributes(JsonObject jo, Resilience4jConfigurationCommon def) {
         doWriteIdentifiedTypeAttributes(jo, def);
+        doWriteAttribute(jo, "circuitBreaker", def.getCircuitBreaker(), null);
+        doWriteAttribute(jo, "config", def.getConfig(), null);
         doWriteAttribute(jo, "failureRateThreshold", def.getFailureRateThreshold(), "50");
-        doWriteAttribute(jo, "bulkheadMaxWaitDuration", def.getBulkheadMaxWaitDuration(), "0");
-        doWriteAttribute(jo, "slowCallDurationThreshold", def.getSlowCallDurationThreshold(), "60");
-        doWriteAttribute(jo, "timeoutCancelRunningFuture", def.getTimeoutCancelRunningFuture(), "true");
-        doWriteAttribute(jo, "minimumNumberOfCalls", def.getMinimumNumberOfCalls(), "100");
-        doWriteAttribute(jo, "timeoutDuration", def.getTimeoutDuration(), "1000");
-        doWriteAttribute(jo, "timeoutEnabled", def.getTimeoutEnabled(), "false");
-        doWriteAttribute(jo, "timeoutExecutorService", def.getTimeoutExecutorService(), null);
         doWriteAttribute(jo, "permittedNumberOfCallsInHalfOpenState", def.getPermittedNumberOfCallsInHalfOpenState(), "10");
         doWriteAttribute(jo, "throwExceptionWhenHalfOpenOrOpenState", def.getThrowExceptionWhenHalfOpenOrOpenState(), "false");
-        doWriteAttribute(jo, "slowCallRateThreshold", def.getSlowCallRateThreshold(), "100");
-        doWriteAttribute(jo, "micrometerEnabled", def.getMicrometerEnabled(), "false");
-        doWriteAttribute(jo, "writableStackTraceEnabled", def.getWritableStackTraceEnabled(), "true");
-        doWriteAttribute(jo, "automaticTransitionFromOpenToHalfOpenEnabled", def.getAutomaticTransitionFromOpenToHalfOpenEnabled(), "false");
-        doWriteAttribute(jo, "circuitBreaker", def.getCircuitBreaker(), null);
         doWriteAttribute(jo, "slidingWindowSize", def.getSlidingWindowSize(), "100");
-        doWriteAttribute(jo, "config", def.getConfig(), null);
-        doWriteAttribute(jo, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "25");
         doWriteAttribute(jo, "slidingWindowType", def.getSlidingWindowType(), "COUNT_BASED");
-        doWriteAttribute(jo, "bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute(jo, "minimumNumberOfCalls", def.getMinimumNumberOfCalls(), "100");
+        doWriteAttribute(jo, "writableStackTraceEnabled", def.getWritableStackTraceEnabled(), "true");
         doWriteAttribute(jo, "waitDurationInOpenState", def.getWaitDurationInOpenState(), "60");
+        doWriteAttribute(jo, "automaticTransitionFromOpenToHalfOpenEnabled", def.getAutomaticTransitionFromOpenToHalfOpenEnabled(), "false");
+        doWriteAttribute(jo, "slowCallRateThreshold", def.getSlowCallRateThreshold(), "100");
+        doWriteAttribute(jo, "slowCallDurationThreshold", def.getSlowCallDurationThreshold(), "60");
+        doWriteAttribute(jo, "bulkheadEnabled", def.getBulkheadEnabled(), "false");
+        doWriteAttribute(jo, "bulkheadMaxConcurrentCalls", def.getBulkheadMaxConcurrentCalls(), "25");
+        doWriteAttribute(jo, "bulkheadMaxWaitDuration", def.getBulkheadMaxWaitDuration(), "0");
+        doWriteAttribute(jo, "timeoutEnabled", def.getTimeoutEnabled(), "false");
+        doWriteAttribute(jo, "timeoutExecutorService", def.getTimeoutExecutorService(), null);
+        doWriteAttribute(jo, "timeoutDuration", def.getTimeoutDuration(), "1000");
+        doWriteAttribute(jo, "timeoutCancelRunningFuture", def.getTimeoutCancelRunningFuture(), "true");
+        doWriteAttribute(jo, "micrometerEnabled", def.getMicrometerEnabled(), "false");
     }
     protected void doWriteResilience4jConfigurationCommonElements(JsonObject jo, Resilience4jConfigurationCommon def) {
         doWriteStringList(jo, null, "ignoreException", def.getIgnoreExceptions());

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ModelWriterGeneratorMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/ModelWriterGeneratorMojo.java
@@ -338,7 +338,11 @@ public abstract class ModelWriterGeneratorMojo extends AbstractGeneratorMojo {
             modelName = "org.apache.camel.model.ProcessDefinition";
         }
 
-        EipModel m = allModels.get(modelName);
+        EipModel em = allModels.get(modelName);
+        if (em == null && modelName.endsWith("Common")) {
+            em = allModels.get(modelName.replace("Common", "Definition"));
+        }
+        final EipModel m = em;
         if (m != null) {
             // special for DSL where XML vs YAML have different names, and we must use as-is due to JAXB @XmlType propOrder
             final Map<String, String> alias = Map.of(


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Fix non-deterministic property ordering in generated model writers (`YamlModelWriter`, `ModelWriter`, `JavaDslModelWriter`) for `*Common` base classes (`Resilience4jConfigurationCommon`, `FaultToleranceConfigurationCommon`)
- The code generator (`ModelWriterGeneratorMojo`) sorts `doWriteAttribute` calls by JSON metadata `index`, but model lookup used the exact class name — `*Common` classes have no model entry (registered under `*Definition`), so sorting was skipped and property order depended on JDK reflection order
- Add fallback: when no model is found and class name ends with `Common`, retry with `Definition` suffix

This fixes the `YamlModelWriterTest.testCircuitBreaker` failure on JDK 25 in PR #24957, where `minimumNumberOfCalls` appeared before `failureRateThreshold` due to different reflection ordering.

## Test plan

- [x] `YamlModelWriterTest.testCircuitBreaker` passes (was failing on JDK 25)
- [x] Full `camel-yaml-io` test suite passes (148 tests)
- [x] Generated writers for all three DSLs (YAML, XML, Java) now follow JSON metadata index order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>