### PR TITLE
CAMEL-24228: Clarify upgrade guide is for migration only, not new features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,11 +136,13 @@ When merging a PR, an agent MUST perform the following steps **in order**:
 
 - Every PR must include tests for new functionality or bug fixes.
 - Every PR must include documentation updates where applicable.
-  Any user-visible change must be documented in the upgrade guide
-  (`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc`) and in the relevant
-  command or component documentation page. This includes: changed defaults, new auto-detection
-  behavior, removed or renamed options, changed header names or values, API/SPI signature changes,
-  removed or deprecated components, migrated libraries, and renamed documentation pages.
+  New features must be documented in the relevant command or component documentation page.
+  Changes that affect existing users upgrading must also be documented in the upgrade guide
+  (`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_XX.adoc`). This includes:
+  changed defaults, new auto-detection behavior, removed or renamed options, changed header
+  names or values, API/SPI signature changes, removed or deprecated components, migrated
+  libraries, and renamed documentation pages. The upgrade guide is for migration only — do
+  NOT add new features to it.
   For backported changes, the upgrade guide entry must be added on the `main` branch (not on the
   maintenance branch where the fix is backported).
 - All code must pass formatting checks (`mvn formatter:format impsort:sort`) before pushing.


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

Fixes the overly broad wording in the Code Quality section of `AGENTS.md` (and `CLAUDE.md` which symlinks to it) that stated "Any user-visible change must be documented in the upgrade guide." This incorrectly suggested that **new features** should be added to the upgrade guide.

### What changed

- **Before:** "Any user-visible change must be documented in the upgrade guide (...) and in the relevant command or component documentation page."
- **After:** Separates the guidance into two clear directives:
  1. New features → document in the relevant component/command docs page
  2. Migration-affecting changes (changed defaults, removed/renamed options, API/SPI changes, deprecations, etc.) → document in the upgrade guide
- Adds an explicit statement: "The upgrade guide is for migration only — do NOT add new features to it."

### What stays the same

- The list of migration-relevant changes (changed defaults, renamed options, API changes, etc.) is preserved
- The backport guidance ("upgrade guide entry must be on `main` branch") is unchanged
- The Deprecation section (line 552) correctly references the upgrade guide and is unchanged
- The Security checklist (line 474) correctly references upgrade-guide for relaxed defaults and is unchanged

## Test plan

- [x] Verified `CLAUDE.md` is a symlink to `AGENTS.md` — only one file needs editing
- [x] Verified the diff only touches the Code Quality section
- [x] Cross-checked the remaining upgrade-guide references (Deprecation section, Security checklist) are correct and untouched
- [x] Verified the change aligns with the actual upgrade guide content (`camel-4x-upgrade-guide-4_9.adoc` documents API changes, renamed constants, changed behavior — not new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)