### PR TITLE
CAMEL-24215: Circuit breaker dev consoles expose configuration details

### DIFF
--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceConsole.java
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceConsole.java
@@ -84,6 +84,22 @@ public class FaultToleranceConsole extends AbstractDevConsole {
             jo.put("id", cb.getId());
             jo.put("routeId", cb.getRouteId());
             jo.put("state", cb.getCircuitBreakerState());
+            // configuration
+            JsonObject config = new JsonObject();
+            config.put("delay", cb.getDelay());
+            config.put("failureRate", cb.getFailureRate());
+            config.put("requestVolumeThreshold", cb.getRequestVolumeThreshold());
+            config.put("successThreshold", cb.getSuccessThreshold());
+            config.put("bulkheadEnabled", cb.isBulkheadEnabled());
+            if (cb.isBulkheadEnabled()) {
+                config.put("bulkheadMaxConcurrentCalls", cb.getBulkheadMaxConcurrentCalls());
+                config.put("bulkheadWaitingTaskQueue", cb.getBulkheadWaitingTaskQueue());
+            }
+            config.put("timeoutEnabled", cb.isTimeoutEnabled());
+            if (cb.isTimeoutEnabled()) {
+                config.put("timeoutDuration", cb.getTimeoutDuration());
+            }
+            jo.put("configuration", config);
             list.add(jo);
         }
         root.put("circuitBreakers", list);

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceConsole.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceConsole.java
@@ -99,6 +99,28 @@ public class ResilienceConsole extends AbstractDevConsole {
             jo.put("failedCalls", cb.getNumberOfFailedCalls());
             jo.put("notPermittedCalls", cb.getNumberOfNotPermittedCalls());
             jo.put("failureRate", cb.getFailureRate());
+            // configuration
+            JsonObject config = new JsonObject();
+            config.put("failureRateThreshold", cb.getCircuitBreakerFailureRateThreshold());
+            config.put("slowCallRateThreshold", cb.getCircuitBreakerSlowCallRateThreshold());
+            config.put("minimumNumberOfCalls", cb.getCircuitBreakerMinimumNumberOfCalls());
+            config.put("permittedNumberOfCallsInHalfOpenState",
+                    cb.getCircuitBreakerPermittedNumberOfCallsInHalfOpenState());
+            config.put("slidingWindowSize", cb.getCircuitBreakerSlidingWindowSize());
+            config.put("slidingWindowType", cb.getCircuitBreakerSlidingWindowType());
+            config.put("waitDurationInOpenState", cb.getCircuitBreakerWaitDurationInOpenState());
+            config.put("automaticTransitionFromOpenToHalfOpen",
+                    cb.isCircuitBreakerTransitionFromOpenToHalfOpenEnabled());
+            config.put("bulkheadEnabled", cb.isBulkheadEnabled());
+            if (cb.isBulkheadEnabled()) {
+                config.put("bulkheadMaxConcurrentCalls", cb.getBulkheadMaxConcurrentCalls());
+                config.put("bulkheadMaxWaitDuration", cb.getBulkheadMaxWaitDuration());
+            }
+            config.put("timeoutEnabled", cb.isTimeoutEnabled());
+            if (cb.isTimeoutEnabled()) {
+                config.put("timeoutDuration", cb.getTimeoutDuration());
+            }
+            jo.put("configuration", config);
             list.add(jo);
         }
         root.put("circuitBreakers", list);


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

- Add a `configuration` JSON object to the Resilience4j dev console (`ResilienceConsole`) exposing circuit breaker, bulkhead, and timeout configuration
- Add a `configuration` JSON object to the MicroProfile Fault Tolerance dev console (`FaultToleranceConsole`) exposing the same categories of configuration

Previously both consoles only reported runtime metrics (state, call counts, failure rate). The new `configuration` block makes it clear what settings the circuit breaker is running with, separate from the runtime observations.

## Test plan

- [x] Both modules build successfully
- [x] Configuration details are nested under a `"configuration"` key to clearly separate them from runtime metrics
- [x] Bulkhead/timeout sub-options only included when the respective feature is enabled

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>