### PR TITLE
CAMEL-24249: camel-aws2 - fix copy-pasted validation messages in MSK/MQ/STS producers

### DIFF
--- a/components/camel-aws/camel-aws2-mq/pom.xml
+++ b/components/camel-aws/camel-aws2-mq/pom.xml
@@ -76,5 +76,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2Producer.java
+++ b/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2Producer.java
@@ -56,6 +56,8 @@ public class MQ2Producer extends DefaultProducer {
 
     private static final Logger LOG = LoggerFactory.getLogger(MQ2Producer.class);
     public static final String MISSING_BROKER_NAME = "Broker Name must be specified";
+    public static final String MISSING_BROKER_ID = "Broker Id must be specified";
+    public static final String MISSING_CONFIGURATION_ID = "Configuration Id must be specified";
 
     private transient String mqProducerToString;
     private HealthCheck producerHealthCheck;
@@ -257,7 +259,7 @@ public class MQ2Producer extends DefaultProducer {
                 brokerId = exchange.getIn().getHeader(MQ2Constants.BROKER_ID, String.class);
                 builder.brokerId(brokerId);
             } else {
-                throw new IllegalArgumentException(MISSING_BROKER_NAME);
+                throw new IllegalArgumentException(MISSING_BROKER_ID);
             }
             DeleteBrokerResponse result;
             try {
@@ -292,7 +294,7 @@ public class MQ2Producer extends DefaultProducer {
                 brokerId = exchange.getIn().getHeader(MQ2Constants.BROKER_ID, String.class);
                 builder.brokerId(brokerId);
             } else {
-                throw new IllegalArgumentException(MISSING_BROKER_NAME);
+                throw new IllegalArgumentException(MISSING_BROKER_ID);
             }
             RebootBrokerResponse result;
             try {
@@ -328,13 +330,13 @@ public class MQ2Producer extends DefaultProducer {
                 brokerId = exchange.getIn().getHeader(MQ2Constants.BROKER_ID, String.class);
                 builder.brokerId(brokerId);
             } else {
-                throw new IllegalArgumentException(MISSING_BROKER_NAME);
+                throw new IllegalArgumentException(MISSING_BROKER_ID);
             }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(MQ2Constants.CONFIGURATION_ID))) {
                 configurationId = exchange.getIn().getHeader(MQ2Constants.CONFIGURATION_ID, ConfigurationId.class);
                 builder.configuration(configurationId);
             } else {
-                throw new IllegalArgumentException(MISSING_BROKER_NAME);
+                throw new IllegalArgumentException(MISSING_CONFIGURATION_ID);
             }
             UpdateBrokerResponse result;
             try {
@@ -369,7 +371,7 @@ public class MQ2Producer extends DefaultProducer {
                 brokerId = exchange.getIn().getHeader(MQ2Constants.BROKER_ID, String.class);
                 builder.brokerId(brokerId);
             } else {
-                throw new IllegalArgumentException(MISSING_BROKER_NAME);
+                throw new IllegalArgumentException(MISSING_BROKER_ID);
             }
             DescribeBrokerResponse result;
             try {

--- a/components/camel-aws/camel-aws2-mq/src/test/java/org/apache/camel/component/aws2/mq/MQProducerTest.java
+++ b/components/camel-aws/camel-aws2-mq/src/test/java/org/apache/camel/component/aws2/mq/MQProducerTest.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.services.mq.model.ListBrokersResponse;
 import software.amazon.awssdk.services.mq.model.UpdateBrokerResponse;
 import software.amazon.awssdk.services.mq.model.User;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MQProducerTest extends CamelTestSupport {
@@ -170,6 +171,22 @@ public class MQProducerTest extends CamelTestSupport {
         MockEndpoint.assertIsSatisfied(context);
         UpdateBrokerResponse resultGet = (UpdateBrokerResponse) exchange.getIn().getBody();
         assertEquals("1", resultGet.brokerId());
+    }
+
+    @Test
+    void mqUpdateBrokerWithoutBrokerIdReportsThatParameter() {
+        assertThatThrownBy(() -> template.requestBody("direct:updateBroker", "body"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("Broker Id must be specified");
+    }
+
+    @Test
+    void mqUpdateBrokerWithoutConfigurationIdReportsThatParameter() {
+        // the broker id IS supplied, so the error must name the missing configuration id
+        assertThatThrownBy(() -> template.requestBodyAndHeader("direct:updateBroker", "body",
+                MQ2Constants.BROKER_ID, "1"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("Configuration Id must be specified");
     }
 
     @Test

--- a/components/camel-aws/camel-aws2-msk/pom.xml
+++ b/components/camel-aws/camel-aws2-msk/pom.xml
@@ -78,5 +78,10 @@
             <artifactId>camel-test-spring-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-msk/src/main/java/org/apache/camel/component/aws2/msk/MSK2Producer.java
+++ b/components/camel-aws/camel-aws2-msk/src/main/java/org/apache/camel/component/aws2/msk/MSK2Producer.java
@@ -176,7 +176,7 @@ public class MSK2Producer extends DefaultProducer {
                 Integer nodesNumber = exchange.getIn().getHeader(MSK2Constants.BROKER_NODES_NUMBER, Integer.class);
                 builder.numberOfBrokerNodes(nodesNumber);
             } else {
-                throw new IllegalArgumentException("Kafka Version must be specified");
+                throw new IllegalArgumentException("Number of Broker Nodes must be specified");
             }
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(MSK2Constants.BROKER_NODES_GROUP_INFO))) {
                 BrokerNodeGroupInfo brokerNodesGroupInfo

--- a/components/camel-aws/camel-aws2-msk/src/test/java/org/apache/camel/component/aws2/msk/MSKProducerTest.java
+++ b/components/camel-aws/camel-aws2-msk/src/test/java/org/apache/camel/component/aws2/msk/MSKProducerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.aws2.msk;
 
+import java.util.Map;
+
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
@@ -32,6 +34,7 @@ import software.amazon.awssdk.services.kafka.model.DescribeClusterResponse;
 import software.amazon.awssdk.services.kafka.model.ListClustersRequest;
 import software.amazon.awssdk.services.kafka.model.ListClustersResponse;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MSKProducerTest extends CamelTestSupport {
@@ -97,6 +100,17 @@ public class MSKProducerTest extends CamelTestSupport {
         CreateClusterResponse resultGet = (CreateClusterResponse) exchange.getIn().getBody();
         assertEquals("test-kafka", resultGet.clusterName());
         assertEquals(ClusterState.CREATING.name(), resultGet.state().toString());
+    }
+
+    @Test
+    void mskCreateClusterWithoutBrokerNodesNumberReportsThatParameter() {
+        // the Kafka version IS supplied, so the error must name the missing broker-nodes count
+        assertThatThrownBy(() -> template.requestBodyAndHeaders("direct:createCluster", "body",
+                Map.of(
+                        MSK2Constants.CLUSTER_NAME, "test-kafka",
+                        MSK2Constants.CLUSTER_KAFKA_VERSION, "2.1.1")))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("Number of Broker Nodes must be specified");
     }
 
     @Test

--- a/components/camel-aws/camel-aws2-sts/pom.xml
+++ b/components/camel-aws/camel-aws2-sts/pom.xml
@@ -74,5 +74,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-sts/src/main/java/org/apache/camel/component/aws2/sts/STS2Producer.java
+++ b/components/camel-aws/camel-aws2-sts/src/main/java/org/apache/camel/component/aws2/sts/STS2Producer.java
@@ -199,7 +199,7 @@ public class STS2Producer extends DefaultProducer {
                 String federatedName = exchange.getIn().getHeader(STS2Constants.FEDERATED_NAME, String.class);
                 builder.name(federatedName);
             } else {
-                throw new IllegalArgumentException("Federated name needs to be specified for assumeRole operation");
+                throw new IllegalArgumentException("Federated name needs to be specified for getFederationToken operation");
             }
             try {
                 result = stsClient.getFederationToken(builder.build());

--- a/components/camel-aws/camel-aws2-sts/src/test/java/org/apache/camel/component/aws2/sts/STS2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-sts/src/test/java/org/apache/camel/component/aws2/sts/STS2ProducerTest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.GetFederationTokenResponse;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenResponse;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class STS2ProducerTest extends CamelTestSupport {
@@ -90,6 +91,13 @@ public class STS2ProducerTest extends CamelTestSupport {
 
         GetFederationTokenResponse resultGet = (GetFederationTokenResponse) exchange.getIn().getBody();
         assertEquals("xxx", resultGet.credentials().accessKeyId());
+    }
+
+    @Test
+    void stsGetFederationTokenWithoutFederatedNameReportsTheCorrectOperation() {
+        assertThatThrownBy(() -> template.requestBody("direct:getFederationToken", "body"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("Federated name needs to be specified for getFederationToken operation");
     }
 
     @Override


### PR DESCRIPTION
## Problem

Three AWS v2 producers throw `IllegalArgumentException` with a message that was
copy-pasted from a neighbouring check and never updated, so it names the wrong
parameter. A user who omits a required header is told to supply a *different* one.

**camel-aws2-msk — `MSK2Producer.createCluster`**
The missing broker-nodes-number check reused the Kafka-version message:
```java
} else {
    throw new IllegalArgumentException("Kafka Version must be specified"); // broker-nodes count is missing
}
```

**camel-aws2-mq — `MQ2Producer`**
`MISSING_BROKER_NAME = "Broker Name must be specified"` is correct only for
`createBroker` (which takes a broker *name*). It was also thrown for the broker
*id* checks in `deleteBroker`, `rebootBroker`, `updateBroker` and
`describeBroker`, and for the `configurationId` check in `updateBroker` — all of
which take an id, not a name.

**camel-aws2-sts — `STS2Producer.getFederationToken`**
The missing federated-name check carried the wrong operation name:
```java
throw new IllegalArgumentException("Federated name needs to be specified for assumeRole operation");
```

## Impact

No functional misbehaviour, but the diagnostics actively mislead — calling
`createCluster` without a broker-node count reports "Kafka Version must be
specified" even though the Kafka version was supplied; calling `updateBroker`
without a configuration id tells you to specify a broker name.

## Fix

Each check now names the parameter it guards. For MQ, two dedicated constants
were added and used for the id checks, keeping `MISSING_BROKER_NAME` for
`createBroker`:

```java
public static final String MISSING_BROKER_NAME = "Broker Name must be specified";
public static final String MISSING_BROKER_ID = "Broker Id must be specified";
public static final String MISSING_CONFIGURATION_ID = "Configuration Id must be specified";
```

## Tests

Added focused tests asserting the corrected messages, reusing each module's
existing mock client and routes (AssertJ `assertThatThrownBy(...).hasRootCauseMessage(...)`):

- `MSKProducerTest.mskCreateClusterWithoutBrokerNodesNumberReportsThatParameter`
- `MQProducerTest.mqUpdateBrokerWithoutBrokerIdReportsThatParameter`
- `MQProducerTest.mqUpdateBrokerWithoutConfigurationIdReportsThatParameter`
- `STS2ProducerTest.stsGetFederationTokenWithoutFederatedNameReportsTheCorrectOperation`

The MSK test was verified to fail on `main` with the old "Kafka Version must be
specified" message. Modules build and pass: MSK 6/6, MQ 9/9, STS 4/4.

## Backport

All three producers carry these strings verbatim on `camel-4.18.x` and
`camel-4.14.x` → targeted at 4.22.0, 4.18.4 and 4.14.9.

---
_Claude Code on behalf of oscerd_