### PR TITLE
CAMEL-24242: camel-aws2-athena - stop ignoring thread interruption while polling a query

### DIFF
--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -76,6 +76,11 @@
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- test infra -->
         <dependency>

--- a/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2QueryHelper.java
+++ b/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2QueryHelper.java
@@ -169,7 +169,7 @@ class Athena2QueryHelper {
     void doWait() {
         // Use Camel's task API for polling delay instead of Thread.sleep()
         // We use initialDelay for the actual delay, and maxIterations(1) to run once
-        Tasks.foregroundTask()
+        boolean completed = Tasks.foregroundTask()
                 .withBudget(Budgets.iterationBudget()
                         .withMaxIterations(1)
                         .withInitialDelay(Duration.ofMillis(this.currentDelay))
@@ -178,6 +178,14 @@ class Athena2QueryHelper {
                 .withName("AthenaQueryPollingDelay")
                 .build()
                 .run(exchange.getContext(), () -> true);
+
+        if (!completed && Thread.currentThread().isInterrupted()) {
+            // the task API already restored the interrupt status, so only record it here to let the
+            // attempt and wait loops bail out at the earliest opportunity
+            this.interrupted = true;
+            LOG.trace(
+                    "AWS Athena start query execution wait thread was interrupted; will return at earliest opportunity");
+        }
 
         this.currentDelay = this.delay;
     }

--- a/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2QueryHelperTest.java
+++ b/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2QueryHelperTest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.athena.model.QueryExecution;
 import software.amazon.awssdk.services.athena.model.QueryExecutionState;
 import software.amazon.awssdk.services.athena.model.QueryExecutionStatus;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -153,6 +154,36 @@ public class Athena2QueryHelperTest {
         assertFalse(helper.isInterrupted());
 
         assertFalse(helper.shouldAttempt());
+    }
+
+    @Test
+    void doWaitRecordsThreadInterruptionSoTheLoopsStop() {
+        Athena2Configuration configuration = new Athena2Configuration();
+        configuration.setMaxAttempts(3);
+        configuration.setWaitTimeout(60_000);
+        configuration.setInitialDelay(10_000);
+        configuration.setDelay(10_000);
+
+        Athena2QueryHelper helper = new Athena2QueryHelper(
+                new DefaultExchange(new DefaultCamelContext()),
+                configuration);
+
+        helper.markAttempt();
+        assertThat(helper.shouldWait()).isTrue();
+
+        Thread.currentThread().interrupt();
+        try {
+            helper.doWait();
+
+            // without this, the wait loop keeps polling Athena with no delay at all, because every
+            // subsequent sleep returns immediately while the interrupt status is still set
+            assertThat(helper.isInterrupted()).isTrue();
+            assertThat(helper.shouldWait()).isFalse();
+            assertThat(helper.shouldAttempt()).isFalse();
+        } finally {
+            // clear the interrupt status so it does not leak into the following tests
+            Thread.interrupted();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

`Athena2QueryHelper.interrupted` gates both loops that drive `startQueryExecution`:

```java
if (this.interrupted) {
    LOG.trace("AWS Athena start query execution thread was interrupted, will try no more");
    return false;
}
```

It is read at `Athena2QueryHelper.java:113` (`shouldAttempt`) and `:146`
(`shouldWait`) — and **never assigned anywhere in the class**. Both guards are
dead code.

## How it regressed

This is a silent revert of a deliberate fix, so I want to be explicit about the
history:

- **CAMEL-20297** (`9e17300779`, Otavio Piske, Jan 2024) — *"camel-aws2-athena:
  do not swallow interrupted exceptions"* — added the interrupt handling:

  ```java
  try {
      Thread.sleep(this.currentDelay);
  } catch (InterruptedException e) {
      this.interrupted = Thread.interrupted(); // store, then clear, interrupt status
      LOG.trace("...wait thread was interrupted; will return at earliest opportunity");
      Thread.currentThread().interrupt();
  }
  ```

- **CAMEL-22949** (`1b0fca17c0`, PR #21215, Feb 2026) — *"Migrate components from
  Thread.sleep() to Camel's Task API"* — replaced that block with
  `Tasks.foregroundTask()...run(...)` and dropped the `catch` clause, which was
  the only writer of `interrupted`.

## Impact

`ForegroundTask.run()` *does* restore the interrupt status
(`ForegroundTask.java:124`) and return `false` — but `doWait()` discarded the
return value. The result is worse than a missed shutdown signal. After the first
interruption:

1. the thread's interrupt status stays set;
2. `shouldWait()` still returns `true`, because `interrupted` is `false`;
3. the next `doWait()` reaches `Thread.sleep(initialDelay)` inside
   `ForegroundTask.run()`, which throws `InterruptedException` **immediately**
   because the status is set, and returns at once;
4. the polling loop therefore spins with **no delay at all**, issuing
   `GetQueryExecution` calls as fast as the API allows until `waitTimeout`
   elapses — and up to `maxAttempts × waitTimeout` when
   `resetWaitTimeoutOnRetry=true`.

So interrupting an in-flight query (graceful shutdown, route stop) turns a
2-second-interval poll into a tight busy loop against the Athena API.

## Fix

Capture the `run()` return value and record the interruption:

```java
if (!completed && Thread.currentThread().isInterrupted()) {
    // the task API already restored the interrupt status, so only record it here to let the
    // attempt and wait loops bail out at the earliest opportunity
    this.interrupted = true;
    LOG.trace("AWS Athena start query execution wait thread was interrupted; will return at earliest opportunity");
}
```

The interrupt status itself is left in place — `ForegroundTask` already restored
it, which is what CAMEL-20297 wanted the caller to observe.

## Test

`Athena2QueryHelperTest.doWaitRecordsThreadInterruptionSoTheLoopsStop()` interrupts
the calling thread, calls `doWait()`, and asserts that `isInterrupted()`,
`shouldWait()` and `shouldAttempt()` all report the query loop should stop. It
clears the interrupt status in a `finally` block so it cannot leak into
neighbouring tests.

Verified it fails on `main` (`Expecting value to be true but was false`) and
passes with the fix. Full class: 23/23 green.

`assertj-core` is added test-scoped for the new assertions; the pre-existing
JUnit assertions in the file are left untouched.

## Backport

- `camel-4.18.x` — affected (carries the CAMEL-22949 migration) → backport opened.
- `camel-4.14.x` — **not** affected; it still has the original `Thread.sleep()`
  with the `catch (InterruptedException)` block, so there is nothing to fix there.

---
_Claude Code on behalf of oscerd_