### PR TITLE
CAMEL-16789: Fix circuit breaker copy constructor bugs

### DIFF
--- a/core/camel-core-model/src/main/java/org/apache/camel/model/FaultToleranceConfigurationCommon.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/FaultToleranceConfigurationCommon.java
@@ -92,6 +92,7 @@ public class FaultToleranceConfigurationCommon extends IdentifiedType {
         this.timeoutPoolSize = source.timeoutPoolSize;
         this.bulkheadEnabled = source.bulkheadEnabled;
         this.bulkheadMaxConcurrentCalls = source.bulkheadMaxConcurrentCalls;
+        this.bulkheadWaitingTaskQueue = source.bulkheadWaitingTaskQueue;
         this.threadOffloadExecutorService = source.threadOffloadExecutorService;
     }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/Resilience4jConfigurationCommon.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/Resilience4jConfigurationCommon.java
@@ -190,7 +190,7 @@ public class Resilience4jConfigurationCommon extends IdentifiedType {
         this.timeoutExecutorService = source.timeoutExecutorService;
         this.timeoutDuration = source.timeoutDuration;
         this.timeoutCancelRunningFuture = source.timeoutCancelRunningFuture;
-        this.recordExceptions = new ArrayList<>(source.ignoreExceptions);
+        this.recordExceptions = new ArrayList<>(source.recordExceptions);
         this.ignoreExceptions = new ArrayList<>(source.ignoreExceptions);
     }
 


### PR DESCRIPTION
_Claude Code on behalf of davsclaus_

## Summary

Fixes two copy constructor bugs in circuit breaker configuration classes:

- **FaultToleranceConfigurationCommon**: `bulkheadWaitingTaskQueue` was not copied — any config copied via `copyDefinition()` silently lost the bulkhead waiting task queue setting, falling back to the default (10)
- **Resilience4jConfigurationCommon**: `recordExceptions` was incorrectly copied from `source.ignoreExceptions` instead of `source.recordExceptions` — a copy-paste bug that silently replaced recorded exception classes with ignored exception classes

## Test plan

- [x] `camel-core-model` builds successfully
- [x] Both fixes are one-line corrections to copy constructors

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>