### PR TITLE
CAMEL-23460: camel-telemetry - add span decorators for Google Cloud (AI/ML & misc batch)

### DIFF
--- a/components/camel-telemetry/pom.xml
+++ b/components/camel-telemetry/pom.xml
@@ -55,6 +55,11 @@
       <version>${mockito-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Required to test CXF async -->
     <dependency>

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleFunctionsSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleFunctionsSpanDecorator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleFunctionsSpanDecorator extends AbstractSpanDecorator {
+
+    static final String FUNCTIONS_OPERATION = "operation";
+    static final String FUNCTIONS_ENTRY_POINT = "entryPoint";
+    static final String FUNCTIONS_RUNTIME = "runtime";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.functions.GoogleCloudFunctionsConstants}
+     */
+    static final String OPERATION = "CamelGoogleCloudFunctionsOperation";
+    static final String ENTRY_POINT = "CamelGoogleCloudFunctionsEntryPoint";
+    static final String RUNTIME = "CamelGoogleCloudFunctionsRuntime";
+
+    @Override
+    public String getComponent() {
+        return "google-functions";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.functions.GoogleCloudFunctionsComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(FUNCTIONS_OPERATION, operation.toString());
+        }
+
+        String entryPoint = exchange.getIn().getHeader(ENTRY_POINT, String.class);
+        if (entryPoint != null) {
+            span.setTag(FUNCTIONS_ENTRY_POINT, entryPoint);
+        }
+
+        String runtime = exchange.getIn().getHeader(RUNTIME, String.class);
+        if (runtime != null) {
+            span.setTag(FUNCTIONS_RUNTIME, runtime);
+        }
+    }
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleSecretManagerSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleSecretManagerSpanDecorator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleSecretManagerSpanDecorator extends AbstractSpanDecorator {
+
+    static final String SECRET_MANAGER_OPERATION = "operation";
+    static final String SECRET_MANAGER_SECRET_ID = "secretId";
+    static final String SECRET_MANAGER_VERSION_ID = "versionId";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.secret.manager.GoogleSecretManagerConstants}. Only
+     * the secret identifier (name) and version are tagged, never the secret value.
+     */
+    static final String OPERATION = "CamelGoogleSecretManagerOperation";
+    static final String SECRET_ID = "CamelGoogleSecretManagerSecretId";
+    static final String VERSION_ID = "CamelGoogleSecretManagerVersionId";
+
+    @Override
+    public String getComponent() {
+        return "google-secret-manager";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.secret.manager.GoogleSecretManagerComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(SECRET_MANAGER_OPERATION, operation.toString());
+        }
+
+        String secretId = exchange.getIn().getHeader(SECRET_ID, String.class);
+        if (secretId != null) {
+            span.setTag(SECRET_MANAGER_SECRET_ID, secretId);
+        }
+
+        String versionId = exchange.getIn().getHeader(VERSION_ID, String.class);
+        if (versionId != null) {
+            span.setTag(SECRET_MANAGER_VERSION_ID, versionId);
+        }
+    }
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleSpeechToTextSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleSpeechToTextSpanDecorator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleSpeechToTextSpanDecorator extends AbstractSpanDecorator {
+
+    static final String SPEECH_TO_TEXT_OPERATION = "operation";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.speechtotext.GoogleCloudSpeechToTextConstants}.
+     * Only the operation is tagged; the response object may carry large audio/image payloads and is not emitted.
+     */
+    static final String OPERATION = "CamelGoogleCloudSpeechToTextOperation";
+
+    @Override
+    public String getComponent() {
+        return "google-speech-to-text";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.speechtotext.GoogleCloudSpeechToTextComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(SPEECH_TO_TEXT_OPERATION, operation.toString());
+        }
+    }
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleTextToSpeechSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleTextToSpeechSpanDecorator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleTextToSpeechSpanDecorator extends AbstractSpanDecorator {
+
+    static final String TEXT_TO_SPEECH_OPERATION = "operation";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.texttospeech.GoogleCloudTextToSpeechConstants}.
+     * Only the operation is tagged; the response object may carry large audio/image payloads and is not emitted.
+     */
+    static final String OPERATION = "CamelGoogleCloudTextToSpeechOperation";
+
+    @Override
+    public String getComponent() {
+        return "google-text-to-speech";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.texttospeech.GoogleCloudTextToSpeechComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(TEXT_TO_SPEECH_OPERATION, operation.toString());
+        }
+    }
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleVertexAISpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleVertexAISpanDecorator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleVertexAISpanDecorator extends AbstractSpanDecorator {
+
+    static final String VERTEXAI_OPERATION = "operation";
+    static final String VERTEXAI_MODEL_ID = "modelId";
+    static final String VERTEXAI_LOCATION = "location";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.vertexai.GoogleVertexAIConstants}. The prompt and
+     * chat messages carry user content and the tuning parameters are not useful as tags, so they are not emitted.
+     */
+    static final String OPERATION = "CamelGoogleVertexAIOperation";
+    static final String MODEL_ID = "CamelGoogleVertexAIModelId";
+    static final String LOCATION = "CamelGoogleVertexAILocation";
+
+    @Override
+    public String getComponent() {
+        return "google-vertexai";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.vertexai.GoogleVertexAIComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(VERTEXAI_OPERATION, operation.toString());
+        }
+
+        String modelId = exchange.getIn().getHeader(MODEL_ID, String.class);
+        if (modelId != null) {
+            span.setTag(VERTEXAI_MODEL_ID, modelId);
+        }
+
+        String location = exchange.getIn().getHeader(LOCATION, String.class);
+        if (location != null) {
+            span.setTag(VERTEXAI_LOCATION, location);
+        }
+    }
+}

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleVisionSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/GoogleVisionSpanDecorator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.telemetry.Span;
+
+public class GoogleVisionSpanDecorator extends AbstractSpanDecorator {
+
+    static final String VISION_OPERATION = "operation";
+
+    /**
+     * Constants copied from {@link org.apache.camel.component.google.vision.GoogleCloudVisionConstants}. Only the
+     * operation is tagged; the response object may carry large audio/image payloads and is not emitted.
+     */
+    static final String OPERATION = "CamelGoogleCloudVisionOperation";
+
+    @Override
+    public String getComponent() {
+        return "google-vision";
+    }
+
+    @Override
+    public String getComponentClassName() {
+        return "org.apache.camel.component.google.vision.GoogleCloudVisionComponent";
+    }
+
+    @Override
+    public void beforeTracingEvent(Span span, Exchange exchange, Endpoint endpoint) {
+        super.beforeTracingEvent(span, exchange, endpoint);
+
+        Object operation = exchange.getIn().getHeader(OPERATION);
+        if (operation != null) {
+            span.setTag(VISION_OPERATION, operation.toString());
+        }
+    }
+}

--- a/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
+++ b/components/camel-telemetry/src/main/resources/META-INF/services/org.apache.camel.telemetry.SpanDecorator
@@ -68,8 +68,14 @@ org.apache.camel.telemetry.decorators.FtpSpanDecorator
 org.apache.camel.telemetry.decorators.FtpsSpanDecorator
 org.apache.camel.telemetry.decorators.GoogleBigQuerySpanDecorator
 org.apache.camel.telemetry.decorators.GoogleFirestoreSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleFunctionsSpanDecorator
 org.apache.camel.telemetry.decorators.GooglePubsubSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleSecretManagerSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleSpeechToTextSpanDecorator
 org.apache.camel.telemetry.decorators.GoogleStorageSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleTextToSpeechSpanDecorator
+org.apache.camel.telemetry.decorators.GoogleVertexAISpanDecorator
+org.apache.camel.telemetry.decorators.GoogleVisionSpanDecorator
 org.apache.camel.telemetry.decorators.HttpSpanDecorator
 org.apache.camel.telemetry.decorators.HttpsSpanDecorator
 org.apache.camel.telemetry.decorators.IronmqSpanDecorator

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleFunctionsSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleFunctionsSpanDecoratorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleFunctionsSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "callFunction";
+        String entryPoint = "myEntryPoint";
+        String runtime = "java17";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-functions:myFunction");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleFunctionsSpanDecorator.OPERATION)).thenReturn(operation);
+        Mockito.when(message.getHeader(GoogleFunctionsSpanDecorator.ENTRY_POINT, String.class)).thenReturn(entryPoint);
+        Mockito.when(message.getHeader(GoogleFunctionsSpanDecorator.RUNTIME, String.class)).thenReturn(runtime);
+
+        AbstractSpanDecorator decorator = new GoogleFunctionsSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleFunctionsSpanDecorator.FUNCTIONS_OPERATION));
+        assertEquals(entryPoint, span.tags().get(GoogleFunctionsSpanDecorator.FUNCTIONS_ENTRY_POINT));
+        assertEquals(runtime, span.tags().get(GoogleFunctionsSpanDecorator.FUNCTIONS_RUNTIME));
+    }
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleFunctionsSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleFunctionsSpanDecoratorTest.java
@@ -23,12 +23,12 @@ import org.apache.camel.telemetry.mock.MockSpanAdapter;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoogleFunctionsSpanDecoratorTest {
+class GoogleFunctionsSpanDecoratorTest {
 
     @Test
-    public void testPre() {
+    void testPre() {
         String operation = "callFunction";
         String entryPoint = "myEntryPoint";
         String runtime = "java17";
@@ -50,8 +50,8 @@ public class GoogleFunctionsSpanDecoratorTest {
 
         decorator.beforeTracingEvent(span, exchange, endpoint);
 
-        assertEquals(operation, span.tags().get(GoogleFunctionsSpanDecorator.FUNCTIONS_OPERATION));
-        assertEquals(entryPoint, span.tags().get(GoogleFunctionsSpanDecorator.FUNCTIONS_ENTRY_POINT));
-        assertEquals(runtime, span.tags().get(GoogleFunctionsSpanDecorator.FUNCTIONS_RUNTIME));
+        assertThat(span.tags()).containsEntry(GoogleFunctionsSpanDecorator.FUNCTIONS_OPERATION, operation);
+        assertThat(span.tags()).containsEntry(GoogleFunctionsSpanDecorator.FUNCTIONS_ENTRY_POINT, entryPoint);
+        assertThat(span.tags()).containsEntry(GoogleFunctionsSpanDecorator.FUNCTIONS_RUNTIME, runtime);
     }
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSecretManagerSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSecretManagerSpanDecoratorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleSecretManagerSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "getSecretVersion";
+        String secretId = "my-secret";
+        String versionId = "3";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-secret-manager:myProject");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleSecretManagerSpanDecorator.OPERATION)).thenReturn(operation);
+        Mockito.when(message.getHeader(GoogleSecretManagerSpanDecorator.SECRET_ID, String.class)).thenReturn(secretId);
+        Mockito.when(message.getHeader(GoogleSecretManagerSpanDecorator.VERSION_ID, String.class)).thenReturn(versionId);
+
+        AbstractSpanDecorator decorator = new GoogleSecretManagerSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_OPERATION));
+        assertEquals(secretId, span.tags().get(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_SECRET_ID));
+        assertEquals(versionId, span.tags().get(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_VERSION_ID));
+    }
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSecretManagerSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSecretManagerSpanDecoratorTest.java
@@ -23,12 +23,12 @@ import org.apache.camel.telemetry.mock.MockSpanAdapter;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoogleSecretManagerSpanDecoratorTest {
+class GoogleSecretManagerSpanDecoratorTest {
 
     @Test
-    public void testPre() {
+    void testPre() {
         String operation = "getSecretVersion";
         String secretId = "my-secret";
         String versionId = "3";
@@ -50,8 +50,8 @@ public class GoogleSecretManagerSpanDecoratorTest {
 
         decorator.beforeTracingEvent(span, exchange, endpoint);
 
-        assertEquals(operation, span.tags().get(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_OPERATION));
-        assertEquals(secretId, span.tags().get(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_SECRET_ID));
-        assertEquals(versionId, span.tags().get(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_VERSION_ID));
+        assertThat(span.tags()).containsEntry(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_OPERATION, operation);
+        assertThat(span.tags()).containsEntry(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_SECRET_ID, secretId);
+        assertThat(span.tags()).containsEntry(GoogleSecretManagerSpanDecorator.SECRET_MANAGER_VERSION_ID, versionId);
     }
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSpeechToTextSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSpeechToTextSpanDecoratorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleSpeechToTextSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "someOperation";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-speech-to-text:name");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleSpeechToTextSpanDecorator.OPERATION)).thenReturn(operation);
+
+        AbstractSpanDecorator decorator = new GoogleSpeechToTextSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleSpeechToTextSpanDecorator.SPEECH_TO_TEXT_OPERATION));
+    }
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSpeechToTextSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleSpeechToTextSpanDecoratorTest.java
@@ -23,12 +23,12 @@ import org.apache.camel.telemetry.mock.MockSpanAdapter;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoogleSpeechToTextSpanDecoratorTest {
+class GoogleSpeechToTextSpanDecoratorTest {
 
     @Test
-    public void testPre() {
+    void testPre() {
         String operation = "someOperation";
 
         Endpoint endpoint = Mockito.mock(Endpoint.class);
@@ -46,6 +46,6 @@ public class GoogleSpeechToTextSpanDecoratorTest {
 
         decorator.beforeTracingEvent(span, exchange, endpoint);
 
-        assertEquals(operation, span.tags().get(GoogleSpeechToTextSpanDecorator.SPEECH_TO_TEXT_OPERATION));
+        assertThat(span.tags()).containsEntry(GoogleSpeechToTextSpanDecorator.SPEECH_TO_TEXT_OPERATION, operation);
     }
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleTextToSpeechSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleTextToSpeechSpanDecoratorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleTextToSpeechSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "someOperation";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-text-to-speech:name");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleTextToSpeechSpanDecorator.OPERATION)).thenReturn(operation);
+
+        AbstractSpanDecorator decorator = new GoogleTextToSpeechSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleTextToSpeechSpanDecorator.TEXT_TO_SPEECH_OPERATION));
+    }
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleTextToSpeechSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleTextToSpeechSpanDecoratorTest.java
@@ -23,12 +23,12 @@ import org.apache.camel.telemetry.mock.MockSpanAdapter;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoogleTextToSpeechSpanDecoratorTest {
+class GoogleTextToSpeechSpanDecoratorTest {
 
     @Test
-    public void testPre() {
+    void testPre() {
         String operation = "someOperation";
 
         Endpoint endpoint = Mockito.mock(Endpoint.class);
@@ -46,6 +46,6 @@ public class GoogleTextToSpeechSpanDecoratorTest {
 
         decorator.beforeTracingEvent(span, exchange, endpoint);
 
-        assertEquals(operation, span.tags().get(GoogleTextToSpeechSpanDecorator.TEXT_TO_SPEECH_OPERATION));
+        assertThat(span.tags()).containsEntry(GoogleTextToSpeechSpanDecorator.TEXT_TO_SPEECH_OPERATION, operation);
     }
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVertexAISpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVertexAISpanDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class GoogleVertexAISpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "chatCompletion";
+        String modelId = "gemini-1.5-pro";
+        String location = "us-central1";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-vertexai:myProject");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleVertexAISpanDecorator.OPERATION)).thenReturn(operation);
+        Mockito.when(message.getHeader(GoogleVertexAISpanDecorator.MODEL_ID, String.class)).thenReturn(modelId);
+        Mockito.when(message.getHeader(GoogleVertexAISpanDecorator.LOCATION, String.class)).thenReturn(location);
+
+        AbstractSpanDecorator decorator = new GoogleVertexAISpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleVertexAISpanDecorator.VERTEXAI_OPERATION));
+        assertEquals(modelId, span.tags().get(GoogleVertexAISpanDecorator.VERTEXAI_MODEL_ID));
+        assertEquals(location, span.tags().get(GoogleVertexAISpanDecorator.VERTEXAI_LOCATION));
+        // the prompt and chat messages carry user content and must never be emitted as tags
+        assertNull(span.tags().get("prompt"));
+        assertNull(span.tags().get("chatMessages"));
+    }
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVertexAISpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVertexAISpanDecoratorTest.java
@@ -23,13 +23,12 @@ import org.apache.camel.telemetry.mock.MockSpanAdapter;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoogleVertexAISpanDecoratorTest {
+class GoogleVertexAISpanDecoratorTest {
 
     @Test
-    public void testPre() {
+    void testPre() {
         String operation = "chatCompletion";
         String modelId = "gemini-1.5-pro";
         String location = "us-central1";
@@ -51,11 +50,11 @@ public class GoogleVertexAISpanDecoratorTest {
 
         decorator.beforeTracingEvent(span, exchange, endpoint);
 
-        assertEquals(operation, span.tags().get(GoogleVertexAISpanDecorator.VERTEXAI_OPERATION));
-        assertEquals(modelId, span.tags().get(GoogleVertexAISpanDecorator.VERTEXAI_MODEL_ID));
-        assertEquals(location, span.tags().get(GoogleVertexAISpanDecorator.VERTEXAI_LOCATION));
+        assertThat(span.tags()).containsEntry(GoogleVertexAISpanDecorator.VERTEXAI_OPERATION, operation);
+        assertThat(span.tags()).containsEntry(GoogleVertexAISpanDecorator.VERTEXAI_MODEL_ID, modelId);
+        assertThat(span.tags()).containsEntry(GoogleVertexAISpanDecorator.VERTEXAI_LOCATION, location);
         // the prompt and chat messages carry user content and must never be emitted as tags
-        assertNull(span.tags().get("prompt"));
-        assertNull(span.tags().get("chatMessages"));
+        assertThat(span.tags()).doesNotContainKey("prompt");
+        assertThat(span.tags()).doesNotContainKey("chatMessages");
     }
 }

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVisionSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVisionSpanDecoratorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.telemetry.decorators;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.telemetry.mock.MockSpanAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GoogleVisionSpanDecoratorTest {
+
+    @Test
+    public void testPre() {
+        String operation = "someOperation";
+
+        Endpoint endpoint = Mockito.mock(Endpoint.class);
+        Exchange exchange = Mockito.mock(Exchange.class);
+        Message message = Mockito.mock(Message.class);
+
+        Mockito.when(endpoint.getEndpointUri()).thenReturn("google-vision:name");
+        Mockito.when(exchange.getIn()).thenReturn(message);
+        Mockito.when(exchange.getExchangeId()).thenReturn("exchange-1");
+        Mockito.when(message.getHeader(GoogleVisionSpanDecorator.OPERATION)).thenReturn(operation);
+
+        AbstractSpanDecorator decorator = new GoogleVisionSpanDecorator();
+
+        MockSpanAdapter span = new MockSpanAdapter();
+
+        decorator.beforeTracingEvent(span, exchange, endpoint);
+
+        assertEquals(operation, span.tags().get(GoogleVisionSpanDecorator.VISION_OPERATION));
+    }
+}

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVisionSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/GoogleVisionSpanDecoratorTest.java
@@ -23,12 +23,12 @@ import org.apache.camel.telemetry.mock.MockSpanAdapter;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class GoogleVisionSpanDecoratorTest {
+class GoogleVisionSpanDecoratorTest {
 
     @Test
-    public void testPre() {
+    void testPre() {
         String operation = "someOperation";
 
         Endpoint endpoint = Mockito.mock(Endpoint.class);
@@ -46,6 +46,6 @@ public class GoogleVisionSpanDecoratorTest {
 
         decorator.beforeTracingEvent(span, exchange, endpoint);
 
-        assertEquals(operation, span.tags().get(GoogleVisionSpanDecorator.VISION_OPERATION));
+        assertThat(span.tags()).containsEntry(GoogleVisionSpanDecorator.VISION_OPERATION, operation);
     }
 }


### PR DESCRIPTION
### Motivation

[CAMEL-23460](https://issues.apache.org/jira/browse/CAMEL-23460), continuing from batch 1 (#24974, merged). This is the issue's **AI/ML & misc** batch of Google Cloud span decorators.

### Changes

Six new decorators (all `AbstractSpanDecorator`):

| Decorator | Tags emitted |
|---|---|
| `GoogleFunctionsSpanDecorator` | operation, entryPoint, runtime |
| `GoogleSecretManagerSpanDecorator` | operation, secretId, versionId |
| `GoogleVertexAISpanDecorator` | operation, modelId, location |
| `GoogleVisionSpanDecorator` | operation |
| `GoogleSpeechToTextSpanDecorator` | operation |
| `GoogleTextToSpeechSpanDecorator` | operation |

**Tag minimization** per the rules established in the AWS work — sensitive or bulky values are deliberately dropped:

- **VertexAI**: the `prompt` and `chatMessages` headers carry user content and are **not** emitted (the unit test asserts they are never tagged); the tuning parameters (temperature/topP/…) are omitted as low-value.
- **Secret Manager**: only the secret **identifier** and **version** are tagged — never a secret value.
- **Vision / Speech-to-Text / Text-to-Speech**: only `operation` — their `RESPONSE_OBJECT` header can carry large audio/image payloads and is not emitted.

Header constants are **mirrored** from each component's `*Constants` interface (with a Javadoc `@link` back to the source), so `camel-telemetry` gains no hard dependency on the Google component modules. Registered alphabetically in `META-INF/services/org.apache.camel.telemetry.SpanDecorator`, one unit test per decorator.

The remaining batch — workspace/productivity (Calendar, Drive, Mail, Sheets) — needs a different treatment (Mail's headers are To/From/Cc/Subject, i.e. PII; Drive exposes no data headers) and will be a separate PR.

### Testing

- `mvn clean install` in `components/camel-telemetry`: all tests pass (6 new + existing).
- Full reactor `mvn clean install -DskipTests` from root: success, no stale generated files.

Metadata/observability addition — main/4.22.0 only, no backport.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
