### PR TITLE
camel-tui: Fix ConsumersTabRenderTest for new column layout

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
@@ -59,11 +59,12 @@ class ConsumersTabRenderTest {
         addConsumer("route1", "timer://hello", "Started", "org.apache.camel.component.timer.TimerConsumer");
 
         ConsumersTab tab = new ConsumersTab(ctx);
-        String rendered = TuiTestHelper.renderToString(tab, 120, 20);
+        String rendered = TuiTestHelper.renderToString(tab, 160, 20);
 
         assertTrue(rendered.contains("ROUTE"), "Should show ROUTE header");
         assertTrue(rendered.contains("STATUS"), "Should show STATUS header");
         assertTrue(rendered.contains("TYPE"), "Should show TYPE header");
+        assertTrue(rendered.contains("REMOTE"), "Should show REMOTE header");
         assertTrue(rendered.contains("URI"), "Should show URI header");
     }
 


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

- Widen the `renderShowsTableHeaders` virtual terminal from 120→160 columns so the `URI` column (fill constraint) has enough room after the REMOTE column was added in 1c4a959e6e2
- Add assertion for the new `REMOTE` header

The test has been consistently failing (3/3 reruns) since commits 1c4a959e6e2 (Add Remote column) and fd2fc21555e (Swap SCHEDULE and POLLS column order) changed the column layout without updating the test expectations.

## Test plan

- [x] `ConsumersTabRenderTest` — all 13 tests pass
- [x] Code formatted with `formatter:format` + `impsort:sort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)