### PR TITLE
[4.14.x] CAMEL-24240: Align all FHIR core dependencies

### DIFF
--- a/components/camel-fhir/camel-fhir-component/pom.xml
+++ b/components/camel-fhir/camel-fhir-component/pom.xml
@@ -49,7 +49,32 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-utilities-version}</version>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu3</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r4</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r5</artifactId>
+                <version>${hapi-fhir-core-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2016may</artifactId>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/components/camel-fhir/camel-fhir-component/src/test/java/org/apache/camel/component/fhir/FhirCustomClientConfigurationIT.java
+++ b/components/camel-fhir/camel-fhir-component/src/test/java/org/apache/camel/component/fhir/FhirCustomClientConfigurationIT.java
@@ -43,6 +43,7 @@ import ca.uhn.fhir.rest.gclient.IHistory;
 import ca.uhn.fhir.rest.gclient.IMeta;
 import ca.uhn.fhir.rest.gclient.IOperation;
 import ca.uhn.fhir.rest.gclient.IPatch;
+import ca.uhn.fhir.rest.gclient.IRawHttp;
 import ca.uhn.fhir.rest.gclient.IRead;
 import ca.uhn.fhir.rest.gclient.ITransaction;
 import ca.uhn.fhir.rest.gclient.IUntypedQuery;
@@ -267,6 +268,11 @@ public class FhirCustomClientConfigurationIT extends AbstractFhirTestSupport {
 
         @Override
         public IOperation operation() {
+            return null;
+        }
+
+        @Override
+        public IRawHttp rawHttpRequest() {
             return null;
         }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -220,8 +220,8 @@
         <hamcrest-version>3.0</hamcrest-version>
         <hapi-version>2.6.0</hapi-version>
         <hapi-base-version>2.6.0</hapi-base-version>
-        <hapi-fhir-version>8.2.1</hapi-fhir-version>
-        <hapi-fhir-utilities-version>6.9.1</hapi-fhir-utilities-version>
+        <hapi-fhir-version>8.10.0</hapi-fhir-version>
+        <hapi-fhir-core-version>6.9.12</hapi-fhir-core-version>
         <!-- hazelcast needs to stay at 5.4.0 due to changes where the CP subsystem is only available in
         the enterprise hazelcast product -->
         <hazelcast-version>5.4.0</hazelcast-version>


### PR DESCRIPTION
Backport for 4.14.x of https://github.com/apache/camel/pull/25014 including upgrading FHIR to 8.10.0.