### PR TITLE
chore: sync camel-4x-upgrade-guide-4_18.adoc with camel-4.18.x branch

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -40,6 +40,15 @@ The new behavior activates automatically when all of the following are true:
 No configuration changes are required. The existing `maxAutoLockRenewDuration` option controls how long
 Camel will continue renewing a message's lock.
 
+=== camel-http - gzip double decompression with HttpClient 5.6+
+
+When using HttpClient 5.6+ (including transitively via a Spring Boot BOM on Camel 4.18.x), HttpClient
+auto-decompresses gzip response bodies but may leave stale `Content-Encoding`, `Content-Length`, and
+`Content-MD5` headers. Camel now reads content encoding from `entity.getContentEncoding()` instead of
+the response header and strips stale compression headers after the HTTP call. This prevents a second
+decompression attempt that could fail with `ZipException: Not in GZIP format` against gzip-compressing
+servers with default settings.
+
 === camel-mail - MimeMultipartDataFormat inbound header filtering
 
 When unmarshalling a MIME message with `headersInline=true`, the `mime-multipart` data format now applies a


### PR DESCRIPTION
## Summary

- Sync the camel-http gzip double-decompression upgrade guide entry (CAMEL-24234) from the `camel-4.18.x` backport PR (#25073) to the `main` branch.

Per the backport upgrade-guide policy, all version-specific upgrade guide entries must also exist on `main` as the canonical history.

## Test plan

- [ ] Doc-only change, no tests needed

_Claude Code on behalf of Claus Ibsen (@davsclaus)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)