### PR TITLE
Fix SonarCloud S5443: replace publicly writable temp directory usage

### DIFF
--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
@@ -215,9 +215,11 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             return cachedResults != null ? cachedResults : errorJson("No active recording.");
         }
 
+        Path tempDir = null;
         Path tempFile = null;
         try {
-            tempFile = Files.createTempFile("camel-jfr-memory-leak-", ".jfr");
+            tempDir = Files.createTempDirectory("camel-jfr-");
+            tempFile = Files.createTempFile(tempDir, "camel-jfr-memory-leak-", ".jfr");
             // trigger GC before stopping to flush objects into the recording
             System.gc();
             try {
@@ -255,6 +257,13 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             if (tempFile != null) {
                 try {
                     Files.deleteIfExists(tempFile);
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            if (tempDir != null) {
+                try {
+                    Files.deleteIfExists(tempDir);
                 } catch (IOException e) {
                     // ignore
                 }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ExampleBrowserPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/ExampleBrowserPopup.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.dsl.jbang.core.commands.tui;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -264,7 +263,7 @@ class ExampleBrowserPopup {
             if (exampleName.contains("/") && extraArgs.stream().noneMatch(a -> a.startsWith("--name"))) {
                 cmd.add("--name=" + TuiHelper.stripCategory(exampleName));
             }
-            Path outputFile = Files.createTempFile("camel-example-", ".log");
+            Path outputFile = LaunchManager.createSecureTempFile("camel-example-", ".log");
             outputFile.toFile().deleteOnExit();
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.redirectErrorStream(true);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FolderInputPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/FolderInputPopup.java
@@ -345,7 +345,7 @@ class FolderInputPopup {
             }
             cmd.add("--logging-color=true");
             cmd.addAll(extraArgs);
-            Path outputFile = Files.createTempFile("camel-folder-", ".log");
+            Path outputFile = LaunchManager.createSecureTempFile("camel-folder-", ".log");
             outputFile.toFile().deleteOnExit();
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.redirectErrorStream(true);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InfraBrowserPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/InfraBrowserPopup.java
@@ -18,7 +18,6 @@ package org.apache.camel.dsl.jbang.core.commands.tui;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -520,7 +519,7 @@ class InfraBrowserPopup {
             if (!portStr.isEmpty()) {
                 cmd.add("--port=" + portStr);
             }
-            Path outputFile = Files.createTempFile("camel-infra-", ".log");
+            Path outputFile = LaunchManager.createSecureTempFile("camel-infra-", ".log");
             outputFile.toFile().deleteOnExit();
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.redirectErrorStream(true);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LaunchManager.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/LaunchManager.java
@@ -35,6 +35,8 @@ import org.apache.camel.util.json.JsonObject;
 
 class LaunchManager {
 
+    private static volatile Path secureTempDir;
+
     private final Supplier<List<InfraInfo>> infraServices;
     private final List<PendingLaunch> pendingLaunches = new ArrayList<>();
     private DeferredLaunch deferredLaunch;
@@ -75,7 +77,7 @@ class LaunchManager {
     void launchDetached(String displayName, List<String> extraArgs) throws IOException {
         List<String> cmd = new ArrayList<>(LauncherHelper.getCamelCommand());
         cmd.addAll(extraArgs);
-        Path outputFile = Files.createTempFile("camel-launch-", ".log");
+        Path outputFile = createSecureTempFile("camel-launch-", ".log");
         outputFile.toFile().deleteOnExit();
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.redirectErrorStream(true);
@@ -129,7 +131,7 @@ class LaunchManager {
                 cmd.add("run");
                 cmd.add(alias);
                 cmd.add("--background");
-                Path outputFile = Files.createTempFile("camel-infra-", ".log");
+                Path outputFile = createSecureTempFile("camel-infra-", ".log");
                 outputFile.toFile().deleteOnExit();
                 ProcessBuilder pb = new ProcessBuilder(cmd);
                 pb.redirectErrorStream(true);
@@ -147,6 +149,25 @@ class LaunchManager {
         }
         String infraList = String.join(", ", missingInfra);
         notify("Starting infra: " + infraList + " → then: " + displayName, false);
+    }
+
+    /**
+     * Creates a temporary file inside a secure (owner-only permissions) subdirectory rather than directly in the
+     * publicly writable system temp directory. This avoids SonarCloud S5443 (use of publicly writable directories).
+     */
+    static Path createSecureTempFile(String prefix, String suffix) throws IOException {
+        Path dir = secureTempDir;
+        if (dir == null || !Files.isDirectory(dir)) {
+            synchronized (LaunchManager.class) {
+                dir = secureTempDir;
+                if (dir == null || !Files.isDirectory(dir)) {
+                    dir = Files.createTempDirectory("camel-tui-");
+                    dir.toFile().deleteOnExit();
+                    secureTempDir = dir;
+                }
+            }
+        }
+        return Files.createTempFile(dir, prefix, suffix);
     }
 
     static boolean isContainerRuntimeAvailable() {


### PR DESCRIPTION
## Summary

Fix 6 SonarCloud CRITICAL vulnerabilities ([S5443](https://rules.sonarsource.com/java/RSPEC-S5443/)) across two modules. The rule flags code that creates temporary files directly in publicly writable directories (e.g., `/tmp`), which is vulnerable to symlink attacks and information disclosure.

### Changes

**`camel-jbang-plugin-tui`** (5 issues):
- Added `LaunchManager.createSecureTempFile()` — creates a secure temp directory with owner-only permissions (`Files.createTempDirectory()`), then creates temp files inside it (reused across the TUI session)
- Updated `ExampleBrowserPopup`, `FolderInputPopup`, `InfraBrowserPopup`, and `LaunchManager` to use the new utility

**`camel-console`** (1 issue):
- Updated `JfrMemoryLeakDevConsole.doStopRecordingAndParse()` to create a secure temp directory before the JFR dump file, with cleanup of both in the `finally` block

### SonarCloud Dashboard
https://sonarcloud.io/project/issues?id=apache_camel&types=VULNERABILITY&severities=CRITICAL

_Claude Code on behalf of gnodet_

Generated with [Claude Code](https://claude.ai/code)