### PR TITLE
CAMEL-24257: MongoDB/Cassandra kamelets: Unable to export an integration without running instance

### DIFF
--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/KameletMainInjector.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/KameletMainInjector.java
@@ -100,8 +100,6 @@ public class KameletMainInjector implements Injector {
                 } else {
                     accept = true;
                 }
-            } else {
-                accept = true;
             }
         }
         return accept;

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/KameletMainInjectorTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/KameletMainInjectorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main.download;
+
+import org.apache.camel.component.direct.DirectComponent;
+import org.apache.camel.component.stub.StubComponent;
+import org.apache.camel.component.timer.TimerComponent;
+import org.apache.camel.impl.engine.SimpleCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class KameletMainInjectorTest {
+
+    @Test
+    void testWildcardStubsNonWhitelistedComponent() {
+        // TimerComponent is NOT in ACCEPTED_STUB_NAMES, stubPattern="*" (used by camel export), it should be replaced with StubComponent.
+        KameletMainInjector injector = new KameletMainInjector(
+                new SimpleCamelContext().getInjector(), "*", true);
+
+        Object result = injector.newInstance(TimerComponent.class);
+        assertInstanceOf(StubComponent.class, result);
+    }
+
+    @Test
+    void testComponentWildcardStubsNonWhitelistedComponent() {
+        // stubPattern="component:*" (used by --stub=all) should also stub non-whitelisted components.
+        KameletMainInjector injector = new KameletMainInjector(
+                new SimpleCamelContext().getInjector(), "component:*", true);
+
+        Object result = injector.newInstance(TimerComponent.class);
+        assertInstanceOf(StubComponent.class, result);
+    }
+
+    @Test
+    void testWildcardAllowsWhitelistedComponent() {
+        // DirectComponent is in ACCEPTED_STUB_NAMES, so it should not be stubbed.
+        KameletMainInjector injector = new KameletMainInjector(
+                new SimpleCamelContext().getInjector(), "*", true);
+
+        Object result = injector.newInstance(DirectComponent.class);
+        assertInstanceOf(DirectComponent.class, result);
+    }
+
+    @Test
+    void testNonComponentClassIsNotStubbed() {
+        // Non-Component classes should pass through unchanged.
+        KameletMainInjector injector = new KameletMainInjector(
+                new SimpleCamelContext().getInjector(), "*", true);
+
+        Object result = injector.newInstance(String.class);
+        assertInstanceOf(String.class, result);
+    }
+}


### PR DESCRIPTION
## Summary

Fix regression where camel export fails with MongoTimeoutException / AllNodesFailedException for kamelets using #class: Component beans (e.g. mongodb-sink, cassandra-sink) because the real component is instantiated instead of being replaced with StubComponent.

The root cause: commit 5d4c6cbf0746 (CAMEL-22667) added an outer else { accept = true; } branch in KameletMainInjector.acceptComponent(). However, this branch also impact when stubPattern is "*" (used by camel export), overriding accept=false back to true for components not in ACCEPTED_STUB_NAMES, causing real components like MongoDbComponent / CassandraComponent to be loaded and attempt connections to non-existent instances.

## Changes

KameletMainInjector.java — Removed the outer else { accept = true; } branch in acceptComponent(). When stubPattern is "*", accept now remains as returned by accept(type): true for ACCEPTED_STUB_NAMES components, false for everything else, which can fix the loading non existed instance behavior with camel export.

## Test plan

- New KameletMainInjectorTest verifies that non-whitelisted components are stubbed with stubPattern=* and "component:*", whitelisted components are allowed through, and non-Component classes pass unchanged

_Claude Code on behalf of Jinyu Chen_

🤖 Generated with [Claude Code](https://claude.com/claude-code)