### PR TITLE
CAMEL-21314: camel-aws2-s3 - supply the customer key when copying SSE-C objects

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -518,13 +518,18 @@ public class AWS2S3Producer extends DefaultProducer {
             }
 
             if (getConfiguration().isUseCustomerKey()) {
+                // the source object was stored with SSE-C, so the same customer key must also be supplied as the
+                // copy-source key, otherwise S3 cannot decrypt the source and rejects the copy
                 if (ObjectHelper.isNotEmpty(getConfiguration().getCustomerKeyId())) {
+                    copyObjectRequest.copySourceSSECustomerKey(getConfiguration().getCustomerKeyId());
                     copyObjectRequest.sseCustomerKey(getConfiguration().getCustomerKeyId());
                 }
                 if (ObjectHelper.isNotEmpty(getConfiguration().getCustomerKeyMD5())) {
+                    copyObjectRequest.copySourceSSECustomerKeyMD5(getConfiguration().getCustomerKeyMD5());
                     copyObjectRequest.sseCustomerKeyMD5(getConfiguration().getCustomerKeyMD5());
                 }
                 if (ObjectHelper.isNotEmpty(getConfiguration().getCustomerAlgorithm())) {
+                    copyObjectRequest.copySourceSSECustomerAlgorithm(getConfiguration().getCustomerAlgorithm());
                     copyObjectRequest.sseCustomerAlgorithm(getConfiguration().getCustomerAlgorithm());
                 }
             }

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3CopyObjectCustomerKeyIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3CopyObjectCustomerKeyIT.java
@@ -32,7 +32,6 @@ import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.component.aws2.s3.AWS2S3Operations;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.utils.Md5Utils;
@@ -41,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
 
-@Disabled("Broken test")
 public class S3CopyObjectCustomerKeyIT extends Aws2S3Base {
 
     byte[] secretKey = generateSecretKey();


### PR DESCRIPTION
### Motivation

[CAMEL-21314](https://issues.apache.org/jira/browse/CAMEL-21314). `S3CopyObjectCustomerKeyIT` was failing and ended up disabled as a "Broken test". It turns out the test was right and the **producer is broken**: copying an object that was stored with SSE-C does not work at all.

`copyObject` only set the *destination* SSE-C parameters (`sseCustomerKey`, `sseCustomerKeyMD5`, `sseCustomerAlgorithm`). When the *source* object is itself SSE-C encrypted, S3 also needs the copy-source customer key in order to decrypt it, and rejects the request otherwise — which is exactly the failure reported on the issue:

```
InvalidRequest: SSE-C encrypted objects require customer key headers. (Service: S3, Status Code: 400)
```

(the issue also quotes the equivalent `The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.`)

So this is a real user-facing bug, not just a test problem: `copyObject` against any SSE-C encrypted object fails.

### Changes

- `AWS2S3Producer.copyObject` now also sets `copySourceSSECustomerKey`, `copySourceSSECustomerKeyMD5` and `copySourceSSECustomerAlgorithm`, alongside the existing destination parameters, from the same configured customer key — the source was written with that key and the destination is re-encrypted with it.
- Re-enabled `S3CopyObjectCustomerKeyIT` (dropped `@Disabled("Broken test")` and the now-unused import).

### Testing

Verified end-to-end against localstack, including a control run to confirm the fix is what makes the difference:

- **Without** the producer change (fix stashed, test enabled): `S3CopyObjectCustomerKeyIT` fails with `InvalidRequest: SSE-C encrypted objects require customer key headers ... Status Code: 400`.
- **With** the fix: `Tests run: 1, Failures: 0, Errors: 0` — the IT passes, and the module's 41 unit tests pass alongside it.
- Full reactor `mvn clean install -DskipTests` from root: success, no stale generated files.

### Backport

The same destination-only handling is present on `camel-4.18.x` and `camel-4.14.x` (verified: neither branch sets any `copySourceSSECustomerKey*` parameter), so this is a backport candidate for both once merged here.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
