### PR TITLE
(chores): fix SonarCloud MAJOR vulnerabilities (S6506, S5144)

### DIFF
--- a/.github/actions/setup-llvm-mingw/install-llvm-mingw.sh
+++ b/.github/actions/setup-llvm-mingw/install-llvm-mingw.sh
@@ -39,7 +39,7 @@ DEST="${INSTALL_DIR}/llvm-mingw-${VERSION}-ucrt-ubuntu-22.04-x86_64"
 
 if [ ! -x "${DEST}/bin/x86_64-w64-mingw32-clang" ]; then
     mkdir -p "$INSTALL_DIR"
-    curl -fsSL -o "${INSTALL_DIR}/${TARBALL}" \
+    curl -fsSL --proto '=https' -o "${INSTALL_DIR}/${TARBALL}" \
         "https://github.com/mstorsjo/llvm-mingw/releases/download/${VERSION}/${TARBALL}"
     echo "${SHA256}  ${INSTALL_DIR}/${TARBALL}" | sha256sum -c -
     tar -xf "${INSTALL_DIR}/${TARBALL}" -C "$INSTALL_DIR"

--- a/.github/workflows/camel-launcher-native-exe.yml
+++ b/.github/workflows/camel-launcher-native-exe.yml
@@ -167,7 +167,7 @@ jobs:
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -N)
           META="https://repository.apache.org/snapshots/org/apache/camel/camel-launcher/${VERSION}/maven-metadata.xml"
           echo "Checking ${META}"
-          if ! curl -fsSL -o /dev/null "${META}"; then
+          if ! curl -fsSL --proto '=https' -o /dev/null "${META}"; then
             echo "ERROR: camel-launcher ${VERSION} is not on the Apache snapshot repository."
             echo "This job resolves the launcher's upstream modules from there (no -am build)."
             echo "Wait for a main-branch snapshot deploy of ${VERSION}, or rebuild with -am."

--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -192,7 +192,10 @@ abstract class AbstractExchange implements Exchange, ExchangeExtension {
         return evalPropertyValue(type, value);
     }
 
-    @SuppressWarnings("unchecked")
+    // Suppressed S5144: exchange properties are set by trusted route authors — type conversion of
+    // exchange-internal values is intentional framework behavior, not user-controlled URL construction.
+    // See the Camel security model (docs/user-manual/modules/ROOT/pages/security-model.adoc).
+    @SuppressWarnings({ "unchecked", "java:S5144" })
     private <T> T evalPropertyValue(final Class<T> type, final Object value) {
         if (value == null) {
             // let's avoid NullPointerException when converting to boolean for null values


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix 3 SonarCloud MAJOR vulnerabilities ([dashboard](https://sonarcloud.io/project/issues?id=apache_camel&types=VULNERABILITY&severities=MAJOR)):

- **S6506** — `.github/workflows/camel-launcher-native-exe.yml:170` and `.github/actions/setup-llvm-mingw/install-llvm-mingw.sh:42`: Added `--proto '=https'` to `curl` commands to enforce HTTPS-only connections and prevent redirections to insecure websites.
- **S5144** — `core/camel-support/AbstractExchange.java:211`: Suppressed with `@SuppressWarnings("java:S5144")` and documented justification. The flagged code is `ExchangeHelper.convertToType()` called from `evalPropertyValue()`, which performs type conversion on exchange properties. Per the [Camel security model](https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/security-model.adoc), route authors are **fully trusted** — exchange properties are set by trusted route code, making this type conversion intentional framework behavior rather than a user-controlled URL construction vulnerability.

## Test plan

- [x] `mvn formatter:format impsort:sort` — formatting passes
- [x] `mvn -Psourcecheck validate` — style check passes
- [x] `mvn test` on `core/camel-support` — all tests pass
- [ ] CI pipeline (SonarCloud should clear the 3 MAJOR vulnerabilities after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)