### PR TITLE
CAMEL-24277: camel-aws2-msk - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-msk/src/main/java/org/apache/camel/component/aws2/msk/MSK2Producer.java
+++ b/components/camel-aws/camel-aws2-msk/src/main/java/org/apache/camel/component/aws2/msk/MSK2Producer.java
@@ -115,6 +115,9 @@ public class MSK2Producer extends DefaultProducer {
                 message.setBody(result);
                 message.setHeader(MSK2Constants.NEXT_TOKEN, result.nextToken());
                 message.setHeader(MSK2Constants.IS_TRUNCATED, ObjectHelper.isNotEmpty(result.nextToken()));
+            } else {
+                throw new IllegalArgumentException(
+                        "listClusters operation requires ListClustersRequest in POJO mode");
             }
         } else {
             ListClustersRequest.Builder builder = ListClustersRequest.builder();
@@ -157,6 +160,9 @@ public class MSK2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(response);
+            } else {
+                throw new IllegalArgumentException(
+                        "createCluster operation requires CreateClusterRequest in POJO mode");
             }
         } else {
             CreateClusterRequest.Builder builder = CreateClusterRequest.builder();
@@ -212,6 +218,9 @@ public class MSK2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteCluster operation requires DeleteClusterRequest in POJO mode");
             }
         } else {
             DeleteClusterRequest.Builder builder = DeleteClusterRequest.builder();
@@ -246,6 +255,9 @@ public class MSK2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeCluster operation requires DescribeClusterRequest in POJO mode");
             }
         } else {
             DescribeClusterRequest.Builder builder = DescribeClusterRequest.builder();

--- a/components/camel-aws/camel-aws2-msk/src/test/java/org/apache/camel/component/aws2/msk/MSKProducerTest.java
+++ b/components/camel-aws/camel-aws2-msk/src/test/java/org/apache/camel/component/aws2/msk/MSKProducerTest.java
@@ -149,6 +149,34 @@ public class MSKProducerTest extends CamelTestSupport {
         assertEquals(ClusterState.ACTIVE.name(), resultGet.clusterInfo().state().toString());
     }
 
+    @Test
+    void listClustersWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:listClustersPojo", "not a ListClustersRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("listClusters operation requires ListClustersRequest in POJO mode");
+    }
+
+    @Test
+    void createClusterWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:createClusterPojo", "not a CreateClusterRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("createCluster operation requires CreateClusterRequest in POJO mode");
+    }
+
+    @Test
+    void deleteClusterWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:deleteClusterPojo", "not a DeleteClusterRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("deleteCluster operation requires DeleteClusterRequest in POJO mode");
+    }
+
+    @Test
+    void describeClusterWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:describeClusterPojo", "not a DescribeClusterRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("describeCluster operation requires DescribeClusterRequest in POJO mode");
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -165,6 +193,12 @@ public class MSKProducerTest extends CamelTestSupport {
                         .to("mock:result");
                 from("direct:describeCluster").to("aws2-msk://test?mskClient=#amazonMskClient&operation=describeCluster")
                         .to("mock:result");
+                from("direct:createClusterPojo")
+                        .to("aws2-msk://test?mskClient=#amazonMskClient&operation=createCluster&pojoRequest=true");
+                from("direct:deleteClusterPojo")
+                        .to("aws2-msk://test?mskClient=#amazonMskClient&operation=deleteCluster&pojoRequest=true");
+                from("direct:describeClusterPojo")
+                        .to("aws2-msk://test?mskClient=#amazonMskClient&operation=describeCluster&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `MSK2Producer`'s `listClusters`, `createCluster`,
`deleteCluster` and `describeCluster` branches only acted when the body was the
matching request type; any other body fell through the `instanceof` with no
`else`, so no AWS call was made, no response was set, and the original body was
returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g.:

```java
} else {
    throw new IllegalArgumentException(
            "createCluster operation requires CreateClusterRequest in POJO mode");
}
```

## Tests

Four tests in `MSKProducerTest` send a wrong-typed body to `pojoRequest=true`
routes (reusing the module's `AmazonMSKClientMock`) and assert the message. Each
was verified to fail (silent no-op) before the fix — the `createCluster` one, for
example, reports "Expecting code to raise a throwable" on `main`. Class 10/10 green.

These are hermetic unit tests against the in-JVM mock client (run region-free) —
no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_