### PR TITLE
Reduce flakiness of RedeliveryErrorHandlerNonBlockedRedeliveryHeaderTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryErrorHandlerNonBlockedRedeliveryHeaderTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/RedeliveryErrorHandlerNonBlockedRedeliveryHeaderTest.java
@@ -23,6 +23,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,12 +32,17 @@ public class RedeliveryErrorHandlerNonBlockedRedeliveryHeaderTest extends Contex
 
     private static final Logger LOG = LoggerFactory.getLogger(RedeliveryErrorHandlerNonBlockedRedeliveryHeaderTest.class);
 
-    private static final LongAdder attempt = new LongAdder();
+    private static LongAdder attempt;
+
+    @BeforeEach
+    void setup() {
+        attempt = new LongAdder();
+    }
 
     @Test
     public void testRedelivery() throws Exception {
-        MockEndpoint before = getMockEndpoint("mock:result");
-        before.expectedBodiesReceived("Hello World", "Hello Camel");
+        MockEndpoint before = getMockEndpoint("mock:before");
+        before.expectedBodiesReceived("World", "Camel");
 
         // we use NON blocked redelivery delay so the messages arrive which
         // completes first


### PR DESCRIPTION
after a first failure, the 2nd and 3rd run were always failing because the counter was not reset.

also fixed the first mock endpoint, previously it was checking 2 times the same mock endpoint

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

