### PR TITLE
CAMEL-22000: Fix flaky EventBridge integration tests

### DIFF
--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.eventbridge.model.ListRulesRequest;
 import software.amazon.awssdk.services.eventbridge.model.ListRulesResponse;
 import software.amazon.awssdk.services.eventbridge.model.ListTargetsByRuleRequest;
 import software.amazon.awssdk.services.eventbridge.model.ListTargetsByRuleResponse;
+import software.amazon.awssdk.services.eventbridge.model.PutRuleRequest;
 import software.amazon.awssdk.services.eventbridge.model.RemoveTargetsRequest;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
@@ -61,10 +62,10 @@ public class Aws2EventbridgeBase extends CamelTestSupport {
     }
 
     /**
-     * Waits for the EventBridge service to be ready (the container health check may pass before all services are
-     * available), then cleans up all rules on the default event bus. This prevents test interference when using a
-     * singleton container (floci/LocalStack) shared across test classes — leftover rules from a prior test could cause
-     * assertions on rule counts or rule state to fail.
+     * Waits for the EventBridge service to be fully ready for both read and write operations (the container health
+     * check may pass before all services are available), then cleans up all rules on the default event bus. This
+     * prevents test interference when using a singleton container (floci/LocalStack) shared across test classes —
+     * leftover rules from a prior test could cause assertions on rule counts or rule state to fail.
      */
     @BeforeEach
     void waitForServiceAndCleanUp() {
@@ -72,26 +73,41 @@ public class Aws2EventbridgeBase extends CamelTestSupport {
             return;
         }
 
-        // Wait for the EventBridge service to accept requests — the container health check
-        // may return 200 before all services are fully initialized
-        ListRulesResponse listResponse;
+        // Wait for the EventBridge service to accept write requests — the container health
+        // check may return 200, and even listRules may succeed, before write operations like
+        // putRule are ready. We probe with a real putRule + deleteRule cycle to confirm the
+        // service is fully initialized.
         try {
-            listResponse = await().atMost(30, TimeUnit.SECONDS)
+            await().atMost(30, TimeUnit.SECONDS)
                     .pollInterval(2, TimeUnit.SECONDS)
                     .ignoreExceptions()
-                    .until(() -> eventBridgeClient.listRules(
-                            ListRulesRequest.builder().eventBusName(DEFAULT_EVENT_BUS).build()),
-                            r -> r != null);
+                    .until(() -> {
+                        eventBridgeClient.putRule(PutRuleRequest.builder()
+                                .name("__readiness_probe__")
+                                .eventBusName(DEFAULT_EVENT_BUS)
+                                .eventPattern("{\"source\":[\"readiness-probe\"]}")
+                                .build());
+                        eventBridgeClient.deleteRule(DeleteRuleRequest.builder()
+                                .name("__readiness_probe__")
+                                .eventBusName(DEFAULT_EVENT_BUS)
+                                .build());
+                        return true;
+                    });
         } catch (Exception e) {
-            LOG.warn("EventBridge service not ready after 30s, proceeding anyway: {}", e.getMessage());
-            return;
+            LOG.warn("EventBridge service not ready for writes after 30s, proceeding anyway: {}", e.getMessage());
         }
 
         // Clean up any leftover rules from previous test classes
-        if (listResponse != null && listResponse.hasRules()) {
-            for (var rule : listResponse.rules()) {
-                removeTargetsAndDeleteRule(rule.name());
+        try {
+            ListRulesResponse listResponse = eventBridgeClient.listRules(
+                    ListRulesRequest.builder().eventBusName(DEFAULT_EVENT_BUS).build());
+            if (listResponse != null && listResponse.hasRules()) {
+                for (var rule : listResponse.rules()) {
+                    removeTargetsAndDeleteRule(rule.name());
+                }
             }
+        } catch (Exception e) {
+            LOG.warn("Failed to clean up rules: {}", e.getMessage());
         }
     }
 

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
@@ -22,20 +22,89 @@ import org.apache.camel.test.infra.aws.common.services.AWSService;
 import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
 import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.DeleteRuleRequest;
+import software.amazon.awssdk.services.eventbridge.model.ListRulesRequest;
+import software.amazon.awssdk.services.eventbridge.model.ListRulesResponse;
+import software.amazon.awssdk.services.eventbridge.model.ListTargetsByRuleRequest;
+import software.amazon.awssdk.services.eventbridge.model.ListTargetsByRuleResponse;
+import software.amazon.awssdk.services.eventbridge.model.RemoveTargetsRequest;
+import software.amazon.awssdk.services.eventbridge.model.Target;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class Aws2EventbridgeBase extends CamelTestSupport {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Aws2EventbridgeBase.class);
+    private static final String DEFAULT_EVENT_BUS = "default";
+
     @RegisterExtension
     public static AWSService service = AWSServiceFactory.createSingletonEventBridgeService();
+
+    protected EventBridgeClient eventBridgeClient;
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext context = super.createCamelContext();
+        eventBridgeClient = AWSSDKClientUtils.newEventBridgeClient();
         EventbridgeComponent eventbridgeComponent = context.getComponent("aws2-eventbridge", EventbridgeComponent.class);
-        eventbridgeComponent.getConfiguration().setEventbridgeClient(AWSSDKClientUtils.newEventBridgeClient());
+        eventbridgeComponent.getConfiguration().setEventbridgeClient(eventBridgeClient);
         return context;
+    }
+
+    /**
+     * Cleans up all EventBridge rules on the default event bus before each test. This prevents test interference when
+     * using a singleton LocalStack container shared across test classes — leftover rules from a prior test could cause
+     * assertions on rule counts or rule state to fail.
+     */
+    @BeforeEach
+    void cleanUpEventBridgeRules() {
+        if (eventBridgeClient == null) {
+            return;
+        }
+        try {
+            ListRulesResponse listResponse = eventBridgeClient.listRules(
+                    ListRulesRequest.builder().eventBusName(DEFAULT_EVENT_BUS).build());
+            if (listResponse.hasRules()) {
+                for (var rule : listResponse.rules()) {
+                    removeTargetsAndDeleteRule(rule.name());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to clean up EventBridge rules before test: {}", e.getMessage());
+        }
+    }
+
+    private void removeTargetsAndDeleteRule(String ruleName) {
+        try {
+            ListTargetsByRuleResponse targets = eventBridgeClient.listTargetsByRule(
+                    ListTargetsByRuleRequest.builder()
+                            .rule(ruleName)
+                            .eventBusName(DEFAULT_EVENT_BUS)
+                            .build());
+            if (targets.hasTargets() && !targets.targets().isEmpty()) {
+                eventBridgeClient.removeTargets(
+                        RemoveTargetsRequest.builder()
+                                .rule(ruleName)
+                                .ids(targets.targets().stream().map(Target::id).toList())
+                                .eventBusName(DEFAULT_EVENT_BUS)
+                                .build());
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to remove targets for rule {}: {}", ruleName, e.getMessage());
+        }
+        try {
+            eventBridgeClient.deleteRule(
+                    DeleteRuleRequest.builder()
+                            .name(ruleName)
+                            .eventBusName(DEFAULT_EVENT_BUS)
+                            .build());
+        } catch (Exception e) {
+            LOG.warn("Failed to delete rule {}: {}", ruleName, e.getMessage());
+        }
     }
 }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
@@ -58,8 +58,8 @@ public class Aws2EventbridgeBase extends CamelTestSupport {
 
     /**
      * Cleans up all EventBridge rules on the default event bus before each test. This prevents test interference when
-     * using a singleton LocalStack container shared across test classes — leftover rules from a prior test could cause
-     * assertions on rule counts or rule state to fail.
+     * using a singleton container (floci/LocalStack) shared across test classes — leftover rules from a prior test
+     * could cause assertions on rule counts or rule state to fail.
      */
     @BeforeEach
     void cleanUpEventBridgeRules() {

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/Aws2EventbridgeBase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.aws2.eventbridge.localstack;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.aws2.eventbridge.EventbridgeComponent;
 import org.apache.camel.test.infra.aws.common.services.AWSService;
@@ -35,6 +37,8 @@ import software.amazon.awssdk.services.eventbridge.model.ListTargetsByRuleReques
 import software.amazon.awssdk.services.eventbridge.model.ListTargetsByRuleResponse;
 import software.amazon.awssdk.services.eventbridge.model.RemoveTargetsRequest;
 import software.amazon.awssdk.services.eventbridge.model.Target;
+
+import static org.awaitility.Awaitility.await;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class Aws2EventbridgeBase extends CamelTestSupport {
@@ -57,25 +61,37 @@ public class Aws2EventbridgeBase extends CamelTestSupport {
     }
 
     /**
-     * Cleans up all EventBridge rules on the default event bus before each test. This prevents test interference when
-     * using a singleton container (floci/LocalStack) shared across test classes — leftover rules from a prior test
-     * could cause assertions on rule counts or rule state to fail.
+     * Waits for the EventBridge service to be ready (the container health check may pass before all services are
+     * available), then cleans up all rules on the default event bus. This prevents test interference when using a
+     * singleton container (floci/LocalStack) shared across test classes — leftover rules from a prior test could cause
+     * assertions on rule counts or rule state to fail.
      */
     @BeforeEach
-    void cleanUpEventBridgeRules() {
+    void waitForServiceAndCleanUp() {
         if (eventBridgeClient == null) {
             return;
         }
+
+        // Wait for the EventBridge service to accept requests — the container health check
+        // may return 200 before all services are fully initialized
+        ListRulesResponse listResponse;
         try {
-            ListRulesResponse listResponse = eventBridgeClient.listRules(
-                    ListRulesRequest.builder().eventBusName(DEFAULT_EVENT_BUS).build());
-            if (listResponse.hasRules()) {
-                for (var rule : listResponse.rules()) {
-                    removeTargetsAndDeleteRule(rule.name());
-                }
-            }
+            listResponse = await().atMost(30, TimeUnit.SECONDS)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    .ignoreExceptions()
+                    .until(() -> eventBridgeClient.listRules(
+                            ListRulesRequest.builder().eventBusName(DEFAULT_EVENT_BUS).build()),
+                            r -> r != null);
         } catch (Exception e) {
-            LOG.warn("Failed to clean up EventBridge rules before test: {}", e.getMessage());
+            LOG.warn("EventBridge service not ready after 30s, proceeding anyway: {}", e.getMessage());
+            return;
+        }
+
+        // Clean up any leftover rules from previous test classes
+        if (listResponse != null && listResponse.hasRules()) {
+            for (var rule : listResponse.rules()) {
+                removeTargetsAndDeleteRule(rule.name());
+            }
         }
     }
 


### PR DESCRIPTION
## CAMEL-22000: Fix flaky EventBridge floci integration tests

### Problem

Five EventBridge integration tests fail in ~40% of CI builds with `mock://result Expected: <1> but was: <0>`:
- `EventbridgeEnableRuleIT`
- `EventbridgeListRulesIT`
- `EventbridgeListTargetsByRuleIT`
- `EventbridgePutRuleIT`
- `EventbridgeRemoveTargetsIT`

### Root Causes

1. **Shared state interference**: All test classes share a singleton floci container and use the hardcoded rule name `"firstrule"`. Some tests clean up their rules, others don't. When test execution order varies, leftover rules cause assertions on rule counts or rule state to fail.

2. **Service readiness gap**: The floci container health check returns 200, and even `listRules` (read operations) succeed, before `putRule` (write operations) are ready. The first `putRule` call in a test fails silently via `template.send()` (which does not throw on exchange exceptions), so the message never reaches `mock:result`.

### Fix

Modified only `Aws2EventbridgeBase.java` (the shared base class):

- **Write-based readiness probe**: Added a `@BeforeEach` method that uses Awaitility (30s timeout, 2s poll) to probe with a real `putRule` + `deleteRule` cycle, confirming the service accepts write operations before any test runs. This replaced the weaker read-only `listRules` check.

- **Pre-test cleanup**: After the readiness check, removes all rules (and their targets) from the default event bus. This isolates each test class from leftover state.

- **Stored `EventBridgeClient`**: The client is stored as a `protected` field in `createCamelContext()` (was previously created inline and discarded), enabling direct SDK calls for readiness probing and cleanup.

### Testing

- 10/10 local runs over 5 minutes with the write-based probe — zero failures
- All 8 IT tests pass consistently (`EventbridgePutRuleIT`, `EventbridgeRemoveTargetsIT`, `EventbridgeEnableRuleIT`, `EventbridgeListRulesIT`, `EventbridgeListTargetsByRuleIT`, `EventbridgeDescribeRuleIT`, `EventbridgeDeleteRuleIT`, `EventbridgeDisableRuleIT`)