### PR TITLE
CAMEL-23938: add Camel-managed session lock renewal for session-enabled Service Bus consumers

### DIFF
--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -452,7 +452,9 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
                 if (elapsed.compareTo(maxRenewDuration) >= 0) {
                     LOG.debug("Max session lock renewal duration exceeded for exchangeId {}, stopping renewal",
                             exchangeId);
-                    entries.remove(exchangeId);
+                    if (entries.remove(exchangeId) != null) {
+                        releaseSessionReceiver(entry.sessionId);
+                    }
                     continue;
                 }
 
@@ -476,21 +478,21 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
                                     error -> {
                                         LOG.warn("Failed to renew session lock for sessionId {}, exchangeId {}: {}",
                                                 entry.sessionId, exchangeId, error.getMessage());
-                                        entries.remove(exchangeId);
+                                        if (entries.remove(exchangeId) != null) {
+                                            releaseSessionReceiver(entry.sessionId);
+                                        }
                                     });
                 }
             }
         }
 
+        // Acquire and release are both guarded by sessionReceiverCreationLock so the
+        // increment/create and decrement/close operations on a SessionReceiverHolder are
+        // atomic relative to each other. This prevents a race where a newly arriving message
+        // increments a holder that a concurrently completing exchange is about to close.
         private ServiceBusReceiverAsyncClient acquireSessionReceiver(String sessionId) {
-            SessionReceiverHolder existing = sessionReceivers.get(sessionId);
-            if (existing != null) {
-                existing.inFlightCount.incrementAndGet();
-                return existing.client;
-            }
-
             synchronized (sessionReceiverCreationLock) {
-                existing = sessionReceivers.get(sessionId);
+                SessionReceiverHolder existing = sessionReceivers.get(sessionId);
                 if (existing != null) {
                     existing.inFlightCount.incrementAndGet();
                     return existing.client;
@@ -510,14 +512,16 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
         }
 
         private void releaseSessionReceiver(String sessionId) {
-            SessionReceiverHolder holder = sessionReceivers.get(sessionId);
-            if (holder == null) {
-                return;
-            }
+            synchronized (sessionReceiverCreationLock) {
+                SessionReceiverHolder holder = sessionReceivers.get(sessionId);
+                if (holder == null) {
+                    return;
+                }
 
-            if (holder.inFlightCount.decrementAndGet() <= 0) {
-                sessionReceivers.remove(sessionId, holder);
-                holder.client.close();
+                if (holder.inFlightCount.decrementAndGet() <= 0) {
+                    sessionReceivers.remove(sessionId);
+                    holder.client.close();
+                }
             }
         }
 

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumer.java
@@ -31,6 +31,7 @@ import com.azure.messaging.servicebus.ServiceBusProcessorClient;
 import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
 import com.azure.messaging.servicebus.ServiceBusReceivedMessageContext;
 import com.azure.messaging.servicebus.ServiceBusReceiverAsyncClient;
+import com.azure.messaging.servicebus.ServiceBusSessionReceiverAsyncClient;
 import com.azure.messaging.servicebus.models.DeadLetterOptions;
 import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
 import com.azure.messaging.servicebus.models.SubQueue;
@@ -57,7 +58,9 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
     private ServiceBusProcessorClient client;
     private boolean clientCloseable;
     private ServiceBusReceiverAsyncClient renewalClient;
+    private ServiceBusSessionReceiverAsyncClient sessionRenewalClient;
     private LockRenewer lockRenewer;
+    private SessionLockRenewer sessionLockRenewer;
     private final AtomicInteger pendingExchanges = new AtomicInteger();
 
     public ServiceBusConsumer(final ServiceBusEndpoint endpoint, final Processor processor) {
@@ -104,16 +107,21 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
         // which returns immediately for async routes, making maxAutoLockRenewDuration ineffective
         if (getConfiguration().getProcessorClient() == null
                 && getConfiguration().getServiceBusReceiveMode() == ServiceBusReceiveMode.PEEK_LOCK
-                && getConfiguration().getMaxAutoLockRenewDuration() > 0
-                && !getConfiguration().isSessionEnabled()) {
-            renewalClient = getEndpoint().getServiceBusClientFactory()
-                    .createServiceBusReceiverAsyncClient(getConfiguration());
-
+                && getConfiguration().getMaxAutoLockRenewDuration() > 0) {
             long maxRenewMs = getConfiguration().getMaxAutoLockRenewDuration();
-            lockRenewer = new LockRenewer(renewalClient, Duration.ofMillis(maxRenewMs));
-
             PeriodTaskScheduler scheduler = PluginHelper.getPeriodTaskScheduler(getEndpoint().getCamelContext());
-            scheduler.schedulePeriodTask(lockRenewer, LOCK_RENEW_INTERVAL_SECONDS * 1000L);
+
+            if (Boolean.TRUE.equals(getConfiguration().isSessionEnabled())) {
+                sessionRenewalClient = getEndpoint().getServiceBusClientFactory()
+                        .createServiceBusSessionReceiverAsyncClient(getConfiguration());
+                sessionLockRenewer = new SessionLockRenewer(sessionRenewalClient, Duration.ofMillis(maxRenewMs));
+                scheduler.schedulePeriodTask(sessionLockRenewer, LOCK_RENEW_INTERVAL_SECONDS * 1000L);
+            } else {
+                renewalClient = getEndpoint().getServiceBusClientFactory()
+                        .createServiceBusReceiverAsyncClient(getConfiguration());
+                lockRenewer = new LockRenewer(renewalClient, Duration.ofMillis(maxRenewMs));
+                scheduler.schedulePeriodTask(lockRenewer, LOCK_RENEW_INTERVAL_SECONDS * 1000L);
+            }
         }
     }
 
@@ -128,6 +136,8 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
             // track for Camel-managed lock renewal
             if (lockRenewer != null) {
                 lockRenewer.add(exchange, message);
+            } else if (sessionLockRenewer != null) {
+                sessionLockRenewer.add(exchange, message);
             }
             // use default consumer callback
             AsyncCallback cb = defaultConsumerCallback(exchange, true);
@@ -161,9 +171,17 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
             lockRenewer.cancel();
             lockRenewer = null;
         }
+        if (sessionLockRenewer != null) {
+            sessionLockRenewer.cancel();
+            sessionLockRenewer = null;
+        }
         if (renewalClient != null) {
             renewalClient.close();
             renewalClient = null;
+        }
+        if (sessionRenewalClient != null) {
+            sessionRenewalClient.close();
+            sessionRenewalClient = null;
         }
         if (client != null) {
             if (clientCloseable) {
@@ -186,9 +204,17 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
             lockRenewer.cancel();
             lockRenewer = null;
         }
+        if (sessionLockRenewer != null) {
+            sessionLockRenewer.cancel();
+            sessionLockRenewer = null;
+        }
         if (renewalClient != null) {
             renewalClient.close();
             renewalClient = null;
+        }
+        if (sessionRenewalClient != null) {
+            sessionRenewalClient.close();
+            sessionRenewalClient = null;
         }
         if (clientCloseable && client != null) {
             client.close();
@@ -352,6 +378,153 @@ public class ServiceBusConsumer extends DefaultConsumer implements ShutdownAware
         }
 
         private record LockRenewerEntry(ServiceBusReceivedMessage message, OffsetDateTime lockedUntil, Instant startTime) {
+        }
+    }
+
+    private class SessionLockRenewer implements Runnable {
+
+        private final ServiceBusSessionReceiverAsyncClient sessionReceiverClient;
+        private final Duration maxRenewDuration;
+        private final AtomicBoolean run = new AtomicBoolean(true);
+        private final Object sessionReceiverCreationLock = new Object();
+        private final Map<String, SessionLockRenewerEntry> entries = new ConcurrentHashMap<>();
+        private final Map<String, SessionReceiverHolder> sessionReceivers = new ConcurrentHashMap<>();
+
+        SessionLockRenewer(ServiceBusSessionReceiverAsyncClient sessionReceiverClient, Duration maxRenewDuration) {
+            this.sessionReceiverClient = sessionReceiverClient;
+            this.maxRenewDuration = maxRenewDuration;
+        }
+
+        public void add(Exchange exchange, ServiceBusReceivedMessage message) {
+            String sessionId = message.getSessionId();
+            if (ObjectHelper.isEmpty(sessionId)) {
+                LOG.warn("Cannot renew session lock for message without sessionId");
+                return;
+            }
+
+            if (acquireSessionReceiver(sessionId) == null) {
+                return;
+            }
+
+            exchange.getExchangeExtension().addOnCompletion(new SynchronizationAdapter() {
+                @Override
+                public void onComplete(Exchange exchange) {
+                    remove(exchange);
+                }
+
+                @Override
+                public void onFailure(Exchange exchange) {
+                    remove(exchange);
+                }
+
+                private void remove(Exchange exchange) {
+                    LOG.trace("Removing exchangeId {} from the SessionLockRenewer, processing done",
+                            exchange.getExchangeId());
+                    SessionLockRenewerEntry entry = entries.remove(exchange.getExchangeId());
+                    if (entry != null) {
+                        releaseSessionReceiver(entry.sessionId);
+                    }
+                }
+            });
+
+            entries.put(exchange.getExchangeId(),
+                    new SessionLockRenewerEntry(sessionId, message.getLockedUntil(), Instant.now()));
+        }
+
+        public void cancel() {
+            run.set(false);
+            sessionReceivers.values().forEach(holder -> holder.client.close());
+            sessionReceivers.clear();
+        }
+
+        @Override
+        public void run() {
+            if (!run.get()) {
+                return;
+            }
+
+            Instant now = Instant.now();
+            for (Map.Entry<String, SessionLockRenewerEntry> mapEntry : entries.entrySet()) {
+                String exchangeId = mapEntry.getKey();
+                SessionLockRenewerEntry entry = mapEntry.getValue();
+
+                Duration elapsed = Duration.between(entry.startTime, now);
+                if (elapsed.compareTo(maxRenewDuration) >= 0) {
+                    LOG.debug("Max session lock renewal duration exceeded for exchangeId {}, stopping renewal",
+                            exchangeId);
+                    entries.remove(exchangeId);
+                    continue;
+                }
+
+                Instant lockExpiry = entry.lockedUntil.toInstant();
+                if (now.plusSeconds(LOCK_RENEW_INTERVAL_SECONDS).isAfter(lockExpiry)) {
+                    SessionReceiverHolder holder = sessionReceivers.get(entry.sessionId);
+                    if (holder == null) {
+                        continue;
+                    }
+
+                    holder.client.renewSessionLock()
+                            .subscribe(
+                                    newLockedUntil -> {
+                                        LOG.trace("Renewed session lock for sessionId {}, exchangeId {}, new expiry: {}",
+                                                entry.sessionId, exchangeId, newLockedUntil);
+                                        entries.replace(exchangeId,
+                                                new SessionLockRenewerEntry(
+                                                        entry.sessionId, newLockedUntil,
+                                                        entry.startTime));
+                                    },
+                                    error -> {
+                                        LOG.warn("Failed to renew session lock for sessionId {}, exchangeId {}: {}",
+                                                entry.sessionId, exchangeId, error.getMessage());
+                                        entries.remove(exchangeId);
+                                    });
+                }
+            }
+        }
+
+        private ServiceBusReceiverAsyncClient acquireSessionReceiver(String sessionId) {
+            SessionReceiverHolder existing = sessionReceivers.get(sessionId);
+            if (existing != null) {
+                existing.inFlightCount.incrementAndGet();
+                return existing.client;
+            }
+
+            synchronized (sessionReceiverCreationLock) {
+                existing = sessionReceivers.get(sessionId);
+                if (existing != null) {
+                    existing.inFlightCount.incrementAndGet();
+                    return existing.client;
+                }
+
+                try {
+                    ServiceBusReceiverAsyncClient sessionReceiver
+                            = sessionReceiverClient.acceptSession(sessionId).block();
+                    SessionReceiverHolder holder = new SessionReceiverHolder(sessionReceiver, new AtomicInteger(1));
+                    sessionReceivers.put(sessionId, holder);
+                    return sessionReceiver;
+                } catch (Exception e) {
+                    LOG.warn("Failed to acquire session receiver for sessionId {}: {}", sessionId, e.getMessage());
+                    return null;
+                }
+            }
+        }
+
+        private void releaseSessionReceiver(String sessionId) {
+            SessionReceiverHolder holder = sessionReceivers.get(sessionId);
+            if (holder == null) {
+                return;
+            }
+
+            if (holder.inFlightCount.decrementAndGet() <= 0) {
+                sessionReceivers.remove(sessionId, holder);
+                holder.client.close();
+            }
+        }
+
+        private record SessionLockRenewerEntry(String sessionId, OffsetDateTime lockedUntil, Instant startTime) {
+        }
+
+        private record SessionReceiverHolder(ServiceBusReceiverAsyncClient client, AtomicInteger inFlightCount) {
         }
     }
 

--- a/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
+++ b/components/camel-azure/camel-azure-servicebus/src/main/java/org/apache/camel/component/azure/servicebus/client/ServiceBusClientFactory.java
@@ -130,6 +130,29 @@ public final class ServiceBusClientFactory {
         return clientBuilder.buildAsyncClient();
     }
 
+    public ServiceBusSessionReceiverAsyncClient createServiceBusSessionReceiverAsyncClient(
+            final ServiceBusConfiguration configuration) {
+        final ServiceBusClientBuilder busClientBuilder = createBaseServiceBusClient(configuration);
+        final ServiceBusClientBuilder.ServiceBusSessionReceiverClientBuilder clientBuilder
+                = busClientBuilder.sessionReceiver();
+
+        clientBuilder.disableAutoComplete();
+
+        switch (configuration.getServiceBusType()) {
+            case queue -> clientBuilder.queueName(configuration.getTopicOrQueueName());
+            case topic -> clientBuilder.topicName(configuration.getTopicOrQueueName());
+        }
+
+        clientBuilder
+                .subscriptionName(configuration.getSubscriptionName())
+                .receiveMode(configuration.getServiceBusReceiveMode())
+                .maxAutoLockRenewDuration(Duration.ZERO)
+                .prefetchCount(configuration.getPrefetchCount())
+                .subQueue(configuration.getSubQueue());
+
+        return clientBuilder.buildAsyncClient();
+    }
+
     public ServiceBusProcessorClient createServiceBusProcessorClient(
             ServiceBusConfiguration configuration, Consumer<ServiceBusReceivedMessageContext> processMessage,
             Consumer<ServiceBusErrorContext> processError) {

--- a/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumerTest.java
+++ b/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumerTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -93,6 +94,8 @@ public class ServiceBusConsumerTest {
     private final PeriodTaskScheduler periodTaskScheduler = mock();
     private final UuidGenerator uuidGenerator = mock();
     private final ServiceBusReceiverAsyncClient renewalClient = mock();
+    private final ServiceBusSessionReceiverAsyncClient sessionRenewalClient = mock();
+    private final ServiceBusReceiverAsyncClient sessionBoundReceiver = mock();
     private final ArgumentCaptor<Consumer<ServiceBusReceivedMessageContext>> processMessageCaptor = ArgumentCaptor.captor();
     private final ArgumentCaptor<Consumer<ServiceBusErrorContext>> processErrorCaptor = ArgumentCaptor.captor();
     private final ArgumentCaptor<Exchange> exchangeCaptor = ArgumentCaptor.captor();
@@ -120,6 +123,9 @@ public class ServiceBusConsumerTest {
         when(context.getUuidGenerator()).thenReturn(uuidGenerator);
         when(uuidGenerator.generateExchangeUuid()).thenReturn("test-exchange-id");
         when(clientFactory.createServiceBusReceiverAsyncClient(any())).thenReturn(renewalClient);
+        when(clientFactory.createServiceBusSessionReceiverAsyncClient(any())).thenReturn(sessionRenewalClient);
+        when(sessionRenewalClient.acceptSession(any())).thenReturn(Mono.just(sessionBoundReceiver));
+        when(sessionBoundReceiver.renewSessionLock()).thenReturn(Mono.just(MESSAGE_LOCKED_UNTIL.plusMinutes(1)));
     }
 
     @Test
@@ -549,14 +555,166 @@ public class ServiceBusConsumerTest {
     }
 
     @Test
-    void lockRenewerNotCreatedForSessionEnabledConsumer() throws Exception {
+    void lockRenewerCreatedForSessionEnabledPeekLockMode() throws Exception {
         when(configuration.isSessionEnabled()).thenReturn(true);
         when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
         when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
         try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
             consumer.doStart();
+            verify(clientFactory).createServiceBusSessionReceiverAsyncClient(any());
             verify(clientFactory, never()).createServiceBusReceiverAsyncClient(any());
+            verify(periodTaskScheduler).schedulePeriodTask(any(), anyLong());
         }
+    }
+
+    @Test
+    void lockRenewerNotCreatedForSessionEnabledReceiveAndDeleteMode() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.RECEIVE_AND_DELETE);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
+            consumer.doStart();
+            verify(clientFactory, never()).createServiceBusSessionReceiverAsyncClient(any());
+        }
+    }
+
+    @Test
+    void sessionLockRenewerTracksAndRemovesExchanges() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        when(messageContext.getMessage()).thenReturn(message);
+        configureMockMessage();
+        when(message.getLockedUntil()).thenReturn(OffsetDateTime.now().plusSeconds(5));
+        try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
+            consumer.doStart();
+
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.captor();
+            verify(periodTaskScheduler).schedulePeriodTask(taskCaptor.capture(), anyLong());
+            Runnable sessionLockRenewerTask = taskCaptor.getValue();
+
+            processMessageCaptor.getValue().accept(messageContext);
+
+            verify(sessionRenewalClient).acceptSession(MESSAGE_SESSION_ID);
+
+            Exchange exchange = exchangeCaptor.getValue();
+            for (Synchronization sync : exchange.getExchangeExtension().handoverCompletions()) {
+                sync.onComplete(exchange);
+            }
+
+            sessionLockRenewerTask.run();
+            verify(sessionBoundReceiver, never()).renewSessionLock();
+            verify(sessionBoundReceiver).close();
+        }
+    }
+
+    @Test
+    void sessionLockRenewerRenewsSessionLockWhenExpiring() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        when(messageContext.getMessage()).thenReturn(message);
+        configureMockMessage();
+        when(message.getLockedUntil()).thenReturn(OffsetDateTime.now().plusSeconds(5));
+        try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
+            consumer.doStart();
+
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.captor();
+            verify(periodTaskScheduler).schedulePeriodTask(taskCaptor.capture(), anyLong());
+
+            processMessageCaptor.getValue().accept(messageContext);
+            taskCaptor.getValue().run();
+
+            verify(sessionBoundReceiver).renewSessionLock();
+        }
+    }
+
+    @Test
+    void sessionLockRenewerReusesSessionReceiverForSameSession() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        when(messageContext.getMessage()).thenReturn(message);
+        configureMockMessage();
+        when(uuidGenerator.generateExchangeUuid()).thenReturn("exchange-1", "exchange-2");
+        try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
+            consumer.doStart();
+
+            processMessageCaptor.getValue().accept(messageContext);
+            processMessageCaptor.getValue().accept(messageContext);
+
+            verify(sessionRenewalClient, times(1)).acceptSession(MESSAGE_SESSION_ID);
+        }
+    }
+
+    @Test
+    void sessionLockRenewerKeepsSessionReceiverOpenUntilLastExchangeCompletes() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        when(messageContext.getMessage()).thenReturn(message);
+        configureMockMessage();
+        when(uuidGenerator.generateExchangeUuid()).thenReturn("exchange-1", "exchange-2");
+        try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
+            consumer.doStart();
+
+            processMessageCaptor.getValue().accept(messageContext);
+            processMessageCaptor.getValue().accept(messageContext);
+
+            Exchange firstExchange = exchangeCaptor.getAllValues().get(0);
+            for (Synchronization sync : firstExchange.getExchangeExtension().handoverCompletions()) {
+                sync.onComplete(firstExchange);
+            }
+
+            verify(sessionBoundReceiver, never()).close();
+
+            Exchange secondExchange = exchangeCaptor.getAllValues().get(1);
+            for (Synchronization sync : secondExchange.getExchangeExtension().handoverCompletions()) {
+                sync.onComplete(secondExchange);
+            }
+
+            verify(sessionBoundReceiver).close();
+        }
+    }
+
+    @Test
+    void doStopCleansUpSessionLockRenewer() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor);
+        consumer.doStart();
+
+        verify(clientFactory).createServiceBusSessionReceiverAsyncClient(any());
+
+        consumer.doStop();
+
+        verify(sessionRenewalClient).close();
+        verify(client).close();
+    }
+
+    @Test
+    void stopStartCycleRecreatesSessionLockRenewer() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor);
+        consumer.doStart();
+
+        verify(clientFactory, times(1)).createServiceBusSessionReceiverAsyncClient(any());
+
+        consumer.doStop();
+        verify(sessionRenewalClient).close();
+
+        ServiceBusSessionReceiverAsyncClient sessionRenewalClient2 = mock();
+        when(clientFactory.createServiceBusSessionReceiverAsyncClient(any())).thenReturn(sessionRenewalClient2);
+        consumer.doStart();
+
+        verify(clientFactory, times(2)).createServiceBusSessionReceiverAsyncClient(any());
+        verify(periodTaskScheduler, times(2)).schedulePeriodTask(any(), anyLong());
+
+        consumer.doShutdown();
+        verify(sessionRenewalClient2).close();
     }
 
     @Test

--- a/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumerTest.java
+++ b/components/camel-azure/camel-azure-servicebus/src/test/java/org/apache/camel/component/azure/servicebus/ServiceBusConsumerTest.java
@@ -630,6 +630,31 @@ public class ServiceBusConsumerTest {
     }
 
     @Test
+    void sessionLockRenewerReleasesSessionReceiverOnRenewalFailure() throws Exception {
+        when(configuration.isSessionEnabled()).thenReturn(true);
+        when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);
+        when(configuration.getMaxAutoLockRenewDuration()).thenReturn(300000L);
+        when(messageContext.getMessage()).thenReturn(message);
+        configureMockMessage();
+        when(message.getLockedUntil()).thenReturn(OffsetDateTime.now().plusSeconds(5));
+        // renewal fails -> the renewer must still release/close the session receiver (no leak)
+        when(sessionBoundReceiver.renewSessionLock())
+                .thenReturn(Mono.error(new RuntimeException("renew failed")));
+        try (ServiceBusConsumer consumer = new ServiceBusConsumer(endpoint, processor)) {
+            consumer.doStart();
+
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.captor();
+            verify(periodTaskScheduler).schedulePeriodTask(taskCaptor.capture(), anyLong());
+
+            processMessageCaptor.getValue().accept(messageContext);
+            taskCaptor.getValue().run();
+
+            verify(sessionBoundReceiver).renewSessionLock();
+            verify(sessionBoundReceiver).close();
+        }
+    }
+
+    @Test
     void sessionLockRenewerReusesSessionReceiverForSameSession() throws Exception {
         when(configuration.isSessionEnabled()).thenReturn(true);
         when(configuration.getServiceBusReceiveMode()).thenReturn(ServiceBusReceiveMode.PEEK_LOCK);

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -217,23 +217,27 @@ to the true average throughput rather than oscillating between zero and spike va
 If you have tooling that consumes the JMX throughput value and expects the old instantaneous
 behavior, be aware that the reported value will now ramp up and decay gradually.
 
-=== camel-azure-servicebus - Camel-managed message lock renewal
+=== camel-azure-servicebus - Camel-managed message and session lock renewal
 
 When consuming from Azure Service Bus in `PEEK_LOCK` mode with `maxAutoLockRenewDuration > 0`, Camel now
-actively renews message locks using a dedicated `ServiceBusReceiverAsyncClient` and Camel's internal
+actively renews message and session locks using dedicated Azure Service Bus receiver clients and Camel's internal
 `PeriodTaskScheduler`. This addresses a limitation where the Azure SDK's built-in lock renewal is tied
 to the `processMessage` callback duration, which returns immediately for asynchronous Camel routes —
-causing long-running exchanges to silently lose their message locks.
+causing long-running exchanges to silently lose their message or session locks.
 
 The new behavior activates automatically when all of the following are true:
 
 * No custom `processorClient` is provided
 * Receive mode is `PEEK_LOCK`
 * `maxAutoLockRenewDuration > 0`
-* Session mode is disabled
+
+For non-session consumers, Camel uses `ServiceBusReceiverAsyncClient.renewMessageLock()`. For session-enabled
+consumers, Camel creates session-bound receivers on demand via `ServiceBusSessionReceiverAsyncClient.acceptSession()`
+and renews locks with `renewSessionLock()`, cleaning up session receivers when no exchanges for that session
+are in flight.
 
 No configuration changes are required. The existing `maxAutoLockRenewDuration` option controls how long
-Camel will continue renewing a message's lock.
+Camel will continue renewing a message's or session's lock.
 
 === camel-azure - component-specific CredentialType enums removed
 


### PR DESCRIPTION
# CAMEL-23938: Camel-managed session lock renewal for session-enabled Service Bus consumers

Follow-up from CAMEL-23937.

## Problem

CAMEL-23937 added Camel-managed lock renewal for **non-session** Azure Service Bus consumers using `ServiceBusReceiverAsyncClient.renewMessageLock()`. Session-enabled consumers were **explicitly excluded**, because session locks require a different API:

- Session locks must be renewed via `renewSessionLock()` instead of `renewMessageLock()`
- This requires a session-bound receiver (`acceptSession(sessionId)`)
- The session id is only known at message-receive time, not at consumer startup

As a result, session-enabled consumers in async routes still suffered from silent session-lock expiry mid-processing.

## Solution

Added a `SessionLockRenewer` in `ServiceBusConsumer` that:

1. Creates session-bound async receivers on demand, keyed by session id, via `ServiceBusSessionReceiverAsyncClient.acceptSession(sessionId)`
2. Renews session locks with `renewSessionLock()` as they approach expiry
3. Reference-counts in-flight exchanges per session and closes the session receiver once the last exchange for that session completes
4. Honours `maxAutoLockRenewDuration` per exchange

Also added `ServiceBusClientFactory.createServiceBusSessionReceiverAsyncClient()`.

The behavior activates automatically when: no custom `processorClient`, `PEEK_LOCK` mode, `maxAutoLockRenewDuration > 0`, and session mode is enabled.

## Tests

Added AssertJ test coverage in `ServiceBusConsumerTest`:

- Session lock renewer created for session-enabled PEEK_LOCK, not for RECEIVE_AND_DELETE
- Exchange tracking and cleanup (session receiver closed after completion)
- `renewSessionLock()` invoked when the lock is expiring
- Session receiver reused across messages of the same session
- Session receiver kept open until the last exchange for the session completes
- Stop/start lifecycle recreates and cleans up the session renewer

`mvn test -pl components/camel-azure/camel-azure-servicebus` passes.

## Docs

Updated the 4.22 upgrade guide entry to cover session lock renewal.

---
_Claude Opus 4.8 on behalf of atiaomar1978-hub_