### PR TITLE
CAMEL-24279: sync camel-google-storage download containment note to the 4.18/4.14 upgrade guides on main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -1615,3 +1615,17 @@ by the file-based consumers.
 
 Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
 `IllegalArgumentException`.
+
+=== camel-google-storage - downloads are confined to the configured directory
+
+When the consumer is configured with `downloadFileName` pointing at a directory, the
+remote object name is appended to that directory to build the local file to write.
+The resolved path is now verified to stay within the configured directory, and an
+`IllegalArgumentException` is thrown if it does not.
+
+Object names are still allowed to contain `/` and are mapped to sub-directories of the
+download directory as before, so nested object names keep working unchanged. Only names
+that resolve outside the configured directory are rejected.
+
+If `downloadFileName` is configured with an expression (i.e. it contains `$`), the local
+path is built by that expression as before and is not subject to this check.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -1934,3 +1934,17 @@ by the file-based consumers.
 
 Ordinary object names are unaffected. A name that resolves outside `fileDir` is now rejected with an
 `IllegalArgumentException`.
+
+=== camel-google-storage - downloads are confined to the configured directory
+
+When the consumer is configured with `downloadFileName` pointing at a directory, the
+remote object name is appended to that directory to build the local file to write.
+The resolved path is now verified to stay within the configured directory, and an
+`IllegalArgumentException` is thrown if it does not.
+
+Object names are still allowed to contain `/` and are mapped to sub-directories of the
+download directory as before, so nested object names keep working unchanged. Only names
+that resolve outside the configured directory are rejected.
+
+If `downloadFileName` is configured with an expression (i.e. it contains `$`), the local
+path is built by that expression as before and is not subject to this check.


### PR DESCRIPTION
Docs-only follow-up to #25179.

CAMEL-24279 is backported to `camel-4.18.x` (#25180 → 4.18.4) and `camel-4.14.x` (#25181 → 4.14.9),
and each backport adds the upgrade-guide note to its own branch's guide.

Per the backport upgrade-guide policy, the `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the
canonical history across all release lines, so the matching entries are added to `main`'s copies of
the 4.18 and 4.14 guides here. Without this, `main`'s version-specific guides drift out of sync with
what actually ships on the maintenance branches.

The 4.22 guide entry is already part of #25179.

_Claude Code on behalf of oscerd_