### PR TITLE
chore(deps): upgrade IBM MQ to 10.0

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -293,7 +293,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
   "version" : "4.22.0-SNAPSHOT",
-  "serviceVersion" : "9.4.5.0-r2",
+  "serviceVersion" : "10.0.0.0-r2",
   "uiSupported" : true
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,7 @@
         <citrus-version>5.0.0-M2</citrus-version>
         <classgraph-version>4.8.184</classgraph-version>
         <cloudant-version>0.10.20</cloudant-version>
-        <com-ibm-mq-jakarta-client-version>9.4.5.1</com-ibm-mq-jakarta-client-version>
+        <com-ibm-mq-jakarta-client-version>10.0.0.0</com-ibm-mq-jakarta-client-version>
         <cometd-java-client-version>9.0.1</cometd-java-client-version>
         <cometd-java-server-version>9.0.1</cometd-java-server-version>
         <commons-beanutils-version>1.11.0</commons-beanutils-version>

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -293,7 +293,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
   "version" : "4.22.0-SNAPSHOT",
-  "serviceVersion" : "9.4.5.0-r2",
+  "serviceVersion" : "10.0.0.0-r2",
   "uiSupported" : true
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-ibmmq/src/main/resources/org/apache/camel/test/infra/ibmmq/services/container.properties
+++ b/test-infra/camel-test-infra-ibmmq/src/main/resources/org/apache/camel/test/infra/ibmmq/services/container.properties
@@ -14,5 +14,5 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-ibm.mq.container=icr.io/ibm-messaging/mq:9.4.5.0-r2
+ibm.mq.container=icr.io/ibm-messaging/mq:10.0.0.0-r2
 ibm.mq.container.version.exclude=amd64,arm64,ppc64le,s390x,x86_64


### PR DESCRIPTION
## Summary

Upgrade IBM MQ client and container to version 10.0, combining PR #24040 and PR #24640:

- `com.ibm.mq:com.ibm.mq.jakarta.client`: 9.4.5.1 → 10.0.0.0
- Container image `icr.io/ibm-messaging/mq`: 9.4.5.0-r2 → 10.0.0.0-r2

Closes #24040
Closes #24640

_Claude Code on behalf of davsclaus_