### PR TITLE
CAMEL-24223: camel-jbang-mcp - Locale.ROOT cost formatting and model-specific disclaimer (follow-up)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteCostEstimateTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteCostEstimateTools.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -134,8 +135,10 @@ public class RouteCostEstimateTools {
                 breakdown.isEmpty() ? null : breakdown,
                 projection, summary,
                 optimizationTips.isEmpty() ? null : optimizationTips,
-                "Cost estimates are approximate based on published AWS pricing (us-east-1). "
-                                                                      + "Actual costs vary by region, volume tier, and model.",
+                "Cost estimates are approximate based on published AWS pricing (us-east-1). Token-based (LLM) "
+                                                                      + "components are priced as a specific model — see each component's pricingNote — and are NOT a "
+                                                                      + "provider-wide figure: a route on Nova Lite, Haiku or a local/self-hosted model (Ollama) will cost "
+                                                                      + "far less, often ~zero. Actual costs vary by region, volume tier, and model.",
                 "2025-Q2");
     }
 
@@ -179,10 +182,12 @@ public class RouteCostEstimateTools {
     }
 
     private static String formatCost(double cost) {
+        // Locale.ROOT so the decimal separator is always '.' regardless of the server locale — MCP clients
+        // parse these strings and a comma separator (e.g. "$0,003000" under a French locale) would break them.
         if (cost < 0.01) {
-            return String.format("$%.6f", cost);
+            return String.format(Locale.ROOT, "$%.6f", cost);
         }
-        return String.format("$%.4f", cost);
+        return String.format(Locale.ROOT, "$%.4f", cost);
     }
 
     private static Map<String, ComponentCostProfile> buildCostProfiles() {

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteCostEstimateToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/RouteCostEstimateToolsTest.java
@@ -76,10 +76,18 @@ class RouteCostEstimateToolsTest {
 
         assertThat(result).isNotNull();
         assertThat(result.costBreakdown()).isNotNull();
-        assertThat(result.costBreakdown()).hasSizeGreaterThanOrEqualTo(2);
+        // docling, aws-bedrock and aws2-s3 have cost profiles; the file: scheme does not, so exactly 3 are priced.
+        assertThat(result.costBreakdown()).hasSize(3);
         assertThat(result.summary().mostExpensiveComponent()).isEqualTo("aws-bedrock");
         assertThat(result.projection().messagesPerHour()).isEqualTo(100);
         assertThat(result.disclaimer()).isNotBlank();
+
+        // aws-bedrock is estimated at Claude Sonnet 4 pricing: 1000 in * $3/MTok + 500 out * $15/MTok.
+        double expectedBedrock = 1000 * 3.0 / 1_000_000 + 500 * 15.0 / 1_000_000;
+        assertThat(result.costBreakdown())
+                .filteredOn(c -> "aws-bedrock".equals(c.scheme()))
+                .singleElement()
+                .satisfies(c -> assertThat(c.estimatedCostPerExecution()).isEqualTo(expectedBedrock));
     }
 
     @Test
@@ -132,8 +140,9 @@ class RouteCostEstimateToolsTest {
     void shouldExtractSchemesCorrectly() {
         List<String> schemes = tools.extractSchemes(AI_PIPELINE_ROUTE);
 
-        assertThat(schemes).contains("docling", "aws-bedrock", "aws2-s3");
-        assertThat(schemes).doesNotContain("uri");
+        // Exact set: the from: uri is file, then the three to: schemes. This catches both a false "uri" capture
+        // (from the multi-line from:\n  uri: form) and a dropped "file" scheme.
+        assertThat(schemes).containsExactlyInAnyOrder("file", "docling", "aws-bedrock", "aws2-s3");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Follow-up to [CAMEL-24223](https://issues.apache.org/jira/browse/CAMEL-24223) / #25052, which merged before these review refinements landed. Picks up the remaining points from that PR's review.

### Changes

- **`formatCost` now uses `Locale.ROOT`** for both branches. Previously `String.format("$%.6f", cost)` used the JVM default locale, so under a comma-decimal locale (e.g. French) the tool emitted `$0,003000` — MCP clients that parse these strings would break. This is the substantive fix.
- **Model-specific disclaimer.** The top-level disclaimer now states explicitly that token-based (LLM) components are priced as a *specific* model, not a provider-wide figure, and that Nova Lite / Haiku / local models (Ollama) cost far less, often ~zero — so the estimate is not misread as a real cost for those. Addresses davsclaus's concern about phantom costs for provider-agnostic components.
- **Tighter tests.** `shouldExtractSchemesCorrectly` now uses `containsExactlyInAnyOrder("file", "docling", "aws-bedrock", "aws2-s3")` (catches both a false `uri` capture and a dropped `file` scheme), and `shouldEstimateCostForAiPipeline` pins the breakdown to exactly 3 priced components and asserts the computed `aws-bedrock` per-execution cost rather than only the count.

### Testing

`RouteCostEstimateToolsTest` — 11 tests, all passing against current `main`.

Main-only (4.22.0), additive — no backport.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
