### PR TITLE
chore(test-infra): suppress S2068 hard-coded password warnings in all test infra services

### DIFF
--- a/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBInfraService.java
+++ b/test-infra/camel-test-infra-arangodb/src/main/java/org/apache/camel/test/infra/arangodb/services/ArangoDBInfraService.java
@@ -19,6 +19,8 @@ package org.apache.camel.test.infra.arangodb.services;
 import com.arangodb.ArangoDB;
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface ArangoDBInfraService extends InfrastructureService {
 
     // User port

--- a/test-infra/camel-test-infra-cassandra/src/main/java/org/apache/camel/test/infra/cassandra/services/CassandraInfraService.java
+++ b/test-infra/camel-test-infra-cassandra/src/main/java/org/apache/camel/test/infra/cassandra/services/CassandraInfraService.java
@@ -22,6 +22,8 @@ import org.apache.camel.test.infra.common.services.InfrastructureService;
 /**
  * Represents an endpoint to a Cassandra instance
  */
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface CassandraInfraService extends InfrastructureService {
 
     int getCQL3Port();

--- a/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseInfraService.java
+++ b/test-infra/camel-test-infra-couchbase/src/main/java/org/apache/camel/test/infra/couchbase/services/CouchbaseInfraService.java
@@ -19,6 +19,8 @@ package org.apache.camel.test.infra.couchbase.services;
 
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface CouchbaseInfraService extends InfrastructureService {
 
     String getConnectionString();

--- a/test-infra/camel-test-infra-couchdb/src/main/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-couchdb/src/main/java/org/apache/camel/test/infra/couchdb/services/CouchDbLocalContainerInfraService.java
@@ -27,6 +27,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 @InfraService(service = CouchDbInfraService.class,
               description = "Apache CouchDB is an open source NoSQL document database",
               serviceAlias = { "couchdb" },

--- a/test-infra/camel-test-infra-elasticsearch/src/main/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchInfraService.java
+++ b/test-infra/camel-test-infra-elasticsearch/src/main/java/org/apache/camel/test/infra/elasticsearch/services/ElasticSearchInfraService.java
@@ -23,6 +23,8 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface ElasticSearchInfraService extends InfrastructureService {
 
     @Deprecated

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/FtpInfraService.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/FtpInfraService.java
@@ -23,6 +23,8 @@ import org.apache.camel.test.infra.common.services.InfrastructureService;
 /**
  * Test infra service for Ftp
  */
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface FtpInfraService extends InfrastructureService {
     @Deprecated
     // Use port

--- a/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/EmbeddedConfigurationBuilder.java
+++ b/test-infra/camel-test-infra-ftp/src/main/java/org/apache/camel/test/infra/ftp/services/embedded/EmbeddedConfigurationBuilder.java
@@ -17,6 +17,8 @@
 
 package org.apache.camel.test.infra.ftp.services.embedded;
 
+// Credentials are intentional test-only fixtures for embedded FTP services — no security risk
+@SuppressWarnings("java:S2068")
 public final class EmbeddedConfigurationBuilder {
     private final EmbeddedConfiguration embeddedConfiguration = new EmbeddedConfiguration();
 

--- a/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/HiveMQInfraService.java
+++ b/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/HiveMQInfraService.java
@@ -18,6 +18,8 @@ package org.apache.camel.test.infra.hivemq.services;
 
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface HiveMQInfraService extends InfrastructureService {
 
     @Deprecated

--- a/test-infra/camel-test-infra-ibmmq/src/main/java/org/apache/camel/test/infra/ibmmq/services/IbmMQInfraService.java
+++ b/test-infra/camel-test-infra-ibmmq/src/main/java/org/apache/camel/test/infra/ibmmq/services/IbmMQInfraService.java
@@ -21,6 +21,8 @@ import org.apache.camel.test.infra.common.services.InfrastructureService;
 /**
  * Test infra service for IBM MQ.
  */
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface IbmMQInfraService extends InfrastructureService {
 
     String channel();

--- a/test-infra/camel-test-infra-infinispan/src/main/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-infinispan/src/main/java/org/apache/camel/test/infra/infinispan/services/InfinispanLocalContainerInfraService.java
@@ -32,6 +32,8 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 @InfraService(service = InfinispanInfraService.class,
               description = "Infinispan is a distributed in-memory key/value data store",
               serviceAlias = { "infinispan" },

--- a/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
+++ b/test-infra/camel-test-infra-kafka/src/main/java/org/apache/camel/test/infra/kafka/services/ContainerLocalAuthKafkaService.java
@@ -25,6 +25,8 @@ import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public class ContainerLocalAuthKafkaService implements KafkaService, ContainerService<KafkaContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalAuthKafkaService.class);
     protected final KafkaContainer kafka;

--- a/test-infra/camel-test-infra-keycloak/src/main/java/org/apache/camel/test/infra/keycloak/services/KeycloakInfraService.java
+++ b/test-infra/camel-test-infra-keycloak/src/main/java/org/apache/camel/test/infra/keycloak/services/KeycloakInfraService.java
@@ -22,6 +22,8 @@ import org.keycloak.admin.client.Keycloak;
 /**
  * Test infra service for Keycloak
  */
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface KeycloakInfraService extends InfrastructureService {
 
     @Deprecated

--- a/test-infra/camel-test-infra-nats/src/main/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerAuthService.java
+++ b/test-infra/camel-test-infra-nats/src/main/java/org/apache/camel/test/infra/nats/services/NatsLocalContainerAuthService.java
@@ -20,6 +20,8 @@ import org.apache.camel.test.infra.nats.common.NatsProperties;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public class NatsLocalContainerAuthService extends NatsLocalContainerService implements NatsService {
     private static final String USERNAME = "admin";
     private static final String PASSWORD = "password";

--- a/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQInfraService.java
+++ b/test-infra/camel-test-infra-rabbitmq/src/main/java/org/apache/camel/test/infra/rabbitmq/services/RabbitMQInfraService.java
@@ -19,6 +19,8 @@ package org.apache.camel.test.infra.rabbitmq.services;
 
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface RabbitMQInfraService extends InfrastructureService {
 
     /**

--- a/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbInfraService.java
+++ b/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbInfraService.java
@@ -19,6 +19,8 @@ package org.apache.camel.test.infra.smb.services;
 
 import org.apache.camel.test.infra.common.services.InfrastructureService;
 
+// Credentials are intentional test-only fixtures for testcontainer services — no security risk
+@SuppressWarnings("java:S2068")
 public interface SmbInfraService extends InfrastructureService {
     String address();
 


### PR DESCRIPTION
## Summary

Suppress SonarCloud S2068 (hard-coded passwords) warnings across **all** test-infra service interfaces and implementations. These are intentional test-only fixture credentials used to configure testcontainer services — they pose no security risk.

### Files changed

**Original 4 BLOCKER-level findings:**
- `CassandraInfraService`
- `CouchbaseInfraService`
- `FtpInfraService`
- `SmbInfraService`

**Additional services (same pattern):**
- `ArangoDBInfraService`
- `CouchDbLocalContainerInfraService`
- `ElasticSearchInfraService`
- `EmbeddedConfigurationBuilder` (FTP embedded)
- `HiveMQInfraService`
- `IbmMQInfraService`
- `InfinispanLocalContainerInfraService`
- `ContainerLocalAuthKafkaService`
- `KeycloakInfraService`
- `NatsLocalContainerAuthService`
- `RabbitMQInfraService`

Each file gets a `@SuppressWarnings("java:S2068")` annotation with an explanatory comment.

_Claude Code on behalf of gnodet_