### PR TITLE
CAMEL-24280: camel-aws2-mq - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2Producer.java
+++ b/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2Producer.java
@@ -133,6 +133,9 @@ public class MQ2Producer extends DefaultProducer {
                 message.setBody(result);
                 message.setHeader(MQ2Constants.NEXT_TOKEN, result.nextToken());
                 message.setHeader(MQ2Constants.IS_TRUNCATED, ObjectHelper.isNotEmpty(result.nextToken()));
+            } else {
+                throw new IllegalArgumentException(
+                        "listBrokers operation requires ListBrokersRequest in POJO mode");
             }
         } else {
             ListBrokersRequest.Builder builder = ListBrokersRequest.builder();
@@ -179,6 +182,9 @@ public class MQ2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createBroker operation requires CreateBrokerRequest in POJO mode");
             }
         } else {
             CreateBrokerRequest.Builder builder = CreateBrokerRequest.builder();
@@ -252,6 +258,9 @@ public class MQ2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteBroker operation requires DeleteBrokerRequest in POJO mode");
             }
         } else {
             DeleteBrokerRequest.Builder builder = DeleteBrokerRequest.builder();
@@ -287,6 +296,9 @@ public class MQ2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "rebootBroker operation requires RebootBrokerRequest in POJO mode");
             }
         } else {
             RebootBrokerRequest.Builder builder = RebootBrokerRequest.builder();
@@ -323,6 +335,9 @@ public class MQ2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "updateBroker operation requires UpdateBrokerRequest in POJO mode");
             }
         } else {
             UpdateBrokerRequest.Builder builder = UpdateBrokerRequest.builder();
@@ -364,6 +379,9 @@ public class MQ2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeBroker operation requires DescribeBrokerRequest in POJO mode");
             }
         } else {
             DescribeBrokerRequest.Builder builder = DescribeBrokerRequest.builder();

--- a/components/camel-aws/camel-aws2-mq/src/test/java/org/apache/camel/component/aws2/mq/MQProducerTest.java
+++ b/components/camel-aws/camel-aws2-mq/src/test/java/org/apache/camel/component/aws2/mq/MQProducerTest.java
@@ -210,6 +210,48 @@ public class MQProducerTest extends CamelTestSupport {
         assertEquals("1", resultGet.brokerId());
     }
 
+    @Test
+    void listBrokersWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:listBrokersPojo", "not a ListBrokersRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("listBrokers operation requires ListBrokersRequest in POJO mode");
+    }
+
+    @Test
+    void createBrokerWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:createBrokerPojo", "not a CreateBrokerRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("createBroker operation requires CreateBrokerRequest in POJO mode");
+    }
+
+    @Test
+    void deleteBrokerWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:deleteBrokerPojo", "not a DeleteBrokerRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("deleteBroker operation requires DeleteBrokerRequest in POJO mode");
+    }
+
+    @Test
+    void rebootBrokerWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:rebootBrokerPojo", "not a RebootBrokerRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("rebootBroker operation requires RebootBrokerRequest in POJO mode");
+    }
+
+    @Test
+    void updateBrokerWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:updateBrokerPojo", "not an UpdateBrokerRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("updateBroker operation requires UpdateBrokerRequest in POJO mode");
+    }
+
+    @Test
+    void describeBrokerWithPojoRequestAndWrongBodyTypeThrows() {
+        assertThatThrownBy(() -> template.requestBody("direct:describeBrokerPojo", "not a DescribeBrokerRequest"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("describeBroker operation requires DescribeBrokerRequest in POJO mode");
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -230,6 +272,16 @@ public class MQProducerTest extends CamelTestSupport {
                         .to("mock:result");
                 from("direct:describeBroker").to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=describeBroker")
                         .to("mock:result");
+                from("direct:createBrokerPojo")
+                        .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=createBroker&pojoRequest=true");
+                from("direct:deleteBrokerPojo")
+                        .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=deleteBroker&pojoRequest=true");
+                from("direct:rebootBrokerPojo")
+                        .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=rebootBroker&pojoRequest=true");
+                from("direct:updateBrokerPojo")
+                        .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=updateBroker&pojoRequest=true");
+                from("direct:describeBrokerPojo")
+                        .to("aws2-mq://test?amazonMqClient=#amazonMqClient&operation=describeBroker&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `MQ2Producer`'s `listBrokers`, `createBroker`,
`deleteBroker`, `rebootBroker`, `updateBroker` and `describeBroker` branches only
acted when the body was the matching request type; any other body fell through
the `instanceof` with no `else`, so no AWS call was made, no response was set,
and the original body was returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g.:

```java
} else {
    throw new IllegalArgumentException(
            "updateBroker operation requires UpdateBrokerRequest in POJO mode");
}
```

## Tests

Six tests in `MQProducerTest` send a wrong-typed body to `pojoRequest=true`
routes (reusing the module's `AmazonMQClientMock`) and assert the message. Each
was verified to fail (silent no-op) before the fix — `rebootBroker`, for example,
reports "Expecting code to raise a throwable" on `main`. Class 15/15 green.
Hermetic unit tests against the in-JVM mock (run region-free) — no localstack or
real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_