### PR TITLE
CAMEL-24225: Fix test-visibility guidance that mandates non-compiling code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,14 @@ class MyComponentTest extends CamelTestSupport {
     void testSendMessage() { ... }
 
     @Override
-    void configure() throws Exception { ... }
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {   // stays public — overrides RouteBuilder.configure()
+                from("direct:start").to("mock:result");
+            }
+        };
+    }
 }
 
 // Avoid — unnecessary public:
@@ -275,8 +282,16 @@ public class MyComponentTest extends CamelTestSupport {
 - When modifying an existing test file, remove the `public` modifier from the class declaration
   and from any test methods you touch. Do NOT sweep the entire file — only change what you are
   already modifying.
-- `@BeforeAll`, `@AfterAll`, `@BeforeEach`, `@AfterEach`, and `@Override` methods follow the
-  same rule: drop `public` when adding or modifying them.
+- `@BeforeAll`, `@AfterAll`, `@BeforeEach` and `@AfterEach` methods follow the same rule: drop
+  `public` when adding or modifying them.
+- **Exception — methods that override or implement a supertype method keep the supertype's
+  visibility.** Java forbids reducing visibility on an override (JLS 8.4.8.3), so
+  `public void configure()` in a `RouteBuilder`, and any override of a public method from
+  `CamelTestSupport` or an implemented interface, MUST stay `public`.
+- **Exception — base and support classes stay `public`** when they are extended from another
+  package or module (a package-private class cannot be), and anything under
+  `components/camel-test/**` or `test-infra/**` stays `public` because those are released
+  artifacts consumed by downstream projects and by users' own tests.
 - Do NOT create a standalone PR solely to remove `public` from test files in bulk — apply the
   convention incrementally as part of other work.
 


### PR DESCRIPTION
## Motivation

The `Test Visibility: Drop public From Test Classes and Methods` section recently added to `AGENTS.md` (symlinked as `CLAUDE.md`) contains three statements that instruct agents to write code which does not compile. Since this file is consumed as normative instructions by AI coding agents, the defects propagate straight into contributions.

The underlying convention is correct and is **not** changed here — JUnit 5 genuinely does not require `public`, and the repo already has ~750 package-private test classes. Only the incorrect statements are fixed.

## What was wrong

**1. Dropping `public` from `@Override` methods is illegal Java.**

The rule listed `@Override` alongside `@BeforeEach`/`@AfterEach`. Reducing visibility on an overriding method violates JLS 8.4.8.3. Verified with `javac`:

```
error: configure() in Sub cannot override configure() in Base
  attempting to assign weaker access privileges; was public
```

`RouteBuilder.configure()` is `public abstract` (`core/camel-core-model/src/main/java/org/apache/camel/builder/RouteBuilder.java:200`), and there are ~8,900 anonymous `RouteBuilder` overrides under `src/test`. The ~27 `src/test` overrides of `configureContext` / `configureTest` are also affected, since interface methods are implicitly public.

**2. The "Preferred" example did not compile.**

It showed `@Override void configure()` on a `CamelTestSupport` subclass. `CamelTestSupport` has no `configure()` method — only `configureContext()` and `configureTest()` — so the `@Override` fails outright; read instead as `RouteBuilder.configure()`, it fails with the weaker-access error above.

Replaced with the actual idiom, which is already visible at `CamelTestSupport.java:356`: `createRouteBuilder()` returning an anonymous `RouteBuilder` whose `configure()` stays `public`.

**3. No carve-out for cross-package or released test-support classes.**

A package-private class cannot be extended from another package. This repo has 183 `public abstract class` declarations under `src/test`; `ContextTestSupport` alone is imported ~2,500 times, including across modules via the published test-jar.

More seriously, "test classes" is ambiguous enough that an agent could apply the rule to `components/camel-test/**` and `test-infra/**`. Those live in `src/main`, deploy normally, and are consumed by camel-quarkus, camel-spring-boot and by users' own tests — stripping `public` there would be a breaking API change.

## Changes

Docs only, `AGENTS.md`, +18/-3:

- Replaced the broken example with the `createRouteBuilder()` idiom, annotated to show why `configure()` stays `public`.
- Removed `@Override` from the drop-`public` list and added an explicit exception for methods that override or implement a supertype method.
- Added an explicit exception for base/support classes extended cross-package or cross-module, and for `components/camel-test/**` and `test-infra/**`.

No build files, no Java, no generated files touched.

---

_Claude Code on behalf of @oscerd_