### PR TITLE
Fix flakiness of CxfTimeoutTest.testInvokingJaxWsServerWithBusUriParams

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfTimeoutTest.java
@@ -93,13 +93,15 @@ public class CxfTimeoutTest extends CamelSpringTestSupport {
         Exchange reply = sendJaxWsMessage(endpointUri);
         Exception e = reply.getException();
         assertThat(e).as("exchange exception").isNotNull();
-        // CXF may either propagate HttpTimeoutException directly or wrap it in a
+        // CXF may either propagate HttpTimeoutException directly or wrap an HttpConnectTimeoutException in a
         // Fault ("Could not send Message.") depending on where in the interceptor
         // chain the timeout is caught. Both cases indicate the timeout was applied
         // correctly, so check the entire cause chain.
         assertThat(e).satisfiesAnyOf(
                 ex -> assertThat(ex).isInstanceOf(HttpTimeoutException.class),
-                ex -> assertThat(ex).hasRootCauseInstanceOf(HttpTimeoutException.class));
+                //TODO: when AssertJ 4 is released, to replace with throwableChains() for more precise and robust check
+                ex -> assertThat(ex).hasStackTraceContaining(
+                        "Caused by: java.net.http.HttpConnectTimeoutException: HTTP connect timed out"));
     }
 
     protected Exchange sendJaxWsMessage(String endpointUri) throws InterruptedException {


### PR DESCRIPTION
the other potential stack is not using HttpTimeoutException and is not the rootCause but the parent of the root cause.

```
Multiple Failures (2 failures)
-- failure 1 --
Expecting actual throwable to be an instance of:
  java.net.http.HttpTimeoutException
but was:
  org.apache.cxf.interceptor.Fault: Could not send Message.
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientWrappedOutputStream.isConnectionAttemptCompleted(HttpClientHTTPConduit.java:979)
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientPipedOutputStream.canWrite(HttpClientHTTPConduit.java:577)
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientPipedOutputStream.write(HttpClientHTTPConduit.java:587)
 ...(106 remaining lines not displayed - this can be changed with
Assertions.setMaxStackTraceElementsDisplayed)
at CxfTimeoutTest.lambda$sendTimeOutMessage$0(CxfTimeoutTest.java:101)
-- failure 2 --
Expecting a throwable with root cause being an instance of:
  java.net.http.HttpTimeoutException
but was an instance of:
  java.net.ConnectException

Throwable that failed the check:
org.apache.cxf.interceptor.Fault: Could not send Message.
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientWrappedOutputStream.isConnectionAttemptCompleted(HttpClientHTTPConduit.java:979)
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientPipedOutputStream.canWrite(HttpClientHTTPConduit.java:577)
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientPipedOutputStream.write(HttpClientHTTPConduit.java:587)
 at org.apache.cxf.io.AbstractWrappedOutputStream.write(AbstractWrappedOutputStream.java:51)
 at org.apache.cxf.io.AbstractThresholdOutputStream.write(AbstractThresholdOutputStream.java:69)
 at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1405)
 at org.apache.cxf.transport.http.HttpClientHTTPConduit$HttpClientWrappedOutputStream.close(HttpClientHTTPConduit.java:859)
 at org.apache.cxf.transport.AbstractConduit.close(AbstractConduit.java:56)
 at org.apache.cxf.transport.http.HTTPConduit.close(HTTPConduit.java:717)
 at org.apache.cxf.transport.http.HttpClientHTTPConduit.close(HttpClientHTTPConduit.java:284)
 at org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:63)
 at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
 at org.apache.cxf.endpoint.ClientImpl.doInvoke(ClientImpl.java:530)
 at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:434)
 at org.apache.camel.component.cxf.jaxws.CxfProducer.process(CxfProducer.java:122)
 at org.apache.camel.impl.engine.SharedCamelInternalProcessor.processNonTransacted(SharedCamelInternalProcessor.java:156)
 at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:133)
 at org.apache.camel.impl.engine.SharedCamelInternalProcessor$1.process(SharedCamelInternalProcessor.java:89)
 at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:81)
 at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86)
 at org.apache.camel.support.cache.DefaultProducerCache.send(DefaultProducerCache.java:180)
 at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:175)
 at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:171)
 at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:136)
 at org.apache.camel.component.cxf.CxfTimeoutTest.sendJaxWsMessage(CxfTimeoutTest.java:106)
 at org.apache.camel.component.cxf.CxfTimeoutTest.sendTimeOutMessage(CxfTimeoutTest.java:93)
 at org.apache.camel.component.cxf.CxfTimeoutTest.testInvokingJaxWsServerWithBusUriParams(CxfTimeoutTest.java:61)
 at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
 at java.base/java.lang.reflect.Method.invoke(Method.java:580)
 at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:700)
 at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:528)
 at org.junit.jupiter.engine.support.MethodReflectionUtils.invoke(MethodReflectionUtils.java:53)
 at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:61)
 at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:124)
 at org.junit.jupiter.engine.extension.SameThreadTimeoutInvocation.proceed(SameThreadTimeoutInvocation.java:51)
 at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:163)
 at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:148)
 at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
 at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:124)
 at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:105)
 at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:99)
 at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:66)
 at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:47)
 at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:39)
 at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:104)
 at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:98)
 at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invokeVoid(InterceptingExecutableInvoker.java:71)
 at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$0(TestMethodTestDescriptor.java:219)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:215)
 at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:157)
 at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:176)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
 at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:139)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
 at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
 at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:42)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
 at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:139)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
 at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
 at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:42)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
 at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:139)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
 at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:36)
 at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:52)
 at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:58)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:256)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:228)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:189)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:109)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:66)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:168)
 at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:65)
 at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:137)
 at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:126)
 at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:71)
 at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$2(InterceptingLauncher.java:66)
 at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
 at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:65)
 at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:71)
 at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
 at java.base/java.lang.reflect.Method.invoke(Method.java:580)
 at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:125)
 at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithCancellationToken(LauncherAdapter.java:68)
 at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:54)
 at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
 at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
 at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:134)
 at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
 at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
 at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
 at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: java.net.http.HttpConnectTimeoutException: HTTP connect timed
out
 at java.net.http/jdk.internal.net.http.ResponseTimerEvent.handle(ResponseTimerEvent.java:68)
 at java.net.http/jdk.internal.net.http.HttpClientImpl.purgeTimeoutsAndReturnNextDeadline(HttpClientImpl.java:1778)
 at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.run(HttpClientImpl.java:1376)
Caused by: java.net.ConnectException: HTTP connect timed out
 at java.net.http/jdk.internal.net.http.ResponseTimerEvent.handle(ResponseTimerEvent.java:69)
 ... 2 more
at CxfTimeoutTest.lambda$sendTimeOutMessage$1(CxfTimeoutTest.java:102)
```
follow-up to https://github.com/apache/camel/commit/e1d72c68e1431eeac2e4d9c84e2736290182db9b

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

