### PR TITLE
fix(CAMEL-24264): throw IllegalArgumentException for wrong body type in pojoRequest mode [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2Producer.java
+++ b/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2Producer.java
@@ -100,6 +100,10 @@ public class Translate2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.translatedText());
+            } else {
+                throw new IllegalArgumentException(
+                        "translateText operation requires TranslateTextRequest in POJO mode" +
+                        " or non-POJO mode with String body and source/target language specified");
             }
         } else {
             Builder request = TranslateTextRequest.builder();


### PR DESCRIPTION
## CAMEL-24264: throw IllegalArgumentException when `pojoRequest=true` with wrong body type

**Problem:**
With `pojoRequest=true`, `Translate2Producer.translateText` only acted when the
body was a `TranslateTextRequest`. Any other body type fell through the
`instanceof` with no `else`, so no AWS call was made, no response was set, and
the original body was returned silently — making the bug extremely hard to debug.

**Fix:**
Add an `else` branch in the POJO mode `if` block that throws
`IllegalArgumentException`, making the failure visible immediately.

**Scope:**
Only the `pojoRequest=true` path. The non-POJO path (String body) is
unchanged — it already handles its input validation separately.
