### PR TITLE
CAMEL-24275: Native Google Gemini API for Camel JBang TUI

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -56,6 +56,10 @@ instead of hardcoded `3.33.1.1` (https://github.com/apache/camel/commit/d1f4713e
 The Camel CLI and TUI AI prompt (`camel ask`, TUI F8 panel) now auto-detect **Azure OpenAI**
 when `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set (optional `AZURE_OPENAI_DEPLOYMENT_NAME`
 and `AZURE_OPENAI_API_VERSION`). Azure requests use the `api-key` header instead of `Authorization: Bearer`.
+
+The Camel CLI and TUI AI prompt now support native **Google Gemini** when `GEMINI_API_KEY` is set
+(auto-detected before OpenAI). With `--api-type=gemini`, `GOOGLE_API_KEY` is also accepted. Gemini uses
+the `generativelanguage.googleapis.com` API with function-calling support.
 See xref:camel-jbang-ai.adoc[Camel CLI - AI Tools] for the full detection order.
 
 The `camel cmd route-diagram` and `camel cmd route-topology` now accept one or more Camel route source files

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-ai.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-ai.adoc
@@ -117,9 +117,10 @@ All commands auto-detect the LLM provider. The detection order is:
 1. `ANTHROPIC_API_KEY` environment variable → Anthropic API (`ask` and `explain` only)
 2. `CLOUD_ML_REGION` + `ANTHROPIC_VERTEX_PROJECT_ID` → Vertex AI (`ask` and `explain` only)
 3. `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` → Azure OpenAI (uses the `api-key` header; optional `AZURE_OPENAI_DEPLOYMENT_NAME` and `AZURE_OPENAI_API_VERSION`)
-4. `OPENAI_API_KEY` or `LLM_API_KEY` → OpenAI-compatible API
-5. Ollama running via `camel infra` → local Ollama
-6. Ollama at `localhost:11434` → local Ollama
+4. `GEMINI_API_KEY` environment variable → Google Gemini native API (`generativelanguage.googleapis.com`). With `--api-type=gemini`, `GOOGLE_API_KEY` is also accepted.
+5. `OPENAI_API_KEY` or `LLM_API_KEY` → OpenAI-compatible API
+6. Ollama running via `camel infra` → local Ollama
+7. Ollama at `localhost:11434` → local Ollama
 
 Override with explicit options:
 
@@ -127,6 +128,7 @@ Override with explicit options:
 ----
 camel ask "check health" --api-type=anthropic --api-key=sk-...
 camel ask "check health" --api-type=openai --model=gpt-4
+camel ask "check health" --api-type=gemini --model=gemini-2.0-flash
 camel ask "check health" --api-type=ollama --model=llama3.1
 ----
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -767,7 +767,7 @@ public class LlmClient {
             }
         }
         String stopReason = !toolCalls.isEmpty() ? "tool_calls" : finishReason;
-        String contentText = text.length() > 0 ? text.toString() : null;
+        String contentText = !text.isEmpty() ? text.toString() : null;
         return new ChatResponse(contentText, toolCalls, stopReason, false, usage);
     }
 
@@ -794,7 +794,7 @@ public class LlmClient {
                 sb.append(part.getString("text"));
             }
         }
-        return sb.length() > 0 ? sb.toString() : null;
+        return !sb.isEmpty() ? sb.toString() : null;
     }
 
     private TokenUsage extractGeminiUsage(JsonObject response) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -1696,8 +1696,8 @@ public class LlmClient {
             return isEndpointReachable(url);
         }
         for (Map.Entry<String, ApiType> check : EXPLICIT_URL_HEALTH_CHECK_SUFFIXES) {
-            if (check.getValue() == ApiType.gemini && isGeminiEndpoint(url)) {
-                if (isEndpointReachable(url)) {
+            if (check.getValue() == ApiType.gemini) {
+                if (tryDetectGeminiAtExplicitUrl(url)) {
                     apiType = ApiType.gemini;
                     return true;
                 }
@@ -1713,6 +1713,22 @@ public class LlmClient {
             return true;
         }
         return false;
+    }
+
+    private boolean tryDetectGeminiAtExplicitUrl(String endpoint) {
+        if (isGeminiEndpoint(endpoint)) {
+            return isEndpointReachable(endpoint);
+        }
+        String key = apiKey;
+        if (key == null || key.isBlank()) {
+            key = resolveGeminiApiKeyFromEnv();
+        }
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+        apiKey = key;
+        String base = normalizeGeminiBaseUrl(endpoint);
+        return tryHealthCheck(base + "/models", buildGeminiHeaders(key));
     }
 
     private boolean isOllamaRoot(String endpoint) {

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -40,8 +40,8 @@ import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
 /**
- * Shared LLM HTTP client supporting Ollama, OpenAI-compatible, Anthropic (including Vertex AI), and IBM watsonx.ai
- * APIs.
+ * Shared LLM HTTP client supporting Ollama, OpenAI-compatible, Anthropic (including Vertex AI), Google Gemini, and
+ * IBM watsonx.ai APIs.
  */
 public class LlmClient {
 
@@ -58,6 +58,8 @@ public class LlmClient {
     private static final String DEFAULT_AZURE_API_VERSION = "2024-10-21";
     /** Last-resort Azure deployment segment when URL normalization runs before model detection completes. */
     private static final String DEFAULT_AZURE_DEPLOYMENT_FALLBACK = "gpt-4o";
+    private static final String DEFAULT_GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta";
+    private static final String DEFAULT_GEMINI_MODEL = "gemini-2.0-flash";
     private static final int CONNECT_TIMEOUT_SECONDS = 10;
     private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 5;
 
@@ -71,6 +73,7 @@ public class LlmClient {
         ollama,
         openai,
         anthropic,
+        gemini,
         watsonx
     }
 
@@ -246,14 +249,16 @@ public class LlmClient {
             found = switch (apiType) {
                 case anthropic -> tryAnthropicOrVertex();
                 case openai -> tryAzureOpenAi() || tryOpenAi();
+                case gemini -> tryGemini();
                 case ollama -> tryInfraOllama() || tryDefaultOllama();
                 case watsonx -> tryWatsonx();
             };
         } else {
-            // auto-detect priority: anthropic → vertex → azure openai → openai → watsonx → ollama
+            // auto-detect priority: anthropic → vertex → azure openai → gemini → openai → watsonx → ollama
             found = tryAnthropicApiKey()
                     || tryVertexAi()
                     || tryAzureOpenAi()
+                    || tryGemini()
                     || tryOpenAi()
                     || tryWatsonx()
                     || tryInfraOllama()
@@ -290,6 +295,11 @@ public class LlmClient {
                     model = DEFAULT_OPENAI_MODEL;
                 }
             }
+            case gemini -> {
+                if (model == null || model.isBlank() || DEFAULT_OLLAMA_MODEL.equals(model)) {
+                    model = DEFAULT_GEMINI_MODEL;
+                }
+            }
             case ollama -> {
                 if (model == null || model.isBlank()) {
                     model = resolveDefaultOllamaModel();
@@ -316,6 +326,14 @@ public class LlmClient {
                 return key;
             }
             // Vertex AI uses gcloud token, not API key
+            return null;
+        }
+        if (apiType == ApiType.gemini) {
+            String key = resolveGeminiApiKeyFromEnv();
+            if (key != null) {
+                apiKey = key;
+                return key;
+            }
             return null;
         }
         if (apiType == ApiType.watsonx) {
@@ -354,6 +372,7 @@ public class LlmClient {
             case ollama -> generateOllama(systemPrompt, userPrompt);
             case openai, watsonx -> generateOpenAi(systemPrompt, userPrompt);
             case anthropic -> generateAnthropic(systemPrompt, userPrompt);
+            case gemini -> generateGemini(systemPrompt, userPrompt);
         };
     }
 
@@ -364,6 +383,7 @@ public class LlmClient {
             case ollama -> chatOllamaFormat(systemPrompt, messages, tools);
             case openai, watsonx -> chatOpenAiFormat(systemPrompt, messages, tools);
             case anthropic -> chatAnthropicFormat(systemPrompt, messages, tools);
+            case gemini -> chatGeminiFormat(systemPrompt, messages, tools);
         };
     }
 
@@ -384,6 +404,7 @@ public class LlmClient {
             case ollama -> listOllamaModels();
             case openai -> listOpenAiModels();
             case anthropic -> isVertexAi() ? List.of() : listAnthropicModels();
+            case gemini -> listGeminiModels();
             case watsonx -> listWatsonxModels();
         };
     }
@@ -416,6 +437,46 @@ public class LlmClient {
         String base = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
         JsonObject response = sendGetRequest(base + "/v1/models", buildAnthropicHeaders());
         return extractStringList(response, "data", "id");
+    }
+
+    private List<String> listGeminiModels() {
+        String key = resolveGeminiApiKey();
+        if (key == null || key.isBlank()) {
+            return List.of();
+        }
+        String base = normalizeGeminiBaseUrl(url);
+        JsonObject response = sendGetRequest(appendGeminiApiKey(base + "/models", key), Map.of());
+        return extractGeminiModelIds(response);
+    }
+
+    static List<String> extractGeminiModelIds(JsonObject response) {
+        if (response == null || !(response.get("models") instanceof JsonArray models)) {
+            return List.of();
+        }
+        List<String> ids = new ArrayList<>();
+        for (Object obj : models) {
+            if (!(obj instanceof JsonObject model)) {
+                continue;
+            }
+            JsonArray methods = (JsonArray) model.get("supportedGenerationMethods");
+            if (methods != null) {
+                boolean supportsGenerate = false;
+                for (Object method : methods) {
+                    if ("generateContent".equals(String.valueOf(method))) {
+                        supportsGenerate = true;
+                        break;
+                    }
+                }
+                if (!supportsGenerate) {
+                    continue;
+                }
+            }
+            String name = model.getString("name");
+            if (name != null && !name.isBlank()) {
+                ids.add(normalizeGeminiModelId(name));
+            }
+        }
+        return ids;
     }
 
     private List<String> listWatsonxModels() {
@@ -516,6 +577,287 @@ public class LlmClient {
 
         JsonObject response = sendRequest(apiUrl, request, resolvedKey);
         return extractOpenAiContent(response);
+    }
+
+    // ---- Gemini generate ----
+
+    private String generateGemini(String systemPrompt, String userPrompt) {
+        JsonObject request = buildGeminiGenerateRequest(systemPrompt, userPrompt, null);
+        String apiUrl = geminiGenerateContentUrl(resolveGeminiApiKey());
+        JsonObject response = sendGeminiRequest(apiUrl, request);
+        return extractGeminiTextFromResponse(response);
+    }
+
+    private ChatResponse chatGeminiFormat(String systemPrompt, List<Message> messages, List<ToolDef> tools) {
+        JsonObject request = buildGeminiGenerateRequest(systemPrompt, null, tools);
+        request.put("contents", buildGeminiContents(messages));
+        String apiUrl = geminiGenerateContentUrl(resolveGeminiApiKey());
+        JsonObject response = sendGeminiRequest(apiUrl, request);
+        return parseGeminiChatResponse(response);
+    }
+
+    private JsonObject buildGeminiGenerateRequest(String systemPrompt, String userPrompt, List<ToolDef> tools) {
+        JsonObject request = new JsonObject();
+        if (systemPrompt != null && !systemPrompt.isBlank()) {
+            JsonObject systemInstruction = new JsonObject();
+            JsonArray parts = new JsonArray();
+            JsonObject text = new JsonObject();
+            text.put("text", systemPrompt);
+            parts.add(text);
+            systemInstruction.put("parts", parts);
+            request.put("systemInstruction", systemInstruction);
+        }
+        if (userPrompt != null) {
+            JsonArray contents = new JsonArray();
+            JsonObject user = new JsonObject();
+            user.put("role", "user");
+            JsonArray parts = new JsonArray();
+            JsonObject text = new JsonObject();
+            text.put("text", userPrompt);
+            parts.add(text);
+            user.put("parts", parts);
+            contents.add(user);
+            request.put("contents", contents);
+        }
+        JsonObject generationConfig = new JsonObject();
+        generationConfig.put("temperature", temperature);
+        if (maxTokens > 0) {
+            generationConfig.put("maxOutputTokens", maxTokens);
+        }
+        request.put("generationConfig", generationConfig);
+        JsonArray declarations = buildGeminiFunctionDeclarations(tools);
+        if (declarations != null) {
+            JsonObject toolsObj = new JsonObject();
+            toolsObj.put("functionDeclarations", declarations);
+            JsonArray toolsArray = new JsonArray();
+            toolsArray.add(toolsObj);
+            request.put("tools", toolsArray);
+        }
+        return request;
+    }
+
+    JsonObject buildGeminiGenerateRequestForTest(String systemPrompt, List<Message> messages, List<ToolDef> tools) {
+        JsonObject request = buildGeminiGenerateRequest(systemPrompt, null, tools);
+        request.put("contents", buildGeminiContents(messages));
+        return request;
+    }
+
+    private JsonArray buildGeminiContents(List<Message> messages) {
+        JsonArray contents = new JsonArray();
+        for (Message msg : messages) {
+            if (msg.toolCalls() != null && !msg.toolCalls().isEmpty()) {
+                JsonObject modelMsg = new JsonObject();
+                modelMsg.put("role", "model");
+                JsonArray parts = new JsonArray();
+                if (msg.content() != null && !msg.content().isBlank()) {
+                    JsonObject text = new JsonObject();
+                    text.put("text", msg.content());
+                    parts.add(text);
+                }
+                for (ToolCall tc : msg.toolCalls()) {
+                    JsonObject functionCall = new JsonObject();
+                    functionCall.put("name", tc.name());
+                    functionCall.put("args", tc.arguments());
+                    JsonObject part = new JsonObject();
+                    part.put("functionCall", functionCall);
+                    parts.add(part);
+                }
+                modelMsg.put("parts", parts);
+                contents.add(modelMsg);
+            } else if (msg.toolResults() != null && !msg.toolResults().isEmpty()) {
+                JsonObject userMsg = new JsonObject();
+                userMsg.put("role", "user");
+                JsonArray parts = new JsonArray();
+                for (ToolResult tr : msg.toolResults()) {
+                    JsonObject responseBody = new JsonObject();
+                    responseBody.put("content", tr.content());
+                    JsonObject functionResponse = new JsonObject();
+                    functionResponse.put("name", toolResultFunctionName(tr.toolCallId()));
+                    functionResponse.put("response", responseBody);
+                    JsonObject part = new JsonObject();
+                    part.put("functionResponse", functionResponse);
+                    parts.add(part);
+                }
+                userMsg.put("parts", parts);
+                contents.add(userMsg);
+            } else {
+                JsonObject turn = new JsonObject();
+                turn.put("role", "user".equals(msg.role()) ? "user" : "model");
+                JsonArray parts = new JsonArray();
+                JsonObject text = new JsonObject();
+                text.put("text", msg.content());
+                parts.add(text);
+                turn.put("parts", parts);
+                contents.add(turn);
+            }
+        }
+        return contents;
+    }
+
+    private static String toolResultFunctionName(String toolCallId) {
+        if (toolCallId == null || toolCallId.isBlank()) {
+            return "tool";
+        }
+        return toolCallId;
+    }
+
+    private JsonArray buildGeminiFunctionDeclarations(List<ToolDef> tools) {
+        if (tools == null || tools.isEmpty()) {
+            return null;
+        }
+        JsonArray declarations = new JsonArray();
+        for (ToolDef tool : tools) {
+            JsonObject decl = new JsonObject();
+            decl.put("name", tool.name());
+            decl.put("description", tool.description());
+            decl.put("parameters", tool.parameters());
+            declarations.add(decl);
+        }
+        return declarations;
+    }
+
+    ChatResponse parseGeminiChatResponse(JsonObject response) {
+        if (response == null) {
+            return new ChatResponse(null, List.of(), "error", false, TokenUsage.EMPTY);
+        }
+        TokenUsage usage = extractGeminiUsage(response);
+        JsonArray candidates = (JsonArray) response.get("candidates");
+        if (candidates == null || candidates.isEmpty()) {
+            return new ChatResponse(null, List.of(), "error", false, usage);
+        }
+        JsonObject candidate = (JsonObject) candidates.get(0);
+        String finishReason = candidate.getString("finishReason");
+        JsonObject content = (JsonObject) candidate.get("content");
+        if (content == null) {
+            return new ChatResponse(null, List.of(), finishReason, false, usage);
+        }
+        JsonArray parts = (JsonArray) content.get("parts");
+        if (parts == null) {
+            return new ChatResponse(null, List.of(), finishReason, false, usage);
+        }
+        StringBuilder text = new StringBuilder();
+        List<ToolCall> toolCalls = new ArrayList<>();
+        for (Object obj : parts) {
+            if (!(obj instanceof JsonObject part)) {
+                continue;
+            }
+            if (part.get("text") != null) {
+                text.append(part.getString("text"));
+            }
+            JsonObject functionCall = (JsonObject) part.get("functionCall");
+            if (functionCall != null) {
+                String name = functionCall.getString("name");
+                JsonObject args = functionCall.get("args") instanceof JsonObject jo ? jo : new JsonObject();
+                toolCalls.add(new ToolCall(name, name, args));
+            }
+        }
+        String stopReason = !toolCalls.isEmpty() ? "tool_calls" : finishReason;
+        String contentText = text.length() > 0 ? text.toString() : null;
+        return new ChatResponse(contentText, toolCalls, stopReason, false, usage);
+    }
+
+    String extractGeminiTextFromResponse(JsonObject response) {
+        if (response == null) {
+            return null;
+        }
+        JsonArray candidates = (JsonArray) response.get("candidates");
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+        JsonObject candidate = (JsonObject) candidates.get(0);
+        JsonObject content = (JsonObject) candidate.get("content");
+        if (content == null) {
+            return null;
+        }
+        JsonArray parts = (JsonArray) content.get("parts");
+        if (parts == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Object obj : parts) {
+            if (obj instanceof JsonObject part && part.get("text") != null) {
+                sb.append(part.getString("text"));
+            }
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    private TokenUsage extractGeminiUsage(JsonObject response) {
+        JsonObject usageMetadata = (JsonObject) response.get("usageMetadata");
+        if (usageMetadata == null) {
+            return TokenUsage.EMPTY;
+        }
+        int input = getIntValue(usageMetadata, "promptTokenCount");
+        int output = getIntValue(usageMetadata, "candidatesTokenCount");
+        int total = getIntValue(usageMetadata, "totalTokenCount");
+        if (total == 0) {
+            total = input + output;
+        }
+        return new TokenUsage(input, output, total);
+    }
+
+    private JsonObject sendGeminiRequest(String requestUrl, JsonObject body) {
+        return sendRequestWithHeaders(requestUrl, body, Map.of("Content-Type", "application/json"));
+    }
+
+    String geminiGenerateContentUrl(String key) {
+        String base = normalizeGeminiBaseUrl(url);
+        String modelId = normalizeGeminiModelId(model);
+        return appendGeminiApiKey(base + "/models/" + modelId + "%3AgenerateContent", key);
+    }
+
+    static String normalizeGeminiModelId(String modelId) {
+        if (modelId == null) {
+            return DEFAULT_GEMINI_MODEL;
+        }
+        if (modelId.startsWith("models/")) {
+            return modelId.substring("models/".length());
+        }
+        return modelId;
+    }
+
+    static String normalizeGeminiBaseUrl(String endpoint) {
+        if (endpoint == null || endpoint.isBlank()) {
+            return DEFAULT_GEMINI_URL;
+        }
+        String u = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+        if (u.endsWith(":generateContent")) {
+            int modelsIdx = u.indexOf("/models/");
+            if (modelsIdx > 0) {
+                return u.substring(0, modelsIdx);
+            }
+        }
+        return u;
+    }
+
+    static String appendGeminiApiKey(String requestUrl, String key) {
+        if (key == null || key.isBlank()) {
+            return requestUrl;
+        }
+        return requestUrl + (requestUrl.contains("?") ? "&" : "?") + "key=" + key;
+    }
+
+    static boolean isGeminiEndpoint(String endpoint) {
+        return endpoint != null && endpoint.contains("generativelanguage.googleapis.com");
+    }
+
+    private String resolveGeminiApiKey() {
+        if (apiKey != null && !apiKey.isBlank()) {
+            return apiKey;
+        }
+        String key = resolveGeminiApiKeyFromEnv();
+        if (key != null) {
+            apiKey = key;
+        }
+        return key;
+    }
+
+    static String resolveGeminiApiKeyFromEnv() {
+        return Stream.of("GEMINI_API_KEY", "GOOGLE_API_KEY")
+                .map(System::getenv)
+                .filter(k -> k != null && !k.isBlank())
+                .findFirst()
+                .orElse(null);
     }
 
     // ---- Anthropic generate ----
@@ -1321,6 +1663,7 @@ public class LlmClient {
     // Order matters: /api/tags is checked before /v1/models, matching the original priority.
     private static final List<Map.Entry<String, ApiType>> EXPLICIT_URL_HEALTH_CHECK_SUFFIXES = List.of(
             Map.entry("/api/tags", ApiType.ollama),
+            Map.entry("/v1beta/models", ApiType.gemini),
             Map.entry("/v1/models", ApiType.openai));
 
     private boolean tryExplicitUrl() {
@@ -1428,6 +1771,19 @@ public class LlmClient {
         if (deployment != null && !deployment.isBlank()
                 && (model == null || model.isBlank() || isGenericPlaceholderModel(model))) {
             model = deployment;
+        }
+        return true;
+    }
+
+    private boolean tryGemini() {
+        String key = resolveGeminiApiKeyFromEnv();
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+        apiType = ApiType.gemini;
+        apiKey = key;
+        if (url == null || url.isBlank()) {
+            url = DEFAULT_GEMINI_URL;
         }
         return true;
     }
@@ -1561,6 +1917,14 @@ public class LlmClient {
             String base = azureResourceBase(stripTrailingSlash(endpoint));
             String healthUrl = appendAzureApiVersionQuery(base + "/openai/models");
             return tryHealthCheck(healthUrl, buildOpenAiAuthHeaders(resolveApiKey()), true);
+        }
+        if (isGeminiEndpoint(endpoint)) {
+            String key = resolveGeminiApiKey();
+            if (key == null || key.isBlank()) {
+                return false;
+            }
+            String base = normalizeGeminiBaseUrl(endpoint);
+            return tryHealthCheck(appendGeminiApiKey(base + "/models", key));
         }
         return tryHealthCheck(endpoint + "/api/tags", Map.of(), false)
                 || tryHealthCheck(endpoint + "/v1/models", Map.of(), false)

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -1983,6 +1983,10 @@ public class LlmClient {
         return tryHealthCheck(healthUrl, Map.of(), false);
     }
 
+    private boolean tryHealthCheck(String healthUrl, Map<String, String> headers) {
+        return tryHealthCheck(healthUrl, headers, false);
+    }
+
     private boolean tryHealthCheck(String healthUrl, Map<String, String> headers, boolean azureEndpoint) {
         try {
             HttpRequest.Builder builder = HttpRequest.newBuilder()

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -87,7 +87,11 @@ public class LlmClient {
     public record ToolDef(String name, String description, JsonObject parameters) {
     }
 
-    public record ToolCall(String id, String name, JsonObject arguments) {
+    public record ToolCall(String id, String name, JsonObject arguments, String thoughtSignature) {
+
+        public ToolCall(String id, String name, JsonObject arguments) {
+            this(id, name, arguments, null);
+        }
     }
 
     public record ToolResult(String toolCallId, String content) {
@@ -249,7 +253,7 @@ public class LlmClient {
             found = switch (apiType) {
                 case anthropic -> tryAnthropicOrVertex();
                 case openai -> tryAzureOpenAi() || tryOpenAi();
-                case gemini -> tryGemini();
+                case gemini -> tryGemini(true);
                 case ollama -> tryInfraOllama() || tryDefaultOllama();
                 case watsonx -> tryWatsonx();
             };
@@ -258,7 +262,7 @@ public class LlmClient {
             found = tryAnthropicApiKey()
                     || tryVertexAi()
                     || tryAzureOpenAi()
-                    || tryGemini()
+                    || tryGemini(false)
                     || tryOpenAi()
                     || tryWatsonx()
                     || tryInfraOllama()
@@ -445,7 +449,7 @@ public class LlmClient {
             return List.of();
         }
         String base = normalizeGeminiBaseUrl(url);
-        JsonObject response = sendGetRequest(appendGeminiApiKey(base + "/models", key), Map.of());
+        JsonObject response = sendGetRequest(base + "/models", buildGeminiHeaders(key));
         return extractGeminiModelIds(response);
     }
 
@@ -658,6 +662,12 @@ public class LlmClient {
                     JsonObject functionCall = new JsonObject();
                     functionCall.put("name", tc.name());
                     functionCall.put("args", tc.arguments());
+                    if (tc.id() != null && !tc.id().isBlank() && !tc.id().equals(tc.name())) {
+                        functionCall.put("id", tc.id());
+                    }
+                    if (tc.thoughtSignature() != null && !tc.thoughtSignature().isBlank()) {
+                        functionCall.put("thoughtSignature", tc.thoughtSignature());
+                    }
                     JsonObject part = new JsonObject();
                     part.put("functionCall", functionCall);
                     parts.add(part);
@@ -747,8 +757,13 @@ public class LlmClient {
             JsonObject functionCall = (JsonObject) part.get("functionCall");
             if (functionCall != null) {
                 String name = functionCall.getString("name");
+                String callId = functionCall.getString("id");
+                if (callId == null || callId.isBlank()) {
+                    callId = name;
+                }
                 JsonObject args = functionCall.get("args") instanceof JsonObject jo ? jo : new JsonObject();
-                toolCalls.add(new ToolCall(name, name, args));
+                String thoughtSignature = functionCall.getString("thoughtSignature");
+                toolCalls.add(new ToolCall(callId, name, args, thoughtSignature));
             }
         }
         String stopReason = !toolCalls.isEmpty() ? "tool_calls" : finishReason;
@@ -797,13 +812,13 @@ public class LlmClient {
     }
 
     private JsonObject sendGeminiRequest(String requestUrl, JsonObject body) {
-        return sendRequestWithHeaders(requestUrl, body, Map.of("Content-Type", "application/json"));
+        return sendRequestWithHeaders(requestUrl, body, buildGeminiHeaders(resolveGeminiApiKey()));
     }
 
     String geminiGenerateContentUrl(String key) {
         String base = normalizeGeminiBaseUrl(url);
         String modelId = normalizeGeminiModelId(model);
-        return appendGeminiApiKey(base + "/models/" + modelId + "%3AgenerateContent", key);
+        return base + "/models/" + modelId + ":generateContent";
     }
 
     static String normalizeGeminiModelId(String modelId) {
@@ -821,13 +836,22 @@ public class LlmClient {
             return DEFAULT_GEMINI_URL;
         }
         String u = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
-        if (u.endsWith(":generateContent")) {
+        if (u.endsWith(":generateContent") || u.endsWith("%3AgenerateContent")) {
             int modelsIdx = u.indexOf("/models/");
             if (modelsIdx > 0) {
                 return u.substring(0, modelsIdx);
             }
         }
         return u;
+    }
+
+    static Map<String, String> buildGeminiHeaders(String key) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        if (key != null && !key.isBlank()) {
+            headers.put("x-goog-api-key", key);
+        }
+        return headers;
     }
 
     static String appendGeminiApiKey(String requestUrl, String key) {
@@ -858,6 +882,11 @@ public class LlmClient {
                 .filter(k -> k != null && !k.isBlank())
                 .findFirst()
                 .orElse(null);
+    }
+
+    static String resolveGeminiApiKeyFromEnvForAutoDetect() {
+        String key = System.getenv("GEMINI_API_KEY");
+        return key != null && !key.isBlank() ? key : null;
     }
 
     // ---- Anthropic generate ----
@@ -1674,6 +1703,13 @@ public class LlmClient {
             return isEndpointReachable(url);
         }
         for (Map.Entry<String, ApiType> check : EXPLICIT_URL_HEALTH_CHECK_SUFFIXES) {
+            if (check.getValue() == ApiType.gemini && isGeminiEndpoint(url)) {
+                if (isEndpointReachable(url)) {
+                    apiType = ApiType.gemini;
+                    return true;
+                }
+                continue;
+            }
             if (tryHealthCheck(url + check.getKey())) {
                 apiType = check.getValue();
                 return true;
@@ -1775,8 +1811,11 @@ public class LlmClient {
         return true;
     }
 
-    private boolean tryGemini() {
-        String key = resolveGeminiApiKeyFromEnv();
+    private boolean tryGemini(boolean includeGoogleApiKeyEnv) {
+        String key = apiKey;
+        if (key == null || key.isBlank()) {
+            key = includeGoogleApiKeyEnv ? resolveGeminiApiKeyFromEnv() : resolveGeminiApiKeyFromEnvForAutoDetect();
+        }
         if (key == null || key.isBlank()) {
             return false;
         }
@@ -1924,7 +1963,7 @@ public class LlmClient {
                 return false;
             }
             String base = normalizeGeminiBaseUrl(endpoint);
-            return tryHealthCheck(appendGeminiApiKey(base + "/models", key));
+            return tryHealthCheck(base + "/models", buildGeminiHeaders(key));
         }
         return tryHealthCheck(endpoint + "/api/tags", Map.of(), false)
                 || tryHealthCheck(endpoint + "/v1/models", Map.of(), false)

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -40,8 +40,8 @@ import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
 /**
- * Shared LLM HTTP client supporting Ollama, OpenAI-compatible, Anthropic (including Vertex AI), Google Gemini, and
- * IBM watsonx.ai APIs.
+ * Shared LLM HTTP client supporting Ollama, OpenAI-compatible, Anthropic (including Vertex AI), Google Gemini, and IBM
+ * watsonx.ai APIs.
  */
 public class LlmClient {
 

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -587,7 +587,7 @@ public class LlmClient {
 
     private String generateGemini(String systemPrompt, String userPrompt) {
         JsonObject request = buildGeminiGenerateRequest(systemPrompt, userPrompt, null);
-        String apiUrl = geminiGenerateContentUrl(resolveGeminiApiKey());
+        String apiUrl = geminiGenerateContentUrl();
         JsonObject response = sendGeminiRequest(apiUrl, request);
         return extractGeminiTextFromResponse(response);
     }
@@ -595,7 +595,7 @@ public class LlmClient {
     private ChatResponse chatGeminiFormat(String systemPrompt, List<Message> messages, List<ToolDef> tools) {
         JsonObject request = buildGeminiGenerateRequest(systemPrompt, null, tools);
         request.put("contents", buildGeminiContents(messages));
-        String apiUrl = geminiGenerateContentUrl(resolveGeminiApiKey());
+        String apiUrl = geminiGenerateContentUrl();
         JsonObject response = sendGeminiRequest(apiUrl, request);
         return parseGeminiChatResponse(response);
     }
@@ -815,7 +815,7 @@ public class LlmClient {
         return sendRequestWithHeaders(requestUrl, body, buildGeminiHeaders(resolveGeminiApiKey()));
     }
 
-    String geminiGenerateContentUrl(String key) {
+    String geminiGenerateContentUrl() {
         String base = normalizeGeminiBaseUrl(url);
         String modelId = normalizeGeminiModelId(model);
         return base + "/models/" + modelId + ":generateContent";
@@ -852,13 +852,6 @@ public class LlmClient {
             headers.put("x-goog-api-key", key);
         }
         return headers;
-    }
-
-    static String appendGeminiApiKey(String requestUrl, String key) {
-        if (key == null || key.isBlank()) {
-            return requestUrl;
-        }
-        return requestUrl + (requestUrl.contains("?") ? "&" : "?") + "key=" + key;
     }
 
     static boolean isGeminiEndpoint(String endpoint) {

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
@@ -80,7 +80,7 @@ class LlmClientGeminiTest {
                 .withModel("gemini-2.0-flash")
                 .withApiKey("gemini-key");
 
-        assertThat(client.geminiGenerateContentUrl("gemini-key"))
+        assertThat(client.geminiGenerateContentUrl())
                 .isEqualTo(
                         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent");
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
@@ -49,6 +49,16 @@ class LlmClientGeminiTest {
     }
 
     @Test
+    void normalizeGeminiBaseUrlStripsGenerateContentSuffix() {
+        assertThat(LlmClient.normalizeGeminiBaseUrl(
+                "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"))
+                .isEqualTo("https://generativelanguage.googleapis.com/v1beta");
+        assertThat(LlmClient.normalizeGeminiBaseUrl(
+                "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash%3AgenerateContent"))
+                .isEqualTo("https://generativelanguage.googleapis.com/v1beta");
+    }
+
+    @Test
     void extractGeminiModelIdsKeepsGenerateContentModelsOnly() throws Exception {
         String json = """
                 {
@@ -63,7 +73,7 @@ class LlmClientGeminiTest {
     }
 
     @Test
-    void geminiGenerateContentUrlAppendsApiKeyQueryParameter() {
+    void geminiGenerateContentUrlUsesColonActionSegment() {
         LlmClient client = LlmClient.create()
                 .withApiType(LlmClient.ApiType.gemini)
                 .withUrl("https://generativelanguage.googleapis.com/v1beta")
@@ -72,34 +82,52 @@ class LlmClientGeminiTest {
 
         assertThat(client.geminiGenerateContentUrl("gemini-key"))
                 .isEqualTo(
-                        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash%3AgenerateContent?key=gemini-key");
+                        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent");
     }
 
     @Test
-    void listsGeminiModelsWithKeyQueryParameter() throws IOException {
-        AtomicReference<String> query = new AtomicReference<>();
-        String baseUrl = startGeminiModelsServer(query);
+    void listsGeminiModelsWithApiKeyHeader() throws IOException {
+        AtomicReference<String> apiKeyHeader = new AtomicReference<>();
+        String baseUrl = startGeminiModelsServer(apiKeyHeader);
         LlmClient client = LlmClient.create()
                 .withApiType(LlmClient.ApiType.gemini)
                 .withUrl(baseUrl)
                 .withApiKey("gemini-key");
 
         assertThat(client.listModels()).containsExactly("gemini-2.0-flash", "gemini-1.5-flash");
-        assertThat(query.get()).contains("key=gemini-key");
+        assertThat(apiKeyHeader.get()).isEqualTo("gemini-key");
     }
 
     @Test
-    void parseGeminiChatResponseExtractsFunctionCall() throws Exception {
+    void parseGeminiChatResponseExtractsFunctionCallIdArgsAndThoughtSignature() throws Exception {
         String json
                 = """
-                        {"candidates":[{"content":{"parts":[{"functionCall":{"name":"list_routes","args":{"q":"x"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}
+                        {"candidates":[{"content":{"parts":[{"functionCall":{"id":"call-42","name":"list_routes","args":{"q":"x"},"thoughtSignature":"sig-abc"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}
                         """;
         LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.gemini);
         LlmClient.ChatResponse response = client.parseGeminiChatResponse((JsonObject) Jsoner.deserialize(json));
 
         assertThat(response.toolCalls()).hasSize(1);
-        assertThat(response.toolCalls().get(0).name()).isEqualTo("list_routes");
+        LlmClient.ToolCall call = response.toolCalls().get(0);
+        assertThat(call.id()).isEqualTo("call-42");
+        assertThat(call.name()).isEqualTo("list_routes");
+        assertThat(call.arguments().getString("q")).isEqualTo("x");
+        assertThat(call.thoughtSignature()).isEqualTo("sig-abc");
         assertThat(response.stopReason()).isEqualTo("tool_calls");
+    }
+
+    @Test
+    void buildGeminiGenerateRequestPreservesThoughtSignatureOnModelTurn() {
+        JsonObject args = new JsonObject();
+        args.put("q", "x");
+        LlmClient.ToolCall call = new LlmClient.ToolCall("call-42", "list_routes", args, "sig-abc");
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.gemini);
+        JsonObject request = client.buildGeminiGenerateRequestForTest(
+                "system",
+                List.of(LlmClient.Message.assistantWithToolCalls(null, List.of(call))),
+                null);
+
+        assertThat(request.toJson()).contains("thoughtSignature").contains("sig-abc").contains("call-42");
     }
 
     @Test
@@ -126,10 +154,20 @@ class LlmClientGeminiTest {
         assertThat(request.toJson()).contains("functionDeclarations").contains("list_routes");
     }
 
-    private String startGeminiModelsServer(AtomicReference<String> capturedQuery) throws IOException {
+    @Test
+    void detectEndpointAcceptsConfiguredGeminiApiKeyWithoutEnv() {
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.gemini)
+                .withApiKey("configured-key");
+
+        assertThat(client.detectEndpoint()).isTrue();
+        assertThat(client.apiType()).isEqualTo(LlmClient.ApiType.gemini);
+    }
+
+    private String startGeminiModelsServer(AtomicReference<String> capturedApiKeyHeader) throws IOException {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/v1beta/models", exchange -> {
-            capturedQuery.set(exchange.getRequestURI().getQuery());
+            capturedApiKeyHeader.set(exchange.getRequestHeaders().getFirst("x-goog-api-key"));
             byte[] bytes = """
                     {"models":[
                       {"name":"models/gemini-2.0-flash","supportedGenerationMethods":["generateContent"]},

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.Jsoner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmClientGeminiTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void normalizeGeminiModelIdStripsModelsPrefix() {
+        assertThat(LlmClient.normalizeGeminiModelId("models/gemini-2.0-flash")).isEqualTo("gemini-2.0-flash");
+        assertThat(LlmClient.normalizeGeminiModelId("gemini-2.0-flash")).isEqualTo("gemini-2.0-flash");
+    }
+
+    @Test
+    void extractGeminiModelIdsKeepsGenerateContentModelsOnly() throws Exception {
+        String json = """
+                {
+                  "models": [
+                    {"name": "models/gemini-2.0-flash", "supportedGenerationMethods": ["generateContent"]},
+                    {"name": "models/embedding-001", "supportedGenerationMethods": ["embedContent"]}
+                  ]
+                }
+                """;
+        assertThat(LlmClient.extractGeminiModelIds((JsonObject) Jsoner.deserialize(json)))
+                .containsExactly("gemini-2.0-flash");
+    }
+
+    @Test
+    void geminiGenerateContentUrlAppendsApiKeyQueryParameter() {
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.gemini)
+                .withUrl("https://generativelanguage.googleapis.com/v1beta")
+                .withModel("gemini-2.0-flash")
+                .withApiKey("gemini-key");
+
+        assertThat(client.geminiGenerateContentUrl("gemini-key"))
+                .isEqualTo(
+                        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash%3AgenerateContent?key=gemini-key");
+    }
+
+    @Test
+    void listsGeminiModelsWithKeyQueryParameter() throws IOException {
+        AtomicReference<String> query = new AtomicReference<>();
+        String baseUrl = startGeminiModelsServer(query);
+        LlmClient client = LlmClient.create()
+                .withApiType(LlmClient.ApiType.gemini)
+                .withUrl(baseUrl)
+                .withApiKey("gemini-key");
+
+        assertThat(client.listModels()).containsExactly("gemini-2.0-flash", "gemini-1.5-flash");
+        assertThat(query.get()).contains("key=gemini-key");
+    }
+
+    @Test
+    void parseGeminiChatResponseExtractsFunctionCall() throws Exception {
+        String json
+                = """
+                        {"candidates":[{"content":{"parts":[{"functionCall":{"name":"list_routes","args":{"q":"x"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}
+                        """;
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.gemini);
+        LlmClient.ChatResponse response = client.parseGeminiChatResponse((JsonObject) Jsoner.deserialize(json));
+
+        assertThat(response.toolCalls()).hasSize(1);
+        assertThat(response.toolCalls().get(0).name()).isEqualTo("list_routes");
+        assertThat(response.stopReason()).isEqualTo("tool_calls");
+    }
+
+    @Test
+    void extractGeminiTextFromResponseReadsCandidateParts() throws Exception {
+        String json = """
+                {"candidates":[{"content":{"parts":[{"text":"Gemini says hi"}]},"finishReason":"STOP"}]}
+                """;
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.gemini);
+
+        assertThat(client.extractGeminiTextFromResponse((JsonObject) Jsoner.deserialize(json))).isEqualTo("Gemini says hi");
+    }
+
+    @Test
+    void buildGeminiGenerateRequestIncludesFunctionDeclarations() {
+        JsonObject parameters = new JsonObject();
+        parameters.put("type", "object");
+        LlmClient client = LlmClient.create().withApiType(LlmClient.ApiType.gemini);
+        JsonObject request = client.buildGeminiGenerateRequestForTest(
+                "system",
+                List.of(LlmClient.Message.user("hello")),
+                List.of(new LlmClient.ToolDef("list_routes", "List routes", parameters)));
+
+        assertThat(request.get("tools")).isNotNull();
+        assertThat(request.toJson()).contains("functionDeclarations").contains("list_routes");
+    }
+
+    private String startGeminiModelsServer(AtomicReference<String> capturedQuery) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/v1beta/models", exchange -> {
+            capturedQuery.set(exchange.getRequestURI().getQuery());
+            byte[] bytes = """
+                    {"models":[
+                      {"name":"models/gemini-2.0-flash","supportedGenerationMethods":["generateContent"]},
+                      {"name":"models/gemini-1.5-flash","supportedGenerationMethods":["generateContent"]}
+                    ]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        return "http://127.0.0.1:" + server.getAddress().getPort() + "/v1beta";
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/LlmClientGeminiTest.java
@@ -155,6 +155,19 @@ class LlmClientGeminiTest {
     }
 
     @Test
+    void detectEndpointRecognizesGeminiCompatibleProxyWithApiKeyHeader() throws IOException {
+        AtomicReference<String> apiKeyHeader = new AtomicReference<>();
+        String baseUrl = startGeminiModelsServer(apiKeyHeader);
+        LlmClient client = LlmClient.create()
+                .withUrl(baseUrl)
+                .withApiKey("proxy-key");
+
+        assertThat(client.detectEndpoint()).isTrue();
+        assertThat(client.apiType()).isEqualTo(LlmClient.ApiType.gemini);
+        assertThat(apiKeyHeader.get()).isEqualTo("proxy-key");
+    }
+
+    @Test
     void detectEndpointAcceptsConfiguredGeminiApiKeyWithoutEnv() {
         LlmClient client = LlmClient.create()
                 .withApiType(LlmClient.ApiType.gemini)

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -291,7 +291,7 @@ class AiPanel {
             client = created;
             if (!client.detectEndpoint()) {
                 initError
-                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, OPENAI_API_KEY, WATSONX_APIKEY, or start Ollama.";
+                        = "No LLM service reachable. Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GEMINI_API_KEY, OPENAI_API_KEY, WATSONX_APIKEY, or start Ollama.";
                 client = null;
                 return;
             }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiProviderSelector.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiProviderSelector.java
@@ -52,6 +52,9 @@ final class AiProviderSelector {
         if (!"openai".equals(defaultProvider)) {
             choices.add(new AiProviderSwitchPopup.ProviderChoice("openai", "", "", false));
         }
+        if (!"gemini".equals(defaultProvider)) {
+            choices.add(new AiProviderSwitchPopup.ProviderChoice("gemini", "", "", false));
+        }
         if (!"ollama".equals(defaultProvider)) {
             choices.add(new AiProviderSwitchPopup.ProviderChoice("ollama", "", "", false));
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -294,6 +294,8 @@ class DoctorPopup {
             provider = "Gemini";
         } else if (envSet("OPENAI_API_KEY")) {
             provider = "OpenAI";
+        } else if (envSet("WATSONX_APIKEY")) {
+            provider = "watsonx.ai";
         } else if (envSet("LLM_API_KEY")) {
             provider = "Custom (LLM_API_KEY)";
         }
@@ -310,7 +312,7 @@ class DoctorPopup {
                     Span.raw(String.format("%-30s", "No API key configured")),
                     Span.raw(" " + TuiIcons.WARN)));
             result.add(Line.from(Span.styled(
-                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GEMINI_API_KEY, or OPENAI_API_KEY",
+                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GEMINI_API_KEY, OPENAI_API_KEY, or WATSONX_APIKEY",
                     Style.EMPTY.dim())));
         }
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/DoctorPopup.java
@@ -290,6 +290,8 @@ class DoctorPopup {
             provider = "Vertex AI";
         } else if (envSet("AZURE_OPENAI_API_KEY") && envSet("AZURE_OPENAI_ENDPOINT")) {
             provider = "Azure OpenAI";
+        } else if (envSet("GEMINI_API_KEY")) {
+            provider = "Gemini";
         } else if (envSet("OPENAI_API_KEY")) {
             provider = "OpenAI";
         } else if (envSet("LLM_API_KEY")) {
@@ -308,7 +310,7 @@ class DoctorPopup {
                     Span.raw(String.format("%-30s", "No API key configured")),
                     Span.raw(" " + TuiIcons.WARN)));
             result.add(Line.from(Span.styled(
-                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, or OPENAI_API_KEY",
+                    "                    Set ANTHROPIC_API_KEY, AZURE_OPENAI_*, GEMINI_API_KEY, or OPENAI_API_KEY",
                     Style.EMPTY.dim())));
         }
     }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/AiProviderSelectorTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/AiProviderSelectorTest.java
@@ -58,7 +58,7 @@ class AiProviderSelectorTest {
 
         List<AiProviderSwitchPopup.ProviderChoice> choices = selector.buildChoices();
 
-        assertEquals(List.of("auto", "anthropic", "openai", "ollama", "watsonx"),
+        assertEquals(List.of("auto", "anthropic", "openai", "gemini", "ollama", "watsonx"),
                 choices.stream().map(AiProviderSwitchPopup.ProviderChoice::provider).toList(),
                 "all known providers must be offered, even without a detected API key, so they remain selectable");
         assertTrue(choices.get(0).persistedDefault());
@@ -73,7 +73,7 @@ class AiProviderSelectorTest {
 
         List<AiProviderSwitchPopup.ProviderChoice> choices = selector.buildChoices();
 
-        assertEquals(List.of("anthropic", "openai", "ollama", "watsonx"),
+        assertEquals(List.of("anthropic", "openai", "gemini", "ollama", "watsonx"),
                 choices.stream().map(AiProviderSwitchPopup.ProviderChoice::provider).toList(),
                 "anthropic must not be listed twice when it's already the default");
     }
@@ -87,7 +87,7 @@ class AiProviderSelectorTest {
 
         List<AiProviderSwitchPopup.ProviderChoice> choices = selector.buildChoices();
 
-        assertEquals(List.of("ollama", "anthropic", "openai", "watsonx"),
+        assertEquals(List.of("ollama", "anthropic", "openai", "gemini", "watsonx"),
                 choices.stream().map(AiProviderSwitchPopup.ProviderChoice::provider).toList());
     }
 
@@ -100,7 +100,7 @@ class AiProviderSelectorTest {
 
         List<AiProviderSwitchPopup.ProviderChoice> choices = selector.buildChoices();
 
-        assertEquals(List.of("watsonx", "anthropic", "openai", "ollama"),
+        assertEquals(List.of("watsonx", "anthropic", "openai", "gemini", "ollama"),
                 choices.stream().map(AiProviderSwitchPopup.ProviderChoice::provider).toList());
     }
 
@@ -127,6 +127,16 @@ class AiProviderSelectorTest {
     }
 
     @Test
+    void applyChoiceAcceptsGeminiProvider() {
+        LlmClient client = LlmClient.create();
+
+        selector.applyChoice(client, "gemini", "gemini-2.0-flash", "");
+
+        assertEquals(LlmClient.ApiType.gemini, client.apiType());
+        assertEquals("gemini-2.0-flash", client.model());
+    }
+
+    @Test
     void applyChoiceRejectsUnknownProviderWithActionableMessage() {
         LlmClient client = LlmClient.create();
 
@@ -134,6 +144,7 @@ class AiProviderSelectorTest {
                 () -> selector.applyChoice(client, "bogus", null, null));
 
         assertTrue(ex.getMessage().contains("bogus"));
+        assertTrue(ex.getMessage().contains("gemini"));
         assertTrue(ex.getMessage().contains("ollama"));
         assertTrue(ex.getMessage().contains("openai"));
         assertTrue(ex.getMessage().contains("anthropic"));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/AiProviderSelectorTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/AiProviderSelectorTest.java
@@ -26,8 +26,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -132,22 +133,21 @@ class AiProviderSelectorTest {
 
         selector.applyChoice(client, "gemini", "gemini-2.0-flash", "");
 
-        assertEquals(LlmClient.ApiType.gemini, client.apiType());
-        assertEquals("gemini-2.0-flash", client.model());
+        assertThat(client.apiType()).isEqualTo(LlmClient.ApiType.gemini);
+        assertThat(client.model()).isEqualTo("gemini-2.0-flash");
     }
 
     @Test
     void applyChoiceRejectsUnknownProviderWithActionableMessage() {
         LlmClient client = LlmClient.create();
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> selector.applyChoice(client, "bogus", null, null));
-
-        assertTrue(ex.getMessage().contains("bogus"));
-        assertTrue(ex.getMessage().contains("gemini"));
-        assertTrue(ex.getMessage().contains("ollama"));
-        assertTrue(ex.getMessage().contains("openai"));
-        assertTrue(ex.getMessage().contains("anthropic"));
-        assertTrue(ex.getMessage().contains("watsonx"));
+        assertThatThrownBy(() -> selector.applyChoice(client, "bogus", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bogus")
+                .hasMessageContaining("gemini")
+                .hasMessageContaining("ollama")
+                .hasMessageContaining("openai")
+                .hasMessageContaining("anthropic")
+                .hasMessageContaining("watsonx");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ApiType.gemini` to `LlmClient` for the Google Generative Language API (`generativelanguage.googleapis.com`), including env auto-detection (`GEMINI_API_KEY`; `GOOGLE_API_KEY` when `--api-type=gemini` is explicit), model listing, chat/generate with function calling (including `id` and `thoughtSignature` round-trip), and Gemini-aware URL health checks.
- Uses `x-goog-api-key` for Gemini HTTP calls; generate URLs follow Google’s `:generateContent` path form.
- Exposes **gemini** in the TUI provider selector; Doctor/AiPanel hints match auto-detection (`GEMINI_API_KEY` only).
- Documents detection order and `--api-type=gemini` in the JBang AI manual and 4.22 upgrade guide.

## Review follow-ups

- **Bugbot + Grok (`425158b`):** configured API key, headers, thoughtSignature, auto-detect scope, URL health checks.
- **@davsclaus (`d8e0e0f`):** Doctor/AiPanel aligned with auto-detect; removed dead query-param auth code.
- **@davsclaus follow-up (latest):** explicit `--url` Gemini/proxy detection uses authenticated `/models` probe (`tryDetectGeminiAtExplicitUrl`).

**Review status:** @davsclaus approved on `d8e0e0f`; follow-up commit addresses non-blocking explicit-URL note.

## Test plan

- [x] `mvn test -pl dsl/camel-jbang/camel-jbang-core -Dtest=LlmClientGeminiTest,LlmClientListModelsTest`
- [x] `mvn test -pl dsl/camel-jbang/camel-jbang-plugin-tui -Dtest=AiProviderSelectorTest`

https://issues.apache.org/jira/browse/CAMEL-24275

_AI-generated PR description on behalf of atiaomar1978-hub_