### PR TITLE
CAMEL-24270: Make AiToolSpecToLangChain4j public for reuse by downstream projects

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/AiToolSpecToLangChain4j.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/AiToolSpecToLangChain4j.java
@@ -32,12 +32,16 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import org.apache.camel.component.ai.tool.AiToolParameterHelper;
 import org.apache.camel.component.ai.tool.AiToolSpec;
 
-final class AiToolSpecToLangChain4j {
+/**
+ * Converts {@link AiToolSpec} instances to langchain4j {@link ToolSpecification} objects, mapping Camel parameter
+ * definitions to the corresponding JSON Schema types.
+ */
+public final class AiToolSpecToLangChain4j {
 
     private AiToolSpecToLangChain4j() {
     }
 
-    static ToolSpecification toToolSpecification(AiToolSpec spec) {
+    public static ToolSpecification toToolSpecification(AiToolSpec spec) {
         ToolSpecification.Builder builder = ToolSpecification.builder()
                 .name(spec.getName())
                 .description(spec.getDescription());


### PR DESCRIPTION
## Summary
- Make `AiToolSpecToLangChain4j` class and its `toToolSpecification()` method public
- Add Javadoc to the class

## Motivation
Downstream projects like camel-quarkus need to convert `AiToolSpec` to langchain4j `ToolSpecification` when bridging `AiToolRegistry` to langchain4j's `ToolProvider` SPI. Without public access, they must either duplicate ~45 lines of type-mapping logic or use reflection.

The change is minimal — no behavioral change, no new API surface beyond exposing the existing utility.

Jira: https://issues.apache.org/jira/browse/CAMEL-24270