### PR TITLE
CAMEL-24215: camel-resilience4j - JMX waitDurationInOpenState now returns millis

### DIFF
--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceProcessor.java
@@ -469,7 +469,7 @@ public class ResilienceProcessor extends BaseProcessorSupport
 
     @ManagedAttribute
     public long getCircuitBreakerWaitDurationInOpenState() {
-        return Duration.ofMillis(circuitBreakerConfig.getWaitIntervalFunctionInOpenState().apply(1)).getSeconds();
+        return Duration.ofMillis(circuitBreakerConfig.getWaitIntervalFunctionInOpenState().apply(1)).toMillis();
     }
 
     @ManagedAttribute

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1066,6 +1066,17 @@ The `io.vavr:vavr` and `io.vavr:vavr-match` runtime dependencies have been remov
 `camel-resilience4j`. The single internal usage of Vavr's `Try` monad has been replaced with a
 plain try-catch. This eliminates two transitive runtime JARs. No user-facing behavior change.
 
+=== camel-resilience4j - JMX waitDurationInOpenState now reports milliseconds
+
+The JMX managed attribute `CircuitBreakerWaitDurationInOpenState` previously reported seconds
+(using `Duration.getSeconds()`). It now reports milliseconds (using `Duration.toMillis()`) to be
+consistent with all other duration attributes (`BulkheadMaxWaitDuration`, `TimeoutDuration`) and
+with the option itself, which was changed from seconds to milliseconds in the same release
+(see above).
+
+If you have JMX-based monitoring that reads this attribute, update the expected unit from seconds
+to milliseconds.
+
 === camel-clickhouse (new component)
 
 A new `camel-clickhouse` producer component has been added. It integrates with


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Fix JMX managed attribute `CircuitBreakerWaitDurationInOpenState` to return milliseconds (`.toMillis()`) instead of seconds (`.getSeconds()`), consistent with sibling attributes `BulkheadMaxWaitDuration` and `TimeoutDuration`
- Add upgrade guide entry documenting the JMX contract change

This is a follow-up from CAMEL-24137 which converted `waitDurationInOpenState` from seconds to milliseconds but missed updating the JMX getter.

## Test plan

- [x] Verified all three duration-returning JMX attributes now consistently use `.toMillis()`
- [x] Checked dev console — it doesn't expose configuration values, only runtime metrics
- [x] Module builds successfully

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>