### PR TITLE
CAMEL-24230: Fix jsonpath writeAsString for object expressions

### DIFF
--- a/components/camel-jsonpath/pom.xml
+++ b/components/camel-jsonpath/pom.xml
@@ -100,6 +100,11 @@
             <version>${hamcrest-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
+++ b/components/camel-jsonpath/src/main/java/org/apache/camel/jsonpath/JsonPathEngine.java
@@ -152,18 +152,6 @@ public class JsonPathEngine {
                     }
                 }
                 return list;
-            } else if (answer instanceof Map) {
-                Map<Object, Object> map = (Map<Object, Object>) answer;
-                for (Map.Entry<Object, Object> entry : map.entrySet()) {
-                    Object value = entry.getValue();
-                    if (adapter != null) {
-                        String json = adapter.writeAsString(value, exchange);
-                        if (json != null) {
-                            map.put(entry.getKey(), json);
-                        }
-                    }
-                }
-                return map;
             } else {
                 String json = adapter.writeAsString(answer, exchange);
                 if (json != null) {

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathEngineWriteAsStringTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathEngineWriteAsStringTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.jsonpath;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link JsonPathEngine} {@code writeAsString} handling.
+ */
+public class JsonPathEngineWriteAsStringTest extends CamelTestSupport {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String HTTPBIN_JSON = """
+            {
+              "args": {
+                "age": 30,
+                "name": "Alice"
+              },
+              "content": [
+                {"id": 1, "value": "first"},
+                {"id": 2, "value": "second"}
+              ]
+            }
+            """;
+
+    @Test
+    void writeAsStringSerializesObjectExpressionAsJsonString() throws Exception {
+        JsonPathEngine engine = new JsonPathEngine("$.args", null, true, false, true, null, context);
+
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(HTTPBIN_JSON);
+
+        Object result = engine.read(exchange);
+
+        assertThat(result).isInstanceOf(String.class);
+        assertThat(MAPPER.readTree((String) result)).isEqualTo(MAPPER.readTree("""
+                {"age":30,"name":"Alice"}
+                """));
+    }
+
+    @Test
+    void writeAsStringWithoutFlagReturnsMap() throws Exception {
+        JsonPathEngine engine = new JsonPathEngine("$.args", null, false, false, true, null, context);
+
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(HTTPBIN_JSON);
+
+        Object result = engine.read(exchange);
+
+        assertThat(result).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertThat(map)
+                .containsEntry("age", 30)
+                .containsEntry("name", "Alice");
+    }
+
+    @Test
+    void writeAsStringSerializesEachArrayElement() throws Exception {
+        JsonPathEngine engine = new JsonPathEngine("$.content[*]", null, true, false, true, null, context);
+
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(HTTPBIN_JSON);
+
+        Object result = engine.read(exchange);
+
+        assertThat(result).isInstanceOf(List.class);
+        @SuppressWarnings("unchecked")
+        List<String> jsonRows = (List<String>) result;
+        assertThat(jsonRows).hasSize(2);
+        assertThat(MAPPER.readTree(jsonRows.get(0))).isEqualTo(MAPPER.readTree("""
+                {"id":1,"value":"first"}
+                """));
+        assertThat(MAPPER.readTree(jsonRows.get(1))).isEqualTo(MAPPER.readTree("""
+                {"id":2,"value":"second"}
+                """));
+    }
+}

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitWriteAsStringMapTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathSplitWriteAsStringMapTest.java
@@ -17,14 +17,11 @@
 package org.apache.camel.jsonpath;
 
 import java.io.File;
-import java.util.Map;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JsonPathSplitWriteAsStringMapTest extends CamelTestSupport {
 
@@ -34,7 +31,7 @@ public class JsonPathSplitWriteAsStringMapTest extends CamelTestSupport {
             @Override
             public void configure() {
                 from("direct:start")
-                        .split().jsonpathWriteAsString("$.content")
+                        .split().jsonpathWriteAsString("$.content.*")
                         .to("mock:line")
                         .to("log:line")
                         .end();
@@ -46,18 +43,13 @@ public class JsonPathSplitWriteAsStringMapTest extends CamelTestSupport {
     public void testSplitToJSon() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:line");
         mock.expectedMessageCount(2);
+        mock.allMessages().body().isInstanceOf(String.class);
+        mock.message(0).body().isEqualTo("{\"action\":\"CU\",\"id\":123,\"modifiedTime\":\"2015-07-28T11:40:09.520+02:00\"}");
+        mock.message(1).body().isEqualTo("{\"action\":\"CU\",\"id\":456,\"modifiedTime\":\"2015-07-28T11:42:29.510+02:00\"}");
 
         template.sendBody("direct:start", new File("src/test/resources/content-map.json"));
 
         MockEndpoint.assertIsSatisfied(context);
-
-        Map.Entry<?, ?> row = mock.getReceivedExchanges().get(0).getIn().getBody(Map.Entry.class);
-        assertEquals("foo", row.getKey());
-        assertEquals("{\"action\":\"CU\",\"id\":123,\"modifiedTime\":\"2015-07-28T11:40:09.520+02:00\"}", row.getValue());
-
-        row = mock.getReceivedExchanges().get(1).getIn().getBody(Map.Entry.class);
-        assertEquals("bar", row.getKey());
-        assertEquals("{\"action\":\"CU\",\"id\":456,\"modifiedTime\":\"2015-07-28T11:42:29.510+02:00\"}", row.getValue());
     }
 
 }

--- a/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathWriteAsStringObjectTest.java
+++ b/components/camel-jsonpath/src/test/java/org/apache/camel/jsonpath/JsonPathWriteAsStringObjectTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.jsonpath;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@code writeAsString=true} when the JsonPath expression evaluates to a single JSON object (Map).
+ */
+public class JsonPathWriteAsStringObjectTest extends CamelTestSupport {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String HTTPBIN_JSON = """
+            {
+              "args": {
+                "age": 30,
+                "name": "Alice"
+              },
+              "headers": {
+                "Host": "httpbin.org",
+                "Accept": "application/json"
+              },
+              "origin": "178.227.111.11",
+              "url": "https://httpbin.org/get?name=Alice&age=30"
+            }
+            """;
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:header")
+                        .setHeader("NewBody").jsonpathWriteAsString("$.args")
+                        .to("mock:header");
+
+                from("direct:body")
+                        .setBody().jsonpathWriteAsString("$.args")
+                        .to("mock:body");
+
+                from("direct:nested")
+                        .setBody().jsonpathWriteAsString("$.headers")
+                        .to("mock:nested");
+            }
+        };
+    }
+
+    @Test
+    void writeAsStringOnObjectExpressionInHeader() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:header");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:header", HTTPBIN_JSON);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String header = mock.getReceivedExchanges().get(0).getIn().getHeader("NewBody", String.class);
+        assertThat(header).isNotNull();
+        assertJsonEquals(header, """
+                {"age":30,"name":"Alice"}
+                """);
+    }
+
+    @Test
+    void writeAsStringOnObjectExpressionInBody() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:body");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:body", HTTPBIN_JSON);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String body = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertThat(body).isNotNull();
+        assertJsonEquals(body, """
+                {"age":30,"name":"Alice"}
+                """);
+    }
+
+    @Test
+    void writeAsStringOnNestedObjectExpression() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:nested");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:nested", HTTPBIN_JSON);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String body = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertThat(body).isNotNull();
+        assertJsonEquals(body, """
+                {"Host":"httpbin.org","Accept":"application/json"}
+                """);
+    }
+
+    @Test
+    void writeAsStringDoesNotReturnMapToString() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:body");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:body", HTTPBIN_JSON);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        String body = mock.getReceivedExchanges().get(0).getIn().getBody(String.class);
+        assertThat(body)
+                .startsWith("{")
+                .endsWith("}")
+                .doesNotContain("=");
+    }
+
+    private static void assertJsonEquals(String actual, String expected) throws Exception {
+        assertThat(MAPPER.readTree(actual)).isEqualTo(MAPPER.readTree(expected));
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -519,6 +519,14 @@ The `camel infra list` table now sizes its `DESCRIPTION` column to the terminal 
 the `IMPLEMENTATION` and `SERVICE_DATA` columns with an ellipsis instead of letting the raw service
 data overflow the terminal. The complete, structured service data remains available via `--json`.
 
+=== camel-jsonpath
+
+The `writeAsString` option now correctly serializes single JSON object results (Maps) to a JSON String.
+Previously, a JsonPath expression evaluating to a JSON object (e.g. `$.args`) with `writeAsString=true`
+would return a `java.util.Map` with individually stringified values instead of a valid JSON String.
+If you were relying on the old behavior to split a Map result, change the expression to use a wildcard
+(e.g. `$.content.*` instead of `$.content`) to get a splittable list of JSON strings.
+
 === camel-aws2-kinesis - Fixed-shardId consumer no longer calls DescribeStream on every poll
 
 The Kinesis consumer with a configured `shardId` previously called the `DescribeStream` API on every


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24230](https://issues.apache.org/jira/browse/CAMEL-24230): with `writeAsString=true`, a JsonPath expression that evaluates to a single JSON object (e.g. `$.args`) now returns a valid JSON **String** instead of a `java.util.Map` whose `toString()` looks like `{age=30, name="Alice"}`.

**Root cause:** `JsonPathEngine` had a special `Map` branch that only stringified individual values and returned the Map itself. Non-iterable results (including Maps) now use `adapter.writeAsString(answer, exchange)` like scalars already did.

**Regression fix:** `JsonPathSplitWriteAsStringMapTest` updated to split on `$.content.*` (array of object values) instead of relying on the old Map-entry behaviour.

**Upgrade guide:** Added a `camel-jsonpath` entry to `camel-4x-upgrade-guide-4_22.adoc` documenting the behavioral change and migration path for split routes that relied on the old Map behaviour.

## Test plan

- [x] `JsonPathWriteAsStringObjectTest` (4) — route-level setHeader/setBody with `jsonpathWriteAsString("$.args")`, nested object, valid JSON output (AssertJ + JsonNode comparison)
- [x] `JsonPathEngineWriteAsStringTest` (3) — engine unit tests: object → JSON string, flag off → Map, array → List of JSON strings
- [x] Updated `JsonPathSplitWriteAsStringMapTest` — split on `$.content.*` expects String bodies
- [x] Full module: `mvn test -pl components/camel-jsonpath` — **119 tests passed**
- [x] Code formatted (`formatter:format`, `impsort:sort`)

---

_Generated by Cursor Agent on behalf of @atiaomar1978-hub._
