### PR TITLE
[4.18.x] CAMEL-24240: Align all FHIR core dependencies

### DIFF
--- a/components/camel-fhir/camel-fhir-component/pom.xml
+++ b/components/camel-fhir/camel-fhir-component/pom.xml
@@ -49,7 +49,32 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-utilities-version}</version>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu3</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r4</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r5</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2016may</artifactId>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -236,8 +236,8 @@
         <hamcrest-version>3.0</hamcrest-version>
         <hapi-version>2.6.0</hapi-version>
         <hapi-base-version>2.6.0</hapi-base-version>
-        <hapi-fhir-version>8.6.5</hapi-fhir-version>
-        <hapi-fhir-utilities-version>6.9.1</hapi-fhir-utilities-version>
+        <hapi-fhir-version>8.10.0</hapi-fhir-version>
+        <hapi-fhir-core-version>6.9.12</hapi-fhir-core-version>
         <hawtio-version>4.6.2</hawtio-version>
         <!-- hazelcast version should stay at 5.4.0 due to commercial changes in 5.5.0 -->
         <hazelcast-version>5.4.0</hazelcast-version>


### PR DESCRIPTION
Backport for 4.18.x of #25014 including upgrading FHIR to 8.10.0.