### PR TITLE
chore: Improve exchange pattern documentation to clarify behavior

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/event-message.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/event-message.adoc
@@ -17,7 +17,7 @@ a oneway event message. Camel xref:ROOT:index.adoc[Components] then
 implement this pattern using the underlying transport or protocols.
 
 The default behaviour of many xref:ROOT:index.adoc[Components] is `InOnly`
-such as for xref:ROOT:jms-component.adoc[JMS], xref:ROOT:jms-component.adoc[File] or
+such as for xref:ROOT:jms-component.adoc[JMS], xref:ROOT:file-component.adoc[File] or
 xref:ROOT:seda-component.adoc[SEDA].
 
 Some components support both `InOnly` and `InOut` and act accordingly.
@@ -76,6 +76,24 @@ YAML::
             uri: activemq:queue:one-way
 ----
 ====
+
+== How It Works
+
+The `InOnly` exchange pattern is a contract between the route and the component endpoint.
+It tells the producer component that the caller does *not* expect a reply (fire-and-forget).
+
+The exchange pattern does *not* affect how EIPs and processors work within the route.
+Processors such as `setBody`, `transform`, `process`, and `bean` always operate on the
+current message regardless of the exchange pattern. The pattern only matters when the exchange
+reaches a producer endpoint that acts on it.
+
+Whether a component acts on the pattern depends on the component.
+Components that support both modes, such as xref:ROOT:jms-component.adoc[JMS],
+xref:ROOT:seda-component.adoc[SEDA], and xref:ROOT:amqp-component.adoc[AMQP],
+use `InOnly` to dispatch the message without waiting for a reply (fire-and-forget).
+Synchronous components such as xref:ROOT:direct-component.adoc[Direct] always process
+in the same thread and call stack, so the pattern has no practical effect on the dispatch
+behavior — the caller still waits for the called route to complete.
 
 == Using `setExchangePattern` EIP
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/requestReply-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/requestReply-eip.adoc
@@ -80,6 +80,25 @@ YAML::
 ----
 ====
 
+== How It Works
+
+The `InOut` exchange pattern is a contract between the route and the component endpoint.
+It tells the producer component that the caller expects a reply message.
+
+The exchange pattern does *not* affect how EIPs and processors work within the route.
+Processors such as `setBody`, `transform`, `process`, and `bean` always operate on the
+current message regardless of the exchange pattern. The pattern only matters when the exchange
+reaches a producer endpoint that acts on it.
+
+Whether a component acts on the pattern depends on the component.
+Components that support both modes, such as xref:ROOT:jms-component.adoc[JMS],
+xref:ROOT:seda-component.adoc[SEDA], and xref:ROOT:amqp-component.adoc[AMQP],
+use `InOut` to switch to request/reply messaging.
+For example, with JMS the component sets up a temporary reply queue
+(via `JMSReplyTo`) and waits for a response.
+Synchronous components such as xref:ROOT:direct-component.adoc[Direct] always process
+in the same thread and call stack, so the pattern has no practical effect on the dispatch behavior.
+
 == Using setExchangePattern EIP
 
 You can specify the

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
@@ -77,6 +77,24 @@ YAML::
 ----
 ====
 
+== How It Works
+
+The `InOnly` exchange pattern is a contract between the route and the component endpoint.
+It tells the producer component that the caller does *not* expect a reply (fire-and-forget).
+
+The exchange pattern does *not* affect how EIPs and processors work within the route.
+Processors such as `setBody`, `transform`, `process`, and `bean` always operate on the
+current message regardless of the exchange pattern. The pattern only matters when the exchange
+reaches a producer endpoint that acts on it.
+
+Whether a component acts on the pattern depends on the component.
+Components that support both modes, such as xref:ROOT:jms-component.adoc[JMS],
+xref:ROOT:seda-component.adoc[SEDA], and xref:ROOT:amqp-component.adoc[AMQP],
+use `InOnly` to dispatch the message without waiting for a reply (fire-and-forget).
+Synchronous components such as xref:ROOT:direct-component.adoc[Direct] always process
+in the same thread and call stack, so the pattern has no practical effect on the dispatch
+behavior — the caller still waits for the called route to complete.
+
 == Using `setExchangePattern` EIP
 
 You can specify the

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/event-message.adoc
@@ -17,7 +17,7 @@ a oneway event message. Camel xref:ROOT:index.adoc[Components] then
 implement this pattern using the underlying transport or protocols.
 
 The default behaviour of many xref:ROOT:index.adoc[Components] is `InOnly`
-such as for xref:ROOT:jms-component.adoc[JMS], xref:ROOT:jms-component.adoc[File] or
+such as for xref:ROOT:jms-component.adoc[JMS], xref:ROOT:file-component.adoc[File] or
 xref:ROOT:seda-component.adoc[SEDA].
 
 Some components support both `InOnly` and `InOut` and act accordingly.

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/requestReply-eip.adoc
@@ -80,6 +80,25 @@ YAML::
 ----
 ====
 
+== How It Works
+
+The `InOut` exchange pattern is a contract between the route and the component endpoint.
+It tells the producer component that the caller expects a reply message.
+
+The exchange pattern does *not* affect how EIPs and processors work within the route.
+Processors such as `setBody`, `transform`, `process`, and `bean` always operate on the
+current message regardless of the exchange pattern. The pattern only matters when the exchange
+reaches a producer endpoint that acts on it.
+
+Whether a component acts on the pattern depends on the component.
+Components that support both modes, such as xref:ROOT:jms-component.adoc[JMS],
+xref:ROOT:seda-component.adoc[SEDA], and xref:ROOT:amqp-component.adoc[AMQP],
+use `InOut` to switch to request/reply messaging.
+For example, with JMS the component sets up a temporary reply queue
+(via `JMSReplyTo`) and waits for a response.
+Synchronous components such as xref:ROOT:direct-component.adoc[Direct] always process
+in the same thread and call stack, so the pattern has no practical effect on the dispatch behavior.
+
 == Using setExchangePattern EIP
 
 You can specify the

--- a/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
+++ b/docs/user-manual/modules/ROOT/pages/exchange-pattern.adoc
@@ -1,9 +1,9 @@
 = Exchange Pattern
 
-There are two _Message Exchange Patterns_ you can use in
+There are two _Message Exchange Patterns_ (MEP) you can use in
 messaging.
 
-From there xref:components:eips:enterprise-integration-patterns.adoc[Enterprise
+From the xref:components:eips:enterprise-integration-patterns.adoc[Enterprise
 Integration Patterns] they are:
 
 * xref:components:eips:event-message.adoc[Event Message] (or one-way)
@@ -15,6 +15,29 @@ enumeration which can be configured on the *exchangePattern* property on
 the Message Exchange indicating if a message
 exchange is a one way xref:components:eips:event-message.adoc[Event Message] (*InOnly*) or
 a xref:components:eips:requestReply-eip.adoc[Request Reply] message exchange (*InOut*).
+
+== How Exchange Pattern Works
+
+The exchange pattern is a contract between the route and the *component endpoint*.
+It tells the component whether the caller expects a reply (`InOut`) or not (`InOnly`).
+
+The exchange pattern does *not* affect how EIPs and processors work within the route.
+Processors such as `setBody`, `transform`, `process`, and `bean` always operate on the
+current message body regardless of the exchange pattern.
+The pattern only matters when the exchange reaches a *producer endpoint* (i.e., a `to` step)
+that acts on it.
+
+Most components have a fixed exchange pattern — for example,
+xref:components::http-component.adoc[HTTP] is always `InOut` (request/reply) and
+xref:components::kafka-component.adoc[Kafka] is always `InOnly` (fire-and-forget).
+For these components the exchange pattern setting has no effect.
+
+The exchange pattern is historically used by a limited set of components that support *both*
+`InOnly` and `InOut`, such as xref:components::jms-component.adoc[JMS],
+xref:components::seda-component.adoc[SEDA], and xref:components::amqp-component.adoc[AMQP].
+These components use the pattern to decide between fire-and-forget and request/reply messaging.
+For example, with JMS `InOnly` sends a message to a queue without waiting for a reply,
+while `InOut` sets up a temporary reply queue (via `JMSReplyTo`) and waits for a response.
 
 For example to override the default pattern on a xref:components::jms-component.adoc[JMS]
 endpoint you could use the `exchangePattern` parameter in the Endpoint xref:uris.adoc[URI]


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Improves the exchange pattern documentation to clarify how `InOnly` and `InOut` actually work, addressing recurring confusion from users on the mailing list.

**Changes:**
- `exchange-pattern.adoc` — Added "How Exchange Pattern Works" section explaining it is a component-level contract, does not affect processors like `setBody`, and clarifying async vs sync component behavior (seda/jms fire-and-forget vs direct same-thread)
- `requestReply-eip.adoc` — Added "How It Works" section explaining `InOut` is a contract with the endpoint, not a flow control mechanism
- `event-message.adoc` — Added "How It Works" section for `InOnly` with the same clarifications
- `event-message.adoc` — Fixed pre-existing broken xref link (was linking to JMS with "File" label instead of File component)
- Regenerated catalog copies of `event-message.adoc` and `requestReply-eip.adoc`

Prompted by discussion with Raymond Meester on the Camel users mailing list.

## Test plan
- [ ] Documentation-only change, no code impact
- [x] Full reactor build passes (`mvn clean install -Dquickly`)
- [x] Generated catalog docs are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>