### PR TITLE
chore: Bump actions/setup-java from v5.2.0 to v5.6.0 across CI workflows

### DIFF
--- a/.github/workflows/alternative-os-build-main.yml
+++ b/.github/workflows/alternative-os-build-main.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK ${{ matrix.os }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: 25

--- a/.github/workflows/camel-launcher-native-exe.yml
+++ b/.github/workflows/camel-launcher-native-exe.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -138,7 +138,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -163,7 +163,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/generate-sbom-main.yml
+++ b/.github/workflows/generate-sbom-main.yml
@@ -42,7 +42,7 @@ jobs:
       - id: install-mvnd
         uses: ./.github/actions/install-mvnd
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -46,7 +46,7 @@ jobs:
       - id: install-mvnd
         uses: ./.github/actions/install-mvnd
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -111,7 +111,7 @@ jobs:
       - id: install-mvnd
         uses: ./.github/actions/install-mvnd
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/sonar-build.yml
+++ b/.github/workflows/sonar-build.yml
@@ -68,7 +68,7 @@ jobs:
         uses: ./.github/actions/install-packages
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -117,7 +117,7 @@ jobs:
         run: tar -xzf target.tar.gz
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '25'


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-java` from `v5.2.0` (`be666c2`) to `v5.6.0` (`03ad4de`) across all CI workflow files
- Also pins `security-scan.yml` which used a bare `@v5` tag to the full commit hash
- Aligns all workflows with the version already used by `package-native-validation.yml` (#25030)

## Files changed (8)

- `.github/workflows/alternative-os-build-main.yml`
- `.github/workflows/camel-launcher-native-exe.yml`
- `.github/workflows/generate-sbom-main.yml`
- `.github/workflows/main-build.yml`
- `.github/workflows/pr-build-main.yml`
- `.github/workflows/security-scan.yml`
- `.github/workflows/sonar-build.yml`
- `.github/workflows/sonar-scan.yml`

## Test plan

- [ ] CI workflows pass with the updated action version

_Claude Code on behalf of davsclaus_