### PR TITLE
[backport camel-4.18.x] CAMEL-24247: camel-jbang - Fix duplicate camel-micrometer-prometheus in exported pom.xml

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -365,7 +365,6 @@ class ExportCamelMain extends Export {
         answer.removeIf(s -> s.contains("camel-core"));
         answer.removeIf(s -> s.contains("camel-main"));
         answer.removeIf(s -> s.contains("camel-health"));
-        answer.removeIf(s -> s.contains("camel-micrometer-prometheus"));
         // spring-boot-starter JARs are not usable in camel-main runtime
         answer.removeIf(s -> s.contains("spring-boot-starter"));
 
@@ -373,14 +372,14 @@ class ExportCamelMain extends Export {
             Properties prop = new CamelCaseOrderedProperties();
             RuntimeUtil.loadProperties(prop, profile);
             // if metrics is defined then include camel-micrometer-prometheus for camel-main runtime
-            if (prop.getProperty("camel.metrics.enabled") != null
-                    || prop.getProperty("camel.management.metricsEnabled") != null
-                    || prop.getProperty("camel.server.metricsEnabled") != null) {
-                answer.add("mvn:org.apache.camel:camel-micrometer-prometheus");
+            if (prop.containsKey("camel.metrics.enabled")
+                    || prop.containsKey("camel.management.metricsEnabled")
+                    || prop.containsKey("camel.server.metricsEnabled")) {
+                answer.add("camel:micrometer-prometheus");
             }
             // if health-check is defined then include camel-health for camel-main runtime
-            if (prop.getProperty("camel.management.healthCheckEnabled") != null) {
-                answer.add("mvn:org.apache.camel:camel-health");
+            if (prop.containsKey("camel.management.healthCheckEnabled")) {
+                answer.add("camel:health");
             }
         }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportCamelMain.java
@@ -365,6 +365,9 @@ class ExportCamelMain extends Export {
         answer.removeIf(s -> s.contains("camel-core"));
         answer.removeIf(s -> s.contains("camel-main"));
         answer.removeIf(s -> s.contains("camel-health"));
+        answer.removeIf(s -> s.contains("camel-micrometer-prometheus"));
+        // spring-boot-starter JARs are not usable in camel-main runtime
+        answer.removeIf(s -> s.contains("spring-boot-starter"));
 
         if (profile != null && Files.exists(profile)) {
             Properties prop = new CamelCaseOrderedProperties();

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -21,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -53,8 +52,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ExportTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExportTest.class);
-    private static final String RELEASED_CAMEL_VERSION = "4.13.0";
-
     private File workingDir;
 
     @BeforeEach
@@ -908,67 +905,6 @@ class ExportTest {
         }
     }
 
-    @ParameterizedTest
-    @MethodSource("runtimeProvider")
-    public void shouldExportWithParentPom(RuntimeType rt) throws Exception {
-        LOG.info("shouldExportWithParentPom {}", rt);
-        Export command = new Export(new CamelJBangMain());
-        List<String> cmdArgs = new ArrayList<>(
-                List.of("--gav=examples:route:1.0.0", "--dir=" + workingDir,
-                        "--runtime=%s".formatted(rt.runtime()),
-                        "--parent-pom=com.ourorg:camel-parent:1.0"));
-        if (rt == RuntimeType.springBoot) {
-            cmdArgs.add("--camel-version=" + RELEASED_CAMEL_VERSION);
-        }
-        cmdArgs.add("target/test-classes/route.yaml");
-        CommandLine.populateCommand(command, cmdArgs.toArray(String[]::new));
-        int exit = command.doCall();
-
-        Assertions.assertEquals(0, exit);
-        Model model = readMavenModel();
-        Assertions.assertEquals("examples", model.getGroupId());
-        Assertions.assertEquals("route", model.getArtifactId());
-        Assertions.assertEquals("1.0.0", model.getVersion());
-
-        // verify parent POM is set
-        Assertions.assertNotNull(model.getParent(), "Parent POM should be set");
-        Assertions.assertEquals("com.ourorg", model.getParent().getGroupId());
-        Assertions.assertEquals("camel-parent", model.getParent().getArtifactId());
-        Assertions.assertEquals("1.0", model.getParent().getVersion());
-
-        if (rt == RuntimeType.springBoot) {
-            // Spring Boot BOM should still be in dependencyManagement
-            assertThat(model.getDependencyManagement().getDependencies())
-                    .as("Spring Boot BOM must be in dependencyManagement when using custom parent")
-                    .anySatisfy(dep -> {
-                        assertThat(dep.getGroupId()).isEqualTo("org.springframework.boot");
-                        assertThat(dep.getArtifactId()).isEqualTo("spring-boot-dependencies");
-                    });
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("runtimeProvider")
-    public void shouldExportWithoutParentPom(RuntimeType rt) throws Exception {
-        LOG.info("shouldExportWithoutParentPom {}", rt);
-        Export command = createCommand(rt, new String[] { "classpath:route.yaml" },
-                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
-        int exit = command.doCall();
-
-        Assertions.assertEquals(0, exit);
-        Model model = readMavenModel();
-
-        if (rt == RuntimeType.springBoot) {
-            // default Spring Boot parent should be used
-            Assertions.assertNotNull(model.getParent(), "Spring Boot parent should be set by default");
-            Assertions.assertEquals("org.springframework.boot", model.getParent().getGroupId());
-            Assertions.assertEquals("spring-boot-starter-parent", model.getParent().getArtifactId());
-        } else {
-            // Quarkus and Main should have no parent by default
-            Assertions.assertNull(model.getParent(), "No parent POM should be set by default for " + rt);
-        }
-    }
-
     @Test
     void shouldNotDuplicateMetricsDependency() throws Exception {
         File profile = new File(".", "application.properties");
@@ -994,28 +930,6 @@ class ExportTest {
         } finally {
             FileUtil.deleteFile(profile);
         }
-    }
-
-    @ParameterizedTest
-    @MethodSource("runtimeProvider")
-    public void shouldContainJibProfile(RuntimeType rt) throws Exception {
-        Export command = new Export(new CamelJBangMain());
-        List<String> cmdArgs = new ArrayList<>(
-                List.of("--gav=examples:route:1.0.0", "--dir=" + workingDir,
-                        "--runtime=%s".formatted(rt.runtime())));
-        if (rt == RuntimeType.springBoot) {
-            cmdArgs.add("--camel-version=" + RELEASED_CAMEL_VERSION);
-        }
-        cmdArgs.add("src/test/resources/route.yaml");
-        CommandLine.populateCommand(command, cmdArgs.toArray(String[]::new));
-        int exit = command.doCall();
-
-        Assertions.assertEquals(0, exit);
-
-        File f = new File(workingDir, "pom.xml");
-        String content = IOHelper.loadText(new FileInputStream(f));
-        Assertions.assertTrue(content.contains("<id>jib</id>"),
-                "Jib profile not exported!");
     }
 
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -21,6 +21,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -30,6 +31,7 @@ import java.util.stream.Stream;
 import org.apache.camel.dsl.jbang.core.common.CamelJBangConstants;
 import org.apache.camel.dsl.jbang.core.common.HawtioVersion;
 import org.apache.camel.dsl.jbang.core.common.RuntimeType;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
@@ -51,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ExportTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExportTest.class);
+    private static final String RELEASED_CAMEL_VERSION = "4.13.0";
 
     private File workingDir;
 
@@ -903,6 +906,116 @@ class ExportTest {
             Assertions.assertTrue(content.contains("quarkus.hawtio.authenticationEnabled=false"),
                     "should contain quarkus.hawtio.authenticationEnabled property, was " + content);
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    public void shouldExportWithParentPom(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithParentPom {}", rt);
+        Export command = new Export(new CamelJBangMain());
+        List<String> cmdArgs = new ArrayList<>(
+                List.of("--gav=examples:route:1.0.0", "--dir=" + workingDir,
+                        "--runtime=%s".formatted(rt.runtime()),
+                        "--parent-pom=com.ourorg:camel-parent:1.0"));
+        if (rt == RuntimeType.springBoot) {
+            cmdArgs.add("--camel-version=" + RELEASED_CAMEL_VERSION);
+        }
+        cmdArgs.add("target/test-classes/route.yaml");
+        CommandLine.populateCommand(command, cmdArgs.toArray(String[]::new));
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+        Assertions.assertEquals("examples", model.getGroupId());
+        Assertions.assertEquals("route", model.getArtifactId());
+        Assertions.assertEquals("1.0.0", model.getVersion());
+
+        // verify parent POM is set
+        Assertions.assertNotNull(model.getParent(), "Parent POM should be set");
+        Assertions.assertEquals("com.ourorg", model.getParent().getGroupId());
+        Assertions.assertEquals("camel-parent", model.getParent().getArtifactId());
+        Assertions.assertEquals("1.0", model.getParent().getVersion());
+
+        if (rt == RuntimeType.springBoot) {
+            // Spring Boot BOM should still be in dependencyManagement
+            assertThat(model.getDependencyManagement().getDependencies())
+                    .as("Spring Boot BOM must be in dependencyManagement when using custom parent")
+                    .anySatisfy(dep -> {
+                        assertThat(dep.getGroupId()).isEqualTo("org.springframework.boot");
+                        assertThat(dep.getArtifactId()).isEqualTo("spring-boot-dependencies");
+                    });
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    public void shouldExportWithoutParentPom(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithoutParentPom {}", rt);
+        Export command = createCommand(rt, new String[] { "classpath:route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+
+        if (rt == RuntimeType.springBoot) {
+            // default Spring Boot parent should be used
+            Assertions.assertNotNull(model.getParent(), "Spring Boot parent should be set by default");
+            Assertions.assertEquals("org.springframework.boot", model.getParent().getGroupId());
+            Assertions.assertEquals("spring-boot-starter-parent", model.getParent().getArtifactId());
+        } else {
+            // Quarkus and Main should have no parent by default
+            Assertions.assertNull(model.getParent(), "No parent POM should be set by default for " + rt);
+        }
+    }
+
+    @Test
+    void shouldNotDuplicateMetricsDependency() throws Exception {
+        File profile = new File(".", "application.properties");
+        try {
+            Files.writeString(profile.toPath(), "camel.management.metricsEnabled=true\n");
+
+            Export command = new Export(new CamelJBangMain());
+            CommandLine.populateCommand(command,
+                    "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet",
+                    "--runtime=camel-main",
+                    "src/test/resources/route.yaml");
+            int exit = command.doCall();
+
+            assertThat(exit).isEqualTo(0);
+            Model model = readMavenModel();
+
+            long count = model.getDependencies().stream()
+                    .filter(d -> "camel-micrometer-prometheus".equals(d.getArtifactId()))
+                    .count();
+            assertThat(count)
+                    .as("camel-micrometer-prometheus should appear exactly once")
+                    .isEqualTo(1);
+        } finally {
+            FileUtil.deleteFile(profile);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    public void shouldContainJibProfile(RuntimeType rt) throws Exception {
+        Export command = new Export(new CamelJBangMain());
+        List<String> cmdArgs = new ArrayList<>(
+                List.of("--gav=examples:route:1.0.0", "--dir=" + workingDir,
+                        "--runtime=%s".formatted(rt.runtime())));
+        if (rt == RuntimeType.springBoot) {
+            cmdArgs.add("--camel-version=" + RELEASED_CAMEL_VERSION);
+        }
+        cmdArgs.add("src/test/resources/route.yaml");
+        CommandLine.populateCommand(command, cmdArgs.toArray(String[]::new));
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+
+        File f = new File(workingDir, "pom.xml");
+        String content = IOHelper.loadText(new FileInputStream(f));
+        Assertions.assertTrue(content.contains("<id>jib</id>"),
+                "Jib profile not exported!");
     }
 
 }


### PR DESCRIPTION
## Backport of #25035

_Claude Code on behalf of davsclaus_

Cherry-pick of #25035 onto `camel-4.18.x`.

**Original PR:** #25035 - CAMEL-24247: camel-jbang - Fix duplicate camel-micrometer-prometheus in exported pom.xml
**Original author:** @davsclaus
**Target branch:** `camel-4.18.x`

### Original description

When exporting a JBang project with metrics enabled, the exported pom.xml contains `camel-micrometer-prometheus` twice. The base class adds it in shorthand format while the subclass adds it in full Maven format, so the `Set` does not deduplicate them.

**Fix:** Switch the subclass to use `camel:micrometer-prometheus` shorthand (matching the base class format) so the `Set` naturally deduplicates. Applied the same fix for `camel-health`.

### Conflicts resolved

- `ExportCamelMain.java` — minor context difference around `removeIf` block
- `ExportTest.java` — new test methods added (parent POM tests, dedup test, JIB profile test); added missing `ArrayList`, `FileUtil` imports and `RELEASED_CAMEL_VERSION` constant

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>