### PR TITLE
CAMEL-24217: Document the camel-main Resilience4j Integer->String API break in the 4.22 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1102,6 +1102,29 @@ camel.resilience4j.waitDurationInOpenState = 60s
 camel.resilience4j.waitDurationInOpenState = 60000
 ----
 
+*Programmatic configuration (camel-main):*
+
+The same change applies to the Java API in `org.apache.camel.main.Resilience4jConfigurationProperties`.
+The getters, setters and fluent builders for `waitDurationInOpenState`, `slowCallDurationThreshold`,
+`timeoutDuration` and `bulkheadMaxWaitDuration` now use `String` instead of `Integer`, so code that
+configures the circuit breaker through `MainConfigurationProperties` must be updated:
+
+[source,java]
+----
+// Before:
+main.configure().resilience4j().withTimeoutDuration(1000);
+
+// After (milliseconds):
+main.configure().resilience4j().withTimeoutDuration("1000");
+
+// Or using a duration string (preferred):
+main.configure().resilience4j().withTimeoutDuration("1s");
+----
+
+`timeoutDuration` and `bulkheadMaxWaitDuration` were already expressed in milliseconds, so for those
+two this is only a type change (quote the value) with no unit conversion; `waitDurationInOpenState`
+and `slowCallDurationThreshold` additionally change from seconds to milliseconds as described above.
+
 === camel-resilience4j - Vavr dependency removed
 
 The `io.vavr:vavr` and `io.vavr:vavr-match` runtime dependencies have been removed from


### PR DESCRIPTION
## The gap

CAMEL-24137 changed the getters, setters and fluent builders in `org.apache.camel.main.Resilience4jConfigurationProperties` from `Integer` to `String` — verified on current `main`:

```java
public String getWaitDurationInOpenState() { ... }
public void setWaitDurationInOpenState(String waitDurationInOpenState) { ... }
public Resilience4jConfigurationProperties withTimeoutDuration(String timeoutDuration) { ... }
```

(plus the `slowCallDurationThreshold` and `bulkheadMaxWaitDuration` members).

That is a source-incompatible change for anyone configuring the circuit breaker programmatically through `MainConfigurationProperties`:

```java
main.configure().resilience4j().withTimeoutDuration(1000);   // no longer compiles
```

The 4.22 upgrade guide's `camel-resilience4j - Duration options` entry documents the **Java DSL** overloads and the **`application.properties`** keys thoroughly, but never mentions this programmatic `camel-main` API. A user migrating their `MainConfigurationProperties` code hits a compile error with no corresponding guide entry.

## The change

Docs only. Adds a `*Programmatic configuration (camel-main):*` subsection to the existing `camel-resilience4j` Duration entry, with before/after examples.

It also draws the same distinction the DSL section makes: `timeoutDuration` and `bulkheadMaxWaitDuration` were already milliseconds, so for those two it is a pure type change (quote the value) with no unit conversion; `waitDurationInOpenState` and `slowCallDurationThreshold` additionally change from seconds to milliseconds.

## Related

Last of the CAMEL-24137 follow-ups I filed from reviewing that PR. The other two are done: CAMEL-24214 (jbang example, PR #25103) and CAMEL-24215 (JMX now reports millis, fixed by Claus in `240b97ee8a37`).

---

_Claude Code on behalf of @oscerd_
