### PR TITLE
CAMEL-24241: Apply the tool argument allowlist to tools declaring no parameters

### DIFF
--- a/components/camel-ai/camel-ai-tool/src/main/java/org/apache/camel/component/ai/tool/AiToolExecutor.java
+++ b/components/camel-ai/camel-ai-tool/src/main/java/org/apache/camel/component/ai/tool/AiToolExecutor.java
@@ -97,7 +97,9 @@ public final class AiToolExecutor {
 
         // Filter out undeclared arguments -- LLMs frequently hallucinate extra parameters
         // and the generated schema advertises additionalProperties: false.
-        if (!argsCopy.isEmpty() && !spec.getParameterDefs().isEmpty()) {
+        // A tool that declares no parameters accepts none, so an empty declaration must filter
+        // everything rather than let every argument through.
+        if (!argsCopy.isEmpty()) {
             Set<String> declaredParams = spec.getParameterDefs().keySet();
 
             argsCopy.keySet().removeIf(name -> {

--- a/components/camel-ai/camel-ai-tool/src/test/java/org/apache/camel/component/ai/tool/AiToolExecutorTest.java
+++ b/components/camel-ai/camel-ai-tool/src/test/java/org/apache/camel/component/ai/tool/AiToolExecutorTest.java
@@ -49,6 +49,16 @@ public class AiToolExecutorTest extends CamelTestSupport {
                      + "&description=A tool with no parameters")
                         .setBody(constant("no-param result"));
 
+                // declares the Camel-prefixed names so they survive the undeclared-argument filter
+                // and actually reach the Camel-prefix rejection this tool is used to test
+                from("ai-tool:prefixTool"
+                     + "?tags=test"
+                     + "&description=A tool declaring Camel-prefixed parameters"
+                     + "&parameter.CamelOverrideEndpoint=string"
+                     + "&parameter.camelFoo=string"
+                     + "&parameter.safeParam=string")
+                        .setBody(constant("prefix result"));
+
                 from("ai-tool:nullBodyTool"
                      + "?tags=test"
                      + "&description=A tool that returns null body")
@@ -115,6 +125,29 @@ public class AiToolExecutorTest extends CamelTestSupport {
         assertThat(result).isInstanceOf(AiToolResult.Success.class);
         assertThat(((AiToolResult.Success) result).value())
                 .isEqualTo("no-param result");
+    }
+
+    @Test
+    public void testExecuteIgnoresUndeclaredArgumentsForToolWithoutParameters() {
+        AiToolSpec spec = findSpec("noParams");
+        Exchange exchange = new DefaultExchange(context);
+
+        // a tool declaring no parameters accepts none, so every supplied argument is undeclared
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("injected", "should-be-ignored");
+        arguments.put("anotherOne", 42);
+
+        AiToolResult result = AiToolExecutor.execute(spec, arguments, exchange);
+
+        assertThat(result).isInstanceOf(AiToolResult.Success.class);
+        assertThat(((AiToolResult.Success) result).value())
+                .isEqualTo("no-param result");
+        assertThat(exchange.getMessage().getHeader("injected"))
+                .as("Undeclared argument must not be set as header on a tool with no parameters")
+                .isNull();
+        assertThat(exchange.getMessage().getHeader("anotherOne"))
+                .as("Undeclared argument must not be set as header on a tool with no parameters")
+                .isNull();
     }
 
     @Test
@@ -236,7 +269,9 @@ public class AiToolExecutorTest extends CamelTestSupport {
 
     @Test
     public void testCamelPrefixedArgumentsRejectedFromHeaders() {
-        AiToolSpec spec = findSpec("noParams");
+        // prefixTool declares these names, so they reach the Camel-prefix check rather than being
+        // dropped earlier as undeclared -- otherwise this test would pass even without that check
+        AiToolSpec spec = findSpec("prefixTool");
         Exchange exchange = new DefaultExchange(context);
 
         Map<String, Object> arguments = new HashMap<>();
@@ -253,11 +288,13 @@ public class AiToolExecutorTest extends CamelTestSupport {
         assertThat(exchange.getMessage().getHeader("camelFoo"))
                 .as("camel-prefixed argument must not be set as header")
                 .isNull();
+        // a dotted name cannot be declared through the endpoint URI (the key is split on the first
+        // dot), so this one is dropped as an undeclared argument rather than by the prefix check
         assertThat(exchange.getMessage().getHeader("org.apache.camel.hack"))
                 .as("org.apache.camel. prefixed argument must not be set as header")
                 .isNull();
         assertThat(exchange.getMessage().getHeader("safeParam", String.class))
-                .as("Non-Camel argument should be set as header")
+                .as("Declared non-Camel argument should be set as header")
                 .isEqualTo("ok");
     }
 


### PR DESCRIPTION
## The problem

`AiToolExecutor` gates the undeclared-argument filter on the parameter map being non-empty:

```java
if (!argsCopy.isEmpty() && !spec.getParameterDefs().isEmpty()) {
    Set<String> declaredParams = spec.getParameterDefs().keySet();
    argsCopy.keySet().removeIf(name -> { ... });   // filter undeclared
}
```

So a tool that declares **no** parameters skips filtering entirely, and every argument the model sends becomes an exchange header.

A tool declaring no parameters accepts none. `AiToolParameterHelper.buildJsonSchemaFromDefs` emits `"additionalProperties": false` **unconditionally**, so the schema such a tool advertises already forbids every property — which is exactly the rationale the filter's own comment cites.

This also re-introduced a bypass that was removed on purpose. Commit `e9c4541a91ce` ("CAMEL-23621: remove backwards-compatibility bypass") stripped the identical `isEmpty()` guard from three places:

```diff
-    if (!allowedParams.isEmpty() && !allowedParams.contains(name)) {
+    if (!allowedParams.contains(name)) {
```

`LangChain4jToolsProducer` and `SpringAiToolsEndpoint` still carry the strict form; only the newer shared executor regressed it.

## Severity

Hardening rather than a CVE. The Camel-internal prefix rejection (`camel` / `org.apache.camel.`, case-insensitive) still applies, so the CVE-2025-27636 header-injection family is **not** reachable through this path. What is unfiltered is arbitrary **non-Camel** header names originating from model output — and LLM output is attacker-influenceable via prompt injection, while tool routes commonly forward headers to downstream components (HTTP producers, SQL named parameters).

## The fix

Drop the `&& !spec.getParameterDefs().isEmpty()` condition, so an empty declaration means "no arguments accepted" instead of "all arguments accepted".

## Tests

- **New:** `testExecuteIgnoresUndeclaredArgumentsForToolWithoutParameters` — arguments sent to a zero-parameter tool must not reach the exchange headers. Verified it fails without the fix (`expected: null but was: "should-be-ignored"`) and passes with it.
- **Adjusted:** `testCamelPrefixedArgumentsRejectedFromHeaders` used the `noParams` tool and depended on the bypass to get its non-Camel argument through, so the fix broke it. Simply flipping that assertion to `isNull()` would have made the test vacuous — all four arguments would then be dropped by the allowlist, and it would pass even if the Camel-prefix check were deleted. Instead it now points at a new `prefixTool` that **declares** those names, so the Camel-prefixed arguments survive the allowlist and genuinely exercise the prefix check.

  One caveat recorded in a comment: a dotted name such as `org.apache.camel.hack` cannot be declared through the endpoint URI (`parseParameterMetadata` splits the key on the first dot), so that one is dropped as undeclared rather than by the prefix check.

Full `AiToolExecutorTest` suite: 13 tests, green.

## Upgrade guide

Not required — `camel-ai-tool` is new in 4.22 (CAMEL-23382) and the permissive behaviour has never appeared in a release.

---

_Claude Code on behalf of @oscerd_