### PR TITLE
chore: Use OS-independent sort for endpoint DSL factory files

### DIFF
--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointDslMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/EndpointDslMojo.java
@@ -384,7 +384,7 @@ public class EndpointDslMojo extends AbstractGeneratorMojo {
         }
 
         // load components
-        return Arrays.stream(files).sorted().toList();
+        return Arrays.stream(files).sorted(Comparator.comparing(File::getName)).toList();
     }
 
     public String camelCaseLower(String s) {


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Fix `EndpointDslMojo` to use `Comparator.comparing(File::getName)` instead of `File.compareTo()` when sorting endpoint DSL factory files
- `File.compareTo()` delegates to the OS filesystem comparator: case-insensitive on Windows (NTFS) but case-sensitive on Linux/macOS
- This caused contributors building on Windows to generate `EndpointBuilders.java` and `EndpointBuilderFactory.java` with a different sort order, failing CI's uncommitted-changes check

## Root cause

`File.compareTo()` on Windows treats `CMEndpointBuilderFactory` and `CaffeineEndpointBuilderFactory` as `cm...` vs `caffeine...` (case-insensitive), producing a different order than Linux where `CM` (uppercase) sorts before `Ca` (uppercase then lowercase) by Unicode code point.

## Fix

Sort by `File.getName()` which uses `String.compareTo()` — ordinal Unicode comparison that produces identical output on every platform and locale.

## Test plan

- [x] Verified the plugin compiles
- [ ] CI should pass with no uncommitted generated file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>