### PR TITLE
CAMEL-24242: camel-aws2-athena - stop ignoring thread interruption while polling a query

### DIFF
--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -76,6 +76,11 @@
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- test infra -->
        <dependency>

--- a/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2QueryHelper.java
+++ b/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2QueryHelper.java
@@ -169,7 +169,7 @@ class Athena2QueryHelper {
     void doWait() {
         // Use Camel's task API for polling delay instead of Thread.sleep()
         // We use initialDelay for the actual delay, and maxIterations(1) to run once
-        Tasks.foregroundTask()
+        boolean completed = Tasks.foregroundTask()
                 .withBudget(Budgets.iterationBudget()
                         .withMaxIterations(1)
                         .withInitialDelay(Duration.ofMillis(this.currentDelay))
@@ -178,6 +178,14 @@ class Athena2QueryHelper {
                 .withName("AthenaQueryPollingDelay")
                 .build()
                 .run(exchange.getContext(), () -> true);
+
+        if (!completed && Thread.currentThread().isInterrupted()) {
+            // the task API already restored the interrupt status, so only record it here to let the
+            // attempt and wait loops bail out at the earliest opportunity
+            this.interrupted = true;
+            LOG.trace(
+                    "AWS Athena start query execution wait thread was interrupted; will return at earliest opportunity");
+        }
 
         this.currentDelay = this.delay;
     }

--- a/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2QueryHelperTest.java
+++ b/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2QueryHelperTest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.athena.model.QueryExecution;
 import software.amazon.awssdk.services.athena.model.QueryExecutionState;
 import software.amazon.awssdk.services.athena.model.QueryExecutionStatus;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -153,6 +154,36 @@ public class Athena2QueryHelperTest {
         assertFalse(helper.isInterrupted());
 
         assertFalse(helper.shouldAttempt());
+    }
+
+    @Test
+    void doWaitRecordsThreadInterruptionSoTheLoopsStop() {
+        Athena2Configuration configuration = new Athena2Configuration();
+        configuration.setMaxAttempts(3);
+        configuration.setWaitTimeout(60_000);
+        configuration.setInitialDelay(10_000);
+        configuration.setDelay(10_000);
+
+        Athena2QueryHelper helper = new Athena2QueryHelper(
+                new DefaultExchange(new DefaultCamelContext()),
+                configuration);
+
+        helper.markAttempt();
+        assertThat(helper.shouldWait()).isTrue();
+
+        Thread.currentThread().interrupt();
+        try {
+            helper.doWait();
+
+            // without this, the wait loop keeps polling Athena with no delay at all, because every
+            // subsequent sleep returns immediately while the interrupt status is still set
+            assertThat(helper.isInterrupted()).isTrue();
+            assertThat(helper.shouldWait()).isFalse();
+            assertThat(helper.shouldAttempt()).isFalse();
+        } finally {
+            // clear the interrupt status so it does not leak into the following tests
+            Thread.interrupted();
+        }
     }
 
     @Test


### PR DESCRIPTION
Backport of #25029 to `camel-4.18.x`.

`Athena2QueryHelper.interrupted` gates both `shouldAttempt()` and `shouldWait()`
but has no writer, so both guards are dead code. CAMEL-20297 had added the
interrupt handling in `doWait()`; the CAMEL-22949 Task-API migration
(`1b0fca17c0`) dropped the `catch (InterruptedException)` block that was its only
writer.

Because `ForegroundTask.run()` restores the interrupt status and `doWait()`
discarded its return value, an interrupted poll loop spins with **no delay**,
hammering `GetQueryExecution` until `waitTimeout` elapses. The fix records the
interruption so both loops bail out.

This branch carries the CAMEL-22949 migration, so it is affected. `camel-4.14.x`
is **not** — it still has the original `Thread.sleep()` with its `catch` block,
so no backport is needed there.

Cherry-picked cleanly; `Athena2QueryHelperTest` passes 23/23 on this branch.

No upgrade-guide entry — this restores intended behaviour with no user-visible
configuration change.

---
_Claude Code on behalf of oscerd_