### PR TITLE
CAMEL-24253: Endpoint DSL auto-wraps values with + or % in RAW()

### DIFF
--- a/dsl/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/AbstractEndpointBuilder.java
+++ b/dsl/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/AbstractEndpointBuilder.java
@@ -113,8 +113,7 @@ public class AbstractEndpointBuilder {
                     changed = camelContext.getCamelContextExtension().resolvePropertyPlaceholders(text, true);
                 }
                 if (changed != null && !changed.startsWith(PropertiesComponent.PREFIX_OPTIONAL_TOKEN)) {
-                    // resolve then use
-                    params.put(key, changed);
+                    params.put(key, wrapRawIfNeeded(changed));
                 }
             } else if (val instanceof Number || val instanceof Boolean || val instanceof Enum<?>) {
                 params.put(key, val.toString());
@@ -126,6 +125,26 @@ public class AbstractEndpointBuilder {
                 remaining.put(key, val);
             }
         }
+    }
+
+    /**
+     * Wraps the value in RAW() if it contains characters that would be mangled during URI encoding/decoding round-trip
+     * (+ is decoded as space by URLDecoder, % causes double-decode issues).
+     */
+    private static String wrapRawIfNeeded(String value) {
+        if (value.startsWith("RAW(")) {
+            return value;
+        }
+        if (value.startsWith("#")) {
+            return value;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '+' || ch == '%') {
+                return "RAW(" + value + ")";
+            }
+        }
+        return value;
     }
 
     @Override

--- a/dsl/camel-endpointdsl/src/test/java/org/apache/camel/builder/endpoint/FtpSpecialCharParameterTest.java
+++ b/dsl/camel-endpointdsl/src/test/java/org/apache/camel/builder/endpoint/FtpSpecialCharParameterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.builder.endpoint;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.file.remote.FtpEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FtpSpecialCharParameterTest extends BaseEndpointDslTest {
+
+    @Test
+    void testPlusAndPercentPreservedWithoutManualRaw() throws Exception {
+        FtpEndpoint ftp = (FtpEndpoint) context.getEndpoints().stream()
+                .filter(e -> e.getEndpointUri().startsWith("ftp"))
+                .findFirst().get();
+        assertNotNull(ftp);
+        assertEquals("foo+bar", ftp.getConfiguration().getUsername());
+        assertEquals("baz+bang%ok", ftp.getConfiguration().getPassword());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new EndpointRouteBuilder() {
+            public void configure() throws Exception {
+                from(ftp("localhost:2121/inbox").username("foo+bar").password("baz+bang%ok").binary(true).delay(5000))
+                        .routeId("myroute").autoStartup(false)
+                        .to(mock("result"));
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Fixes a regression introduced in 4.14.0 (by CAMEL-22293 / PR #18772) where `+` and `%` characters in Endpoint DSL option values are silently mangled during the URI encoding/decoding round-trip.

**Root cause**: `AbstractEndpointBuilder.resolve()` was changed to resolve endpoints from the URI string alone, removing the safety net where raw properties overwrote values parsed from the URI. The `+` character gets double-decoded: `URLEncoder` encodes it as `%2B`, `URI.getQuery()` percent-decodes it back to literal `+`, then `URLDecoder.decode()` interprets that `+` as a space.

**Fix**: `computeProperties()` now automatically wraps string values containing `+` or `%` in `RAW()` so the URI parser preserves the value verbatim. Values already wrapped in `RAW()` or starting with `#` (registry references) are left alone.

This affects any endpoint option value containing `+` or `%` when set via the Endpoint DSL, including SFTP `knownHosts` (SSH public keys contain `+`), passwords, SQL queries, etc.

- [`AbstractEndpointBuilder.java`](dsl/camel-endpointdsl/src/main/java/org/apache/camel/builder/endpoint/AbstractEndpointBuilder.java) — added `wrapRawIfNeeded()` helper
- [`FtpSpecialCharParameterTest.java`](dsl/camel-endpointdsl/src/test/java/org/apache/camel/builder/endpoint/FtpSpecialCharParameterTest.java) — new test verifying `+` and `%` are preserved without manual `RAW()` wrapping

## Test plan

- [x] New `FtpSpecialCharParameterTest` verifies `+` and `%` preserved without manual `RAW()`
- [x] Existing `FtpRawParameterTest` still passes (manual `RAW()` wrapping still works)
- [x] Full `camel-endpointdsl` test suite passes (66 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>