### PR TITLE
CAMEL-24263: camel-aws2-sts - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-sts/src/main/java/org/apache/camel/component/aws2/sts/STS2Producer.java
+++ b/components/camel-aws/camel-aws2-sts/src/main/java/org/apache/camel/component/aws2/sts/STS2Producer.java
@@ -103,6 +103,9 @@ public class STS2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "assumeRole operation requires AssumeRoleRequest in POJO mode");
             }
         } else {
             Builder builder = AssumeRoleRequest.builder();
@@ -157,6 +160,9 @@ public class STS2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getSessionToken operation requires GetSessionTokenRequest in POJO mode");
             }
         } else {
             GetSessionTokenRequest.Builder builder = GetSessionTokenRequest.builder();
@@ -191,6 +197,9 @@ public class STS2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getFederationToken operation requires GetFederationTokenRequest in POJO mode");
             }
         } else {
             GetFederationTokenRequest.Builder builder = GetFederationTokenRequest.builder();

--- a/components/camel-aws/camel-aws2-sts/src/test/java/org/apache/camel/component/aws2/sts/STS2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-sts/src/test/java/org/apache/camel/component/aws2/sts/STS2ProducerTest.java
@@ -100,6 +100,27 @@ public class STS2ProducerTest extends CamelTestSupport {
                 .hasRootCauseMessage("Federated name needs to be specified for getFederationToken operation");
     }
 
+    @Test
+    void assumeRoleWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:assumeRolePojo", "not an AssumeRoleRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("assumeRole operation requires AssumeRoleRequest in POJO mode");
+    }
+
+    @Test
+    void getSessionTokenWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:getSessionTokenPojo", "not a GetSessionTokenRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("getSessionToken operation requires GetSessionTokenRequest in POJO mode");
+    }
+
+    @Test
+    void getFederationTokenWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:getFederationTokenPojo", "not a GetFederationTokenRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("getFederationToken operation requires GetFederationTokenRequest in POJO mode");
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -111,6 +132,12 @@ public class STS2ProducerTest extends CamelTestSupport {
                         .to("mock:result");
                 from("direct:getFederationToken").to("aws2-sts://test?stsClient=#amazonStsClient&operation=getFederationToken")
                         .to("mock:result");
+                from("direct:assumeRolePojo")
+                        .to("aws2-sts://test?stsClient=#amazonStsClient&operation=assumeRole&pojoRequest=true");
+                from("direct:getSessionTokenPojo")
+                        .to("aws2-sts://test?stsClient=#amazonStsClient&operation=getSessionToken&pojoRequest=true");
+                from("direct:getFederationTokenPojo")
+                        .to("aws2-sts://test?stsClient=#amazonStsClient&operation=getFederationToken&pojoRequest=true");
             }
         };
     }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1274,3 +1274,20 @@ Update any catch blocks or method `throws` declarations accordingly.
 } catch (MinioException e) { ... }
 ----
 
+=== camel-aws2 - producers now fail fast on a wrong POJO request type
+
+When an AWS2 producer is configured with `pojoRequest=true`, it expects the
+Exchange body to be the AWS SDK request object for the selected operation
+(for example an `AssumeRoleRequest` for the `assumeRole` operation of
+`camel-aws2-sts`). Previously, if the body was some other type, the operation
+silently did nothing: no AWS call was made, no response was set, and the
+original body was returned with no error.
+
+These producers now throw an `IllegalArgumentException` naming the required
+request type, consistent with the behaviour already shipped for
+`camel-aws-bedrock` in 4.21 (CAMEL-23462). This roll-out across the remaining
+AWS2 producers is tracked by CAMEL-24261.
+
+If you relied on the previous silent no-op, ensure the body is the correct
+request type when `pojoRequest=true`, or drive the operation through headers
+with `pojoRequest=false`.


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `STS2Producer` expects the body to be the AWS SDK
request for the operation. Each branch has the shape:

```java
if (getConfiguration().isPojoRequest()) {
    Object payload = exchange.getIn().getMandatoryBody();
    if (payload instanceof AssumeRoleRequest request) {
        ... call AWS, set response ...
    }
    // no else: a wrong-typed body falls straight through
}
```

If the body is not the expected type, the `instanceof` is false, the branch is
skipped, and the method returns without calling STS or setting a response — the
caller silently gets the original body back and no error. Reproduced for all
three operations (`assumeRole`, `getSessionToken`, `getFederationToken`).

## Fix

Add the missing `else` that throws `IllegalArgumentException` naming the required
request type, exactly as CAMEL-23462 did for `camel-aws-bedrock`:

```java
} else {
    throw new IllegalArgumentException(
            "assumeRole operation requires AssumeRoleRequest in POJO mode");
}
```

## Tests

Three tests in `STS2ProducerTest` send a wrong-typed body to a `pojoRequest=true`
route and assert the `IllegalArgumentException` message. Each was verified to
fail (silent no-op) before the fix. Full class 7/7 green.

## Docs

Behaviour change → a single 4.22 upgrade-guide entry (`=== camel-aws2 -
producers now fail fast on a wrong POJO request type`) covering the whole
CAMEL-24261 roll-out; subsequent per-component PRs won't re-add it.

## Backport

Main only, matching CAMEL-23462 (which shipped in 4.21.0 and was not backported)
— this is a behaviour change, not a crash fix.

---
_Claude Code on behalf of oscerd_