### PR TITLE
CAMEL-24251: camel-aws2 - guard nullable awsErrorDetails() in producer health checks

### DIFF
--- a/components/camel-aws/camel-aws-config/src/main/java/org/apache/camel/component/aws/config/AWSConfigProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws-config/src/main/java/org/apache/camel/component/aws/config/AWSConfigProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class AWSConfigProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws-parameter-store/src/main/java/org/apache/camel/component/aws/parameterstore/ParameterStoreProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/main/java/org/apache/camel/component/aws/parameterstore/ParameterStoreProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class ParameterStoreProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/SecretsManagerProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/SecretsManagerProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class SecretsManagerProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws-security-hub/src/main/java/org/apache/camel/component/aws/securityhub/SecurityHubProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws-security-hub/src/main/java/org/apache/camel/component/aws/securityhub/SecurityHubProducerHealthCheck.java
@@ -54,7 +54,7 @@ public class SecurityHubProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -84,5 +84,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-athena/src/main/java/org/apache/camel/component/aws2/athena/Athena2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Athena2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2ProducerHealthCheckErrorDetailsTest.java
+++ b/components/camel-aws/camel-aws2-athena/src/test/java/org/apache/camel/component/aws2/athena/Athena2ProducerHealthCheckErrorDetailsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.athena;
+
+import org.apache.camel.health.HealthCheck;
+import org.apache.camel.impl.health.AbstractHealthCheck;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.athena.model.ListQueryExecutionsRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AwsServiceException#awsErrorDetails()} is nullable, so the health check must not dereference it blindly when
+ * recording the AWS error code.
+ */
+class Athena2ProducerHealthCheckErrorDetailsTest {
+
+    @Test
+    void reportsDownWithoutFailingWhenTheExceptionCarriesNoErrorDetails() {
+        HealthCheck.Result result = callHealthCheckThrowing(
+                AwsServiceException.builder().message("boom").statusCode(500).build());
+
+        assertThat(result.getState()).isEqualTo(HealthCheck.State.DOWN);
+        assertThat(result.getMessage()).contains("boom");
+        assertThat(result.getDetails()).containsEntry(AbstractHealthCheck.SERVICE_STATUS_CODE, 500);
+        // there were no error details to report, so the detail is simply absent
+        assertThat(result.getDetails()).doesNotContainKey(AbstractHealthCheck.SERVICE_ERROR_CODE);
+    }
+
+    @Test
+    void stillReportsTheErrorCodeWhenTheExceptionCarriesErrorDetails() {
+        HealthCheck.Result result = callHealthCheckThrowing(
+                AwsServiceException.builder()
+                        .message("boom")
+                        .statusCode(400)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .errorCode("InvalidRequestException")
+                                .build())
+                        .build());
+
+        assertThat(result.getState()).isEqualTo(HealthCheck.State.DOWN);
+        assertThat(result.getDetails())
+                .containsEntry(AbstractHealthCheck.SERVICE_ERROR_CODE, "InvalidRequestException");
+    }
+
+    private HealthCheck.Result callHealthCheckThrowing(AwsServiceException exception) {
+        AthenaClient client = mock(AthenaClient.class);
+        when(client.listQueryExecutions(any(ListQueryExecutionsRequest.class))).thenThrow(exception);
+
+        Athena2Endpoint endpoint = mock(Athena2Endpoint.class);
+        // a null region skips the region check and takes the health check straight to the client call
+        when(endpoint.getConfiguration()).thenReturn(new Athena2Configuration());
+        when(endpoint.getAthenaClient()).thenReturn(client);
+
+        return new Athena2ProducerHealthCheck(endpoint, "test").call();
+    }
+}

--- a/components/camel-aws/camel-aws2-comprehend/src/main/java/org/apache/camel/component/aws2/comprehend/Comprehend2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-comprehend/src/main/java/org/apache/camel/component/aws2/comprehend/Comprehend2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Comprehend2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-cw/src/main/java/org/apache/camel/component/aws2/cw/Cw2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-cw/src/main/java/org/apache/camel/component/aws2/cw/Cw2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Cw2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-ddb/src/main/java/org/apache/camel/component/aws2/ddb/Db2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-ddb/src/main/java/org/apache/camel/component/aws2/ddb/Db2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Db2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-ec2/src/main/java/org/apache/camel/component/aws2/ec2/AWS2EC2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-ec2/src/main/java/org/apache/camel/component/aws2/ec2/AWS2EC2ProducerHealthCheck.java
@@ -54,7 +54,7 @@ public class AWS2EC2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-ecs/src/main/java/org/apache/camel/component/aws2/ecs/ECS2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-ecs/src/main/java/org/apache/camel/component/aws2/ecs/ECS2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class ECS2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-eks/src/main/java/org/apache/camel/component/aws2/eks/EKS2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-eks/src/main/java/org/apache/camel/component/aws2/eks/EKS2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class EKS2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class EventbridgeProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Lambda2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class MQ2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-polly/src/main/java/org/apache/camel/component/aws2/polly/Polly2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-polly/src/main/java/org/apache/camel/component/aws2/polly/Polly2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Polly2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-rekognition/src/main/java/org/apache/camel/component/aws2/rekognition/Rekognition2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-rekognition/src/main/java/org/apache/camel/component/aws2/rekognition/Rekognition2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Rekognition2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class StepFunctions2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-textract/src/main/java/org/apache/camel/component/aws2/textract/Textract2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-textract/src/main/java/org/apache/camel/component/aws2/textract/Textract2ProducerHealthCheck.java
@@ -62,9 +62,10 @@ public class Textract2ProducerHealthCheck extends AbstractHealthCheck {
             // This will likely fail because "test" is not a valid document, but it will validate credentials and connectivity
             textractClient.detectDocumentText(testRequest);
         } catch (AwsServiceException e) {
+            // awsErrorDetails() is nullable, so read the error code defensively before using it below
+            String errorCode = e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null;
             // For health check, we consider certain errors as "healthy" since they indicate the service is reachable
-            if ("InvalidParameterException".equals(e.awsErrorDetails().errorCode()) ||
-                    "UnsupportedDocumentException".equals(e.awsErrorDetails().errorCode())) {
+            if ("InvalidParameterException".equals(errorCode) || "UnsupportedDocumentException".equals(errorCode)) {
                 // These errors mean the service is reachable but our test document is invalid - this is expected
                 builder.up();
                 return;
@@ -75,8 +76,8 @@ public class Textract2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
-                builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
+            if (ObjectHelper.isNotEmpty(errorCode)) {
+                builder.detail(SERVICE_ERROR_CODE, errorCode);
             }
             builder.down();
             return;

--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerHealthCheck.java
@@ -56,7 +56,7 @@ public class Timestream2QueryProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducerHealthCheck.java
@@ -56,7 +56,7 @@ public class Timestream2WriteProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();

--- a/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2ProducerHealthCheck.java
+++ b/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2ProducerHealthCheck.java
@@ -55,7 +55,7 @@ public class Translate2ProducerHealthCheck extends AbstractHealthCheck {
             if (ObjectHelper.isNotEmpty(e.statusCode())) {
                 builder.detail(SERVICE_STATUS_CODE, e.statusCode());
             }
-            if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
+            if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
                 builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
             }
             builder.down();


### PR DESCRIPTION
## Problem

Every AWS producer health check catches `AwsServiceException` and records two
details — the HTTP status code and the AWS error code. The status code is
guarded for null; `awsErrorDetails()` is dereferenced directly:

```java
if (ObjectHelper.isNotEmpty(e.statusCode())) {                    // guarded
    builder.detail(SERVICE_STATUS_CODE, e.statusCode());
}
if (ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {   // dereferenced unguarded
    builder.detail(SERVICE_ERROR_CODE, e.awsErrorDetails().errorCode());
}
```

`AwsServiceException.awsErrorDetails()` is nullable — it is a builder field that
defaults to null and is only populated when the SDK successfully unmarshals a
structured error response.

**This is reproduced, not theoretical.** Driving `Athena2ProducerHealthCheck`
with a client that throws
`AwsServiceException.builder().message("boom").statusCode(500).build()` fails on
`main` with:

```
java.lang.NullPointerException: Cannot invoke
"software.amazon.awssdk.awscore.exception.AwsErrorDetails.errorCode()" because
the return value of
"software.amazon.awssdk.awscore.exception.AwsServiceException.awsErrorDetails()" is null
```

So instead of reporting the endpoint `DOWN` with the message it had already
prepared, the health check propagates an NPE — a genuine "service unreachable"
signal is turned into a health-check failure.

The inconsistency is the tell: the author guarded `statusCode()` one line above.

## Fix

Guarded `awsErrorDetails()` consistently with the neighbouring `statusCode()`
check, across all **21** producer health checks (athena, comprehend, cw, ddb,
ec2, ecs, eks, eventbridge, lambda, mq, polly, rekognition, step-functions,
textract, timestream query + write, translate, config, parameter-store,
secrets-manager, security-hub):

```java
if (ObjectHelper.isNotEmpty(e.awsErrorDetails()) && ObjectHelper.isNotEmpty(e.awsErrorDetails().errorCode())) {
```

`Textract2ProducerHealthCheck` additionally dereferenced it in an `equals(...)`
test that classifies certain errors as healthy — two unguarded sites — so it now
reads the error code once into a local:

```java
String errorCode = e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null;
if ("InvalidParameterException".equals(errorCode) || "UnsupportedDocumentException".equals(errorCode)) {
```

## Tests

`Athena2ProducerHealthCheckErrorDetailsTest` drives the health check with a
mocked client and covers both paths:

- **null details** → `DOWN`, `service.status.code` present, `service.error.code`
  absent. Verified to fail on `main` with the NPE quoted above.
- **populated details** → `DOWN` and the error code still reported, so the fix
  does not silently drop the detail it was meant to record.

Full `camel-aws2-athena` suite: 49/49 green. Full reactor build clean.

## Backport

- `camel-4.18.x` — all 21 health checks present → backport opened.
- `camel-4.14.x` — 15 of the 21 present (parameter-store, security-hub,
  comprehend, polly, rekognition and textract do not exist on that branch) →
  backport covers those 15.

---
_Claude Code on behalf of oscerd_