### PR TITLE
CAMEL-24234: Backport gzip double-decompression fix to camel-4.18.x

### DIFF
--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpProducer.java
@@ -72,6 +72,7 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HeaderElements;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
@@ -261,6 +262,10 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("Http responseCode: {}", responseCode);
                             }
+                            // httpclient 5.6+ auto-decompresses but no longer removes the stale
+                            // Content-Encoding, Content-Length, and Content-MD5 headers.
+                            // Strip them here to restore the 5.5.2 invariant for all downstream code.
+                            removeStaleCompressionHeaders(httpResponse);
                             if (!throwException) {
                                 // if we do not use failed exception then populate response for all response codes
                                 HttpProducer.this.populateResponse(exchange, httpRequest, httpResponse, strategy, responseCode);
@@ -520,6 +525,21 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
     }
 
     /**
+     * httpclient 5.6+ auto-decompresses response bodies but no longer strips the stale Content-Encoding, Content-Length
+     * (compressed byte count), and Content-MD5 headers. Remove them here so every downstream reader sees the same
+     * invariant as 5.5.2.
+     */
+    private static void removeStaleCompressionHeaders(ClassicHttpResponse httpResponse) {
+        HttpEntity entity = httpResponse.getEntity();
+        if (entity != null && entity.getContentEncoding() == null
+                && httpResponse.containsHeader(Exchange.CONTENT_ENCODING)) {
+            httpResponse.removeHeaders(Exchange.CONTENT_ENCODING);
+            httpResponse.removeHeaders(Exchange.CONTENT_LENGTH);
+            httpResponse.removeHeaders(HttpHeaders.CONTENT_MD5);
+        }
+    }
+
+    /**
      * Extracts the response from the method as a InputStream.
      */
     protected Object extractResponseBody(
@@ -535,8 +555,7 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
             return null;
         }
 
-        Header header = httpResponse.getFirstHeader(HttpConstants.CONTENT_ENCODING);
-        String contentEncoding = header != null ? header.getValue() : null;
+        String contentEncoding = entity.getContentEncoding();
 
         final boolean gzipEncoding = exchange.getProperty(Exchange.SKIP_GZIP_ENCODING, Boolean.FALSE, Boolean.class);
         if (!gzipEncoding) {
@@ -544,7 +563,7 @@ public class HttpProducer extends DefaultProducer implements LineNumberAware {
         }
         // Honor the character encoding
         String contentType = null;
-        header = httpResponse.getFirstHeader("content-type");
+        Header header = httpResponse.getFirstHeader("content-type");
         if (header != null) {
             contentType = header.getValue();
             // find the charset and set it to the Exchange

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpCompressionTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpCompressionTest.java
@@ -54,8 +54,7 @@ import static org.apache.camel.http.common.HttpMethods.POST;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_ENCODING;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HttpCompressionTest extends BaseHttpTest {
 
@@ -94,15 +93,68 @@ public class HttpCompressionTest extends BaseHttpTest {
                     exchange1.getIn().setBody(getBody());
                 });
 
-        assertNotNull(exchange);
+        assertThat(exchange).isNotNull();
 
         Message out = exchange.getMessage();
-        assertNotNull(out);
+        assertThat(out).isNotNull();
 
         Map<String, Object> headers = out.getHeaders();
-        assertEquals(HttpStatus.SC_OK, headers.get(Exchange.HTTP_RESPONSE_CODE));
+        assertThat(headers.get(Exchange.HTTP_RESPONSE_CODE)).isEqualTo(HttpStatus.SC_OK);
+        // CAMEL-24234: HttpClient 5.6+ auto-decompresses the body but no longer strips the stale gzip
+        // Content-Encoding header. Camel must remove it so downstream readers do not attempt a second
+        // decompression (which would fail with a ZipException).
+        assertThat(headers.get(Exchange.CONTENT_ENCODING)).isNull();
 
         assertBody(out.getBody(String.class));
+    }
+
+    @Test
+    public void compressedHttpPostWithEndpointContentCompressionDisabled() {
+        // CAMEL-24234: decompression can also be disabled per-endpoint via
+        // httpClient.contentCompressionEnabled=false. HttpClient then does not decompress, so the raw gzip body
+        // reaches Camel with a "gzip" Content-Encoding on the entity, and Camel must decompress it itself.
+        Exchange exchange = template.request(
+                "http://localhost:" + localServer.getLocalPort() + "/?httpClient.contentCompressionEnabled=false",
+                exchange1 -> {
+                    exchange1.getIn().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                    exchange1.getIn().setHeader(Exchange.CONTENT_ENCODING, "gzip");
+                    exchange1.getIn().setBody(getBody());
+                });
+
+        assertThat(exchange).isNotNull();
+
+        Message out = exchange.getMessage();
+        assertThat(out).isNotNull();
+        assertThat(out.getHeader(Exchange.HTTP_RESPONSE_CODE)).isEqualTo(HttpStatus.SC_OK);
+
+        assertBody(out.getBody(String.class));
+    }
+
+    @Test
+    public void compressedHttpPostWithAutoDecompressionDisabled() {
+        HttpComponent http = context.getComponent("http", HttpComponent.class);
+        http.setContentCompressionDisabled(true);
+        try {
+            Exchange exchange = template.request(
+                    "http://localhost:" + localServer.getLocalPort() + "/",
+                    exchange1 -> {
+                        exchange1.getIn().setHeader(Exchange.CONTENT_TYPE, "text/plain");
+                        exchange1.getIn().setHeader(Exchange.CONTENT_ENCODING, "gzip");
+                        exchange1.getIn().setBody(getBody());
+                    });
+
+            assertThat(exchange).isNotNull();
+
+            Message out = exchange.getMessage();
+            assertThat(out).isNotNull();
+
+            Map<String, Object> headers = out.getHeaders();
+            assertThat(headers.get(Exchange.HTTP_RESPONSE_CODE)).isEqualTo(HttpStatus.SC_OK);
+
+            assertBody(out.getBody(String.class));
+        } finally {
+            http.setContentCompressionDisabled(false);
+        }
     }
 
     @Override

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -40,6 +40,15 @@ The new behavior activates automatically when all of the following are true:
 No configuration changes are required. The existing `maxAutoLockRenewDuration` option controls how long
 Camel will continue renewing a message's lock.
 
+=== camel-http - gzip double decompression with HttpClient 5.6+
+
+When using HttpClient 5.6+ (including transitively via a Spring Boot BOM on Camel 4.18.x), HttpClient
+auto-decompresses gzip response bodies but may leave stale `Content-Encoding`, `Content-Length`, and
+`Content-MD5` headers. Camel now reads content encoding from `entity.getContentEncoding()` instead of
+the response header and strips stale compression headers after the HTTP call. This prevents a second
+decompression attempt that could fail with `ZipException: Not in GZIP format` against gzip-compressing
+servers with default settings.
+
 == Upgrading from 4.18.2 to 4.18.3
 
 === camel-spring-ws - potential breaking change


### PR DESCRIPTION
## Summary

- Backport CAMEL-24234 fix to `camel-4.18.x`: avoid double gzip decompression when HttpClient 5.6+ auto-decompresses responses but leaves stale `Content-Encoding` headers.
- `HttpProducer` reads encoding from `entity.getContentEncoding()` and strips stale compression headers via `removeStaleCompressionHeaders()`.
- Strengthen `HttpCompressionTest` with AssertJ regression tests for default auto-decompression, `?httpClient.contentCompressionEnabled=false`, and component-level `contentCompressionDisabled`.
- Document the fix in the 4.18.4 upgrade guide (`camel-4x-upgrade-guide-4_18.adoc`).

## Test plan

- [x] `mvn -pl components/camel-http -am -DskipTests install`
- [x] `mvn -pl components/camel-http -Dtest=HttpCompressionTest test` (3 tests, all green)

_AI-generated on behalf of atiaomar1978-hub_
