### PR TITLE
CAMEL-24264: camel-aws2-translate - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-translate/pom.xml
+++ b/components/camel-aws/camel-aws2-translate/pom.xml
@@ -78,5 +78,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2Producer.java
+++ b/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2Producer.java
@@ -100,6 +100,9 @@ public class Translate2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.translatedText());
+            } else {
+                throw new IllegalArgumentException(
+                        "translateText operation requires TranslateTextRequest in POJO mode");
             }
         } else {
             Builder request = TranslateTextRequest.builder();

--- a/components/camel-aws/camel-aws2-translate/src/test/java/org/apache/camel/component/aws2/translate/Translate2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-translate/src/test/java/org/apache/camel/component/aws2/translate/Translate2ProducerTest.java
@@ -26,6 +26,7 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.translate.model.TranslateTextRequest;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Translate2ProducerTest extends CamelTestSupport {
@@ -74,6 +75,13 @@ public class Translate2ProducerTest extends CamelTestSupport {
         String resultGet = exchange.getIn().getBody(String.class);
         assertEquals("Hello", resultGet);
 
+    }
+
+    @Test
+    void translateTextWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:translatePojoText", "not a TranslateTextRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("translateText operation requires TranslateTextRequest in POJO mode");
     }
 
     @Test


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `Translate2Producer.translateText` only acted when the
body was a `TranslateTextRequest`; any other body fell through the `instanceof`
with no `else`, so no AWS call was made, no response was set, and the original
body was returned with no error.

## Fix

```java
} else {
    throw new IllegalArgumentException(
            "translateText operation requires TranslateTextRequest in POJO mode");
}
```

## Test

`translateTextWithPojoRequestAndWrongBodyTypeThrows` sends a wrong-typed body to
the existing `pojoRequest=true` route and asserts the message. Verified to fail
(silent no-op) before the fix. Class 4/4 green.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_