### PR TITLE
CAMEL-24214: Fix circuit-breaker jbang example after the seconds-to-millis change

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/resources/examples/eip/circuit-breaker/route.camel.yaml
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/resources/examples/eip/circuit-breaker/route.camel.yaml
@@ -27,7 +27,7 @@
         - circuitBreaker:
             resilience4jConfiguration:
               minimumNumberOfCalls: 10
-              waitDurationInOpenState: 20
+              waitDurationInOpenState: 20s
             steps:
               - filter:
                   expression:


### PR DESCRIPTION
## The problem

CAMEL-24137 redefined `waitDurationInOpenState` from **seconds** to **milliseconds** (also accepting Camel duration strings such as `60s`). The shipped jbang example was not migrated:

`dsl/camel-jbang/camel-jbang-core/src/main/resources/examples/eip/circuit-breaker/route.camel.yaml`

```yaml
- circuitBreaker:
    resilience4jConfiguration:
      minimumNumberOfCalls: 10
      waitDurationInOpenState: 20      # was 20 seconds, now 20 milliseconds
```

Before the change this meant 20 seconds. On 4.22.0 it means **20 milliseconds**, so the open state expires almost immediately and the example no longer demonstrates a circuit breaker at all.

This is precisely the migration trap the 4.22 upgrade guide warns users about — left unmigrated in the example users are most likely to copy.

## The fix

```yaml
waitDurationInOpenState: 20s
```

The duration form is preferred over `20000` because it is self-documenting and immune to a future unit change. The YAML DSL schema declares this option as `"type": "string"`, so `20s` is valid:

```json
"waitDurationInOpenState": { "type": "string", "title": "Wait Duration In Open State", "default": "60000" }
```

Verified the file still parses and the value is carried as the string `"20s"`.

## Scope

I grepped the tree for bare integer values of `waitDurationInOpenState` / `slowCallDurationThreshold` (both spellings) — this was the only remaining one. The other matches are the before/after snippets inside the upgrade guide itself, which are intentional.

Related follow-ups from the same review of CAMEL-24137, filed separately: CAMEL-24215 (the JMX attribute still reports seconds) and CAMEL-24217 (the `camel-main` `Integer`→`String` API break is missing from the upgrade guide).

---

_Claude Code on behalf of @oscerd_
