### PR TITLE
Fix flakiness of CxfMessageHeaderTimeoutTest

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfMessageHeaderTimeoutTest.java
+++ b/components/camel-cxf/camel-cxf-spring-soap/src/test/java/org/apache/camel/component/cxf/CxfMessageHeaderTimeoutTest.java
@@ -39,8 +39,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CxfMessageHeaderTimeoutTest extends CamelSpringTestSupport {
 
@@ -66,8 +66,17 @@ public class CxfMessageHeaderTimeoutTest extends CamelSpringTestSupport {
         Exchange reply = sendJaxWsMessage(endpointUri);
         Exception e = reply.getException();
         assertNotNull(e, "We should get the exception cause here");
-        assertTrue(e instanceof HttpTimeoutException,
-                String.format("Expected HttpTimeoutException, but got %s", e.getClass().getName()));
+        // CXF may either propagate HttpTimeoutException directly or wrap an HttpConnectTimeoutException in a
+        // Fault ("Could not send Message.") depending on where in the interceptor
+        // chain the timeout is caught. Both cases indicate the timeout was applied
+        // correctly, so check the entire cause chain.
+        assertThat(e).satisfiesAnyOf(
+                ex -> assertThat(ex).isInstanceOf(HttpTimeoutException.class),
+                //TODO: when AssertJ 4 is released, to replace with throwableChains() for more precise and robust check
+                ex -> assertThat(ex).hasStackTraceContaining(
+                        "Caused by: java.net.http.HttpConnectTimeoutException: HTTP connect timed out"),
+                ex -> assertThat(ex).hasStackTraceContaining(
+                        "Caused by: java.net.http.HttpTimeoutException: request timed out"));
     }
 
     protected Exchange sendJaxWsMessage(String endpointUri) throws InterruptedException {


### PR DESCRIPTION
applying same pattern than for CxfTimeOutTest
https://github.com/apache/camel/commit/391ff6ce0a38f4cf7b7bafd5d7b8a269ff5f4588 https://github.com/apache/camel/commit/2b9bdeddf790b773f831aee25751741f9ff1c095

based on this request on develocity
https://develocity.apache.org/scans/tests?search.query=project:camel%20tag:main&search.startTimeMax=1785241434521&search.startTimeMin=1784757600000&search.timeZoneId=Europe%2FParis&tests.container=*cxf* , it is the only other which is regularly failing (not just flaky)

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

