### PR TITLE
[backport camel-4.14.x] CAMEL-24231: camel-ftp - Fix pollNamedFile to use dynamic exchange for useList=false

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
@@ -90,8 +90,18 @@ public final class GenericFileHelper {
 
     public static <T> Exchange createDummy(GenericFileEndpoint<T> endpoint, Exchange dynamic, Supplier<GenericFile<T>> file) {
         Exchange dummy = endpoint.createExchange(file.get());
+        enrichFromDynamic(dummy, dynamic);
+        return dummy;
+    }
+
+    public static <T> Exchange createDummy(GenericFileEndpoint<T> endpoint, Exchange dynamic) {
+        Exchange dummy = endpoint.createExchange();
+        enrichFromDynamic(dummy, dynamic);
+        return dummy;
+    }
+
+    private static void enrichFromDynamic(Exchange dummy, Exchange dynamic) {
         if (dynamic != null) {
-            // enrich with data from dynamic source
             if (dynamic.getMessage().hasHeaders()) {
                 MessageHelper.copyHeaders(dynamic.getMessage(), dummy.getMessage(), true);
             }
@@ -102,7 +112,6 @@ public final class GenericFileHelper {
                 dummy.getProperties().putAll(dynamic.getProperties());
             }
         }
-        return dummy;
     }
 
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/FtpConsumer.java
@@ -27,9 +27,9 @@ import org.apache.camel.Processor;
 import org.apache.camel.api.management.ManagedAttribute;
 import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.component.file.GenericFile;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileProcessStrategy;
-import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
@@ -136,7 +136,7 @@ public class FtpConsumer extends RemoteFileConsumer<FTPFile> {
         // compute dir depending on stepwise is enabled or not
         final String dir = computeDir(absolutePath, dirName);
 
-        final FTPFile[] files = getFtpFiles(dir);
+        final FTPFile[] files = getFtpFiles(dynamic, dir);
 
         if (files == null || files.length == 0) {
             // no files in this directory to poll
@@ -235,11 +235,11 @@ public class FtpConsumer extends RemoteFileConsumer<FTPFile> {
         return dir;
     }
 
-    private FTPFile[] pollNamedFile() {
+    private FTPFile[] pollNamedFile(Exchange dynamic) {
         FTPFile[] files = null;
         // we cannot use the LIST command(s) so we can only poll a named
         // file so created a pseudo file with that name
-        Exchange dummy = ExchangeHelper.getDummy(getEndpoint().getCamelContext());
+        Exchange dummy = GenericFileHelper.createDummy(getEndpoint(), dynamic);
         String name = evaluateFileExpression(dummy);
         if (name != null) {
             FTPFile file = new FTPFile();
@@ -259,14 +259,14 @@ public class FtpConsumer extends RemoteFileConsumer<FTPFile> {
         return operations.listFiles(dir);
     }
 
-    private FTPFile[] getFtpFiles(String dir) {
+    private FTPFile[] getFtpFiles(Exchange dynamic, String dir) {
         FTPFile[] files = null;
         try {
             LOG.trace("Polling directory: {}", dir);
             if (isUseList()) {
                 files = listFiles(dir);
             } else {
-                files = pollNamedFile();
+                files = pollNamedFile(dynamic);
             }
         } catch (GenericFileOperationFailedException e) {
             if (ignoreCannotRetrieveFile(null, null, e)) {

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpConsumer.java
@@ -27,9 +27,9 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.component.file.GenericFile;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileProcessStrategy;
-import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
@@ -136,7 +136,7 @@ public class SftpConsumer extends RemoteFileConsumer<SftpRemoteFile> {
             dir = absolutePath;
         }
 
-        final SftpRemoteFile[] files = getSftpRemoteFiles(dir);
+        final SftpRemoteFile[] files = getSftpRemoteFiles(dynamic, dir);
 
         if (files == null || files.length == 0) {
             // no files in this directory to poll
@@ -209,14 +209,14 @@ public class SftpConsumer extends RemoteFileConsumer<SftpRemoteFile> {
         return operations.listFiles(dir);
     }
 
-    private SftpRemoteFile[] getSftpRemoteFiles(String dir) {
+    private SftpRemoteFile[] getSftpRemoteFiles(Exchange dynamic, String dir) {
         SftpRemoteFile[] files = null;
         try {
             LOG.trace("Polling directory: {}", dir);
             if (isUseList()) {
                 files = listFiles(dir);
             } else {
-                files = pollNamedFile();
+                files = pollNamedFile(dynamic);
             }
         } catch (GenericFileOperationFailedException e) {
             if (ignoreCannotRetrieveFile(null, null, e)) {
@@ -228,12 +228,12 @@ public class SftpConsumer extends RemoteFileConsumer<SftpRemoteFile> {
         return files;
     }
 
-    private SftpRemoteFile[] pollNamedFile() {
+    private SftpRemoteFile[] pollNamedFile(Exchange dynamic) {
         SftpRemoteFile[] files = null;
 
         // we cannot use the LIST command(s) so we can only poll a named
         // file so created a pseudo file with that name
-        Exchange dummy = ExchangeHelper.getDummy(getEndpoint().getCamelContext());
+        Exchange dummy = GenericFileHelper.createDummy(getEndpoint(), dynamic);
         String name = evaluateFileExpression(dummy);
         if (name != null) {
             SftpRemoteFile file = new SftpRemoteFileSingle(name);


### PR DESCRIPTION
## Backport of #25031

_Claude Code on behalf of davsclaus_

Cherry-pick of #25031 onto `camel-4.14.x`.

**Original PR:** #25031 - CAMEL-24231: camel-ftp - Fix pollNamedFile to use dynamic exchange for useList=false
**Original author:** @davsclaus
**Target branch:** `camel-4.14.x`

### Changes

On 4.14.x there is no `camel-mina-sftp` module yet, so only two consumers are affected:
- `FtpConsumer.java` - thread `dynamic` through `getFtpFiles()` → `pollNamedFile()`
- `SftpConsumer.java` - thread `dynamic` through `getSftpRemoteFiles()` → `pollNamedFile()`

Plus the `GenericFileHelper.createDummy(endpoint, dynamic)` 2-arg overload and `enrichFromDynamic()` extraction.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>