### PR TITLE
Improve test assertion for ConsumersTabRenderTest.renderShowsTableHeaders()

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/ConsumersTabRenderTest.java
@@ -30,6 +30,7 @@ import dev.tamboui.tui.event.KeyModifiers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -61,10 +62,8 @@ class ConsumersTabRenderTest {
         ConsumersTab tab = new ConsumersTab(ctx);
         String rendered = TuiTestHelper.renderToString(tab, 160, 20);
 
-        assertTrue(rendered.contains("ROUTE"), "Should show ROUTE header");
-        assertTrue(rendered.contains("STATUS"), "Should show STATUS header");
-        assertTrue(rendered.contains("TYPE"), "Should show TYPE header");
-        assertTrue(rendered.contains("URI"), "Should show URI header");
+        assertThat(rendered).as("Should show ROUTE, STATUS, TYPE and URI headers")
+                .contains("ROUTE", "STATUS", "TYPE", "URI");
     }
 
     @Test


### PR DESCRIPTION
org.apache.camel.dsl.jbang.core.commands.tui.ConsumersTabRenderTest.renderShowsTableHeaders()

it gives:

```
org.apache.camel.dsl.jbang.core.commands.tui.ConsumersTabRenderTest.renderShowsTableHeaders
-- Time elapsed: 0.004 s <<< FAILURE!
java.lang.AssertionError:
[Should show ROUTE, STATUS, TYPE and URI headers]
Expecting actual:
  "╭ Consumers
───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│    ROUTE▼              STATUS     TYPE       REMOTE   INFLIGHT
SCHEDULE                 POLLS SINCE-LAST             │
│    route1              Started    Timer                      0
-/-/-                  │
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
│
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
"
to contain:
  ["ROUTE", "STATUS", "TYPE", "URI"]
but could not find:
  ["URI"]

	at org.apache.camel.dsl.jbang.core.commands.tui.ConsumersTabRenderTest.renderShowsTableHeaders(ConsumersTabRenderTest.java:66)
```

instead of:

```
[camel-jbang-plugin-tui] [ERROR] Tests run: 1, Failures: 1, Errors: 0,
Skipped: 0, Time elapsed: 0.009 s <<< FAILURE! -- in
org.apache.camel.dsl.jbang.core.commands.tui.ConsumersTabRenderTest
[camel-jbang-plugin-tui] [ERROR]
org.apache.camel.dsl.jbang.core.commands.tui.ConsumersTabRenderTest.renderShowsTableHeaders
-- Time elapsed: 0.008 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Should show URI header ==>
expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at org.apache.camel.dsl.jbang.core.commands.tui.ConsumersTabRenderTest.renderShowsTableHeaders(ConsumersTabRenderTest.java:67)
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

