### PR TITLE
CAMEL-24222: camel-jbang-mcp - catalog-based scheme detection in dependency audit (follow-up)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/DependencySecurityAuditTools.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/main/java/org/apache/camel/dsl/jbang/core/commands/mcp/DependencySecurityAuditTools.java
@@ -77,7 +77,7 @@ public class DependencySecurityAuditTools {
             List<SecurityAdvisoryModel> allAdvisories = advisoryService.advisories();
 
             List<String> usedSchemes = routes != null && !routes.isBlank()
-                    ? extractUsedSchemes(routes) : List.of();
+                    ? extractUsedSchemes(routes, catalog) : List.of();
 
             Map<String, ArtifactAudit> auditByArtifact = new LinkedHashMap<>();
 
@@ -159,17 +159,26 @@ public class DependencySecurityAuditTools {
         }
     }
 
-    private List<String> extractUsedSchemes(String routes) {
+    /**
+     * Detect which components a route uses by walking the known catalog component names, the same way
+     * {@link DependencyCheckTools} and {@code HardenTools} do. Tokenizing the route text instead would treat the DSL's
+     * own structural keywords ({@code from:}, {@code to:}, {@code steps:}, {@code uri:}) as component schemes.
+     */
+    private List<String> extractUsedSchemes(String routes, CamelCatalog catalog) {
         List<String> schemes = new ArrayList<>();
         String lower = routes.toLowerCase();
-        for (String token : lower.split("[^a-z0-9-]+")) {
-            if (token.length() > 2 && lower.contains(token + ":")) {
-                if (!schemes.contains(token)) {
-                    schemes.add(token);
-                }
+        for (String comp : catalog.findComponentNames()) {
+            if (containsComponent(lower, comp) && !schemes.contains(comp)) {
+                schemes.add(comp);
             }
         }
         return schemes;
+    }
+
+    private boolean containsComponent(String content, String comp) {
+        return content.contains(comp + ":")
+                || content.contains("\"" + comp + "\"")
+                || content.contains("'" + comp + "'");
     }
 
     private boolean isReachable(String artifactId, List<String> usedSchemes, CamelCatalog catalog) {

--- a/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/DependencySecurityAuditToolsTest.java
+++ b/dsl/camel-jbang/camel-jbang-mcp/src/test/java/org/apache/camel/dsl/jbang/core/commands/mcp/DependencySecurityAuditToolsTest.java
@@ -98,6 +98,8 @@ class DependencySecurityAuditToolsTest {
 
     @Test
     void shouldIncludeReachabilityWhenRoutesProvided() {
+        // The route uses the http component and the POM declares vulnerable camel-http at 4.10.0, so the audit
+        // must flag camel-http as reachable.
         String routes = "from: \"http:example.com\"\nsteps:\n  - to: \"log:out\"";
         DependencySecurityAuditTools.AuditResult result
                 = tools.camel_dependency_security_audit(SIMPLE_POM, routes, null, null, null, null);
@@ -105,7 +107,27 @@ class DependencySecurityAuditToolsTest {
         assertThat(result).isNotNull();
         assertThat(result.summary()).isNotNull();
         assertThat(result.summary().totalDependencies()).isGreaterThan(0);
-        assertThat(result.summary().reachableVulnerableArtifacts()).isGreaterThanOrEqualTo(0);
+        assertThat(result.summary().reachableVulnerableArtifacts()).isGreaterThan(0);
+        assertThat(result.vulnerableArtifacts())
+                .anySatisfy(a -> {
+                    assertThat(a.artifactId()).isEqualTo("camel-http");
+                    assertThat(a.reachable()).isTrue();
+                });
+    }
+
+    @Test
+    void shouldNotFlagReachabilityWhenRoutesUseOtherComponents() {
+        // camel-http is declared and vulnerable, but no route uses it, so it must NOT be reported as reachable.
+        String routes = "from: \"timer:tick\"\nsteps:\n  - to: \"log:out\"";
+        DependencySecurityAuditTools.AuditResult result
+                = tools.camel_dependency_security_audit(SIMPLE_POM, routes, null, null, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.summary().reachableVulnerableArtifacts()).isZero();
+        assertThat(result.vulnerableArtifacts())
+                .filteredOn(a -> a.artifactId().equals("camel-http"))
+                .singleElement()
+                .satisfies(a -> assertThat(a.reachable()).isFalse());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Follow-up to [CAMEL-24222](https://issues.apache.org/jira/browse/CAMEL-24222) / #25051, which merged before this refinement landed. Addresses @gnodet's remaining review point on scheme detection.

### Changes

- **`extractUsedSchemes` now walks the catalog component names** (`catalog.findComponentNames()` + a `containsComponent()` check), the same approach `DependencyCheckTools` and `HardenTools` use, instead of tokenizing the route text with `split("[^a-z0-9-]+")`. Tokenizing treated the DSL's own structural keywords (`from:`, `to:`, `steps:`, `uri:`) as component schemes, producing false positives in the reachability analysis.
- **Real reachability tests.** `shouldIncludeReachabilityWhenRoutesProvided` now asserts `camel-http` is actually flagged `reachable=true` when a route uses the http component, and a new `shouldNotFlagReachabilityWhenRoutesUseOtherComponents` asserts it is NOT reachable when the route uses a different component. The previous assertion (`>= 0`) could never fail.

### Testing

`DependencySecurityAuditToolsTest` — 8 tests, all passing against current `main`.

Main-only (4.22.0), additive — no backport.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
