### PR TITLE
CAMEL-24283: camel-aws2-comprehend - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-comprehend/pom.xml
+++ b/components/camel-aws/camel-aws2-comprehend/pom.xml
@@ -78,5 +78,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-comprehend/src/main/java/org/apache/camel/component/aws2/comprehend/Comprehend2Producer.java
+++ b/components/camel-aws/camel-aws2-comprehend/src/main/java/org/apache/camel/component/aws2/comprehend/Comprehend2Producer.java
@@ -147,6 +147,9 @@ public class Comprehend2Producer extends DefaultProducer {
                     message.setHeader(Comprehend2Constants.DETECTED_LANGUAGE, topLanguage.languageCode());
                     message.setHeader(Comprehend2Constants.DETECTED_LANGUAGE_SCORE, topLanguage.score());
                 }
+            } else {
+                throw new IllegalArgumentException(
+                        "detectDominantLanguage operation requires DetectDominantLanguageRequest in POJO mode");
             }
         } else {
             DetectDominantLanguageRequest.Builder request = DetectDominantLanguageRequest.builder();
@@ -181,6 +184,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.entities());
+            } else {
+                throw new IllegalArgumentException(
+                        "detectEntities operation requires DetectEntitiesRequest in POJO mode");
             }
         } else {
             DetectEntitiesRequest.Builder request = DetectEntitiesRequest.builder();
@@ -211,6 +217,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.keyPhrases());
+            } else {
+                throw new IllegalArgumentException(
+                        "detectKeyPhrases operation requires DetectKeyPhrasesRequest in POJO mode");
             }
         } else {
             DetectKeyPhrasesRequest.Builder request = DetectKeyPhrasesRequest.builder();
@@ -243,6 +252,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 message.setBody(result);
                 message.setHeader(Comprehend2Constants.DETECTED_SENTIMENT, result.sentimentAsString());
                 message.setHeader(Comprehend2Constants.DETECTED_SENTIMENT_SCORE, result.sentimentScore());
+            } else {
+                throw new IllegalArgumentException(
+                        "detectSentiment operation requires DetectSentimentRequest in POJO mode");
             }
         } else {
             DetectSentimentRequest.Builder request = DetectSentimentRequest.builder();
@@ -275,6 +287,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.syntaxTokens());
+            } else {
+                throw new IllegalArgumentException(
+                        "detectSyntax operation requires DetectSyntaxRequest in POJO mode");
             }
         } else {
             DetectSyntaxRequest.Builder request = DetectSyntaxRequest.builder();
@@ -305,6 +320,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.entities());
+            } else {
+                throw new IllegalArgumentException(
+                        "detectPiiEntities operation requires DetectPiiEntitiesRequest in POJO mode");
             }
         } else {
             DetectPiiEntitiesRequest.Builder request = DetectPiiEntitiesRequest.builder();
@@ -335,6 +353,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.resultList());
+            } else {
+                throw new IllegalArgumentException(
+                        "detectToxicContent operation requires DetectToxicContentRequest in POJO mode");
             }
         } else {
             DetectToxicContentRequest.Builder request = DetectToxicContentRequest.builder();
@@ -366,6 +387,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "classifyDocument operation requires ClassifyDocumentRequest in POJO mode");
             }
         } else {
             ClassifyDocumentRequest.Builder request = ClassifyDocumentRequest.builder();
@@ -400,6 +424,9 @@ public class Comprehend2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result.labels());
+            } else {
+                throw new IllegalArgumentException(
+                        "containsPiiEntities operation requires ContainsPiiEntitiesRequest in POJO mode");
             }
         } else {
             ContainsPiiEntitiesRequest.Builder request = ContainsPiiEntitiesRequest.builder();

--- a/components/camel-aws/camel-aws2-comprehend/src/test/java/org/apache/camel/component/aws2/comprehend/Comprehend2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-comprehend/src/test/java/org/apache/camel/component/aws2/comprehend/Comprehend2ProducerTest.java
@@ -26,6 +26,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.comprehend.model.DetectDominantLanguageRequest;
 import software.amazon.awssdk.services.comprehend.model.DetectSentimentRequest;
 import software.amazon.awssdk.services.comprehend.model.DetectSentimentResponse;
@@ -35,6 +37,7 @@ import software.amazon.awssdk.services.comprehend.model.KeyPhrase;
 import software.amazon.awssdk.services.comprehend.model.PiiEntity;
 import software.amazon.awssdk.services.comprehend.model.SyntaxToken;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -222,6 +225,24 @@ public class Comprehend2ProducerTest extends CamelTestSupport {
         assertFalse(results.isEmpty());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:detectDominantLanguagePojo,detectDominantLanguage operation requires DetectDominantLanguageRequest in POJO mode",
+            "direct:detectEntitiesPojo,detectEntities operation requires DetectEntitiesRequest in POJO mode",
+            "direct:detectKeyPhrasesPojo,detectKeyPhrases operation requires DetectKeyPhrasesRequest in POJO mode",
+            "direct:detectSentimentPojo,detectSentiment operation requires DetectSentimentRequest in POJO mode",
+            "direct:detectSyntaxPojo,detectSyntax operation requires DetectSyntaxRequest in POJO mode",
+            "direct:detectPiiEntitiesPojo,detectPiiEntities operation requires DetectPiiEntitiesRequest in POJO mode",
+            "direct:detectToxicContentPojo,detectToxicContent operation requires DetectToxicContentRequest in POJO mode",
+            "direct:classifyDocumentPojo,classifyDocument operation requires ClassifyDocumentRequest in POJO mode",
+            "direct:containsPiiEntitiesPojo,containsPiiEntities operation requires ContainsPiiEntitiesRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -254,6 +275,20 @@ public class Comprehend2ProducerTest extends CamelTestSupport {
                 from("direct:detectToxicContent")
                         .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=detectToxicContent&languageCode=en")
                         .to("mock:result");
+                from("direct:detectEntitiesPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=detectEntities&pojoRequest=true");
+                from("direct:detectKeyPhrasesPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=detectKeyPhrases&pojoRequest=true");
+                from("direct:detectSyntaxPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=detectSyntax&pojoRequest=true");
+                from("direct:detectPiiEntitiesPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=detectPiiEntities&pojoRequest=true");
+                from("direct:detectToxicContentPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=detectToxicContent&pojoRequest=true");
+                from("direct:classifyDocumentPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=classifyDocument&pojoRequest=true");
+                from("direct:containsPiiEntitiesPojo")
+                        .to("aws2-comprehend://test?comprehendClient=#amazonComprehendClient&operation=containsPiiEntities&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `Comprehend2Producer`'s nine operations
(`detectDominantLanguage`, `detectEntities`, `detectKeyPhrases`,
`detectSentiment`, `detectSyntax`, `detectPiiEntities`, `detectToxicContent`,
`classifyDocument`, `containsPiiEntities`) only acted when the body was the
matching request type; any other body fell through the `instanceof` with no
`else`, so no AWS call was made, no response was set, and the original body was
returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"classifyDocument operation requires ClassifyDocumentRequest in POJO
mode"`.

## Tests

A single `@ParameterizedTest` covers all nine operations, sending a wrong-typed
body to `pojoRequest=true` routes (reusing the module's mock client) and
asserting each message. Verified to fail (silent no-op) before the fix — with the
`classifyDocument` else removed, exactly that case reports "Expecting code to
raise a throwable". Class 18/18 green. Hermetic unit tests, region-free — no
localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_