### PR TITLE
CAMEL-24276: Azure OpenAI support for Camel JBang TUI AI prompt

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -24,10 +24,7 @@ instead of hardcoded `3.33.1.1` (https://github.com/apache/camel/commit/d1f4713e
 The Camel CLI and TUI AI prompt (`camel ask`, TUI F8 panel) now auto-detect **Azure OpenAI**
 when `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set (optional `AZURE_OPENAI_DEPLOYMENT_NAME`
 and `AZURE_OPENAI_API_VERSION`). Azure requests use the `api-key` header instead of `Authorization: Bearer`.
-
-**GitHub Models** is opt-in: set `GITHUB_MODELS=1` (or any non-false value) together with `GITHUB_TOKEN`
-to use `https://models.github.ai/inference`. A bare `GITHUB_TOKEN` alone does not select an LLM provider — the opt-in `GITHUB_MODELS` flag is required.
-GitHub Models is scheduled for retirement on 2026-07-30; see xref:camel-jbang-ai.adoc[Camel CLI - AI Tools] for the full detection order.
+See xref:camel-jbang-ai.adoc[Camel CLI - AI Tools] for the full detection order.
 
 The `camel cmd route-diagram` and `camel cmd route-topology` now accept one or more Camel route source files
 (instead of only the name/pid of a running integration), so diagrams and inter-route topology can be

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -26,7 +26,7 @@ when `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set (optional `AZURE
 and `AZURE_OPENAI_API_VERSION`). Azure requests use the `api-key` header instead of `Authorization: Bearer`.
 
 **GitHub Models** is opt-in: set `GITHUB_MODELS=1` (or any non-false value) together with `GITHUB_TOKEN`
-to use `https://models.github.ai/inference`. A bare `GITHUB_TOKEN` alone no longer selects an LLM provider.
+to use `https://models.github.ai/inference`. A bare `GITHUB_TOKEN` alone does not select an LLM provider — the opt-in `GITHUB_MODELS` flag is required.
 GitHub Models is scheduled for retirement on 2026-07-30; see xref:camel-jbang-ai.adoc[Camel CLI - AI Tools] for the full detection order.
 
 The `camel cmd route-diagram` and `camel cmd route-topology` now accept one or more Camel route source files

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -21,6 +21,14 @@ The MCP Server has also been promoted to _Stable_.
 The Camel JBang CLI now automatic resolves quarkus version to use,
 instead of hardcoded `3.33.1.1` (https://github.com/apache/camel/commit/d1f4713ebdf787ab04a31c50a6f07e3ca66f0c2b).
 
+The Camel CLI and TUI AI prompt (`camel ask`, TUI F8 panel) now auto-detect **Azure OpenAI**
+when `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set (optional `AZURE_OPENAI_DEPLOYMENT_NAME`
+and `AZURE_OPENAI_API_VERSION`). Azure requests use the `api-key` header instead of `Authorization: Bearer`.
+
+**GitHub Models** is opt-in: set `GITHUB_MODELS=1` (or any non-false value) together with `GITHUB_TOKEN`
+to use `https://models.github.ai/inference`. A bare `GITHUB_TOKEN` alone no longer selects an LLM provider.
+GitHub Models is scheduled for retirement on 2026-07-30; see xref:camel-jbang-ai.adoc[Camel CLI - AI Tools] for the full detection order.
+
 The `camel cmd route-diagram` and `camel cmd route-topology` now accept one or more Camel route source files
 (instead of only the name/pid of a running integration), so diagrams and inter-route topology can be
 generated at design/source time without starting the application first, for example:

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-ai.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-ai.adoc
@@ -116,9 +116,11 @@ All commands auto-detect the LLM provider. The detection order is:
 
 1. `ANTHROPIC_API_KEY` environment variable → Anthropic API (`ask` and `explain` only)
 2. `CLOUD_ML_REGION` + `ANTHROPIC_VERTEX_PROJECT_ID` → Vertex AI (`ask` and `explain` only)
-3. `OPENAI_API_KEY` or `LLM_API_KEY` → OpenAI-compatible API
-4. Ollama running via `camel infra` → local Ollama
-5. Ollama at `localhost:11434` → local Ollama
+3. `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` → Azure OpenAI (uses the `api-key` header; optional `AZURE_OPENAI_DEPLOYMENT_NAME` and `AZURE_OPENAI_API_VERSION`)
+4. `GITHUB_MODELS` (non-false) + `GITHUB_TOKEN` → GitHub Models at `https://models.github.ai/inference` (Bearer token). GitHub Models is scheduled for retirement on 2026-07-30; prefer Azure OpenAI or another provider for new integrations.
+5. `OPENAI_API_KEY` or `LLM_API_KEY` → OpenAI-compatible API
+6. Ollama running via `camel infra` → local Ollama
+7. Ollama at `localhost:11434` → local Ollama
 
 Override with explicit options:
 

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-ai.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-ai.adoc
@@ -117,10 +117,9 @@ All commands auto-detect the LLM provider. The detection order is:
 1. `ANTHROPIC_API_KEY` environment variable → Anthropic API (`ask` and `explain` only)
 2. `CLOUD_ML_REGION` + `ANTHROPIC_VERTEX_PROJECT_ID` → Vertex AI (`ask` and `explain` only)
 3. `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` → Azure OpenAI (uses the `api-key` header; optional `AZURE_OPENAI_DEPLOYMENT_NAME` and `AZURE_OPENAI_API_VERSION`)
-4. `GITHUB_MODELS` (non-false) + `GITHUB_TOKEN` → GitHub Models at `https://models.github.ai/inference` (Bearer token). GitHub Models is scheduled for retirement on 2026-07-30; prefer Azure OpenAI or another provider for new integrations.
-5. `OPENAI_API_KEY` or `LLM_API_KEY` → OpenAI-compatible API
-6. Ollama running via `camel infra` → local Ollama
-7. Ollama at `localhost:11434` → local Ollama
+4. `OPENAI_API_KEY` or `LLM_API_KEY` → OpenAI-compatible API
+5. Ollama running via `camel infra` → local Ollama
+6. Ollama at `localhost:11434` → local Ollama
 
 Override with explicit options:
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -52,7 +52,6 @@ public class LlmClient {
     private static final String DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
     private static final String DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
     private static final String DEFAULT_OLLAMA_MODEL = "llama3.2";
-    private static final String DEFAULT_GITHUB_MODELS_URL = "https://models.github.ai/inference";
     private static final String DEFAULT_AZURE_API_VERSION = "2024-10-21";
     /** Last-resort Azure deployment segment when URL normalization runs before model detection completes. */
     private static final String DEFAULT_AZURE_DEPLOYMENT_FALLBACK = "gpt-4o";
@@ -242,15 +241,14 @@ public class LlmClient {
         } else if (apiType != null) {
             found = switch (apiType) {
                 case anthropic -> tryAnthropicOrVertex();
-                case openai -> tryAzureOpenAi() || tryGitHubModels() || tryOpenAi();
+                case openai -> tryAzureOpenAi() || tryOpenAi();
                 case ollama -> tryInfraOllama() || tryDefaultOllama();
             };
         } else {
-            // auto-detect priority: anthropic → vertex → azure openai → github models → openai → ollama
+            // auto-detect priority: anthropic → vertex → azure openai → openai → ollama
             found = tryAnthropicApiKey()
                     || tryVertexAi()
                     || tryAzureOpenAi()
-                    || tryGitHubModels()
                     || tryOpenAi()
                     || tryInfraOllama()
                     || tryDefaultOllama();
@@ -1431,33 +1429,6 @@ public class LlmClient {
         }
     }
 
-    private boolean tryGitHubModels() {
-        if (!isGitHubModelsAutoDetectEnabled()) {
-            return false;
-        }
-        String token = System.getenv("GITHUB_TOKEN");
-        if (token == null || token.isBlank()) {
-            return false;
-        }
-        apiType = ApiType.openai;
-        apiKey = token;
-        openAiAuthMode = OpenAiAuthMode.bearer;
-        url = DEFAULT_GITHUB_MODELS_URL;
-        return true;
-    }
-
-    public static boolean isGitHubModelsAutoDetectEnabled() {
-        return isGitHubModelsOptInFlag(System.getenv("GITHUB_MODELS"));
-    }
-
-    static boolean isGitHubModelsOptInFlag(String flag) {
-        return flag != null && !flag.isBlank() && !"0".equals(flag) && !"false".equalsIgnoreCase(flag);
-    }
-
-    static boolean isGitHubModelsEndpoint(String endpoint) {
-        return endpoint != null && endpoint.contains("models.github.ai");
-    }
-
     private boolean tryInfraOllama() {
         try {
             Map<Long, Path> pids = findOllamaPids();
@@ -1691,12 +1662,6 @@ public class LlmClient {
 
     String normalizeOpenAiUrl(String endpoint) {
         String u = stripTrailingSlash(endpoint);
-        if (isGitHubModelsEndpoint(u)) {
-            if (u.endsWith("/chat/completions")) {
-                return u;
-            }
-            return u + "/chat/completions";
-        }
         if (isAzureOpenAiEndpoint(u)) {
             return normalizeAzureOpenAiChatUrl(u);
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -277,7 +277,10 @@ public class LlmClient {
                 }
             }
             case openai -> {
-                if (model == null || model.isBlank()) {
+                if (openAiAuthMode == OpenAiAuthMode.api_key
+                        || (url != null && isAzureOpenAiEndpoint(url))) {
+                    resolveAzureOpenAiModel();
+                } else if (model == null || model.isBlank()) {
                     model = DEFAULT_OPENAI_MODEL;
                 }
             }
@@ -1397,10 +1400,33 @@ public class LlmClient {
         }
         String deployment = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
         if (deployment != null && !deployment.isBlank()
-                && (model == null || model.isBlank() || DEFAULT_OLLAMA_MODEL.equals(model))) {
+                && (model == null || model.isBlank() || isGenericPlaceholderModel(model))) {
             model = deployment;
         }
         return true;
+    }
+
+    private boolean isGenericPlaceholderModel(String configuredModel) {
+        return DEFAULT_OLLAMA_MODEL.equals(configuredModel) || DEFAULT_OPENAI_MODEL.equals(configuredModel);
+    }
+
+    /**
+     * Azure chat URLs use deployment names, not OpenAI model ids. Replace CLI placeholders with env, then the first
+     * listed deployment when reachable.
+     */
+    private void resolveAzureOpenAiModel() {
+        if (model != null && !model.isBlank() && !isGenericPlaceholderModel(model)) {
+            return;
+        }
+        String deployment = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
+        if (deployment != null && !deployment.isBlank()) {
+            model = deployment;
+            return;
+        }
+        List<String> deployments = listModels();
+        if (!deployments.isEmpty()) {
+            model = deployments.get(0);
+        }
     }
 
     private boolean tryGitHubModels() {
@@ -1419,7 +1445,10 @@ public class LlmClient {
     }
 
     static boolean isGitHubModelsAutoDetectEnabled() {
-        String flag = System.getenv("GITHUB_MODELS");
+        return isGitHubModelsOptInFlag(System.getenv("GITHUB_MODELS"));
+    }
+
+    static boolean isGitHubModelsOptInFlag(String flag) {
         return flag != null && !flag.isBlank() && !"0".equals(flag) && !"false".equalsIgnoreCase(flag);
     }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -54,6 +54,8 @@ public class LlmClient {
     private static final String DEFAULT_OLLAMA_MODEL = "llama3.2";
     private static final String DEFAULT_GITHUB_MODELS_URL = "https://models.github.ai/inference";
     private static final String DEFAULT_AZURE_API_VERSION = "2024-10-21";
+    /** Last-resort Azure deployment segment when URL normalization runs before model detection completes. */
+    private static final String DEFAULT_AZURE_DEPLOYMENT_FALLBACK = "gpt-4o";
     private static final int CONNECT_TIMEOUT_SECONDS = 10;
     private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 5;
 
@@ -1444,7 +1446,7 @@ public class LlmClient {
         return true;
     }
 
-    static boolean isGitHubModelsAutoDetectEnabled() {
+    public static boolean isGitHubModelsAutoDetectEnabled() {
         return isGitHubModelsOptInFlag(System.getenv("GITHUB_MODELS"));
     }
 
@@ -1647,12 +1649,30 @@ public class LlmClient {
         return url + (url.contains("?") ? "&" : "?") + "api-version=" + resolveAzureApiVersion();
     }
 
+    /**
+     * Deployment name embedded in Azure chat URLs. Prefer the configured model (usually set by
+     * {@link #resolveAzureOpenAiModel()}), then {@code AZURE_OPENAI_DEPLOYMENT_NAME}, then a generic fallback.
+     */
+    String resolveAzureDeploymentNameForChatUrl() {
+        return resolveAzureDeploymentNameForChatUrl(model, System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"));
+    }
+
+    static String resolveAzureDeploymentNameForChatUrl(String configuredModel, String deploymentFromEnv) {
+        if (configuredModel != null && !configuredModel.isBlank()) {
+            return configuredModel;
+        }
+        if (deploymentFromEnv != null && !deploymentFromEnv.isBlank()) {
+            return deploymentFromEnv;
+        }
+        return DEFAULT_AZURE_DEPLOYMENT_FALLBACK;
+    }
+
     String normalizeAzureOpenAiChatUrl(String endpoint) {
         String u = stripTrailingSlash(endpoint);
         if (u.contains("/openai/deployments/") && u.contains("/chat/completions")) {
             return appendAzureApiVersionQuery(u);
         }
-        String deployment = (model != null && !model.isBlank()) ? model : "gpt-4o";
+        String deployment = resolveAzureDeploymentNameForChatUrl();
         String base = azureResourceBase(u);
         return appendAzureApiVersionQuery(
                 base + "/openai/deployments/" + deployment + "/chat/completions");

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -52,7 +52,7 @@ public class LlmClient {
     private static final String DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
     private static final String DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
     private static final String DEFAULT_OLLAMA_MODEL = "llama3.2";
-    private static final String DEFAULT_GITHUB_MODELS_URL = "https://models.inference.ai.azure.com";
+    private static final String DEFAULT_GITHUB_MODELS_URL = "https://models.github.ai/inference";
     private static final String DEFAULT_AZURE_API_VERSION = "2024-10-21";
     private static final int CONNECT_TIMEOUT_SECONDS = 10;
     private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 5;
@@ -317,7 +317,9 @@ public class LlmClient {
                 .findFirst()
                 .map(k -> {
                     apiKey = k;
-                    openAiAuthMode = OpenAiAuthMode.bearer;
+                    if (openAiAuthMode != OpenAiAuthMode.api_key) {
+                        openAiAuthMode = OpenAiAuthMode.bearer;
+                    }
                     return k;
                 })
                 .orElse(null);
@@ -1394,13 +1396,17 @@ public class LlmClient {
             azureApiVersion = version;
         }
         String deployment = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
-        if (deployment != null && !deployment.isBlank()) {
+        if (deployment != null && !deployment.isBlank()
+                && (model == null || model.isBlank() || DEFAULT_OLLAMA_MODEL.equals(model))) {
             model = deployment;
         }
         return true;
     }
 
     private boolean tryGitHubModels() {
+        if (!isGitHubModelsAutoDetectEnabled()) {
+            return false;
+        }
         String token = System.getenv("GITHUB_TOKEN");
         if (token == null || token.isBlank()) {
             return false;
@@ -1410,6 +1416,15 @@ public class LlmClient {
         openAiAuthMode = OpenAiAuthMode.bearer;
         url = DEFAULT_GITHUB_MODELS_URL;
         return true;
+    }
+
+    static boolean isGitHubModelsAutoDetectEnabled() {
+        String flag = System.getenv("GITHUB_MODELS");
+        return flag != null && !flag.isBlank() && !"0".equals(flag) && !"false".equalsIgnoreCase(flag);
+    }
+
+    static boolean isGitHubModelsEndpoint(String endpoint) {
+        return endpoint != null && endpoint.contains("models.github.ai");
     }
 
     private boolean tryInfraOllama() {
@@ -1501,22 +1516,32 @@ public class LlmClient {
     boolean isEndpointReachable(String endpoint) {
         if (isAzureOpenAiEndpoint(endpoint)) {
             String base = azureResourceBase(stripTrailingSlash(endpoint));
-            return tryHealthCheck(appendAzureApiVersionQuery(base + "/openai/models"));
+            String healthUrl = appendAzureApiVersionQuery(base + "/openai/models");
+            return tryHealthCheck(healthUrl, buildOpenAiAuthHeaders(resolveApiKey()), true);
         }
-        return tryHealthCheck(endpoint + "/api/tags")
-                || tryHealthCheck(endpoint + "/v1/models")
-                || tryHealthCheck(endpoint);
+        return tryHealthCheck(endpoint + "/api/tags", Map.of(), false)
+                || tryHealthCheck(endpoint + "/v1/models", Map.of(), false)
+                || tryHealthCheck(endpoint, Map.of(), false);
     }
 
     private boolean tryHealthCheck(String healthUrl) {
+        return tryHealthCheck(healthUrl, Map.of(), false);
+    }
+
+    private boolean tryHealthCheck(String healthUrl, Map<String, String> headers, boolean azureEndpoint) {
         try {
-            HttpRequest request = HttpRequest.newBuilder()
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
                     .uri(URI.create(healthUrl))
                     .timeout(Duration.ofSeconds(HEALTH_CHECK_TIMEOUT_SECONDS))
-                    .GET()
-                    .build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            return response.statusCode() == 200;
+                    .GET();
+            headers.forEach(builder::header);
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            int status = response.statusCode();
+            if (status == 200) {
+                return true;
+            }
+            // Azure returns 401 without a valid key; treat as reachable when probing explicit URLs with a key configured
+            return azureEndpoint && status == 401 && !headers.isEmpty();
         } catch (Exception e) {
             return false;
         }
@@ -1617,6 +1642,12 @@ public class LlmClient {
 
     String normalizeOpenAiUrl(String endpoint) {
         String u = stripTrailingSlash(endpoint);
+        if (isGitHubModelsEndpoint(u)) {
+            if (u.endsWith("/chat/completions")) {
+                return u;
+            }
+            return u + "/chat/completions";
+        }
         if (isAzureOpenAiEndpoint(u)) {
             return normalizeAzureOpenAiChatUrl(u);
         }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -52,6 +52,8 @@ public class LlmClient {
     private static final String DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
     private static final String DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
     private static final String DEFAULT_OLLAMA_MODEL = "llama3.2";
+    private static final String DEFAULT_GITHUB_MODELS_URL = "https://models.inference.ai.azure.com";
+    private static final String DEFAULT_AZURE_API_VERSION = "2024-10-21";
     private static final int CONNECT_TIMEOUT_SECONDS = 10;
     private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 5;
 
@@ -65,6 +67,11 @@ public class LlmClient {
         ollama,
         openai,
         anthropic
+    }
+
+    enum OpenAiAuthMode {
+        bearer,
+        api_key
     }
 
     // -- Unified abstractions for tool-calling across API formats --
@@ -156,6 +163,10 @@ public class LlmClient {
     private String vertexRegion;
     private String vertexProjectId;
 
+    /** Azure OpenAI uses {@code api-key} instead of {@code Authorization: Bearer}. */
+    private OpenAiAuthMode openAiAuthMode = OpenAiAuthMode.bearer;
+    private String azureApiVersion = DEFAULT_AZURE_API_VERSION;
+
     public String model() {
         return model;
     }
@@ -229,18 +240,23 @@ public class LlmClient {
         } else if (apiType != null) {
             found = switch (apiType) {
                 case anthropic -> tryAnthropicOrVertex();
-                case openai -> tryOpenAi();
+                case openai -> tryAzureOpenAi() || tryGitHubModels() || tryOpenAi();
                 case ollama -> tryInfraOllama() || tryDefaultOllama();
             };
         } else {
-            // auto-detect priority: anthropic → vertex → openai → ollama
+            // auto-detect priority: anthropic → vertex → azure openai → github models → openai → ollama
             found = tryAnthropicApiKey()
                     || tryVertexAi()
+                    || tryAzureOpenAi()
+                    || tryGitHubModels()
                     || tryOpenAi()
                     || tryInfraOllama()
                     || tryDefaultOllama();
         }
         if (found) {
+            if (apiType == ApiType.openai && url != null && isAzureOpenAiEndpoint(url)) {
+                openAiAuthMode = OpenAiAuthMode.api_key;
+            }
             applyDefaultModel();
         }
         return found;
@@ -288,12 +304,20 @@ public class LlmClient {
             // Vertex AI uses gcloud token, not API key
             return null;
         }
+        if (apiType == ApiType.openai && openAiAuthMode == OpenAiAuthMode.api_key) {
+            String key = System.getenv("AZURE_OPENAI_API_KEY");
+            if (key != null && !key.isBlank()) {
+                apiKey = key;
+                return key;
+            }
+        }
         return Stream.of("OPENAI_API_KEY", "LLM_API_KEY")
                 .map(System::getenv)
                 .filter(k -> k != null && !k.isBlank())
                 .findFirst()
                 .map(k -> {
                     apiKey = k;
+                    openAiAuthMode = OpenAiAuthMode.bearer;
                     return k;
                 })
                 .orElse(null);
@@ -345,13 +369,22 @@ public class LlmClient {
     }
 
     private List<String> listOpenAiModels() {
-        Map<String, String> headers = new HashMap<>();
-        String key = resolveApiKey();
-        if (key != null) {
-            headers.put("Authorization", "Bearer " + key);
-        }
+        Map<String, String> headers = buildOpenAiAuthHeaders(resolveApiKey());
         JsonObject response = sendGetRequest(normalizeOpenAiModelsUrl(url), headers);
         return extractStringList(response, "data", "id");
+    }
+
+    Map<String, String> buildOpenAiAuthHeaders(String key) {
+        Map<String, String> headers = new HashMap<>();
+        if (key == null || key.isBlank()) {
+            return headers;
+        }
+        if (openAiAuthMode == OpenAiAuthMode.api_key) {
+            headers.put("api-key", key);
+        } else {
+            headers.put("Authorization", "Bearer " + key);
+        }
+        return headers;
     }
 
     private List<String> listAnthropicModels() {
@@ -380,7 +413,10 @@ public class LlmClient {
     }
 
     String normalizeOpenAiModelsUrl(String endpoint) {
-        String u = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+        String u = stripTrailingSlash(endpoint);
+        if (isAzureOpenAiEndpoint(u)) {
+            return appendAzureApiVersionQuery(azureResourceBase(u) + "/openai/models");
+        }
         // A configured full chat endpoint (.../v1/chat/completions) shares the same /v1 base as the models
         // endpoint, so strip the chat suffix rather than appending /v1/models onto it.
         if (u.endsWith("/v1/chat/completions")) {
@@ -1080,7 +1116,7 @@ public class LlmClient {
                     .POST(HttpRequest.BodyPublishers.ofString(jsonBody));
 
             if (authKey != null && !authKey.isBlank()) {
-                builder.header("Authorization", "Bearer " + authKey);
+                applyOpenAiAuthorization(builder, authKey);
             }
 
             HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
@@ -1152,7 +1188,7 @@ public class LlmClient {
                     .POST(HttpRequest.BodyPublishers.ofString(body.toJson()));
 
             if (authKey != null && !authKey.isBlank()) {
-                builder.header("Authorization", "Bearer " + authKey);
+                applyOpenAiAuthorization(builder, authKey);
             }
 
             HttpResponse<Stream<String>> response = httpClient.send(
@@ -1334,12 +1370,46 @@ public class LlmClient {
         if (key != null && !key.isBlank()) {
             apiType = ApiType.openai;
             apiKey = key;
+            openAiAuthMode = OpenAiAuthMode.bearer;
             if (url == null || url.isBlank()) {
                 url = "https://api.openai.com";
             }
             return true;
         }
         return false;
+    }
+
+    private boolean tryAzureOpenAi() {
+        String key = System.getenv("AZURE_OPENAI_API_KEY");
+        String endpoint = System.getenv("AZURE_OPENAI_ENDPOINT");
+        if (key == null || key.isBlank() || endpoint == null || endpoint.isBlank()) {
+            return false;
+        }
+        apiType = ApiType.openai;
+        apiKey = key;
+        openAiAuthMode = OpenAiAuthMode.api_key;
+        url = stripTrailingSlash(endpoint);
+        String version = System.getenv("AZURE_OPENAI_API_VERSION");
+        if (version != null && !version.isBlank()) {
+            azureApiVersion = version;
+        }
+        String deployment = System.getenv("AZURE_OPENAI_DEPLOYMENT_NAME");
+        if (deployment != null && !deployment.isBlank()) {
+            model = deployment;
+        }
+        return true;
+    }
+
+    private boolean tryGitHubModels() {
+        String token = System.getenv("GITHUB_TOKEN");
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        apiType = ApiType.openai;
+        apiKey = token;
+        openAiAuthMode = OpenAiAuthMode.bearer;
+        url = DEFAULT_GITHUB_MODELS_URL;
+        return true;
     }
 
     private boolean tryInfraOllama() {
@@ -1429,6 +1499,10 @@ public class LlmClient {
     }
 
     boolean isEndpointReachable(String endpoint) {
+        if (isAzureOpenAiEndpoint(endpoint)) {
+            String base = azureResourceBase(stripTrailingSlash(endpoint));
+            return tryHealthCheck(appendAzureApiVersionQuery(base + "/openai/models"));
+        }
         return tryHealthCheck(endpoint + "/api/tags")
                 || tryHealthCheck(endpoint + "/v1/models")
                 || tryHealthCheck(endpoint);
@@ -1481,8 +1555,71 @@ public class LlmClient {
 
     // ---- URL helpers ----
 
+    static boolean isAzureOpenAiEndpoint(String endpoint) {
+        if (endpoint == null || endpoint.isBlank()) {
+            return false;
+        }
+        return endpoint.contains(".openai.azure.com") || endpoint.contains("/openai/deployments/");
+    }
+
+    static String stripTrailingSlash(String endpoint) {
+        if (endpoint == null || endpoint.isEmpty()) {
+            return endpoint;
+        }
+        return endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+    }
+
+    String azureResourceBase(String endpoint) {
+        String u = stripTrailingSlash(endpoint);
+        int openAiPath = u.indexOf("/openai");
+        if (openAiPath > 0) {
+            return u.substring(0, openAiPath);
+        }
+        return u;
+    }
+
+    String resolveAzureApiVersion() {
+        String fromEnv = System.getenv("AZURE_OPENAI_API_VERSION");
+        if (fromEnv != null && !fromEnv.isBlank()) {
+            return fromEnv;
+        }
+        return azureApiVersion != null ? azureApiVersion : DEFAULT_AZURE_API_VERSION;
+    }
+
+    String appendAzureApiVersionQuery(String url) {
+        if (url.contains("api-version=")) {
+            return url;
+        }
+        return url + (url.contains("?") ? "&" : "?") + "api-version=" + resolveAzureApiVersion();
+    }
+
+    String normalizeAzureOpenAiChatUrl(String endpoint) {
+        String u = stripTrailingSlash(endpoint);
+        if (u.contains("/openai/deployments/") && u.contains("/chat/completions")) {
+            return appendAzureApiVersionQuery(u);
+        }
+        String deployment = (model != null && !model.isBlank()) ? model : "gpt-4o";
+        String base = azureResourceBase(u);
+        return appendAzureApiVersionQuery(
+                base + "/openai/deployments/" + deployment + "/chat/completions");
+    }
+
+    void applyOpenAiAuthorization(HttpRequest.Builder builder, String authKey) {
+        if (authKey == null || authKey.isBlank()) {
+            return;
+        }
+        if (apiType == ApiType.openai && openAiAuthMode == OpenAiAuthMode.api_key) {
+            builder.header("api-key", authKey);
+        } else {
+            builder.header("Authorization", "Bearer " + authKey);
+        }
+    }
+
     String normalizeOpenAiUrl(String endpoint) {
-        String u = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+        String u = stripTrailingSlash(endpoint);
+        if (isAzureOpenAiEndpoint(u)) {
+            return normalizeAzureOpenAiChatUrl(u);
+        }
         if (!u.endsWith("/v1/chat/completions")) {
             u = u.endsWith("/v1") ? u : u + "/v1";
             u = u + "/chat/completions";

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
@@ -48,6 +48,13 @@ class LlmClientAzureGitHubTest {
     }
 
     @Test
+    void resolveAzureDeploymentNameForChatUrlPrefersModelThenEnvThenFallback() {
+        assertThat(LlmClient.resolveAzureDeploymentNameForChatUrl("my-deploy", "from-env")).isEqualTo("my-deploy");
+        assertThat(LlmClient.resolveAzureDeploymentNameForChatUrl(null, "from-env")).isEqualTo("from-env");
+        assertThat(LlmClient.resolveAzureDeploymentNameForChatUrl(null, null)).isEqualTo("gpt-4o");
+    }
+
+    @Test
     void normalizeOpenAiUrlBuildsAzureDeploymentChatPathWithApiVersion() {
         LlmClient client = LlmClient.create()
                 .withApiType(LlmClient.ApiType.openai)

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
@@ -79,8 +79,13 @@ class LlmClientAzureGitHubTest {
     void normalizeOpenAiUrlNormalizesGitHubModelsHostLikeOpenAiCompatibleApi() {
         LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
 
-        assertThat(client.normalizeOpenAiUrl("https://models.inference.ai.azure.com"))
-                .isEqualTo("https://models.inference.ai.azure.com/v1/chat/completions");
+        assertThat(client.normalizeOpenAiUrl("https://models.github.ai/inference"))
+                .isEqualTo("https://models.github.ai/inference/chat/completions");
+    }
+
+    @Test
+    void isGitHubModelsAutoDetectRequiresExplicitOptIn() {
+        assertThat(LlmClient.isGitHubModelsAutoDetectEnabled()).isFalse();
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmClientAzureGitHubTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void isAzureOpenAiEndpointDetectsResourceHostAndDeploymentPaths() {
+        assertThat(LlmClient.isAzureOpenAiEndpoint("https://myresource.openai.azure.com")).isTrue();
+        assertThat(LlmClient.isAzureOpenAiEndpoint("http://127.0.0.1:8080/openai/deployments/gpt-4o")).isTrue();
+        assertThat(LlmClient.isAzureOpenAiEndpoint("https://models.inference.ai.azure.com")).isFalse();
+        assertThat(LlmClient.isAzureOpenAiEndpoint("https://api.openai.com")).isFalse();
+    }
+
+    @Test
+    void normalizeOpenAiUrlBuildsAzureDeploymentChatPathWithApiVersion() {
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.openai)
+                .withModel("gpt-4o-deployment");
+
+        String chatUrl = client.normalizeOpenAiUrl("https://myresource.openai.azure.com/");
+
+        assertThat(chatUrl).isEqualTo(
+                "https://myresource.openai.azure.com/openai/deployments/gpt-4o-deployment/chat/completions?api-version=2024-10-21");
+    }
+
+    @Test
+    void normalizeOpenAiUrlPreservesExistingAzureChatCompletionsUrl() {
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
+        String input = "https://myresource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01";
+
+        assertThat(client.normalizeOpenAiUrl(input)).isEqualTo(input);
+    }
+
+    @Test
+    void normalizeOpenAiUrlStillNormalizesStandardOpenAiHost() {
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
+
+        assertThat(client.normalizeOpenAiUrl("https://api.openai.com"))
+                .isEqualTo("https://api.openai.com/v1/chat/completions");
+    }
+
+    @Test
+    void normalizeOpenAiUrlNormalizesGitHubModelsHostLikeOpenAiCompatibleApi() {
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
+
+        assertThat(client.normalizeOpenAiUrl("https://models.inference.ai.azure.com"))
+                .isEqualTo("https://models.inference.ai.azure.com/v1/chat/completions");
+    }
+
+    @Test
+    void normalizeOpenAiModelsUrlBuildsAzureModelsPathWithApiVersion() {
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
+
+        assertThat(client.normalizeOpenAiModelsUrl("https://myresource.openai.azure.com"))
+                .isEqualTo("https://myresource.openai.azure.com/openai/models?api-version=2024-10-21");
+    }
+
+    @Test
+    void buildOpenAiAuthHeadersUsesBearerForStandardOpenAi() {
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai).withApiKey("sk-test");
+
+        assertThat(client.buildOpenAiAuthHeaders("sk-test"))
+                .containsEntry("Authorization", "Bearer sk-test")
+                .doesNotContainKey("api-key");
+    }
+
+    @Test
+    void listsAzureOpenAiModelsWithApiKeyHeader() throws IOException {
+        AtomicReference<String> apiKeyHeader = new AtomicReference<>();
+        String baseUrl = startAzureModelsServer(apiKeyHeader);
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.openai)
+                .withUrl(baseUrl + "/openai/deployments/list-test")
+                .withApiKey("azure-secret");
+
+        assertThat(client.detectEndpoint()).isTrue();
+        assertThat(client.listModels()).containsExactly("deployment-a", "deployment-b");
+        assertThat(apiKeyHeader.get()).isEqualTo("azure-secret");
+        assertThat(client.buildOpenAiAuthHeaders("azure-secret")).containsEntry("api-key", "azure-secret");
+    }
+
+    @Test
+    void listsGitHubModelsWithBearerAuth() throws IOException {
+        AtomicReference<String> authHeader = new AtomicReference<>();
+        String baseUrl = startOpenAiCompatibleModelsServer(authHeader);
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.openai)
+                .withUrl(baseUrl)
+                .withApiKey("ghp_test");
+
+        assertThat(client.detectEndpoint()).isTrue();
+        assertThat(client.listModels()).containsExactly("gpt-4o", "gpt-4o-mini");
+        assertThat(authHeader.get()).isEqualTo("Bearer ghp_test");
+    }
+
+    private String startAzureModelsServer(AtomicReference<String> capturedApiKey) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/openai/models", exchange -> {
+            if (capturedApiKey != null) {
+                capturedApiKey.set(exchange.getRequestHeaders().getFirst("api-key"));
+            }
+            String query = exchange.getRequestURI().getQuery();
+            if (query == null || !query.contains("api-version=")) {
+                exchange.sendResponseHeaders(400, -1);
+                exchange.close();
+                return;
+            }
+            byte[] bytes = "{\"data\":[{\"id\":\"deployment-a\"},{\"id\":\"deployment-b\"}]}"
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    private String startOpenAiCompatibleModelsServer(AtomicReference<String> capturedAuth) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/v1/models", exchange -> {
+            if (capturedAuth != null) {
+                capturedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            }
+            byte[] bytes = "{\"data\":[{\"id\":\"gpt-4o\"},{\"id\":\"gpt-4o-mini\"}]}"
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureGitHubTest.java
@@ -89,6 +89,31 @@ class LlmClientAzureGitHubTest {
     }
 
     @Test
+    void isGitHubModelsOptInFlagRejectsDisabledValues() {
+        assertThat(LlmClient.isGitHubModelsOptInFlag(null)).isFalse();
+        assertThat(LlmClient.isGitHubModelsOptInFlag("")).isFalse();
+        assertThat(LlmClient.isGitHubModelsOptInFlag("0")).isFalse();
+        assertThat(LlmClient.isGitHubModelsOptInFlag("false")).isFalse();
+        assertThat(LlmClient.isGitHubModelsOptInFlag("FALSE")).isFalse();
+        assertThat(LlmClient.isGitHubModelsOptInFlag("1")).isTrue();
+        assertThat(LlmClient.isGitHubModelsOptInFlag("true")).isTrue();
+    }
+
+    @Test
+    void detectEndpointReplacesLlamaPlaceholderWithFirstAzureDeploymentFromModelsApi() throws IOException {
+        AtomicReference<String> apiKeyHeader = new AtomicReference<>();
+        String baseUrl = startAzureModelsServer(apiKeyHeader);
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.openai)
+                .withUrl(baseUrl + "/openai/deployments/ignored")
+                .withApiKey("azure-secret")
+                .withModel("llama3.2");
+
+        assertThat(client.detectEndpoint()).isTrue();
+        assertThat(client.model()).isEqualTo("deployment-a");
+    }
+
+    @Test
     void normalizeOpenAiModelsUrlBuildsAzureModelsPathWithApiVersion() {
         LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
 

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientAzureTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class LlmClientAzureGitHubTest {
+class LlmClientAzureTest {
 
     private HttpServer server;
 
@@ -83,30 +83,6 @@ class LlmClientAzureGitHubTest {
     }
 
     @Test
-    void normalizeOpenAiUrlNormalizesGitHubModelsHostLikeOpenAiCompatibleApi() {
-        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.openai);
-
-        assertThat(client.normalizeOpenAiUrl("https://models.github.ai/inference"))
-                .isEqualTo("https://models.github.ai/inference/chat/completions");
-    }
-
-    @Test
-    void isGitHubModelsAutoDetectRequiresExplicitOptIn() {
-        assertThat(LlmClient.isGitHubModelsAutoDetectEnabled()).isFalse();
-    }
-
-    @Test
-    void isGitHubModelsOptInFlagRejectsDisabledValues() {
-        assertThat(LlmClient.isGitHubModelsOptInFlag(null)).isFalse();
-        assertThat(LlmClient.isGitHubModelsOptInFlag("")).isFalse();
-        assertThat(LlmClient.isGitHubModelsOptInFlag("0")).isFalse();
-        assertThat(LlmClient.isGitHubModelsOptInFlag("false")).isFalse();
-        assertThat(LlmClient.isGitHubModelsOptInFlag("FALSE")).isFalse();
-        assertThat(LlmClient.isGitHubModelsOptInFlag("1")).isTrue();
-        assertThat(LlmClient.isGitHubModelsOptInFlag("true")).isTrue();
-    }
-
-    @Test
     void detectEndpointReplacesLlamaPlaceholderWithFirstAzureDeploymentFromModelsApi() throws IOException {
         AtomicReference<String> apiKeyHeader = new AtomicReference<>();
         String baseUrl = startAzureModelsServer(apiKeyHeader);
@@ -152,20 +128,6 @@ class LlmClientAzureGitHubTest {
         assertThat(client.buildOpenAiAuthHeaders("azure-secret")).containsEntry("api-key", "azure-secret");
     }
 
-    @Test
-    void listsGitHubModelsWithBearerAuth() throws IOException {
-        AtomicReference<String> authHeader = new AtomicReference<>();
-        String baseUrl = startOpenAiCompatibleModelsServer(authHeader);
-        LlmClient client = LlmClient.create()
-                .withApiType(LlmClient.ApiType.openai)
-                .withUrl(baseUrl)
-                .withApiKey("ghp_test");
-
-        assertThat(client.detectEndpoint()).isTrue();
-        assertThat(client.listModels()).containsExactly("gpt-4o", "gpt-4o-mini");
-        assertThat(authHeader.get()).isEqualTo("Bearer ghp_test");
-    }
-
     private String startAzureModelsServer(AtomicReference<String> capturedApiKey) throws IOException {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/openai/models", exchange -> {
@@ -179,23 +141,6 @@ class LlmClientAzureGitHubTest {
                 return;
             }
             byte[] bytes = "{\"data\":[{\"id\":\"deployment-a\"},{\"id\":\"deployment-b\"}]}"
-                    .getBytes(StandardCharsets.UTF_8);
-            exchange.sendResponseHeaders(200, bytes.length);
-            try (OutputStream os = exchange.getResponseBody()) {
-                os.write(bytes);
-            }
-        });
-        server.start();
-        return "http://127.0.0.1:" + server.getAddress().getPort();
-    }
-
-    private String startOpenAiCompatibleModelsServer(AtomicReference<String> capturedAuth) throws IOException {
-        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext("/v1/models", exchange -> {
-            if (capturedAuth != null) {
-                capturedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
-            }
-            byte[] bytes = "{\"data\":[{\"id\":\"gpt-4o\"},{\"id\":\"gpt-4o-mini\"}]}"
                     .getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, bytes.length);
             try (OutputStream os = exchange.getResponseBody()) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -291,7 +291,7 @@ class AiPanel {
             client = created;
             if (!client.detectEndpoint()) {
                 initError
-                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_MODELS+GITHUB_TOKEN, OPENAI_API_KEY, or start Ollama.";
+                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, OPENAI_API_KEY, or start Ollama.";
                 client = null;
                 return;
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -290,7 +290,8 @@ class AiPanel {
             }
             client = created;
             if (!client.detectEndpoint()) {
-                initError = "No LLM service reachable. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or start Ollama.";
+                initError
+                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_TOKEN, OPENAI_API_KEY, or start Ollama.";
                 client = null;
                 return;
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -291,7 +291,7 @@ class AiPanel {
             client = created;
             if (!client.detectEndpoint()) {
                 initError
-                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_TOKEN, OPENAI_API_KEY, or start Ollama.";
+                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_MODELS+GITHUB_TOKEN, OPENAI_API_KEY, or start Ollama.";
                 client = null;
                 return;
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -290,7 +290,7 @@ class DoctorPopup {
             provider = "Vertex AI";
         } else if (envSet("AZURE_OPENAI_API_KEY") && envSet("AZURE_OPENAI_ENDPOINT")) {
             provider = "Azure OpenAI";
-        } else if (envSet("GITHUB_MODELS") && envSet("GITHUB_TOKEN")) {
+        } else if (LlmClient.isGitHubModelsAutoDetectEnabled() && envSet("GITHUB_TOKEN")) {
             provider = "GitHub Models";
         } else if (envSet("OPENAI_API_KEY")) {
             provider = "OpenAI";

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -39,6 +39,7 @@ import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.apache.camel.dsl.jbang.core.commands.LlmClient;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.tooling.maven.MavenDownloaderImpl;
 import org.apache.camel.tooling.maven.MavenResolutionException;

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -39,7 +39,6 @@ import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
-import org.apache.camel.dsl.jbang.core.commands.LlmClient;
 import org.apache.camel.dsl.jbang.core.common.VersionHelper;
 import org.apache.camel.tooling.maven.MavenDownloaderImpl;
 import org.apache.camel.tooling.maven.MavenResolutionException;
@@ -291,8 +290,6 @@ class DoctorPopup {
             provider = "Vertex AI";
         } else if (envSet("AZURE_OPENAI_API_KEY") && envSet("AZURE_OPENAI_ENDPOINT")) {
             provider = "Azure OpenAI";
-        } else if (LlmClient.isGitHubModelsAutoDetectEnabled() && envSet("GITHUB_TOKEN")) {
-            provider = "GitHub Models";
         } else if (envSet("OPENAI_API_KEY")) {
             provider = "OpenAI";
         } else if (envSet("LLM_API_KEY")) {
@@ -311,7 +308,7 @@ class DoctorPopup {
                     Span.raw(String.format("%-30s", "No API key configured")),
                     Span.raw(" " + TuiIcons.WARN)));
             result.add(Line.from(Span.styled(
-                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_MODELS+GITHUB_TOKEN, or OPENAI_API_KEY",
+                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, or OPENAI_API_KEY",
                     Style.EMPTY.dim())));
         }
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -290,7 +290,7 @@ class DoctorPopup {
             provider = "Vertex AI";
         } else if (envSet("AZURE_OPENAI_API_KEY") && envSet("AZURE_OPENAI_ENDPOINT")) {
             provider = "Azure OpenAI";
-        } else if (envSet("GITHUB_TOKEN")) {
+        } else if (envSet("GITHUB_MODELS") && envSet("GITHUB_TOKEN")) {
             provider = "GitHub Models";
         } else if (envSet("OPENAI_API_KEY")) {
             provider = "OpenAI";
@@ -310,7 +310,7 @@ class DoctorPopup {
                     Span.raw(String.format("%-30s", "No API key configured")),
                     Span.raw(" " + TuiIcons.WARN)));
             result.add(Line.from(Span.styled(
-                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_TOKEN, or OPENAI_API_KEY",
+                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_MODELS+GITHUB_TOKEN, or OPENAI_API_KEY",
                     Style.EMPTY.dim())));
         }
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -288,6 +288,10 @@ class DoctorPopup {
             provider = "Anthropic";
         } else if (envSet("CLOUD_ML_REGION") && envSet("ANTHROPIC_VERTEX_PROJECT_ID")) {
             provider = "Vertex AI";
+        } else if (envSet("AZURE_OPENAI_API_KEY") && envSet("AZURE_OPENAI_ENDPOINT")) {
+            provider = "Azure OpenAI";
+        } else if (envSet("GITHUB_TOKEN")) {
+            provider = "GitHub Models";
         } else if (envSet("OPENAI_API_KEY")) {
             provider = "OpenAI";
         } else if (envSet("LLM_API_KEY")) {
@@ -305,7 +309,8 @@ class DoctorPopup {
                     Span.styled(String.format("%-14s", "AI"), Theme.muted()),
                     Span.raw(String.format("%-30s", "No API key configured")),
                     Span.raw(" " + TuiIcons.WARN)));
-            result.add(Line.from(Span.styled("                    Set ANTHROPIC_API_KEY or OPENAI_API_KEY",
+            result.add(Line.from(Span.styled(
+                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GITHUB_TOKEN, or OPENAI_API_KEY",
                     Style.EMPTY.dim())));
         }
     }


### PR DESCRIPTION
## Summary

- Extend `LlmClient` auto-detection for **Azure OpenAI** (`AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`, optional `AZURE_OPENAI_DEPLOYMENT_NAME` and `AZURE_OPENAI_API_VERSION`).
- Azure uses the **`api-key`** header and deployment-style chat URLs; deployment name resolution uses configured model → env → fallback.
- Azure explicit-URL reachability probes send auth and treat HTTP 401 as reachable when a key is configured.
- TUI Doctor/AI panel hints and user manual / **4.22 upgrade guide** updated.

**Note:** GitHub Models support was removed from this PR after review — the service retires 2026-07-30 and should not ship in Camel now.

Fixes: https://issues.apache.org/jira/browse/CAMEL-24276

## Test plan

- [x] `mvn test -pl dsl/camel-jbang/camel-jbang-core -Dtest=LlmClientAzureTest,LlmClientListModelsTest`
- [x] `mvn test -pl dsl/camel-jbang/camel-jbang-plugin-tui -Dtest=TabRegistryTest,AiProviderSelectorTest`

_AI-generated PR description on behalf of atiaomar1978-hub_