### PR TITLE
CAMEL-21933: camel-aws2-eventbridge - re-enable PutRule, PutEvents and RemoveTargets localstack ITs

### DIFF
--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutEventsIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutEventsIT.java
@@ -30,12 +30,10 @@ import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
 import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
 
-@Disabled("Doesn't work with Localstack v4")
 public class EventbridgePutEventsIT extends CamelTestSupport {
 
     @RegisterExtension

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutRuleIT.java
@@ -26,11 +26,9 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
-@Disabled("Doesn't work with Localstack v4")
 public class EventbridgePutRuleIT extends Aws2EventbridgeBase {
 
     @EndpointInject

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeRemoveTargetsIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeRemoveTargetsIT.java
@@ -26,13 +26,11 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("Doesn't work with Localstack v4")
 public class EventbridgeRemoveTargetsIT extends Aws2EventbridgeBase {
 
     @EndpointInject


### PR DESCRIPTION
### Motivation

[CAMEL-21933](https://issues.apache.org/jira/browse/CAMEL-21933). `EventbridgePutRuleIT`, `EventbridgePutEventsIT` and `EventbridgeRemoveTargetsIT` were disabled with *"Doesn't work with Localstack v4"*.

They now pass against the LocalStack image the AWS test-infra currently uses (`mirror.gcr.io/floci/floci:1.5.28`), so the upstream behaviour that broke them has since been fixed.

### Changes

Remove the `@Disabled("Doesn't work with Localstack v4")` annotation (and the now-unused `org.junit.jupiter.api.Disabled` import) from the three ITs. Test-only change.

### Testing

Ran all three against LocalStack via the AWS test-infra:

```
EventbridgePutRuleIT       Tests run: 1, Failures: 0, Errors: 0
EventbridgePutEventsIT     Tests run: 1, Failures: 0, Errors: 0
EventbridgeRemoveTargetsIT Tests run: 1, Failures: 0, Errors: 0
```

Plus the module's 25 unit tests pass, and a full reactor `mvn clean install -DskipTests` from root succeeds.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)