### PR TITLE
CAMEL-24240: align all FHIR core dependencies to 6.9.12

### DIFF
--- a/components/camel-fhir/camel-fhir-component/pom.xml
+++ b/components/camel-fhir/camel-fhir-component/pom.xml
@@ -49,7 +49,32 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-utilities-version}</version>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu3</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r4</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r5</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2016may</artifactId>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -214,7 +214,7 @@
         <hapi-version>2.6.0</hapi-version>
         <hapi-base-version>2.6.0</hapi-base-version>
         <hapi-fhir-version>8.10.0</hapi-fhir-version>
-        <hapi-fhir-utilities-version>6.9.12</hapi-fhir-utilities-version>
+        <hapi-fhir-core-version>6.9.12</hapi-fhir-core-version>
         <hawtio-version>4.6.2</hawtio-version>
         <!-- https://issues.apache.org/jira/browse/CAMEL-22041
             hazelcast needs to stay at 5.4.0 for 4.19.0 due to changes where the CP subsystem is only available in


### PR DESCRIPTION
## Summary

- Rename `hapi-fhir-utilities-version` property to `hapi-fhir-core-version` to reflect its broader scope
- Add `dependencyManagement` overrides for all `org.hl7.fhir.core` transitive artifacts (`dstu2`, `dstu3`, `r4`, `r5`, `dstu2016may`) to pin them at 6.9.12

Previously only `org.hl7.fhir.utilities` was overridden to 6.9.12. The remaining core artifacts were pulled transitively at 6.9.4.1 via `hapi-fhir-structures-*`.

## Test plan

- [x] `mvn verify` passes for `camel-fhir-component` (67 tests, 0 failures)
- [x] `mvn dependency:tree` confirms all `org.hl7.fhir.*` artifacts resolve to 6.9.12

_Claude Code on behalf of jamesnetherton_