### PR TITLE
Specify more precise resource lock on ZXsltTotalOpsTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/ZXsltTotalOpsTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/ZXsltTotalOpsTest.java
@@ -23,11 +23,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
 public class ZXsltTotalOpsTest extends ContextTestSupport {
 
     @Override


### PR DESCRIPTION
TestSupport (the grandparent) declares @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = READ), telling JUnit this test only reads system properties. Since this test writes them, the inherited declaration is incorrect — it should be overridden with the default (READ_WRITE) mode.

follows-up to
https://github.com/apache/camel/pull/24955#pullrequestreview-4750830939

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

