### PR TITLE
[backport camel-4.14.x] CAMEL-24231: camel-file - Fix pollEnrich with dynamic fileName using exchange properties

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
@@ -94,9 +94,12 @@ public final class GenericFileHelper {
             // enrich with data from dynamic source
             if (dynamic.getMessage().hasHeaders()) {
                 MessageHelper.copyHeaders(dynamic.getMessage(), dummy.getMessage(), true);
-                if (dynamic.hasVariables()) {
-                    dummy.getVariables().putAll(dynamic.getVariables());
-                }
+            }
+            if (dynamic.hasVariables()) {
+                dummy.getVariables().putAll(dynamic.getVariables());
+            }
+            if (dynamic.hasProperties()) {
+                dummy.getProperties().putAll(dynamic.getProperties());
             }
         }
         return dummy;

--- a/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollDynamicFileNameExchangePropertyTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/enricher/PollDynamicFileNameExchangePropertyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.enricher;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PollDynamicFileNameExchangePropertyTest extends ContextTestSupport {
+
+    @Test
+    void testPollEnrichFileNameFromExchangeProperty() throws Exception {
+        getMockEndpoint("mock:result").expectedMessageCount(2);
+        getMockEndpoint("mock:result").message(0).body().isEqualTo("Hello World");
+        getMockEndpoint("mock:result").message(1).body().isNull();
+
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "myfile.txt");
+
+        template.sendBodyAndProperty("direct:start", "Foo", "target", "myfile.txt");
+        template.sendBodyAndProperty("direct:start", "Bar", "target", "unknown.txt");
+
+        assertMockEndpointsSatisfied();
+
+        long c = context.getEndpoints().stream()
+                .filter(e -> e.getEndpointKey().startsWith("file") && e.getEndpointUri().contains("?fileName=")).count();
+        assertThat(c).as("Optimized: should reuse a single file endpoint").isEqualTo(1);
+    }
+
+    @Test
+    void testPollEnrichTwoFilesFromExchangeProperty() throws Exception {
+        getMockEndpoint("mock:result").expectedBodiesReceivedInAnyOrder("Hello World", "Bye World");
+
+        template.sendBodyAndHeader(fileUri(), "Hello World", Exchange.FILE_NAME, "myfile.txt");
+        template.sendBodyAndHeader(fileUri(), "Bye World", Exchange.FILE_NAME, "myfile2.txt");
+
+        template.sendBodyAndProperty("direct:start", "Foo", "target", "myfile.txt");
+        template.sendBodyAndProperty("direct:start", "Bar", "target", "myfile2.txt");
+
+        assertMockEndpointsSatisfied();
+
+        long c = context.getEndpoints().stream()
+                .filter(e -> e.getEndpointKey().startsWith("file") && e.getEndpointUri().contains("?fileName=")).count();
+        assertThat(c).as("Optimized: should reuse a single file endpoint").isEqualTo(1);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .pollEnrich().simple(fileUri() + "?noop=true&fileName=${exchangeProperty.target}")
+                        .timeout(500)
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Backport of #24994

Cherry-pick of #24994 onto `camel-4.14.x`.

**Original PR:** #24994 - CAMEL-24231: camel-file - Fix pollEnrich with dynamic fileName using exchange properties
**Original author:** @davsclaus
**Target branch:** `camel-4.14.x`

### Original description

`GenericFileHelper.createDummy()` copies headers and variables from the incoming exchange but missed exchange properties. When pollEnrich uses `fileName=${exchangeProperty.xxx}`, the expression evaluates to null on the dummy exchange, bypassing the filename filter. Also fixes variables copy that was incorrectly nested inside the `hasHeaders()` guard.

Reported by Marcus Ionker on the Camel users mailing list.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>