### PR TITLE
CAMEL-21314: camel-aws2-s3 - supply the customer key when copying SSE-C objects (4.14.x backport)

### DIFF
--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Producer.java
@@ -451,13 +451,18 @@ public class AWS2S3Producer extends DefaultProducer {
             }
 
             if (getConfiguration().isUseCustomerKey()) {
+                // the source object was stored with SSE-C, so the same customer key must also be supplied as the
+                // copy-source key, otherwise S3 cannot decrypt the source and rejects the copy
                 if (ObjectHelper.isNotEmpty(getConfiguration().getCustomerKeyId())) {
+                    copyObjectRequest.copySourceSSECustomerKey(getConfiguration().getCustomerKeyId());
                     copyObjectRequest.sseCustomerKey(getConfiguration().getCustomerKeyId());
                 }
                 if (ObjectHelper.isNotEmpty(getConfiguration().getCustomerKeyMD5())) {
+                    copyObjectRequest.copySourceSSECustomerKeyMD5(getConfiguration().getCustomerKeyMD5());
                     copyObjectRequest.sseCustomerKeyMD5(getConfiguration().getCustomerKeyMD5());
                 }
                 if (ObjectHelper.isNotEmpty(getConfiguration().getCustomerAlgorithm())) {
+                    copyObjectRequest.copySourceSSECustomerAlgorithm(getConfiguration().getCustomerAlgorithm());
                     copyObjectRequest.sseCustomerAlgorithm(getConfiguration().getCustomerAlgorithm());
                 }
             }

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3CopyObjectCustomerKeyIT.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/integration/S3CopyObjectCustomerKeyIT.java
@@ -32,7 +32,6 @@ import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.component.aws2.s3.AWS2S3Operations;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.utils.Md5Utils;
@@ -41,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
 
-@Disabled("Broken test")
 public class S3CopyObjectCustomerKeyIT extends Aws2S3Base {
 
     byte[] secretKey = generateSecretKey();


### PR DESCRIPTION
Backport of #25027 (merged on main) to `camel-4.14.x`. Clean cherry-pick.

`copyObject` set only the destination SSE-C parameters, so copying an object stored with SSE-C failed with `InvalidRequest: SSE-C encrypted objects require customer key headers (400)`. The fix also sets `copySourceSSECustomerKey`/`MD5`/`Algorithm`, and re-enables `S3CopyObjectCustomerKeyIT`.

Verified against localstack on this branch: `S3CopyObjectCustomerKeyIT` passes with the fix (Tests run: 1, Failures: 0, Errors: 0).

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)