### PR TITLE
CAMEL-23460: camel-telemetry - add span decorators for Google Cloud (messaging & storage batch)

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleBigQuerySpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleBigQuerySpanDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleBigQuerySpanDecorator extends AbstractSpanDecorator {
+
+    static final String BIGQUERY_TABLE_ID = "tableId";
+    static final String BIGQUERY_TABLE_SUFFIX = "tableSuffix";
+    static final String BIGQUERY_PARTITION_DECORATOR = "partitionDecorator";
+    static final String BIGQUERY_JOB_ID = "jobId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.bigquery.GoogleBigQueryConstants}
+     */
+    static final String TABLE_ID = "CamelGoogleBigQueryTableId";
+    static final String TABLE_SUFFIX = "CamelGoogleBigQueryTableSuffix";
+    static final String PARTITION_DECORATOR = "CamelGoogleBigQueryPartitionDecorator";
+    static final String JOB_ID = "CamelGoogleBigQueryJobId";
+
+    @Override
+    public String getComponent() {
+        return "google-bigquery";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.bigquery.GoogleBigQueryComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String tableId = exchange.getIn().getHeader(TABLE_ID, String.class);
+        if (tableId != null) {
+            span.setTag(BIGQUERY_TABLE_ID, tableId);
+        }
+
+        String tableSuffix = exchange.getIn().getHeader(TABLE_SUFFIX, String.class);
+        if (tableSuffix != null) {
+            span.setTag(BIGQUERY_TABLE_SUFFIX, tableSuffix);
+        }
+
+        String partitionDecorator = exchange.getIn().getHeader(PARTITION_DECORATOR, String.class);
+        if (partitionDecorator != null) {
+            span.setTag(BIGQUERY_PARTITION_DECORATOR, partitionDecorator);
+        }
+
+        String jobId = exchange.getIn().getHeader(JOB_ID, String.class);
+        if (jobId != null) {
+            span.setTag(BIGQUERY_JOB_ID, jobId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleFirestoreSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleFirestoreSpanDecorator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleFirestoreSpanDecorator extends AbstractSpanDecorator {
+
+    static final String FIRESTORE_OPERATION = "operation";
+    static final String FIRESTORE_COLLECTION_NAME = "collectionName";
+    static final String FIRESTORE_DOCUMENT_ID = "documentId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.firestore.GoogleFirestoreConstants}
+     */
+    static final String OPERATION = "CamelGoogleFirestoreOperation";
+    static final String COLLECTION_NAME = "CamelGoogleFirestoreCollectionName";
+    static final String DOCUMENT_ID = "CamelGoogleFirestoreDocumentId";
+
+    @Override
+    public String getComponent() {
+        return "google-firestore";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.firestore.GoogleFirestoreComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(FIRESTORE_OPERATION, operation.toString());
+        }
+
+        String collectionName = exchange.getIn().getHeader(COLLECTION_NAME, String.class);
+        if (collectionName != null) {
+            span.setTag(FIRESTORE_COLLECTION_NAME, collectionName);
+        }
+
+        String documentId = exchange.getIn().getHeader(DOCUMENT_ID, String.class);
+        if (documentId != null) {
+            span.setTag(FIRESTORE_DOCUMENT_ID, documentId);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GooglePubsubSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GooglePubsubSpanDecorator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GooglePubsubSpanDecorator extends AbstractMessagingSpanDecorator {
+
+    static final String PUBSUB_ORDERING_KEY = "orderingKey";
+    static final String PUBSUB_ACK_ID = "ackId";
+    static final String PUBSUB_DELIVERY_ATTEMPT = "deliveryAttempt";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.pubsub.GooglePubsubConstants}
+     */
+    static final String MESSAGE_ID = "CamelGooglePubsubMessageId";
+    static final String ACK_ID = "CamelGooglePubsubMsgAckId";
+    static final String ORDERING_KEY = "CamelGooglePubsubOrderingKey";
+    static final String DELIVERY_ATTEMPT = "CamelGooglePubsubDeliveryAttempt";
+
+    @Override
+    public String getComponent() {
+        return "google-pubsub";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.pubsub.GooglePubsubComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        String orderingKey = exchange.getIn().getHeader(ORDERING_KEY, String.class);
+        if (orderingKey != null) {
+            span.setTag(PUBSUB_ORDERING_KEY, orderingKey);
+        }
+
+        String ackId = exchange.getIn().getHeader(ACK_ID, String.class);
+        if (ackId != null) {
+            span.setTag(PUBSUB_ACK_ID, ackId);
+        }
+
+        Integer deliveryAttempt = exchange.getIn().getHeader(DELIVERY_ATTEMPT, Integer.class);
+        if (deliveryAttempt != null) {
+            span.setTag(PUBSUB_DELIVERY_ATTEMPT, deliveryAttempt.toString());
+        }
+    }
+
+    @Override
+    protected String getMessageId(Exchange exchange) {
+        return exchange.getIn().getHeader(MESSAGE_ID, String.class);
+    }
+
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleStorageSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleStorageSpanDecorator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleStorageSpanDecorator extends AbstractSpanDecorator {
+
+    static final String STORAGE_OPERATION = "operation";
+    static final String STORAGE_BUCKET_NAME = "bucketName";
+    static final String STORAGE_OBJECT_NAME = "objectName";
+    static final String STORAGE_DESTINATION_BUCKET_NAME = "destinationBucketName";
+    static final String STORAGE_DESTINATION_OBJECT_NAME = "destinationObjectName";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.storage.GoogleCloudStorageConstants}
+     */
+    static final String OPERATION = "CamelGoogleCloudStorageOperation";
+    static final String BUCKET_NAME = "CamelGoogleCloudStorageBucketName";
+    static final String OBJECT_NAME = "CamelGoogleCloudStorageObjectName";
+    static final String DESTINATION_OBJECT_NAME = "CamelGoogleCloudStorageDestinationObjectName";
+    static final String DESTINATION_BUCKET_NAME = "CamelGoogleCloudStorageDestinationBucketName";
+
+    @Override
+    public String getComponent() {
+        return "google-storage";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.storage.GoogleCloudStorageComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(STORAGE_OPERATION, operation.toString());
+        }
+
+        String bucketName = exchange.getIn().getHeader(BUCKET_NAME, String.class);
+        if (bucketName != null) {
+            span.setTag(STORAGE_BUCKET_NAME, bucketName);
+        }
+
+        String objectName = exchange.getIn().getHeader(OBJECT_NAME, String.class);
+        if (objectName != null) {
+            span.setTag(STORAGE_OBJECT_NAME, objectName);
+        }
+
+        String destinationBucketName = exchange.getIn().getHeader(DESTINATION_BUCKET_NAME, String.class);
+        if (destinationBucketName != null) {
+            span.setTag(STORAGE_DESTINATION_BUCKET_NAME, destinationBucketName);
+        }
+
+        String destinationObjectName = exchange.getIn().getHeader(DESTINATION_OBJECT_NAME, String.class);
+        if (destinationObjectName != null) {
+            span.setTag(STORAGE_DESTINATION_OBJECT_NAME, destinationObjectName);
+        }
+    }
+
+}

--- a/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
+++ b/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
@@ -66,6 +66,10 @@ org.apache.camel.telemetry.decorators.ElasticsearchSpanDecorator
 org.apache.camel.telemetry.decorators.FileSpanDecorator
 org.apache.camel.telemetry.decorators.FtpSpanDecorator
 org.apache.camel.telemetry.decorators.FtpsSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleBigQuerySpanDecorator
+org.apache.camel.telemetry.decorators.GoogleFirestoreSpanDecorator
+org.apache.camel.telemetry.decorators.GooglePubsubSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleStorageSpanDecorator
 org.apache.camel.telemetry.decorators.HttpSpanDecorator
 org.apache.camel.telemetry.decorators.HttpsSpanDecorator
 org.apache.camel.telemetry.decorators.IronmqSpanDecorator

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleBigQuerySpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleBigQuerySpanDecoratorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleBigQuerySpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String tableId = "myTable";
+        String tableSuffix = "20260101";
+        String partitionDecorator = "$20260101";
+        String jobId = "job-1";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-bigquery:myProject:myDataset:myTable");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleBigQuerySpanDecorator.TABLE_ID, String.class)).thenReturn(tableId);
+        Mockito.when(message.getHeader(GoogleBigQuerySpanDecorator.TABLE_SUFFIX, String.class)).thenReturn(tableSuffix);
+        Mockito.when(message.getHeader(GoogleBigQuerySpanDecorator.PARTITION_DECORATOR, String.class))
+                .thenReturn(partitionDecorator);
+        Mockito.when(message.getHeader(GoogleBigQuerySpanDecorator.JOB_ID, String.class)).thenReturn(jobId);
+
+        AbstractSpanDecorator decorator = new GoogleBigQuerySpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(tableId, span.tags().get(GoogleBigQuerySpanDecorator.BIGQUERY_TABLE_ID));
+        assertEquals(tableSuffix, span.tags().get(GoogleBigQuerySpanDecorator.BIGQUERY_TABLE_SUFFIX));
+        assertEquals(partitionDecorator, span.tags().get(GoogleBigQuerySpanDecorator.BIGQUERY_PARTITION_DECORATOR));
+        assertEquals(jobId, span.tags().get(GoogleBigQuerySpanDecorator.BIGQUERY_JOB_ID));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleFirestoreSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleFirestoreSpanDecoratorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleFirestoreSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "getDocument";
+        String collectionName = "users";
+        String documentId = "user-1";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-firestore:myProject");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleFirestoreSpanDecorator.OPERATION)).thenReturn(operation);
+        Mockito.when(message.getHeader(GoogleFirestoreSpanDecorator.COLLECTION_NAME, String.class))
+                .thenReturn(collectionName);
+        Mockito.when(message.getHeader(GoogleFirestoreSpanDecorator.DOCUMENT_ID, String.class)).thenReturn(documentId);
+
+        AbstractSpanDecorator decorator = new GoogleFirestoreSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleFirestoreSpanDecorator.FIRESTORE_OPERATION));
+        assertEquals(collectionName, span.tags().get(GoogleFirestoreSpanDecorator.FIRESTORE_COLLECTION_NAME));
+        assertEquals(documentId, span.tags().get(GoogleFirestoreSpanDecorator.FIRESTORE_DOCUMENT_ID));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GooglePubsubSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GooglePubsubSpanDecoratorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.TagConstants;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GooglePubsubSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String messageId = "message-1";
+        String orderingKey = "order-key-1";
+        String ackId = "ack-1";
+        Integer deliveryAttempt = 2;
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-pubsub:myProject:myTopic");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GooglePubsubSpanDecorator.MESSAGE_ID, String.class)).thenReturn(messageId);
+        Mockito.when(message.getHeader(GooglePubsubSpanDecorator.ORDERING_KEY, String.class)).thenReturn(orderingKey);
+        Mockito.when(message.getHeader(GooglePubsubSpanDecorator.ACK_ID, String.class)).thenReturn(ackId);
+        Mockito.when(message.getHeader(GooglePubsubSpanDecorator.DELIVERY_ATTEMPT, Integer.class))
+                .thenReturn(deliveryAttempt);
+
+        AbstractSpanDecorator decorator = new GooglePubsubSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(messageId, span.tags().get(TagConstants.MESSAGE_ID));
+        assertEquals(orderingKey, span.tags().get(GooglePubsubSpanDecorator.PUBSUB_ORDERING_KEY));
+        assertEquals(ackId, span.tags().get(GooglePubsubSpanDecorator.PUBSUB_ACK_ID));
+        assertEquals(deliveryAttempt.toString(), span.tags().get(GooglePubsubSpanDecorator.PUBSUB_DELIVERY_ATTEMPT));
+    }
+
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleStorageSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleStorageSpanDecoratorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleStorageSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "copyObject";
+        String bucketName = "source-bucket";
+        String objectName = "source-object.txt";
+        String destinationBucketName = "dest-bucket";
+        String destinationObjectName = "dest-object.txt";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-storage:source-bucket");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleStorageSpanDecorator.OPERATION)).thenReturn(operation);
+        Mockito.when(message.getHeader(GoogleStorageSpanDecorator.BUCKET_NAME, String.class)).thenReturn(bucketName);
+        Mockito.when(message.getHeader(GoogleStorageSpanDecorator.OBJECT_NAME, String.class)).thenReturn(objectName);
+        Mockito.when(message.getHeader(GoogleStorageSpanDecorator.DESTINATION_BUCKET_NAME, String.class))
+                .thenReturn(destinationBucketName);
+        Mockito.when(message.getHeader(GoogleStorageSpanDecorator.DESTINATION_OBJECT_NAME, String.class))
+                .thenReturn(destinationObjectName);
+
+        AbstractSpanDecorator decorator = new GoogleStorageSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleStorageSpanDecorator.STORAGE_OPERATION));
+        assertEquals(bucketName, span.tags().get(GoogleStorageSpanDecorator.STORAGE_BUCKET_NAME));
+        assertEquals(objectName, span.tags().get(GoogleStorageSpanDecorator.STORAGE_OBJECT_NAME));
+        assertEquals(destinationBucketName, span.tags().get(GoogleStorageSpanDecorator.STORAGE_DESTINATION_BUCKET_NAME));
+        assertEquals(destinationObjectName, span.tags().get(GoogleStorageSpanDecorator.STORAGE_DESTINATION_OBJECT_NAME));
+    }
+
+}


### PR DESCRIPTION
### Motivation

[CAMEL-23460](https://issues.apache.org/jira/browse/CAMEL-23460): follow-up to the AWS span-decorator work (CAMEL-23387) — add equivalent `camel-telemetry` span decorators for the Google Cloud components. This is the **first of the issue's suggested batches** (messaging & storage).

### Changes

Four new decorators following the AWS pattern:

| Decorator | Base | Tags emitted |
|---|---|---|
| `GooglePubsubSpanDecorator` | `AbstractMessagingSpanDecorator` | messageId (destination via base), orderingKey, ackId, deliveryAttempt |
| `GoogleStorageSpanDecorator` | `AbstractSpanDecorator` | operation, bucketName, objectName, destinationBucketName, destinationObjectName |
| `GoogleBigQuerySpanDecorator` | `AbstractSpanDecorator` | tableId, tableSuffix, partitionDecorator, jobId |
| `GoogleFirestoreSpanDecorator` | `AbstractSpanDecorator` | operation, collectionName, documentId |

- Header constants are **mirrored** from each component's `*Constants` interface (with a Javadoc `@link` back to the source), so `camel-telemetry` gains no hard dependency on the Google component modules — identical to the AWS decorators.
- **Tag minimization** per the rules established in the AWS work: only request targets and operational identifiers are tagged; anything that may carry secrets/PII/large payloads is deliberately dropped — PubSub message `attributes`, Firestore `queryValue`, Storage signed `downloadLink` / `kmsKeyName`, BigQuery `translatedQuery`, etc.
- Registered alphabetically in `META-INF/services/org.apache.camel.telemetry.SpanDecorator`.
- One unit test per decorator (header-to-tag extraction), mirroring `AwsCwSpanDecoratorTest`.

**Scope note:** `camel-google-pubsub-lite` appears in the issue's component list but is **not a component module** in the tree (no sources, no pom, no catalog entry), so it is omitted. The remaining two batches from the issue — workspace/productivity (Calendar, Drive, Mail, Sheets) and AI/ML & misc (Speech-to-Text, Text-to-Speech, Vision, VertexAI, Functions, Secret Manager) — will follow as separate PRs.

### Testing

- `mvn clean install` in `components/camel-telemetry`: all tests pass (4 new + existing).
- Full reactor `mvn clean install -DskipTests` from root: success, no stale generated files.

Metadata/observability addition — main/4.22.0 only, no backport.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)