### PR TITLE
CAMEL-24243: camel-aws2-athena - do not relaunch a still-running query when waitTimeout expires

### DIFF
--- a/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2QueryHelper.java
+++ b/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2QueryHelper.java
@@ -125,9 +125,30 @@ class Athena2QueryHelper {
             return false;
         }
 
+        if (isWaitTimeoutExceeded()) {
+            LOG.trace("AWS Athena start query execution exceeded the wait timeout of {} while the query was still"
+                      + " running, will not relaunch it",
+                    this.waitTimeout);
+            return false;
+        }
+
         // if this.isRetry, return true
 
         return true;
+    }
+
+    /**
+     * Did the wait window elapse while the query was still running? Only a completed-and-retryable query is meant to
+     * consume another attempt, so a query that is merely slow must not be relaunched.
+     * <p>
+     * Called from {@link #shouldAttempt()} once success and failure have been ruled out, so {@code isRetry} is the only
+     * completion state left to exclude here.
+     */
+    private boolean isWaitTimeoutExceeded() {
+        if (this.attempts == 0 || this.isRetry) {
+            return false;
+        }
+        return now() - this.startMs >= this.waitTimeout;
     }
 
     /**

--- a/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2QueryHelperTest.java
+++ b/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2QueryHelperTest.java
@@ -187,6 +187,60 @@ public class Athena2QueryHelperTest {
     }
 
     @Test
+    void aStillRunningQueryIsNotRelaunchedWhenTheWaitTimeoutExpires() {
+        Athena2Configuration configuration = new Athena2Configuration();
+        configuration.setMaxAttempts(3);
+        configuration.setWaitTimeout(1);
+        configuration.setInitialDelay(1);
+        configuration.setDelay(1);
+        configuration.setRetry("always");
+
+        Athena2QueryHelper helper = new Athena2QueryHelper(
+                new DefaultExchange(new DefaultCamelContext()),
+                configuration);
+
+        assertThat(helper.shouldAttempt()).isTrue();
+        helper.markAttempt();
+
+        // the query is still running when the wait window elapses, so no completion state gets set
+        helper.doWait();
+        helper.setStatusFrom(newGetQueryExecutionResponse(QueryExecutionState.RUNNING));
+
+        assertThat(helper.shouldWait()).isFalse();
+        assertThat(helper.isSuccess()).isFalse();
+        assertThat(helper.isFailure()).isFalse();
+        assertThat(helper.isRetry()).isFalse();
+
+        // attempts are reserved for retrying completed-and-retryable queries; relaunching here would
+        // orphan the running query and bill the same SQL twice
+        assertThat(helper.shouldAttempt()).isFalse();
+        assertThat(helper.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void aRetryableFailureStillConsumesAnotherAttemptAfterTheWaitTimeout() {
+        Athena2Configuration configuration = new Athena2Configuration();
+        configuration.setMaxAttempts(3);
+        configuration.setWaitTimeout(1);
+        configuration.setInitialDelay(1);
+        configuration.setDelay(1);
+        configuration.setRetry("always");
+
+        Athena2QueryHelper helper = new Athena2QueryHelper(
+                new DefaultExchange(new DefaultCamelContext()),
+                configuration);
+
+        assertThat(helper.shouldAttempt()).isTrue();
+        helper.markAttempt();
+
+        helper.doWait();
+        helper.setStatusFrom(newGetQueryExecutionResponse(QueryExecutionState.FAILED, "GENERIC_INTERNAL_ERROR"));
+
+        assertThat(helper.isRetry()).isTrue();
+        assertThat(helper.shouldAttempt()).isTrue();
+    }
+
+    @Test
     public void isComplete() {
         Athena2QueryHelper helper = defaultAthena2QueryHelper();
 


### PR DESCRIPTION
## Problem

`Athena2Producer.startQueryExecution()` drives two nested loops:

```java
while (athena2QueryHelper.shouldAttempt()) {
    queryExecutionId = doStartQueryExecution(athenaClient, exchange).queryExecutionId();
    athena2QueryHelper.markAttempt();

    while (athena2QueryHelper.shouldWait()) {
        athena2QueryHelper.doWait();
        getQueryExecutionResponse = doGetQueryExecution(queryExecutionId, athenaClient);
        athena2QueryHelper.setStatusFrom(getQueryExecutionResponse);
    }
}
```

The inner loop exits on **three** conditions: success, failure/retry, and
`waitTimeout` expiry. Only the first two set state on the helper —
`setStatusFrom()` assigns `isSuccess`/`isFailure`/`isRetry` only when the query
has actually completed.

When the inner loop exits because `millisWaited >= waitTimeout` while the query
is still `QUEUED`/`RUNNING`, none of those flags are set. `shouldAttempt()` then
sees `attempts < maxAttempts`, no failure, no success, not interrupted — and
returns `true`. The outer loop calls `doStartQueryExecution` again, **submitting
a brand-new Athena query while the previous one is still running.**

## Impact

With `maxAttempts > 1` (the documented way to retry failed queries):

- every `waitTimeout` expiry submits another execution of the same SQL;
- the earlier executions are orphaned — still running, still scanning data, still billed;
- the `CamelAwsAthenaQueryExecutionId` header returned to the route belongs to
  the **last** submission, so the caller cannot correlate or cancel the earlier ones;
- `clientRequestToken` is not auto-generated
  (`Athena2Producer.determineClientRequestToken` reads only a header or the
  endpoint option), so Athena does not deduplicate the submissions by default.

This contradicts the documented contract in `aws2-athena-component.adoc`:

> Upon failure, the query would be automatically retried up to two more times if
> the failure state indicates the query may succeed upon retry

Retry is documented as a response to **failure states**, not to a query simply
taking longer than `waitTimeout`.

## Fix

Treat `waitTimeout` expiry as terminal for the attempt loop. `shouldAttempt()`
now bails out when the wait window elapsed while the query was still running,
after success and failure have been ruled out:

```java
private boolean isWaitTimeoutExceeded() {
    if (this.attempts == 0 || this.isRetry) {
        return false;
    }
    return now() - this.startMs >= this.waitTimeout;
}
```

A completed-and-retryable failure still consumes another attempt, because
`setStatusFrom()` sets `isRetry` for it before `shouldAttempt()` runs — so the
documented retry behaviour is preserved.

## Tests

- `aStillRunningQueryIsNotRelaunchedWhenTheWaitTimeoutExpires()` — query stays
  `RUNNING` past the wait window; asserts `shouldAttempt()` is `false` and
  `attempts` stays at 1. Fails on `main` (`Expecting value to be false but was
  true`), passes with the fix.
- `aRetryableFailureStillConsumesAnotherAttemptAfterTheWaitTimeout()` — a
  `GENERIC_INTERNAL_ERROR` with `retry=always` still yields
  `shouldAttempt() == true`, guarding the retry path.

Full class 24/24 green. `assertj-core` added test-scoped for the new assertions.

## Backport

The loop is identical on `main`, `camel-4.18.x` and `camel-4.14.x` → targeted at
4.22.0, 4.18.4, 4.14.9.

---
_Claude Code on behalf of oscerd_