### PR TITLE
camel-jbang - Redact secrets in structured MCP tool results, not only String results

### DIFF
--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactor.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactor.java
@@ -17,16 +17,20 @@
 package org.apache.camel.dsl.jbang.core.commands.mcp;
 
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 /**
- * Regex-based secret redaction engine for MCP tool responses.
+ * Secret redaction engine for MCP tool responses.
  * <p>
- * Applies configurable patterns to detect and replace credentials, tokens, API keys, and connection strings in tool
- * output text.
+ * Two complementary modes are provided. {@link #redact(String)} applies regex patterns to free-text output, catching
+ * unquoted {@code key=value} pairs, connection strings, AWS keys and PEM private-key blocks. {@link #redactStructured}
+ * walks {@link Map}/{@link List} results (such as the {@code JsonObject} returned by the runtime tools) and blanks the
+ * value of any entry whose key name looks like a secret, so JSON-quoted values that the value regex cannot match are
+ * still redacted. Both are needed: the tools return a mix of plain strings and structured {@code JsonObject} trees.
  */
 @ApplicationScoped
 public class McpSecretRedactor {
@@ -35,15 +39,27 @@ public class McpSecretRedactor {
 
     static final List<Pattern> DEFAULT_PATTERNS = List.of(
             // password/passwd/pwd key-value pairs
-            Pattern.compile("(?i)(password|passwd|pwd)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
-            // API keys, secret keys, access keys
-            Pattern.compile("(?i)(api[_-]?key|apikey|secret[_-]?key|access[_-]?key)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
+            Pattern.compile("(?i)(password|passwd|pwd|passphrase)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
+            // API keys, secret keys, access keys, OAuth client secrets
+            Pattern.compile(
+                    "(?i)(api[_-]?key|apikey|secret[_-]?key|access[_-]?key|client[_-]?secret)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
             // tokens and bearer authorization
             Pattern.compile("(?i)(token|bearer|authorization)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
             // AWS Access Key IDs (AKIA prefix + 16 alphanumeric)
             Pattern.compile("AKIA[0-9A-Z]{16}"),
-            // Connection strings with embedded credentials
-            Pattern.compile("(?i)(mongodb(\\+srv)?://|amqp://|redis://|jdbc:)[^\\s\"']+@[^\\s\"']+"));
+            // Connection strings with embedded userinfo credentials (user:pass@host)
+            Pattern.compile("(?i)(mongodb(\\+srv)?://|amqp://|redis://|jdbc:)[^\\s\"']+@[^\\s\"']+"),
+            // Secrets carried as a URL query parameter (e.g. jdbc:...?password=xxx, which has no userinfo '@')
+            Pattern.compile("(?i)[?&](password|secret|token|access[_-]?key)=[^\\s&\"']+"),
+            // PEM private-key blocks
+            Pattern.compile("(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----"));
+
+    /**
+     * Key names (case-insensitive, ignoring '-'/'_' separators) whose value is blanked during structured redaction.
+     */
+    static final Pattern SECRET_KEY_NAME = Pattern.compile(
+            "(?i).*(password|passwd|pwd|passphrase|secret|secretkey|apikey|accesskey|clientsecret|token|bearer|"
+                                                           + "authorization|credential|credentials|privatekey|keystorepassword|truststorepassword|saslpassword|sasljaasconfig).*");
 
     @Inject
     McpSecurityConfig config;
@@ -71,5 +87,66 @@ public class McpSecretRedactor {
             }
         }
         return false;
+    }
+
+    /**
+     * Whether a map key name denotes a secret whose value should be blanked. The name is normalised by dropping '-' and
+     * '_' so that {@code client-secret}, {@code client_secret} and {@code clientSecret} all match.
+     */
+    static boolean isSecretKeyName(String key) {
+        if (key == null || key.isEmpty()) {
+            return false;
+        }
+        String normalised = key.replace("-", "").replace("_", "");
+        return SECRET_KEY_NAME.matcher(normalised).matches();
+    }
+
+    /**
+     * Redacts a structured tool result in place. {@link Map} values (such as the {@code JsonObject} returned by the
+     * runtime tools) have any secret-named entry blanked and every string value passed through {@link #redact(String)};
+     * {@link List} elements are recursed. The same instance is mutated and returned, so a tool's declared return type
+     * is preserved.
+     *
+     * @param  value the result to scrub (a {@code Map}, {@code List}, or anything else which is returned untouched)
+     * @return       {@code true} if anything was changed
+     */
+    @SuppressWarnings("unchecked")
+    public boolean redactStructured(Object value) {
+        boolean changed = false;
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> mutable = (Map<Object, Object>) map;
+            for (Object key : List.copyOf(mutable.keySet())) {
+                Object current = mutable.get(key);
+                if (key instanceof String name && isSecretKeyName(name)) {
+                    if (current != null && !REDACTED.equals(current)) {
+                        mutable.put(key, REDACTED);
+                        changed = true;
+                    }
+                } else if (current instanceof String s) {
+                    String scrubbed = redact(s);
+                    if (!scrubbed.equals(s)) {
+                        mutable.put(key, scrubbed);
+                        changed = true;
+                    }
+                } else if (current instanceof Map<?, ?> || current instanceof List<?>) {
+                    changed |= redactStructured(current);
+                }
+            }
+        } else if (value instanceof List<?> list) {
+            List<Object> mutable = (List<Object>) list;
+            for (int i = 0; i < mutable.size(); i++) {
+                Object current = mutable.get(i);
+                if (current instanceof String s) {
+                    String scrubbed = redact(s);
+                    if (!scrubbed.equals(s)) {
+                        mutable.set(i, scrubbed);
+                        changed = true;
+                    }
+                } else if (current instanceof Map<?, ?> || current instanceof List<?>) {
+                    changed |= redactStructured(current);
+                }
+            }
+        }
+        return changed;
     }
 }

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactor.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactor.java
@@ -23,54 +23,51 @@ import java.util.regex.Pattern;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.apache.camel.support.processor.DefaultMaskingFormatter;
+import org.apache.camel.util.SensitiveUtils;
+
 /**
  * Secret redaction engine for MCP tool responses.
  * <p>
- * Two complementary modes are provided. {@link #redact(String)} applies regex patterns to free-text output, catching
- * unquoted {@code key=value} pairs, connection strings, AWS keys and PEM private-key blocks. {@link #redactStructured}
- * walks {@link Map}/{@link List} results (such as the {@code JsonObject} returned by the runtime tools) and blanks the
- * value of any entry whose key name looks like a secret, so JSON-quoted values that the value regex cannot match are
- * still redacted. Both are needed: the tools return a mix of plain strings and structured {@code JsonObject} trees.
+ * Both modes reuse Camel's own knowledge of what a secret is, rather than a hand-maintained word list. Free-text output
+ * is masked with {@link DefaultMaskingFormatter}, which blanks the value of any {@code key=value}, XML element or JSON
+ * field whose name is one of {@link SensitiveUtils#getSensitiveKeys()}. Structured results ({@link Map}/{@link List},
+ * such as the {@code JsonObject} returned by the runtime tools) are walked and any entry whose key
+ * {@link SensitiveUtils#containsSensitive(String) is sensitive} has its value blanked, which is what catches
+ * JSON-quoted values inside an object tree. Operators may add extra regex patterns via
+ * {@code camel.mcp.security.redaction.patterns}.
  */
 @ApplicationScoped
 public class McpSecretRedactor {
 
     static final String REDACTED = "***REDACTED***";
 
-    static final List<Pattern> DEFAULT_PATTERNS = List.of(
-            // password/passwd/pwd key-value pairs
-            Pattern.compile("(?i)(password|passwd|pwd|passphrase)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
-            // API keys, secret keys, access keys, OAuth client secrets
-            Pattern.compile(
-                    "(?i)(api[_-]?key|apikey|secret[_-]?key|access[_-]?key|client[_-]?secret)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
-            // tokens and bearer authorization
-            Pattern.compile("(?i)(token|bearer|authorization)\\s*[=:]\\s*[^\\s,;}'\"\\]]+"),
-            // AWS Access Key IDs (AKIA prefix + 16 alphanumeric)
-            Pattern.compile("AKIA[0-9A-Z]{16}"),
-            // Connection strings with embedded userinfo credentials (user:pass@host)
-            Pattern.compile("(?i)(mongodb(\\+srv)?://|amqp://|redis://|jdbc:)[^\\s\"']+@[^\\s\"']+"),
-            // Secrets carried as a URL query parameter (e.g. jdbc:...?password=xxx, which has no userinfo '@')
-            Pattern.compile("(?i)[?&](password|secret|token|access[_-]?key)=[^\\s&\"']+"),
-            // PEM private-key blocks
-            Pattern.compile("(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----"));
-
-    /**
-     * Key names (case-insensitive, ignoring '-'/'_' separators) whose value is blanked during structured redaction.
-     */
-    static final Pattern SECRET_KEY_NAME = Pattern.compile(
-            "(?i).*(password|passwd|pwd|passphrase|secret|secretkey|apikey|accesskey|clientsecret|token|bearer|"
-                                                           + "authorization|credential|credentials|privatekey|keystorepassword|truststorepassword|saslpassword|sasljaasconfig).*");
-
     @Inject
     McpSecurityConfig config;
 
+    private volatile DefaultMaskingFormatter maskingFormatter;
+
+    private DefaultMaskingFormatter maskingFormatter() {
+        DefaultMaskingFormatter mf = maskingFormatter;
+        if (mf == null) {
+            // Masks key=value, XML and JSON using SensitiveUtils.getSensitiveKeys() as the keyword set.
+            mf = new DefaultMaskingFormatter();
+            mf.setMaskString(REDACTED);
+            maskingFormatter = mf;
+        }
+        return mf;
+    }
+
+    /**
+     * Masks secrets in free-text tool output using Camel's masking formatter, then applies any operator-supplied custom
+     * patterns.
+     */
     public String redact(String text) {
         if (text == null || text.isEmpty()) {
             return text;
         }
-        List<Pattern> patterns = config.getRedactionPatterns();
-        String result = text;
-        for (Pattern pattern : patterns) {
+        String result = maskingFormatter().format(text);
+        for (Pattern pattern : config.getRedactionPatterns()) {
             result = pattern.matcher(result).replaceAll(REDACTED);
         }
         return result;
@@ -80,32 +77,14 @@ public class McpSecretRedactor {
         if (text == null || text.isEmpty()) {
             return false;
         }
-        List<Pattern> patterns = config.getRedactionPatterns();
-        for (Pattern pattern : patterns) {
-            if (pattern.matcher(text).find()) {
-                return true;
-            }
-        }
-        return false;
+        return !redact(text).equals(text);
     }
 
     /**
-     * Whether a map key name denotes a secret whose value should be blanked. The name is normalised by dropping '-' and
-     * '_' so that {@code client-secret}, {@code client_secret} and {@code clientSecret} all match.
-     */
-    static boolean isSecretKeyName(String key) {
-        if (key == null || key.isEmpty()) {
-            return false;
-        }
-        String normalised = key.replace("-", "").replace("_", "");
-        return SECRET_KEY_NAME.matcher(normalised).matches();
-    }
-
-    /**
-     * Redacts a structured tool result in place. {@link Map} values (such as the {@code JsonObject} returned by the
-     * runtime tools) have any secret-named entry blanked and every string value passed through {@link #redact(String)};
-     * {@link List} elements are recursed. The same instance is mutated and returned, so a tool's declared return type
-     * is preserved.
+     * Redacts a structured tool result in place. In a {@link Map} (such as the {@code JsonObject} returned by the
+     * runtime tools) any entry whose key {@link SensitiveUtils#containsSensitive(String) is sensitive} has its value
+     * blanked, and every string value is passed through {@link #redact(String)}; {@link List} elements are recursed.
+     * The same instance is mutated and returned, so a tool's declared return type is preserved.
      *
      * @param  value the result to scrub (a {@code Map}, {@code List}, or anything else which is returned untouched)
      * @return       {@code true} if anything was changed
@@ -117,7 +96,7 @@ public class McpSecretRedactor {
             Map<Object, Object> mutable = (Map<Object, Object>) map;
             for (Object key : List.copyOf(mutable.keySet())) {
                 Object current = mutable.get(key);
-                if (key instanceof String name && isSecretKeyName(name)) {
+                if (key instanceof String name && SensitiveUtils.containsSensitive(name)) {
                     if (current != null && !REDACTED.equals(current)) {
                         mutable.put(key, REDACTED);
                         changed = true;

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityConfig.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityConfig.java
@@ -93,7 +93,9 @@ public class McpSecurityConfig {
         if (cached != null) {
             return cached;
         }
-        List<Pattern> patterns = new ArrayList<>(McpSecretRedactor.DEFAULT_PATTERNS);
+        // Built-in secret detection is handled by McpSecretRedactor via Camel's DefaultMaskingFormatter and
+        // SensitiveUtils. These are only the extra, operator-supplied patterns.
+        List<Pattern> patterns = new ArrayList<>();
         if (redactionPatterns.isPresent()) {
             for (String p : redactionPatterns.get().split(",")) {
                 String trimmed = p.trim();

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityInterceptor.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityInterceptor.java
@@ -17,6 +17,8 @@
 package org.apache.camel.dsl.jbang.core.commands.mcp;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
 
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
@@ -84,11 +86,17 @@ public class McpSecurityInterceptor {
         try {
             Object result = ctx.proceed();
 
-            // Secret redaction on string results
-            if (config.isRedactionEnabled() && result instanceof String s) {
-                if (redactor.containsSecret(s)) {
-                    result = redactor.redact(s);
-                    wasRedacted = true;
+            // Secret redaction. Free-text (String) results go through the regex redactor; structured results
+            // (Map/List, such as the JsonObject returned by the runtime tools) are scrubbed by key name in place,
+            // which is what catches JSON-quoted values the value regex cannot match.
+            if (config.isRedactionEnabled() && result != null) {
+                if (result instanceof String s) {
+                    if (redactor.containsSecret(s)) {
+                        result = redactor.redact(s);
+                        wasRedacted = true;
+                    }
+                } else if (result instanceof Map<?, ?> || result instanceof List<?>) {
+                    wasRedacted = redactor.redactStructured(result);
                 }
             }
 

--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityInterceptor.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityInterceptor.java
@@ -91,8 +91,11 @@ public class McpSecurityInterceptor {
             // which is what catches JSON-quoted values the value regex cannot match.
             if (config.isRedactionEnabled() && result != null) {
                 if (result instanceof String s) {
-                    if (redactor.containsSecret(s)) {
-                        result = redactor.redact(s);
+                    // redact() is the single source of truth: if it changes the string, a secret was masked.
+                    // Calling containsSecret() first would run the full masking pipeline a second time.
+                    String redacted = redactor.redact(s);
+                    if (!redacted.equals(s)) {
+                        result = redacted;
                         wasRedacted = true;
                     }
                 } else if (result instanceof Map<?, ?> || result instanceof List<?>) {

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactorTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactorTest.java
@@ -42,72 +42,47 @@ class McpSecretRedactorTest {
     }
 
     @Test
-    void redactsPasswordKeyValue() {
+    void redactsKeyValueUsingCamelSensitiveKeywords() {
         McpSecretRedactor redactor = createRedactor(null);
 
+        // The value is masked and the key is preserved (Camel's DefaultMaskingFormatter behaviour).
         assertThat(redactor.redact("password=secret123"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-        assertThat(redactor.redact("Password: myP@ssw0rd"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-        assertThat(redactor.redact("pwd=abc"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
+                .isEqualTo("password=" + McpSecretRedactor.REDACTED);
+        assertThat(redactor.redact("apikey=sk-12345"))
+                .isEqualTo("apikey=" + McpSecretRedactor.REDACTED);
+        assertThat(redactor.redact("accessToken=abc123"))
+                .isEqualTo("accessToken=" + McpSecretRedactor.REDACTED);
+        // A compound property name is matched via the embedded keyword.
+        assertThat(redactor.redact("datasource.password=hunter2"))
+                .doesNotContain("hunter2")
+                .contains(McpSecretRedactor.REDACTED);
     }
 
     @Test
-    void redactsApiKeys() {
+    void redactsSecretCarriedAsUrlQueryParameter() {
         McpSecretRedactor redactor = createRedactor(null);
 
-        assertThat(redactor.redact("api_key=sk-12345"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-        assertThat(redactor.redact("apiKey: abc123"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-        assertThat(redactor.redact("secret-key=xyz789"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
+        assertThat(redactor.redact("uri: jdbc:postgresql://db:5432/app?ssl=true&password=hunter2"))
+                .doesNotContain("hunter2")
+                .contains(McpSecretRedactor.REDACTED);
     }
 
     @Test
-    void redactsTokensAndBearer() {
+    void redactsSensitiveJsonField() {
         McpSecretRedactor redactor = createRedactor(null);
 
-        assertThat(redactor.redact("token=eyJhbGciOiJIUzI1NiJ9"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-        assertThat(redactor.redact("bearer: some-bearer-token"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
+        assertThat(redactor.redact("{\"password\":\"hunter2\",\"name\":\"orders\"}"))
+                .doesNotContain("hunter2")
+                .contains("orders");
     }
 
     @Test
-    void redactsAwsAccessKeyIds() {
+    void doesNotRedactNonSensitiveKeyValue() {
         McpSecretRedactor redactor = createRedactor(null);
 
-        assertThat(redactor.redact("key is AKIAIOSFODNN7EXAMPLE"))
-                .isEqualTo("key is " + McpSecretRedactor.REDACTED);
-    }
-
-    @Test
-    void redactsConnectionStringsWithCredentials() {
-        McpSecretRedactor redactor = createRedactor(null);
-
-        assertThat(redactor.redact("uri: mongodb://user:pass@host:27017/db"))
-                .isEqualTo("uri: " + McpSecretRedactor.REDACTED);
-        assertThat(redactor.redact("url=amqp://admin:secret@broker:5672/vhost"))
-                .isEqualTo("url=" + McpSecretRedactor.REDACTED);
-    }
-
-    @Test
-    void doesNotRedactNormalText() {
-        McpSecretRedactor redactor = createRedactor(null);
-
-        String normalText = "Route started successfully with 3 endpoints";
-        assertThat(redactor.redact(normalText)).isEqualTo(normalText);
-    }
-
-    @Test
-    void handlesMultipleSecretsInSameString() {
-        McpSecretRedactor redactor = createRedactor(null);
-
-        String input = "password=secret, apiKey=abc123";
-        String result = redactor.redact(input);
-        assertThat(result).doesNotContain("secret").doesNotContain("abc123");
+        assertThat(redactor.redact("route=timer-1")).isEqualTo("route=timer-1");
+        assertThat(redactor.redact("Route started successfully with 3 endpoints"))
+                .isEqualTo("Route started successfully with 3 endpoints");
     }
 
     @Test
@@ -137,27 +112,12 @@ class McpSecretRedactorTest {
     }
 
     @Test
-    void redactsClientSecretAndUrlQueryParamAndPemBlock() {
-        McpSecretRedactor redactor = createRedactor(null);
-
-        assertThat(redactor.redact("client_secret=abcdef123456"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-        // JDBC/URL carrying the password as a query parameter has no userinfo '@' so it is not a connection
-        // string; it must still be caught.
-        assertThat(redactor.redact("jdbc:postgresql://db:5432/app?ssl=true&password=hunter2"))
-                .contains(McpSecretRedactor.REDACTED)
-                .doesNotContain("hunter2");
-        assertThat(redactor.redact("-----BEGIN RSA PRIVATE KEY-----\nMIIEabc\n-----END RSA PRIVATE KEY-----"))
-                .isEqualTo(McpSecretRedactor.REDACTED);
-    }
-
-    @Test
     void redactsStructuredJsonObjectByKeyName() {
         McpSecretRedactor redactor = createRedactor(null);
 
-        // This is the case the String-only path missed: a JsonObject (as returned by the runtime tools) whose
-        // value is JSON-quoted. The value regex cannot match a quoted value, so structured redaction by key name
-        // is what protects it.
+        // The case the String-only path missed: a JsonObject (as returned by the runtime tools) whose value is
+        // JSON-quoted. Structured redaction blanks it by key name using SensitiveUtils.containsSensitive, which
+        // strips a compound property to its last segment (datasource.password -> password).
         JsonObject properties = new JsonObject();
         properties.put("datasource.url", "jdbc:postgresql://db:5432/app");
         properties.put("datasource.password", "hunter2");
@@ -180,9 +140,9 @@ class McpSecretRedactorTest {
     void redactsSecretsEmbeddedInStructuredStringValues() {
         McpSecretRedactor redactor = createRedactor(null);
 
-        // A non-secret key whose string value nonetheless embeds a credential-bearing connection string.
+        // A non-secret key whose string value nonetheless embeds a key=value credential.
         JsonObject config = new JsonObject();
-        config.put("broker", "amqp://admin:secret@broker:5672/vhost");
+        config.put("name", "orders");
         JsonArray endpoints = new JsonArray();
         endpoints.add("timer://foo");
         endpoints.add("sql://bar?dataSource=#ds&password=leaked");
@@ -191,7 +151,7 @@ class McpSecretRedactorTest {
         boolean changed = redactor.redactStructured(config);
 
         assertThat(changed).isTrue();
-        assertThat(config.getString("broker")).doesNotContain("secret").contains(McpSecretRedactor.REDACTED);
+        assertThat(config.getString("name")).isEqualTo("orders");
         assertThat(endpoints.getString(0)).isEqualTo("timer://foo");
         assertThat(endpoints.getString(1)).doesNotContain("leaked").contains(McpSecretRedactor.REDACTED);
     }
@@ -206,18 +166,5 @@ class McpSecretRedactorTest {
 
         assertThat(redactor.redactStructured(clean)).isFalse();
         assertThat(clean.getString("name")).isEqualTo("orders");
-    }
-
-    @Test
-    void secretKeyNameMatchingIsSeparatorAndCaseInsensitive() {
-        assertThat(McpSecretRedactor.isSecretKeyName("password")).isTrue();
-        assertThat(McpSecretRedactor.isSecretKeyName("client-secret")).isTrue();
-        assertThat(McpSecretRedactor.isSecretKeyName("client_secret")).isTrue();
-        assertThat(McpSecretRedactor.isSecretKeyName("clientSecret")).isTrue();
-        assertThat(McpSecretRedactor.isSecretKeyName("api-key")).isTrue();
-        assertThat(McpSecretRedactor.isSecretKeyName("keystorePassword")).isTrue();
-        assertThat(McpSecretRedactor.isSecretKeyName("route.id")).isFalse();
-        assertThat(McpSecretRedactor.isSecretKeyName("name")).isFalse();
-        assertThat(McpSecretRedactor.isSecretKeyName(null)).isFalse();
     }
 }

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactorTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecretRedactorTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.dsl.jbang.core.commands.mcp;
 
 import java.util.Optional;
 
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -132,5 +134,90 @@ class McpSecretRedactorTest {
 
         assertThat(redactor.redact("value: CUSTOM_12345 here"))
                 .isEqualTo("value: " + McpSecretRedactor.REDACTED + " here");
+    }
+
+    @Test
+    void redactsClientSecretAndUrlQueryParamAndPemBlock() {
+        McpSecretRedactor redactor = createRedactor(null);
+
+        assertThat(redactor.redact("client_secret=abcdef123456"))
+                .isEqualTo(McpSecretRedactor.REDACTED);
+        // JDBC/URL carrying the password as a query parameter has no userinfo '@' so it is not a connection
+        // string; it must still be caught.
+        assertThat(redactor.redact("jdbc:postgresql://db:5432/app?ssl=true&password=hunter2"))
+                .contains(McpSecretRedactor.REDACTED)
+                .doesNotContain("hunter2");
+        assertThat(redactor.redact("-----BEGIN RSA PRIVATE KEY-----\nMIIEabc\n-----END RSA PRIVATE KEY-----"))
+                .isEqualTo(McpSecretRedactor.REDACTED);
+    }
+
+    @Test
+    void redactsStructuredJsonObjectByKeyName() {
+        McpSecretRedactor redactor = createRedactor(null);
+
+        // This is the case the String-only path missed: a JsonObject (as returned by the runtime tools) whose
+        // value is JSON-quoted. The value regex cannot match a quoted value, so structured redaction by key name
+        // is what protects it.
+        JsonObject properties = new JsonObject();
+        properties.put("datasource.url", "jdbc:postgresql://db:5432/app");
+        properties.put("datasource.password", "hunter2");
+        properties.put("app.name", "orders");
+        JsonObject nested = new JsonObject();
+        nested.put("client-secret", "s3cr3t");
+        properties.put("oauth", nested);
+
+        boolean changed = redactor.redactStructured(properties);
+
+        assertThat(changed).isTrue();
+        assertThat(properties.getString("datasource.password")).isEqualTo(McpSecretRedactor.REDACTED);
+        assertThat(properties.getString("app.name")).isEqualTo("orders");
+        assertThat(properties.getString("datasource.url")).isEqualTo("jdbc:postgresql://db:5432/app");
+        assertThat(((JsonObject) properties.get("oauth")).getString("client-secret"))
+                .isEqualTo(McpSecretRedactor.REDACTED);
+    }
+
+    @Test
+    void redactsSecretsEmbeddedInStructuredStringValues() {
+        McpSecretRedactor redactor = createRedactor(null);
+
+        // A non-secret key whose string value nonetheless embeds a credential-bearing connection string.
+        JsonObject config = new JsonObject();
+        config.put("broker", "amqp://admin:secret@broker:5672/vhost");
+        JsonArray endpoints = new JsonArray();
+        endpoints.add("timer://foo");
+        endpoints.add("sql://bar?dataSource=#ds&password=leaked");
+        config.put("endpoints", endpoints);
+
+        boolean changed = redactor.redactStructured(config);
+
+        assertThat(changed).isTrue();
+        assertThat(config.getString("broker")).doesNotContain("secret").contains(McpSecretRedactor.REDACTED);
+        assertThat(endpoints.getString(0)).isEqualTo("timer://foo");
+        assertThat(endpoints.getString(1)).doesNotContain("leaked").contains(McpSecretRedactor.REDACTED);
+    }
+
+    @Test
+    void structuredRedactionReportsNoChangeForCleanData() {
+        McpSecretRedactor redactor = createRedactor(null);
+
+        JsonObject clean = new JsonObject();
+        clean.put("name", "orders");
+        clean.put("routes", 3);
+
+        assertThat(redactor.redactStructured(clean)).isFalse();
+        assertThat(clean.getString("name")).isEqualTo("orders");
+    }
+
+    @Test
+    void secretKeyNameMatchingIsSeparatorAndCaseInsensitive() {
+        assertThat(McpSecretRedactor.isSecretKeyName("password")).isTrue();
+        assertThat(McpSecretRedactor.isSecretKeyName("client-secret")).isTrue();
+        assertThat(McpSecretRedactor.isSecretKeyName("client_secret")).isTrue();
+        assertThat(McpSecretRedactor.isSecretKeyName("clientSecret")).isTrue();
+        assertThat(McpSecretRedactor.isSecretKeyName("api-key")).isTrue();
+        assertThat(McpSecretRedactor.isSecretKeyName("keystorePassword")).isTrue();
+        assertThat(McpSecretRedactor.isSecretKeyName("route.id")).isFalse();
+        assertThat(McpSecretRedactor.isSecretKeyName("name")).isFalse();
+        assertThat(McpSecretRedactor.isSecretKeyName(null)).isFalse();
     }
 }

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityConfigTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/McpSecurityConfigTest.java
@@ -99,21 +99,23 @@ class McpSecurityConfigTest {
     // ---- Redaction patterns ----
 
     @Test
-    void defaultRedactionPatternsIncludeBuiltins() {
+    void redactionPatternsAreEmptyWithoutCustomPatterns() {
         McpSecurityConfig config = createConfig(true, "admin", false, true, true, null);
 
+        // Built-in secret detection is handled by McpSecretRedactor (DefaultMaskingFormatter + SensitiveUtils),
+        // so getRedactionPatterns() returns only the operator-supplied extra patterns.
         List<Pattern> patterns = config.getRedactionPatterns();
 
-        assertThat(patterns).hasSizeGreaterThanOrEqualTo(McpSecretRedactor.DEFAULT_PATTERNS.size());
+        assertThat(patterns).isEmpty();
     }
 
     @Test
-    void customRedactionPatternsAppended() {
+    void customRedactionPatternsAreReturned() {
         McpSecurityConfig config = createConfig(true, "admin", false, true, true, "SECRET_\\d+,TOKEN_[A-Z]+");
 
         List<Pattern> patterns = config.getRedactionPatterns();
 
-        assertThat(patterns.size()).isEqualTo(McpSecretRedactor.DEFAULT_PATTERNS.size() + 2);
+        assertThat(patterns).hasSize(2);
     }
 
     // ---- Helper ----


### PR DESCRIPTION
## What

Completes the secret-redaction coverage of the Camel JBang MCP server's opt-in security layer (added in CAMEL-24218). Redaction previously only inspected `String` tool results, so tools returning a `JsonObject` bypassed it entirely.

## Why

The runtime tools return `org.apache.camel.util.json.JsonObject`, not `String`. `camel_runtime_properties` in particular dumps a running application's configuration, which is exactly where a datasource password or an API key surfaces. With redaction enabled, that output was still emitted verbatim because the interceptor only redacted `String` results:

```java
if (config.isRedactionEnabled() && result instanceof String s) { ... }
```

## Change

Reuses Camel's own knowledge of what a secret is (per review feedback), rather than a hand-rolled word list:

- `McpSecretRedactor.redactStructured(Object)` walks `Map`/`List` results in place (`JsonObject` is a `LinkedHashMap`, `JsonArray` an `ArrayList`) and blanks the value of any entry whose key `SensitiveUtils.containsSensitive(...)` reports as sensitive, which is the same helper the jbang `ListProperties` command uses. It also passes string leaf values through the free-text masker. The instance is mutated in place, so a tool's declared return type is preserved.
- Free-text `String` results are masked with Camel's `DefaultMaskingFormatter`, which blanks key=value, XML and JSON values keyed off `SensitiveUtils.getSensitiveKeys()`.
- The hand-maintained `DEFAULT_PATTERNS` and `SECRET_KEY_NAME` are removed. Operator-supplied custom patterns (`camel.mcp.security.redaction.patterns`) still apply on top.
- `McpSecurityInterceptor` now routes `Map`/`List` results through `redactStructured` and keeps the masking path for `String`.
- Tests updated to the canonical behaviour, including the previously-missed `JsonObject` with a `datasource.password` key, a nested `client-secret`, a JSON field, and a `?password=` query parameter embedded in a string value.

Redaction stays opt-in and off by default; this only changes what happens once an operator sets `camel.mcp.security.redaction.enabled=true`, so there is no behaviour change for the default configuration.

## Known follow-ups

- Plain record-returning tools (for example `ExampleFileResult.content`) are still not redacted. Doing that type-safely needs either reflective record rebuilding or a framework-level output filter once the Quarkus MCP server exposes global guardrails (the interceptor already carries a TODO for that). This PR deliberately covers the structured `JsonObject` path, which is where live secrets actually surface.
- Connection-string userinfo (`user:pass@host`) and PEM private-key blocks are no longer special-cased, since `SensitiveUtils`/`DefaultMaskingFormatter` key off names rather than value shapes. If those shapes are worth masking, that belongs in Camel's masker / `SensitiveUtils` project-wide rather than in the MCP layer.

## Scope note

Per the [Camel security model](https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/security-model.adoc), the MCP server is a management surface whose network exposure is operator responsibility, so this is hardening of an opt-in control rather than a framework vulnerability fix. A separate, smaller item worth considering is that `camel mcp --http` binds `0.0.0.0` by default rather than loopback; that is not addressed here.

## Testing

```
Tests run: 30, Failures: 0, Errors: 0
  (McpSecretRedactorTest, McpSecurityInterceptorTest, McpSecurityConfigTest, McpAccessFilterTest)
```
Formatted with `mvn formatter:format impsort:sort`.

## Attribution

_Claude Code on behalf of Andrea Cosentino (@oscerd)._ No JIRA was filed for this change; happy to add a `CAMEL-XXXX` reference and rename the branch/commit if you would prefer to track it in JIRA.
