### PR TITLE
CAMEL-24238: camel-aws2-ses - send RawMessage body content instead of the SdkBytes descriptor

### DIFF
--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -80,5 +80,10 @@
             <artifactId>camel-test-spring-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
+++ b/components/camel-aws/camel-aws2-ses/src/main/java/org/apache/camel/component/aws2/ses/Ses2Producer.java
@@ -101,7 +101,8 @@ public class Ses2Producer extends DefaultProducer {
                 = software.amazon.awssdk.services.ses.model.Message.builder();
         String content;
         if (exchange.getIn().getBody() instanceof RawMessage raw) {
-            content = raw.data().toString();
+            // SdkBytes.toString() is a debug descriptor (SdkBytes(bytes=0x...)), not the payload
+            content = raw.data().asUtf8String();
         } else {
             content = exchange.getIn().getBody(String.class);
         }

--- a/components/camel-aws/camel-aws2-ses/src/test/java/org/apache/camel/component/aws2/ses/SesComponentTest.java
+++ b/components/camel-aws/camel-aws2-ses/src/test/java/org/apache/camel/component/aws2/ses/SesComponentTest.java
@@ -26,15 +26,29 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.ses.model.MessageTag;
+import software.amazon.awssdk.services.ses.model.RawMessage;
 import software.amazon.awssdk.services.ses.model.SendEmailRequest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SesComponentTest extends CamelTestSupport {
 
     @BindToRegistry("amazonSESClient")
     private AmazonSESClientMock sesClient = new AmazonSESClientMock();
+
+    @Test
+    void rawMessageBodyIsSentAsItsContentNotTheSdkBytesDescriptor() {
+        String mime = "From: from@example.com\r\nSubject: Subject\r\n\r\nThis is my message text.";
+        template.send("direct:start", exchange -> exchange.getIn().setBody(
+                RawMessage.builder().data(SdkBytes.fromUtf8String(mime)).build()));
+
+        // SdkBytes.toString() would yield "SdkBytes(bytes=0x...)" rather than the message content
+        String sent = sesClient.getSendEmailRequest().message().body().text().data();
+        assertThat(sent).isEqualTo(mime);
+    }
 
     @Test
     public void sendInOnlyMessageUsingUrlOptions() {


### PR DESCRIPTION
Backport of #25015 to `camel-4.14.x`.

`Ses2Producer.createMessage()` converted a `RawMessage` body with
`raw.data().toString()`, which yields the `SdkBytes` debug descriptor
(`SdkBytes(bytes=0x...)`) rather than the MIME payload — so that descriptor was
sent as the e-mail body. Fixed by reading `raw.data().asUtf8String()`.

The bug is present on this branch verbatim. Cherry-picked cleanly;
`SesComponentTest` passes (5/5) on this branch.

Upgrade-guide note is not applicable — this is a plain bug fix with no
user-visible configuration change.

---
_Claude Code on behalf of oscerd_