### PR TITLE
CAMEL-24247: camel-jbang - Fix duplicate camel-micrometer-prometheus in exported pom.xml

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -292,6 +292,7 @@ class ExportCamelMain extends Export {
         answer.removeIf(s -> s.contains("camel-core"));
         answer.removeIf(s -> s.contains("camel-main"));
         answer.removeIf(s -> s.contains("camel-health"));
+        answer.removeIf(s -> s.contains("camel-micrometer-prometheus"));
         // spring-boot-starter JARs are not usable in camel-main runtime
         answer.removeIf(s -> s.contains("spring-boot-starter"));
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -292,7 +292,6 @@ class ExportCamelMain extends Export {
         answer.removeIf(s -> s.contains("camel-core"));
         answer.removeIf(s -> s.contains("camel-main"));
         answer.removeIf(s -> s.contains("camel-health"));
-        answer.removeIf(s -> s.contains("camel-micrometer-prometheus"));
         // spring-boot-starter JARs are not usable in camel-main runtime
         answer.removeIf(s -> s.contains("spring-boot-starter"));
 
@@ -303,11 +302,11 @@ class ExportCamelMain extends Export {
             if (prop.containsKey("camel.metrics.enabled")
                     || prop.containsKey("camel.management.metricsEnabled")
                     || prop.containsKey("camel.server.metricsEnabled")) {
-                answer.add("mvn:org.apache.camel:camel-micrometer-prometheus");
+                answer.add("camel:micrometer-prometheus");
             }
             // if health-check is defined then include camel-health for camel-main runtime
             if (prop.containsKey("camel.management.healthCheckEnabled")) {
-                answer.add("mvn:org.apache.camel:camel-health");
+                answer.add("camel:health");
             }
         }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -1048,6 +1048,33 @@ class ExportTest {
         }
     }
 
+    @Test
+    void shouldNotDuplicateMetricsDependency() throws Exception {
+        File profile = new File(".", "application.properties");
+        try {
+            Files.writeString(profile.toPath(), "camel.management.metricsEnabled=true\n");
+
+            Export command = new Export(new CamelJBangMain());
+            CommandLine.populateCommand(command,
+                    "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet",
+                    "--runtime=camel-main",
+                    "src/test/resources/route.yaml");
+            int exit = command.doCall();
+
+            assertThat(exit).isEqualTo(0);
+            Model model = readMavenModel();
+
+            long count = model.getDependencies().stream()
+                    .filter(d -> "camel-micrometer-prometheus".equals(d.getArtifactId()))
+                    .count();
+            assertThat(count)
+                    .as("camel-micrometer-prometheus should appear exactly once")
+                    .isEqualTo(1);
+        } finally {
+            FileUtil.deleteFile(profile);
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("runtimeProvider")
     public void shouldContainJibProfile(RuntimeType rt) throws Exception {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes [CAMEL-24247](https://issues.apache.org/jira/browse/CAMEL-24247).

When exporting a JBang project with metrics enabled, the exported pom.xml contains `camel-micrometer-prometheus` twice. The base class `ExportBaseCommand.resolveDependencies()` adds `camel:micrometer-prometheus` (shorthand format) at line 778, then the subclass `ExportCamelMain.resolveDependencies()` adds `mvn:org.apache.camel:camel-micrometer-prometheus` (full format) at line 305. Since these are different strings, the `Set` does not deduplicate them, and both end up in the generated pom.xml.

**Fix:** Switch the subclass to use `camel:micrometer-prometheus` shorthand (matching the base class format) so the `Set` naturally deduplicates. Applied the same fix for `camel-health`. No `removeIf` workaround needed.

## Test plan
- [x] Added `shouldNotDuplicateMetricsDependency` test that exports with `camel.management.metricsEnabled=true` and asserts `camel-micrometer-prometheus` appears exactly once
- [x] All 856 module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>