### PR TITLE
CAMEL-23944: Fix ToolExecutionErrorHandler never invoked for Camel route tools

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -19,23 +19,17 @@ package org.apache.camel.component.langchain4j.agent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.service.Result;
@@ -46,10 +40,6 @@ import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.component.ai.tool.AiToolExecutor;
-import org.apache.camel.component.ai.tool.AiToolRegistry;
-import org.apache.camel.component.ai.tool.AiToolResult;
-import org.apache.camel.component.ai.tool.AiToolSpec;
 import org.apache.camel.component.langchain4j.agent.api.AbstractAgent;
 import org.apache.camel.component.langchain4j.agent.api.Agent;
 import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
@@ -59,7 +49,10 @@ import org.apache.camel.component.langchain4j.agent.api.AgentWithoutMemory;
 import org.apache.camel.component.langchain4j.agent.api.AiAgentBody;
 import org.apache.camel.component.langchain4j.agent.api.CompositeToolProvider;
 import org.apache.camel.component.langchain4j.agent.api.Headers;
+import org.apache.camel.component.langchain4j.tools.spec.CamelToolExecutorCache;
+import org.apache.camel.component.langchain4j.tools.spec.CamelToolSpecification;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -242,25 +235,114 @@ public class LangChain4jAgentProducer extends DefaultProducer {
             }
         }
 
-        Map<String, AiToolSpec> aiTools = discoverAiToolsByName(tags);
+        // Discover tools from Camel LangChain4j Tools routes
+        Map<String, CamelToolSpecification> availableTools = discoverToolsByName(tags);
 
-        if (!aiTools.isEmpty()) {
-            LOG.debug("Creating AI Service with {} ai-tool tools for tags: {}", aiTools.size(), tags);
-            return buildToolProvider(aiTools, exchange);
+        if (!availableTools.isEmpty()) {
+            LOG.debug("Creating AI Service with {} tools for tags: {}", availableTools.size(), tags);
+            return createCamelToolProvider(availableTools, exchange);
         } else {
             LOG.debug("No tools found for tags: {}, using simple AI Service", tags);
             return null;
         }
     }
 
-    private ToolProvider buildToolProvider(Map<String, AiToolSpec> aiTools, Exchange exchange) {
+    /**
+     * Create a dynamic tool provider that returns all Camel route as LangChain4j tools. This uses LangChain4j's
+     * ToolProvider API for dynamic tool registration.
+     */
+    private ToolProvider createCamelToolProvider(Map<String, CamelToolSpecification> availableTools, Exchange exchange) {
         return (ToolProviderRequest toolProviderRequest) -> {
+            // Build the tool provider result with all available Camel tools
             ToolProviderResult.Builder resultBuilder = ToolProviderResult.builder();
 
-            for (Map.Entry<String, AiToolSpec> entry : aiTools.entrySet()) {
-                AiToolSpec spec = entry.getValue();
-                ToolSpecification toolSpec = AiToolSpecToLangChain4j.toToolSpecification(spec);
-                addToolToResult(resultBuilder, spec, toolSpec, exchange);
+            for (Map.Entry<String, CamelToolSpecification> entry : availableTools.entrySet()) {
+                String toolName = entry.getKey();
+                CamelToolSpecification camelToolSpec = entry.getValue();
+
+                // Get the existing ToolSpecification from CamelToolSpecification
+                ToolSpecification toolSpecification = camelToolSpec.getToolSpecification();
+
+                // Create a functional tool executor for this specific Camel route.
+                // A separate exchange is created for each tool invocation to avoid
+                // side-effect leakage (headers, body, exceptions) into the calling exchange.
+                ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
+                    LOG.info("Executing Camel route tool: '{}' with arguments: {}", toolName, toolExecutionRequest.arguments());
+
+                    // Isolate tool execution in its own exchange so that headers,
+                    // body mutations and exceptions do not leak into the producer exchange.
+                    Exchange toolExchange = ExchangeHelper.createCopy(exchange, true);
+
+                    try {
+                        // Parse JSON arguments if provided
+                        String arguments = toolExecutionRequest.arguments();
+                        if (arguments != null && !arguments.trim().isEmpty()) {
+                            // Get declared parameters from tool specification to filter incoming fields
+                            Set<String> declaredParams = Set.of();
+                            JsonObjectSchema paramSchema = toolSpecification.parameters();
+                            if (paramSchema != null && paramSchema.properties() != null) {
+                                declaredParams = paramSchema.properties().keySet();
+                            }
+                            final Set<String> allowedParams = declaredParams;
+
+                            JsonNode jsonNode = objectMapper.readValue(arguments, JsonNode.class);
+                            jsonNode.fieldNames()
+                                    .forEachRemaining(name -> {
+                                        if (!allowedParams.contains(name)) {
+                                            LOG.warn("Skipping undeclared tool argument '{}' for tool '{}'",
+                                                    name, toolName);
+                                            return;
+                                        }
+                                        JsonNode value = jsonNode.get(name);
+                                        Object headerValue;
+                                        if (value.isInt()) {
+                                            headerValue = value.intValue();
+                                        } else if (value.isLong()) {
+                                            headerValue = value.longValue();
+                                        } else if (value.isDouble()) {
+                                            headerValue = value.doubleValue();
+                                        } else if (value.isBoolean()) {
+                                            headerValue = value.booleanValue();
+                                        } else {
+                                            headerValue = value.asText();
+                                        }
+                                        toolExchange.getMessage().setHeader(name, headerValue);
+                                    });
+                        }
+
+                        // Set the tool name as a header for route identification
+                        toolExchange.getMessage().setHeader("CamelToolName", toolName);
+
+                        // Execute the consumer route
+                        camelToolSpec.getConsumer().getProcessor().process(toolExchange);
+
+                        // Check for exchange exceptions stored by the Camel pipeline.
+                        // In Camel, route processors typically catch exceptions and store
+                        // them on the exchange via setException() rather than rethrowing.
+                        // Without this check, LangChain4j never sees the failure and
+                        // ToolExecutionErrorHandler / compensateOnToolErrors never fire.
+                        if (toolExchange.getException() != null) {
+                            throw toolExchange.getException();
+                        }
+
+                        // Return the result
+                        String result = toolExchange.getIn().getBody(String.class);
+                        LOG.info("Tool '{}' execution completed successfully", toolName);
+                        return result != null ? result : "No result";
+
+                    } catch (Exception e) {
+                        LOG.error("Error executing tool '{}': {}", toolName, e.getMessage(), e);
+                        // Rethrow so LangChain4j's error handling machinery
+                        // (ToolExecutionErrorHandler, compensateOnToolErrors) can kick in.
+                        throw new RuntimeException(
+                                String.format("Error executing tool '%s': %s", toolName, e.getMessage()), e);
+                    }
+                };
+
+                // Add this tool to the result
+                resultBuilder.add(toolSpecification, toolExecutor);
+
+                LOG.info("Added dynamic tool: '{}' - {}", toolSpecification.name(), toolSpecification.description());
             }
 
             return resultBuilder.build();
@@ -268,76 +350,24 @@ public class LangChain4jAgentProducer extends DefaultProducer {
     }
 
     /**
-     * Registers a single tool with the langchain4j runtime. Creates a {@link ToolExecutor} that converts the
-     * langchain4j-specific {@link ToolExecutionRequest} into a framework-agnostic {@code Map<String, Object>} and
-     * delegates execution to {@link AiToolExecutor}.
+     * Discover Camel routes by tags and create a map of tool specifications by name.
      */
-    private void addToolToResult(
-            ToolProviderResult.Builder resultBuilder,
-            AiToolSpec spec,
-            ToolSpecification toolSpec,
-            Exchange exchange) {
-
-        ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
-            Map<String, Object> arguments = parseArguments(toolExecutionRequest);
-            if (arguments == null) {
-                return "Invalid arguments: could not parse the provided JSON arguments";
-            }
-            AiToolResult result = AiToolExecutor.execute(spec, arguments, exchange);
-            return toToolResponse(spec.getName(), result);
-        };
-
-        resultBuilder.add(toolSpec, toolExecutor);
-        LOG.debug("Added dynamic tool: '{}' - {}", toolSpec.name(), toolSpec.description());
-    }
-
-    /**
-     * Converts a langchain4j {@link ToolExecutionRequest} arguments into a flat map. Returns {@code null} if the JSON
-     * cannot be parsed, signalling the caller to return an error to the LLM instead of executing the tool with no
-     * arguments.
-     */
-    private Map<String, Object> parseArguments(ToolExecutionRequest request) {
-        String jsonArguments = request.arguments();
-        if (jsonArguments == null || jsonArguments.trim().isEmpty()) {
-            return Map.of();
-        }
-        try {
-            return objectMapper.readValue(jsonArguments, new TypeReference<Map<String, Object>>() {
-            });
-        } catch (Exception e) {
-            LOG.warn("Failed to parse tool arguments from ToolExecutionRequest: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    private String toToolResponse(String toolName, AiToolResult result) {
-        if (result instanceof AiToolResult.Success success) {
-            return success.value();
-        } else if (result instanceof AiToolResult.ArgumentError error) {
-            LOG.warn("Tool '{}' argument error: {}", toolName, error.message(), error.cause());
-            return "Invalid arguments: " + error.message();
-        } else if (result instanceof AiToolResult.ExecutionError error) {
-            LOG.warn("Tool '{}' execution error: {}", toolName, error.message(), error.cause());
-            return "Tool execution failed";
-        }
-        return "Tool execution failed";
-    }
-
-    /**
-     * Discover tools registered via {@code ai-tool:} consumer endpoints in the shared {@link AiToolRegistry}.
-     */
-    private Map<String, AiToolSpec> discoverAiToolsByName(String tags) {
-        final AiToolRegistry registry = AiToolRegistry.getOrCreate(endpoint.getCamelContext());
+    private Map<String, CamelToolSpecification> discoverToolsByName(String tags) {
+        final CamelToolExecutorCache toolCache = CamelToolExecutorCache.getInstance();
+        final Map<String, Set<CamelToolSpecification>> tools = toolCache.getTools();
         final String[] tagArray = ToolsTagsHelper.splitTags(tags);
 
-        final Map<String, AiToolSpec> toolsByName = new LinkedHashMap<>();
-        for (String tag : tagArray) {
-            for (AiToolSpec spec : registry.getToolsByTag(tag.trim())) {
-                toolsByName.putIfAbsent(spec.getName(), spec);
-            }
-        }
+        final Map<String, CamelToolSpecification> toolsByName = Arrays.stream(tagArray)
+                .flatMap(tag -> tools.entrySet().stream()
+                        .filter(entry -> entry.getKey().equals(tag))
+                        .flatMap(entry -> entry.getValue().stream()))
+                .collect(Collectors.toMap(
+                        camelToolSpec -> camelToolSpec.getToolSpecification().name(),
+                        camelToolSpec -> camelToolSpec,
+                        (existing, replacement) -> existing // Keep first if duplicate names
+                ));
 
-        LOG.debug("Discovered {} AI tools for tags: {}", toolsByName.size(), tags);
+        LOG.info("Discovered {} unique tools for tags: {}", toolsByName.size(), tags);
         return toolsByName;
     }
 

--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -19,17 +19,23 @@ package org.apache.camel.component.langchain4j.agent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.service.Result;
@@ -40,6 +46,11 @@ import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.component.ai.tool.AiToolExecutor;
+import org.apache.camel.component.ai.tool.AiToolRegistry;
+import org.apache.camel.component.ai.tool.AiToolResult;
+import org.apache.camel.component.ai.tool.AiToolSpec;
 import org.apache.camel.component.langchain4j.agent.api.AbstractAgent;
 import org.apache.camel.component.langchain4j.agent.api.Agent;
 import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
@@ -49,8 +60,6 @@ import org.apache.camel.component.langchain4j.agent.api.AgentWithoutMemory;
 import org.apache.camel.component.langchain4j.agent.api.AiAgentBody;
 import org.apache.camel.component.langchain4j.agent.api.CompositeToolProvider;
 import org.apache.camel.component.langchain4j.agent.api.Headers;
-import org.apache.camel.component.langchain4j.tools.spec.CamelToolExecutorCache;
-import org.apache.camel.component.langchain4j.tools.spec.CamelToolSpecification;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.ResourceHelper;
@@ -235,114 +244,25 @@ public class LangChain4jAgentProducer extends DefaultProducer {
             }
         }
 
-        // Discover tools from Camel LangChain4j Tools routes
-        Map<String, CamelToolSpecification> availableTools = discoverToolsByName(tags);
+        Map<String, AiToolSpec> aiTools = discoverAiToolsByName(tags);
 
-        if (!availableTools.isEmpty()) {
-            LOG.debug("Creating AI Service with {} tools for tags: {}", availableTools.size(), tags);
-            return createCamelToolProvider(availableTools, exchange);
+        if (!aiTools.isEmpty()) {
+            LOG.debug("Creating AI Service with {} ai-tool tools for tags: {}", aiTools.size(), tags);
+            return buildToolProvider(aiTools, exchange);
         } else {
             LOG.debug("No tools found for tags: {}, using simple AI Service", tags);
             return null;
         }
     }
 
-    /**
-     * Create a dynamic tool provider that returns all Camel route as LangChain4j tools. This uses LangChain4j's
-     * ToolProvider API for dynamic tool registration.
-     */
-    private ToolProvider createCamelToolProvider(Map<String, CamelToolSpecification> availableTools, Exchange exchange) {
+    private ToolProvider buildToolProvider(Map<String, AiToolSpec> aiTools, Exchange exchange) {
         return (ToolProviderRequest toolProviderRequest) -> {
-            // Build the tool provider result with all available Camel tools
             ToolProviderResult.Builder resultBuilder = ToolProviderResult.builder();
 
-            for (Map.Entry<String, CamelToolSpecification> entry : availableTools.entrySet()) {
-                String toolName = entry.getKey();
-                CamelToolSpecification camelToolSpec = entry.getValue();
-
-                // Get the existing ToolSpecification from CamelToolSpecification
-                ToolSpecification toolSpecification = camelToolSpec.getToolSpecification();
-
-                // Create a functional tool executor for this specific Camel route.
-                // A separate exchange is created for each tool invocation to avoid
-                // side-effect leakage (headers, body, exceptions) into the calling exchange.
-                ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
-                    LOG.info("Executing Camel route tool: '{}' with arguments: {}", toolName, toolExecutionRequest.arguments());
-
-                    // Isolate tool execution in its own exchange so that headers,
-                    // body mutations and exceptions do not leak into the producer exchange.
-                    Exchange toolExchange = ExchangeHelper.createCopy(exchange, true);
-
-                    try {
-                        // Parse JSON arguments if provided
-                        String arguments = toolExecutionRequest.arguments();
-                        if (arguments != null && !arguments.trim().isEmpty()) {
-                            // Get declared parameters from tool specification to filter incoming fields
-                            Set<String> declaredParams = Set.of();
-                            JsonObjectSchema paramSchema = toolSpecification.parameters();
-                            if (paramSchema != null && paramSchema.properties() != null) {
-                                declaredParams = paramSchema.properties().keySet();
-                            }
-                            final Set<String> allowedParams = declaredParams;
-
-                            JsonNode jsonNode = objectMapper.readValue(arguments, JsonNode.class);
-                            jsonNode.fieldNames()
-                                    .forEachRemaining(name -> {
-                                        if (!allowedParams.contains(name)) {
-                                            LOG.warn("Skipping undeclared tool argument '{}' for tool '{}'",
-                                                    name, toolName);
-                                            return;
-                                        }
-                                        JsonNode value = jsonNode.get(name);
-                                        Object headerValue;
-                                        if (value.isInt()) {
-                                            headerValue = value.intValue();
-                                        } else if (value.isLong()) {
-                                            headerValue = value.longValue();
-                                        } else if (value.isDouble()) {
-                                            headerValue = value.doubleValue();
-                                        } else if (value.isBoolean()) {
-                                            headerValue = value.booleanValue();
-                                        } else {
-                                            headerValue = value.asText();
-                                        }
-                                        toolExchange.getMessage().setHeader(name, headerValue);
-                                    });
-                        }
-
-                        // Set the tool name as a header for route identification
-                        toolExchange.getMessage().setHeader("CamelToolName", toolName);
-
-                        // Execute the consumer route
-                        camelToolSpec.getConsumer().getProcessor().process(toolExchange);
-
-                        // Check for exchange exceptions stored by the Camel pipeline.
-                        // In Camel, route processors typically catch exceptions and store
-                        // them on the exchange via setException() rather than rethrowing.
-                        // Without this check, LangChain4j never sees the failure and
-                        // ToolExecutionErrorHandler / compensateOnToolErrors never fire.
-                        if (toolExchange.getException() != null) {
-                            throw toolExchange.getException();
-                        }
-
-                        // Return the result
-                        String result = toolExchange.getIn().getBody(String.class);
-                        LOG.info("Tool '{}' execution completed successfully", toolName);
-                        return result != null ? result : "No result";
-
-                    } catch (Exception e) {
-                        LOG.error("Error executing tool '{}': {}", toolName, e.getMessage(), e);
-                        // Rethrow so LangChain4j's error handling machinery
-                        // (ToolExecutionErrorHandler, compensateOnToolErrors) can kick in.
-                        throw new RuntimeException(
-                                String.format("Error executing tool '%s': %s", toolName, e.getMessage()), e);
-                    }
-                };
-
-                // Add this tool to the result
-                resultBuilder.add(toolSpecification, toolExecutor);
-
-                LOG.info("Added dynamic tool: '{}' - {}", toolSpecification.name(), toolSpecification.description());
+            for (Map.Entry<String, AiToolSpec> entry : aiTools.entrySet()) {
+                AiToolSpec spec = entry.getValue();
+                ToolSpecification toolSpec = AiToolSpecToLangChain4j.toToolSpecification(spec);
+                addToolToResult(resultBuilder, spec, toolSpec, exchange);
             }
 
             return resultBuilder.build();
@@ -350,24 +270,89 @@ public class LangChain4jAgentProducer extends DefaultProducer {
     }
 
     /**
-     * Discover Camel routes by tags and create a map of tool specifications by name.
+     * Registers a single tool with the langchain4j runtime. Creates a {@link ToolExecutor} that converts the
+     * langchain4j-specific {@link ToolExecutionRequest} into a framework-agnostic {@code Map<String, Object>} and
+     * delegates execution to {@link AiToolExecutor}.
+     *
+     * <p>
+     * Each tool invocation runs on an isolated exchange copy so that headers, body mutations and exceptions from the
+     * tool route do not leak into the calling producer exchange. This is required because langchain4j can execute tools
+     * concurrently, and because the agent's {@code Result<String>} carries the response — the original exchange must
+     * stay clean.
      */
-    private Map<String, CamelToolSpecification> discoverToolsByName(String tags) {
-        final CamelToolExecutorCache toolCache = CamelToolExecutorCache.getInstance();
-        final Map<String, Set<CamelToolSpecification>> tools = toolCache.getTools();
+    private void addToolToResult(
+            ToolProviderResult.Builder resultBuilder,
+            AiToolSpec spec,
+            ToolSpecification toolSpec,
+            Exchange exchange) {
+
+        ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
+            Map<String, Object> arguments = parseArguments(toolExecutionRequest);
+            if (arguments == null) {
+                return "Invalid arguments: could not parse the provided JSON arguments";
+            }
+            // Isolate each tool invocation in its own exchange copy so that
+            // headers, body mutations and exceptions do not leak into the
+            // calling producer exchange (CAMEL-23944).
+            Exchange toolExchange = ExchangeHelper.createCopy(exchange, true);
+            AiToolResult result = AiToolExecutor.execute(spec, arguments, toolExchange);
+            return toToolResponse(spec.getName(), result);
+        };
+
+        resultBuilder.add(toolSpec, toolExecutor);
+        LOG.debug("Added dynamic tool: '{}' - {}", toolSpec.name(), toolSpec.description());
+    }
+
+    /**
+     * Converts a langchain4j {@link ToolExecutionRequest} arguments into a flat map. Returns {@code null} if the JSON
+     * cannot be parsed, signalling the caller to return an error to the LLM instead of executing the tool with no
+     * arguments.
+     */
+    private Map<String, Object> parseArguments(ToolExecutionRequest request) {
+        String jsonArguments = request.arguments();
+        if (jsonArguments == null || jsonArguments.trim().isEmpty()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(jsonArguments, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (Exception e) {
+            LOG.warn("Failed to parse tool arguments from ToolExecutionRequest: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String toToolResponse(String toolName, AiToolResult result) {
+        if (result instanceof AiToolResult.Success success) {
+            return success.value();
+        } else if (result instanceof AiToolResult.ArgumentError error) {
+            LOG.warn("Tool '{}' argument error: {}", toolName, error.message(), error.cause());
+            return "Invalid arguments: " + error.message();
+        } else if (result instanceof AiToolResult.ExecutionError error) {
+            // Rethrow so LangChain4j's error handling machinery
+            // (ToolExecutionErrorHandler, compensateOnToolErrors) can fire.
+            // Use RuntimeCamelException (the Camel idiom) so downstream error
+            // handlers can type-match the real cause without unwrapping (CAMEL-23944).
+            throw RuntimeCamelException.wrapRuntimeCamelException(error.cause());
+        }
+        return "Tool execution failed";
+    }
+
+    /**
+     * Discover tools registered via {@code ai-tool:} consumer endpoints in the shared {@link AiToolRegistry}.
+     */
+    private Map<String, AiToolSpec> discoverAiToolsByName(String tags) {
+        final AiToolRegistry registry = AiToolRegistry.getOrCreate(endpoint.getCamelContext());
         final String[] tagArray = ToolsTagsHelper.splitTags(tags);
 
-        final Map<String, CamelToolSpecification> toolsByName = Arrays.stream(tagArray)
-                .flatMap(tag -> tools.entrySet().stream()
-                        .filter(entry -> entry.getKey().equals(tag))
-                        .flatMap(entry -> entry.getValue().stream()))
-                .collect(Collectors.toMap(
-                        camelToolSpec -> camelToolSpec.getToolSpecification().name(),
-                        camelToolSpec -> camelToolSpec,
-                        (existing, replacement) -> existing // Keep first if duplicate names
-                ));
+        final Map<String, AiToolSpec> toolsByName = new LinkedHashMap<>();
+        for (String tag : tagArray) {
+            for (AiToolSpec spec : registry.getToolsByTag(tag.trim())) {
+                toolsByName.putIfAbsent(spec.getName(), spec);
+            }
+        }
 
-        LOG.info("Discovered {} unique tools for tags: {}", toolsByName.size(), tags);
+        LOG.debug("Discovered {} AI tools for tags: {}", toolsByName.size(), tags);
         return toolsByName;
     }
 

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
@@ -25,7 +25,6 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.Result;
 import dev.langchain4j.service.tool.AiServiceTool;
-import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import org.apache.camel.Exchange;

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.langchain4j.agent;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.tool.AiServiceTool;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.langchain4j.agent.api.Agent;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that the ToolExecutor created by LangChain4jAgentProducer for Camel route tools correctly propagates
+ * exceptions. This is the reproducer for CAMEL-23944: when a Camel route tool throws, the exception must be rethrown by
+ * the ToolExecutor so that LangChain4j's ToolExecutionErrorHandler / compensateOnToolErrors can fire.
+ *
+ * <p>
+ * Before the fix, the ToolExecutor swallowed exceptions from the route (stored on the exchange via
+ * {@code setException()}) and returned an error string instead, preventing LangChain4j from seeing the failure.
+ */
+class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
+
+    private static final String TOOL_SUCCESS_RESULT = "{\"status\": \"ok\"}";
+
+    /** Captures the ToolProvider passed by the producer so we can test the ToolExecutor directly. */
+    private final AtomicReference<ToolProvider> capturedToolProvider = new AtomicReference<>();
+
+    /** Tracks whether a tool execution error was observed by the agent. */
+    private final AtomicBoolean errorObserved = new AtomicBoolean(false);
+
+    /** Tracks the successful tool result captured by the agent. */
+    private final AtomicReference<String> capturedToolResult = new AtomicReference<>();
+
+    /** Captures the error message when a tool execution fails. */
+    private final AtomicReference<String> capturedErrorMessage = new AtomicReference<>();
+
+    private ToolProviderRequest createToolProviderRequest() {
+        return ToolProviderRequest.builder()
+                .invocationContext(InvocationContext.builder().build())
+                .userMessage(UserMessage.from("test"))
+                .build();
+    }
+
+    @Override
+    protected void bindToRegistry(Registry registry) {
+        // A custom Agent that captures the ToolProvider and exercises the ToolExecutor directly.
+        // This avoids needing a real LLM while still testing the producer's tool execution path.
+        Agent capturingAgent = (body, toolProvider) -> {
+            capturedToolProvider.set(toolProvider);
+
+            if (toolProvider != null) {
+                ToolProviderResult providerResult = toolProvider.provideTools(createToolProviderRequest());
+
+                List<AiServiceTool> aiTools = providerResult.aiServiceTools();
+                for (AiServiceTool aiTool : aiTools) {
+                    ToolExecutionRequest request = ToolExecutionRequest.builder()
+                            .name(aiTool.toolSpecification().name())
+                            .arguments("{}")
+                            .build();
+
+                    try {
+                        String result = aiTool.toolExecutor().execute(request, null);
+                        capturedToolResult.set(result);
+                    } catch (Exception e) {
+                        errorObserved.set(true);
+                        capturedErrorMessage.set(e.getMessage());
+                    }
+                }
+            }
+
+            return Result.<String> builder()
+                    .content("agent response")
+                    .build();
+        };
+
+        registry.bind("capturingAgent", capturingAgent);
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                // Producer route that uses the capturing agent with failing-tool tag
+                from("direct:agent-with-failing-tool")
+                        .to("langchain4j-agent:test?agent=#capturingAgent&tags=failing");
+
+                // Producer route that uses the capturing agent with success-tool tag
+                from("direct:agent-with-success-tool")
+                        .to("langchain4j-agent:test?agent=#capturingAgent&tags=success");
+
+                // Camel route tool that throws an exception
+                from("langchain4j-tools:failingTool?tags=failing"
+                     + "&description=A tool that always fails"
+                     + "&parameter.input=string")
+                        .throwException(new RuntimeException("Simulated tool failure"));
+
+                // Camel route tool that succeeds
+                from("langchain4j-tools:successTool?tags=success"
+                     + "&description=A tool that always succeeds"
+                     + "&parameter.input=string")
+                        .setBody(constant(TOOL_SUCCESS_RESULT));
+            }
+        };
+    }
+
+    /**
+     * CAMEL-23944 reproducer: verifies that the ToolExecutor throws when a Camel route tool fails, so that
+     * LangChain4j's error handling (ToolExecutionErrorHandler, compensateOnToolErrors) can fire.
+     *
+     * <p>
+     * Before the fix, the ToolExecutor caught the exception and returned an error string, making LangChain4j believe
+     * the tool succeeded.
+     */
+    @Test
+    void toolExecutorShouldThrowWhenCamelRouteToolFails() {
+        errorObserved.set(false);
+
+        template.sendBody("direct:agent-with-failing-tool", "test input");
+
+        // The capturing agent should have observed the error
+        assertThat(errorObserved.get())
+                .as("ToolExecutor should throw when Camel route tool fails, "
+                    + "so LangChain4j error handlers can fire (CAMEL-23944)")
+                .isTrue();
+    }
+
+    /**
+     * Verifies that a successful tool execution still works correctly after the fix.
+     */
+    @Test
+    void toolExecutorShouldReturnResultWhenCamelRouteToolSucceeds() {
+        errorObserved.set(false);
+        capturedToolResult.set(null);
+
+        template.sendBody("direct:agent-with-success-tool", "test input");
+
+        // The capturing agent should NOT have observed any error
+        assertThat(errorObserved.get())
+                .as("ToolExecutor should not throw when Camel route tool succeeds")
+                .isFalse();
+
+        // The tool should have returned the expected result
+        assertThat(capturedToolResult.get())
+                .as("ToolExecutor should return the route result body")
+                .isEqualTo(TOOL_SUCCESS_RESULT);
+    }
+
+    /**
+     * Verifies that the ToolExecutor propagates the original exception message from a failing Camel route. The error
+     * message must contain the original cause so that LangChain4j's ToolExecutionErrorHandler receives meaningful
+     * diagnostics.
+     */
+    @Test
+    void toolExecutorShouldPropagateExceptionMessageFromFailingRoute() {
+        capturedErrorMessage.set(null);
+
+        template.sendBody("direct:agent-with-failing-tool", "test input");
+
+        // The exception message should contain the original failure cause
+        assertThat(capturedErrorMessage.get())
+                .as("Exception message should contain the original route failure reason")
+                .isNotNull()
+                .contains("Simulated tool failure");
+    }
+
+    /**
+     * Verifies that tool execution does not leak state (headers, body) into the calling exchange. Each tool invocation
+     * should use an isolated exchange copy.
+     */
+    @Test
+    void toolExecutionShouldNotLeakStateIntoCallingExchange() {
+        // Send a message with a known body and header
+        String originalBody = "original body";
+
+        String response = template.requestBodyAndHeader(
+                "direct:agent-with-success-tool",
+                originalBody,
+                "originalHeader", "originalValue",
+                String.class);
+
+        // The response should come from the agent, not be polluted by tool execution
+        assertThat(response).isEqualTo("agent response");
+    }
+}

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
@@ -28,6 +28,7 @@ import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import org.apache.camel.Exchange;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.langchain4j.agent.api.Agent;
@@ -38,20 +39,23 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests that the ToolExecutor created by LangChain4jAgentProducer for Camel route tools correctly propagates
- * exceptions. This is the reproducer for CAMEL-23944: when a Camel route tool throws, the exception must be rethrown by
- * the ToolExecutor so that LangChain4j's ToolExecutionErrorHandler / compensateOnToolErrors can fire.
+ * Tests that the ToolExecutor created by LangChain4jAgentProducer for Camel route tools correctly propagates exceptions
+ * and isolates tool execution state. This is the reproducer for CAMEL-23944: when a Camel route tool throws, the
+ * exception must be rethrown by the ToolExecutor so that LangChain4j's ToolExecutionErrorHandler /
+ * compensateOnToolErrors can fire.
  *
  * <p>
- * Before the fix, the ToolExecutor swallowed exceptions from the route (stored on the exchange via
- * {@code setException()}) and returned an error string instead, preventing LangChain4j from seeing the failure.
+ * Before the fix, the ToolExecutor had two bugs:
+ * <ol>
+ * <li>Exceptions from tool routes were swallowed and returned as a plain string ("Tool execution failed"), making
+ * LangChain4j believe the tool succeeded.</li>
+ * <li>The live producer exchange was shared with tool execution, causing tool side-effects (headers, body, exceptions)
+ * to leak into the calling exchange.</li>
+ * </ol>
  */
 class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
 
     private static final String TOOL_SUCCESS_RESULT = "{\"status\": \"ok\"}";
-
-    /** Captures the ToolProvider passed by the producer so we can test the ToolExecutor directly. */
-    private final AtomicReference<ToolProvider> capturedToolProvider = new AtomicReference<>();
 
     /** Tracks whether a tool execution error was observed by the agent. */
     private final AtomicBoolean errorObserved = new AtomicBoolean(false);
@@ -74,7 +78,6 @@ class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
         // A custom Agent that captures the ToolProvider and exercises the ToolExecutor directly.
         // This avoids needing a real LLM while still testing the producer's tool execution path.
         Agent capturingAgent = (body, toolProvider) -> {
-            capturedToolProvider.set(toolProvider);
 
             if (toolProvider != null) {
                 ToolProviderResult providerResult = toolProvider.provideTools(createToolProviderRequest());
@@ -83,7 +86,7 @@ class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
                 for (AiServiceTool aiTool : aiTools) {
                     ToolExecutionRequest request = ToolExecutionRequest.builder()
                             .name(aiTool.toolSpecification().name())
-                            .arguments("{}")
+                            .arguments("{\"input\": \"test value\"}")
                             .build();
 
                     try {
@@ -118,15 +121,16 @@ class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
                         .to("langchain4j-agent:test?agent=#capturingAgent&tags=success");
 
                 // Camel route tool that throws an exception
-                from("langchain4j-tools:failingTool?tags=failing"
+                from("ai-tool:failingTool?tags=failing"
                      + "&description=A tool that always fails"
                      + "&parameter.input=string")
                         .throwException(new RuntimeException("Simulated tool failure"));
 
-                // Camel route tool that succeeds
-                from("langchain4j-tools:successTool?tags=success"
+                // Camel route tool that succeeds and sets a side-effect header
+                from("ai-tool:successTool?tags=success"
                      + "&description=A tool that always succeeds"
                      + "&parameter.input=string")
+                        .setHeader("toolSideEffect", constant("leaked"))
                         .setBody(constant(TOOL_SUCCESS_RESULT));
             }
         };
@@ -205,19 +209,70 @@ class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
     /**
      * Verifies that tool execution does not leak state (headers, body) into the calling exchange. Each tool invocation
      * should use an isolated exchange copy.
+     *
+     * <p>
+     * Without exchange isolation, AiToolExecutor sets tool argument headers (like "input") and the tool route may set
+     * additional side-effect headers (like "toolSideEffect") directly on the live producer exchange. This test verifies
+     * that the calling exchange's original headers survive and that no tool-related headers leak through.
      */
     @Test
     void toolExecutionShouldNotLeakStateIntoCallingExchange() {
-        // Send a message with a known body and header
-        String originalBody = "original body";
+        Exchange result = template.request("direct:agent-with-success-tool", exchange -> {
+            exchange.getMessage().setBody("original body");
+            exchange.getMessage().setHeader("originalHeader", "originalValue");
+        });
 
-        String response = template.requestBodyAndHeader(
-                "direct:agent-with-success-tool",
-                originalBody,
-                "originalHeader", "originalValue",
-                String.class);
+        // The response body comes from the agent (via result.content()),
+        // not from the tool route
+        assertThat(result.getMessage().getBody(String.class))
+                .as("Response should come from the agent, not the tool route")
+                .isEqualTo("agent response");
 
-        // The response should come from the agent, not be polluted by tool execution
-        assertThat(response).isEqualTo("agent response");
+        // The caller's original header must survive tool execution
+        assertThat(result.getMessage().getHeader("originalHeader"))
+                .as("Original header should survive tool execution")
+                .isEqualTo("originalValue");
+
+        // Tool argument headers must NOT leak into the calling exchange.
+        // AiToolExecutor sets each tool argument as an exchange header (e.g. "input");
+        // with exchange isolation, these stay on the copy.
+        assertThat(result.getMessage().getHeader("input"))
+                .as("Tool argument header 'input' should not leak into calling exchange")
+                .isNull();
+
+        // Side-effect headers set by the tool route must NOT leak.
+        // The success tool route sets "toolSideEffect" = "leaked"; with exchange
+        // isolation, this stays on the copy.
+        assertThat(result.getMessage().getHeader("toolSideEffect"))
+                .as("Tool route side-effect header should not leak into calling exchange")
+                .isNull();
+    }
+
+    /**
+     * Verifies that a failing tool also does not leak state into the calling exchange. The exchange isolation must be
+     * unconditional — it must happen for both success and failure paths.
+     */
+    @Test
+    void failingToolExecutionShouldNotLeakStateIntoCallingExchange() {
+        Exchange result = template.request("direct:agent-with-failing-tool", exchange -> {
+            exchange.getMessage().setBody("original body");
+            exchange.getMessage().setHeader("originalHeader", "originalValue");
+        });
+
+        // The response body comes from the agent (the capturing agent always
+        // returns "agent response" regardless of tool success/failure)
+        assertThat(result.getMessage().getBody(String.class))
+                .as("Response should come from the agent even after tool failure")
+                .isEqualTo("agent response");
+
+        // The caller's original header must survive even when the tool fails
+        assertThat(result.getMessage().getHeader("originalHeader"))
+                .as("Original header should survive failing tool execution")
+                .isEqualTo("originalValue");
+
+        // Tool argument headers must NOT leak even on the failure path
+        assertThat(result.getMessage().getHeader("input"))
+                .as("Tool argument header 'input' should not leak on failure path")
+                .isNull();
     }
 }

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentToolExecutorErrorHandlingTest.java
@@ -138,15 +138,21 @@ class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
      *
      * <p>
      * Before the fix, the ToolExecutor caught the exception and returned an error string, making LangChain4j believe
-     * the tool succeeded.
+     * the tool succeeded. The sendBody call is wrapped in try-catch because the producer exchange may or may not
+     * propagate the exception (depending on exchange isolation); we only care about whether the ToolExecutor itself
+     * threw inside the capturing agent.
      */
     @Test
     void toolExecutorShouldThrowWhenCamelRouteToolFails() {
         errorObserved.set(false);
 
-        template.sendBody("direct:agent-with-failing-tool", "test input");
+        try {
+            template.sendBody("direct:agent-with-failing-tool", "test input");
+        } catch (Exception e) {
+            // Ignored — we are testing the ToolExecutor behavior, not the exchange propagation
+        }
 
-        // The capturing agent should have observed the error
+        // The capturing agent should have observed the error thrown by the ToolExecutor
         assertThat(errorObserved.get())
                 .as("ToolExecutor should throw when Camel route tool fails, "
                     + "so LangChain4j error handlers can fire (CAMEL-23944)")
@@ -183,7 +189,11 @@ class LangChain4jAgentToolExecutorErrorHandlingTest extends CamelTestSupport {
     void toolExecutorShouldPropagateExceptionMessageFromFailingRoute() {
         capturedErrorMessage.set(null);
 
-        template.sendBody("direct:agent-with-failing-tool", "test input");
+        try {
+            template.sendBody("direct:agent-with-failing-tool", "test input");
+        } catch (Exception e) {
+            // Ignored — we are testing the ToolExecutor error message, not the exchange propagation
+        }
 
         // The exception message should contain the original failure cause
         assertThat(capturedErrorMessage.get())

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -218,6 +218,27 @@ Add the `camel-ai-tool` dependency to your project:
 </dependency>
 ----
 
+==== Exchange isolation for Camel route tools
+
+Each Camel route tool invocation now runs on an isolated exchange copy. Previously, the live
+producer exchange was shared with the tool route, which caused tool side-effects (headers, body
+mutations) to leak into the calling exchange and introduced a data race when LangChain4j executed
+tools concurrently.
+
+After this change:
+
+* Headers set by tool argument mapping (e.g. `input`) no longer appear on the calling exchange
+  after the agent returns.
+* Headers set inside the tool route (e.g. custom side-effect headers) no longer leak.
+* The `CamelToolName` header is no longer visible on the calling exchange.
+* Tool execution errors are rethrown as `RuntimeCamelException` so that LangChain4j's
+  `ToolExecutionErrorHandler` and `compensateOnToolErrors` fire correctly. Previously, errors were
+  swallowed and returned as a plain string, making LangChain4j believe the tool succeeded.
+
+If your code reads tool-related headers from the calling exchange after agent invocation,
+you will need to adjust it. The agent's `Result<String>` (and the new `CamelLangChain4jAgentToolExecutions`
+header) is the intended way to observe tool execution results.
+
 === camel-langchain4j-chat
 
 The helper classes `OpenAiChatLanguageModelBuilder` and `HugginFaceChatLanguageModelBuilder` have been removed.


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

Fix CAMEL-23944: `ToolExecutionErrorHandler` and `compensateOnToolErrors` are never invoked for Camel route tools in `camel-langchain4j-agent`.

## Root Cause

After CAMEL-23382 moved tool execution to the shared `AiToolExecutor`, two of the three original bugs survived the migration:

1. **Exception swallowed as string** — `toToolResponse()` returned `"Tool execution failed"` on `ExecutionError`, making LangChain4j believe the tool succeeded. `ToolExecutionErrorHandler` / `compensateOnToolErrors` never fire.

2. **Shared exchange** — `addToolToResult()` passed the live producer exchange directly to `AiToolExecutor.execute()`, despite the executor's javadoc requiring `"The calling adapter owns the exchange lifecycle: it must create the exchange before calling this method"`. This leaks tool side-effects (headers, body) into the calling exchange and introduces a data race under concurrent tool execution.

*(The third original bug — missing `exchange.getException()` check — was already fixed in `AiToolExecutor` by CAMEL-23382.)*

## Fix

- **`RuntimeCamelException.wrapRuntimeCamelException(error.cause())`** — Rethrows execution errors using the Camel idiom so LangChain4j's error handling machinery fires and downstream error handlers can type-match the real cause without unwrapping
- **`ExchangeHelper.createCopy(exchange, true)`** — Isolates each tool invocation in its own exchange copy (same pattern used in `LangChain4jToolsProducer`)

## Test Plan

- [x] `LangChain4jAgentToolExecutorErrorHandlingTest` — 5 tests covering:
  - ToolExecutor throws when Camel route tool fails (CAMEL-23944 reproducer)
  - ToolExecutor returns result when tool succeeds
  - Exception message propagation from failing route
  - No state leakage into calling exchange (success path) — verifies original headers survive, tool argument headers and route side-effect headers do not leak
  - No state leakage into calling exchange (failure path) — verifies isolation is unconditional
- [x] All tests use `ai-tool:` consumer URIs (aligned with CAMEL-23382)
- [x] Upgrade guide entry for exchange isolation behavior change
- [x] Code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)