### PR TITLE
CAMEL-23866: Migrate camel-aws from apache-client to apache5-client

### DIFF
--- a/components/camel-aws/camel-aws-bedrock/pom.xml
+++ b/components/camel-aws/camel-aws-bedrock/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws-cloudtrail/pom.xml
+++ b/components/camel-aws/camel-aws-cloudtrail/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws-common/pom.xml
+++ b/components/camel-aws/camel-aws-common/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws-common/src/main/java/org/apache/camel/component/aws/common/AwsClientBuilderUtil.java
+++ b/components/camel-aws/camel-aws-common/src/main/java/org/apache/camel/component/aws/common/AwsClientBuilderUtil.java
@@ -35,8 +35,8 @@ import software.amazon.awssdk.core.client.builder.SdkAsyncClientBuilder;
 import software.amazon.awssdk.core.client.builder.SdkSyncClientBuilder;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.http.apache.ProxyConfiguration;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
+import software.amazon.awssdk.http.apache5.ProxyConfiguration;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -73,7 +73,7 @@ public final class AwsClientBuilderUtil {
             Consumer<B> serviceSpecificConfig) {
 
         B clientBuilder = builderSupplier.get();
-        ApacheHttpClient.Builder httpClientBuilder = null;
+        Apache5HttpClient.Builder httpClientBuilder = null;
         boolean httpClientConfigured = false;
 
         // 1. Configure proxy
@@ -85,7 +85,7 @@ public final class AwsClientBuilderUtil {
             ProxyConfiguration proxyConfig = ProxyConfiguration.builder()
                     .endpoint(proxyEndpoint)
                     .build();
-            httpClientBuilder = ApacheHttpClient.builder().proxyConfiguration(proxyConfig);
+            httpClientBuilder = Apache5HttpClient.builder().proxyConfiguration(proxyConfig);
             httpClientConfigured = true;
         }
 
@@ -113,7 +113,7 @@ public final class AwsClientBuilderUtil {
         // 6. Configure trust all certificates
         if (config.isTrustAllCertificates()) {
             if (httpClientBuilder == null) {
-                httpClientBuilder = ApacheHttpClient.builder();
+                httpClientBuilder = Apache5HttpClient.builder();
             }
             SdkHttpClient httpClient = httpClientBuilder.buildWithDefaults(
                     AttributeMap.builder()

--- a/components/camel-aws/camel-aws-config/pom.xml
+++ b/components/camel-aws/camel-aws-config/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws-parameter-store/pom.xml
+++ b/components/camel-aws/camel-aws-parameter-store/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws-secrets-manager/pom.xml
+++ b/components/camel-aws/camel-aws-secrets-manager/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws-security-hub/pom.xml
+++ b/components/camel-aws/camel-aws-security-hub/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-comprehend/pom.xml
+++ b/components/camel-aws/camel-aws2-comprehend/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-cw/pom.xml
+++ b/components/camel-aws/camel-aws2-cw/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-ddb/pom.xml
+++ b/components/camel-aws/camel-aws2-ddb/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-ec2/pom.xml
+++ b/components/camel-aws/camel-aws2-ec2/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-ecs/pom.xml
+++ b/components/camel-aws/camel-aws2-ecs/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-eks/pom.xml
+++ b/components/camel-aws/camel-aws2-eks/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-eventbridge/pom.xml
+++ b/components/camel-aws/camel-aws2-eventbridge/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-iam/pom.xml
+++ b/components/camel-aws/camel-aws2-iam/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-kms/pom.xml
+++ b/components/camel-aws/camel-aws2-kms/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-lambda/pom.xml
+++ b/components/camel-aws/camel-aws2-lambda/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-mq/pom.xml
+++ b/components/camel-aws/camel-aws2-mq/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-msk/pom.xml
+++ b/components/camel-aws/camel-aws2-msk/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-polly/pom.xml
+++ b/components/camel-aws/camel-aws2-polly/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-redshift/pom.xml
+++ b/components/camel-aws/camel-aws2-redshift/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-rekognition/pom.xml
+++ b/components/camel-aws/camel-aws2-rekognition/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-s3-vectors/pom.xml
+++ b/components/camel-aws/camel-aws2-s3-vectors/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-s3/pom.xml
+++ b/components/camel-aws/camel-aws2-s3/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-sns/pom.xml
+++ b/components/camel-aws/camel-aws2-sns/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-sqs/pom.xml
+++ b/components/camel-aws/camel-aws2-sqs/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-step-functions/pom.xml
+++ b/components/camel-aws/camel-aws2-step-functions/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-sts/pom.xml
+++ b/components/camel-aws/camel-aws2-sts/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-textract/pom.xml
+++ b/components/camel-aws/camel-aws2-textract/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-timestream/pom.xml
+++ b/components/camel-aws/camel-aws2-timestream/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 

--- a/components/camel-aws/camel-aws2-transcribe/pom.xml
+++ b/components/camel-aws/camel-aws2-transcribe/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/components/camel-aws/camel-aws2-translate/pom.xml
+++ b/components/camel-aws/camel-aws2-translate/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
         <dependency>

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -722,6 +722,15 @@ The `TemplateParser` now catches `TokenMgrError` (a JavaCC lexer error) and wrap
 `ParseRuntimeException`. Previously a malformed stored-procedure template with characters
 outside the token alphabet would propagate as a raw `java.lang.Error`.
 
+=== camel-aws - Migrated from apache-client to apache5-client
+
+All camel-aws modules now use `software.amazon.awssdk:apache5-client` (Apache HttpClient 5) instead of
+`software.amazon.awssdk:apache-client` (Apache HttpClient 4), aligning with the
+https://github.com/aws/aws-sdk-java-v2/issues/7007[new default] in AWS SDK for Java v2.46.0.
+
+If your project has `<dependencyManagement>` entries, exclusions, or explicit dependencies referencing
+`software.amazon.awssdk:apache-client`, update them to `software.amazon.awssdk:apache5-client`.
+
 === camel-aws-cloudtrail - consumer event delivery fixed
 
 The CloudTrail consumer previously kept its lookup cursor in a `static` field (shared across all

--- a/test-infra/camel-test-infra-aws-v2/pom.xml
+++ b/test-infra/camel-test-infra-aws-v2/pom.xml
@@ -129,7 +129,7 @@
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
+            <artifactId>apache5-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
 


### PR DESCRIPTION
## Summary

- Migrate all camel-aws modules and test-infra from `software.amazon.awssdk:apache-client` (Apache HttpClient 4) to `software.amazon.awssdk:apache5-client` (Apache HttpClient 5), aligning with the [new default](https://github.com/aws/aws-sdk-java-v2/issues/7007) introduced in AWS SDK for Java v2.46.0
- Update `AwsClientBuilderUtil` to use `Apache5HttpClient.Builder` and the `software.amazon.awssdk.http.apache5` package
- Eliminates the redundant classpath overlap where both apache-client and apache5-client JARs were pulled in

## Test plan

- [x] Verify `mvn verify` passes for `camel-aws-common`
- [x] All camel-aws tests pass
- [x] Confirm no remaining references to the old `apache-client` artifact or `ApacheHttpClient` class

_Claude Code on behalf of jamesnetherton_