### PR TITLE
CAMEL-24059: Migrate camel-wasm from Chicory to Endive

### DIFF
--- a/components/camel-wasm/pom.xml
+++ b/components/camel-wasm/pom.xml
@@ -45,9 +45,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.dylibso.chicory</groupId>
+            <groupId>run.endive</groupId>
             <artifactId>runtime</artifactId>
-            <version>${chicory-version}</version>
+            <version>${endive-version}</version>
         </dependency>
 
         <dependency>

--- a/components/camel-wasm/src/main/java/org/apache/camel/component/wasm/WasmProducer.java
+++ b/components/camel-wasm/src/main/java/org/apache/camel/component/wasm/WasmProducer.java
@@ -18,8 +18,6 @@ package org.apache.camel.component.wasm;
 
 import java.io.InputStream;
 
-import com.dylibso.chicory.wasm.Parser;
-import com.dylibso.chicory.wasm.WasmModule;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.Resource;
@@ -28,6 +26,8 @@ import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.wasm.WasmFunction;
 import org.apache.camel.wasm.WasmSupport;
+import run.endive.wasm.Parser;
+import run.endive.wasm.WasmModule;
 
 public class WasmProducer extends DefaultProducer {
 

--- a/components/camel-wasm/src/main/java/org/apache/camel/language/wasm/WasmExpression.java
+++ b/components/camel-wasm/src/main/java/org/apache/camel/language/wasm/WasmExpression.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 
-import com.dylibso.chicory.wasm.Parser;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -33,6 +32,7 @@ import org.apache.camel.support.ExpressionAdapter;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.wasm.WasmFunction;
 import org.apache.camel.wasm.WasmSupport;
+import run.endive.wasm.Parser;
 
 public class WasmExpression extends ExpressionAdapter implements ExpressionResultTypeAware {
     private final String expression;

--- a/components/camel-wasm/src/main/java/org/apache/camel/wasm/WasmFunction.java
+++ b/components/camel-wasm/src/main/java/org/apache/camel/wasm/WasmFunction.java
@@ -20,9 +20,9 @@ import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.dylibso.chicory.runtime.ExportFunction;
-import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasm.WasmModule;
+import run.endive.runtime.ExportFunction;
+import run.endive.runtime.Instance;
+import run.endive.wasm.WasmModule;
 
 public class WasmFunction implements AutoCloseable {
     private final Lock lock;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,6 @@
         <camunda-client-java-version>8.9.13</camunda-client-java-version>
         <cassandra-driver-version>4.19.3</cassandra-driver-version>
         <jta-api-1.2-version>1.2</jta-api-1.2-version>
-        <chicory-version>1.7.5</chicory-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
         <citrus-version>5.0.0-M2</citrus-version>
         <classgraph-version>4.8.184</classgraph-version>
@@ -153,6 +152,7 @@
         <github-api-version>1.330</github-api-version>
         <elasticsearch-java-client-version>9.4.3</elasticsearch-java-client-version>
         <elasticsearch-java-client-sniffer-version>9.4.3</elasticsearch-java-client-sniffer-version>
+        <endive-version>1.0.1</endive-version>
         <extjwnl-version>2.0.5</extjwnl-version>
         <extjwnl-data-wn31-version>1.2</extjwnl-data-wn31-version>
         <exec-maven-plugin-version>3.6.3</exec-maven-plugin-version>


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

Migrate the `camel-wasm` component from Chicory (`com.dylibso.chicory`) to its successor Endive (`run.endive`), now hosted under the Bytecode Alliance.

- Rename version property `chicory-version` → `endive-version` (1.7.5 → 1.0.1) in `parent/pom.xml`
- Update Maven coordinates from `com.dylibso.chicory:runtime` to `run.endive:runtime`
- Update Java package imports from `com.dylibso.chicory.*` to `run.endive.*`

The API is identical — same class names and method signatures — so this is a pure find-and-replace migration with no behavioral changes.

Reference: https://endive.run/blog/endive-1.0/

## Test plan

- [x] `mvn verify` passes in `components/camel-wasm` (all existing tests pass unchanged)
- [x] Full reactor build passes (`mvn clean install -DskipTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>