### PR TITLE
CAMEL-24238: camel-aws2-ses - send RawMessage body content instead of the SdkBytes descriptor

### DIFF
--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -83,5 +83,10 @@
             <artifactId>camel-test-spring-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
+++ b/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
@@ -101,7 +101,8 @@ public class Ses2Producer extends DefaultProducer {
                 = software.amazon.awssdk.services.ses.model.Message.builder();
         String content;
         if (exchange.getIn().getBody() instanceof RawMessage raw) {
-            content = raw.data().toString();
+            // SdkBytes.toString() is a debug descriptor (SdkBytes(bytes=0x...)), not the payload
+            content = raw.data().asUtf8String();
         } else {
             content = exchange.getIn().getBody(String.class);
         }

--- a/components/camel-aws/camel-aws2-ses/src/test/java/org/apache/camel/component/aws2/ses/SesComponentTest.java
+++ b/components/camel-aws/camel-aws2-ses/src/test/java/org/apache/camel/component/aws2/ses/SesComponentTest.java
@@ -26,15 +26,29 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.ses.model.MessageTag;
+import software.amazon.awssdk.services.ses.model.RawMessage;
 import software.amazon.awssdk.services.ses.model.SendEmailRequest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SesComponentTest extends CamelTestSupport {
 
     @BindToRegistry("amazonSESClient")
     private AmazonSESClientMock sesClient = new AmazonSESClientMock();
+
+    @Test
+    void rawMessageBodyIsSentAsItsContentNotTheSdkBytesDescriptor() {
+        String mime = "From: from@example.com\r\nSubject: Subject\r\n\r\nThis is my message text.";
+        template.send("direct:start", exchange -> exchange.getIn().setBody(
+                RawMessage.builder().data(SdkBytes.fromUtf8String(mime)).build()));
+
+        // SdkBytes.toString() would yield "SdkBytes(bytes=0x...)" rather than the message content
+        String sent = sesClient.getSendEmailRequest().message().body().text().data();
+        assertThat(sent).isEqualTo(mime);
+    }
 
     @Test
     public void sendInOnlyMessageUsingUrlOptions() {


### PR DESCRIPTION
## Problem

`Ses2Producer.createMessage()` builds the outgoing `Content` from
`exchange.getIn().getBody(String.class)`. When the body is an SES
`RawMessage`, there is no type converter for it, so the conversion falls back
to `Object.toString()` on the SDK type.

`SdkBytes.toString()` renders a *debug descriptor*, not the payload:

```
SdkBytes(bytes=0x46726f6d3a2066726f6d406578616d706c652e636f6d0d0a...)
```

That descriptor is what ends up in the e-mail body — the actual MIME content
is never sent.

## Fix

When the body is a `RawMessage`, read the payload from
`RawMessage.data().asUtf8String()`:

```java
if (exchange.getIn().getBody() instanceof RawMessage raw) {
    // SdkBytes.toString() is a debug descriptor (SdkBytes(bytes=0x...)), not the payload
    content = raw.data().asUtf8String();
} else {
    content = exchange.getIn().getBody(String.class);
}
```

Note this path is distinct from the `jakarta.mail.Message` body, which already
goes through `sendRawEmail` and is unaffected.

## Test

`SesComponentTest.rawMessageBodyIsSentAsItsContentNotTheSdkBytesDescriptor()`
sends a `RawMessage` and asserts the text captured by the mock SES client
equals the original MIME string. The test fails on `main` with the
`SdkBytes(bytes=0x...)` descriptor and passes with the fix.

`assertj-core` is added test-scoped so the new assertion follows the project's
AssertJ preference; the pre-existing JUnit assertions in the file are left
untouched.

## Backport

The same code is present on `camel-4.18.x` and `camel-4.14.x`, so this is
targeted at 4.22.0, 4.18.4 and 4.14.9.

---
_Claude Code on behalf of oscerd_