### PR TITLE
CAMEL-24022: Fix flaky XsltFromFileExceptionTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
@@ -16,45 +16,65 @@
  */
 package org.apache.camel.component.xslt;
 
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
-import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
-/**
- *
- */
-public class XsltFromFileExceptionTest extends ContextTestSupport {
+import static org.awaitility.Awaitility.await;
 
-    @Test
-    public void testXsltFromFileExceptionOk() throws Exception {
-        getMockEndpoint("mock:result").expectedMessageCount(1);
-        getMockEndpoint("mock:error").expectedMessageCount(0);
+class XsltFromFileExceptionTest extends ContextTestSupport {
 
-        template.sendBodyAndHeader(fileUri(), "<hello>world!</hello>", Exchange.FILE_NAME, "hello.xml");
-
-        oneExchangeDone.matchesWaitTime();
-
-        assertMockEndpointsSatisfied();
-
-        assertFileNotExists(testFile("hello.xml"));
-        assertFileExists(testFile("ok/hello.xml"));
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
     }
 
     @Test
-    public void testXsltFromFileExceptionFail() throws Exception {
-        getMockEndpoint("mock:result").expectedMessageCount(0);
-        getMockEndpoint("mock:error").expectedMessageCount(1);
+    void testXsltFromFileExceptionOk() throws Exception {
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+        getMockEndpoint("mock:error").expectedMessageCount(0);
 
-        // the last tag is not ended properly
-        template.sendBodyAndHeader(fileUri(), "<hello>world!</hello", Exchange.FILE_NAME, "hello2.xml");
+        // Write file BEFORE starting the route so the file consumer
+        // picks it up on its very first poll — eliminates the race between
+        // file write and consumer poll scheduling under CI load
+        Files.writeString(testFile("hello.xml"), "<hello>world!</hello>");
 
-        oneExchangeDone.matchesWaitTime();
+        context.addRoutes(createRouteBuilder());
+        context.start();
 
         assertMockEndpointsSatisfied();
 
-        assertFileNotExists(testFile("hello2.xml"));
-        assertFileExists(testFile("error/hello2.xml"));
+        // File move happens asynchronously after route processing completes
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertFileNotExists(testFile("hello.xml"));
+                    assertFileExists(testFile("ok/hello.xml"));
+                });
+    }
+
+    @Test
+    void testXsltFromFileExceptionFail() throws Exception {
+        getMockEndpoint("mock:result").expectedMessageCount(0);
+        getMockEndpoint("mock:error").expectedMessageCount(1);
+
+        // Write malformed XML (the last tag is not ended properly) BEFORE
+        // starting the route so the file consumer picks it up on first poll
+        Files.writeString(testFile("hello2.xml"), "<hello>world!</hello");
+
+        context.addRoutes(createRouteBuilder());
+        context.start();
+
+        assertMockEndpointsSatisfied();
+
+        // File move happens asynchronously after route processing completes
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertFileNotExists(testFile("hello2.xml"));
+                    assertFileExists(testFile("error/hello2.xml"));
+                });
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
@@ -33,9 +33,9 @@ public class XsltFromFileExceptionTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello>", Exchange.FILE_NAME, "hello.xml");
 
-        assertMockEndpointsSatisfied();
-
         oneExchangeDone.matchesWaitTime();
+
+        assertMockEndpointsSatisfied();
 
         assertFileNotExists(testFile("hello.xml"));
         assertFileExists(testFile("ok/hello.xml"));
@@ -49,9 +49,9 @@ public class XsltFromFileExceptionTest extends ContextTestSupport {
         // the last tag is not ended properly
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello", Exchange.FILE_NAME, "hello2.xml");
 
-        assertMockEndpointsSatisfied();
-
         oneExchangeDone.matchesWaitTime();
+
+        assertMockEndpointsSatisfied();
 
         assertFileNotExists(testFile("hello2.xml"));
         assertFileExists(testFile("error/hello2.xml"));


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

Fix the flaky `XsltFromFileExceptionTest` by eliminating the race condition between file creation and consumer polling.

## Root Cause Analysis

Develocity and JIRA (CAMEL-24026 comments from @apupier) reveal **two distinct failure modes**:

### Mode A — JAXP system property leak (primary cause, already fixed)

`ZXsltTotalOpsTest` set `jdk.xml.xpathTotalOpLimit=1` as a JVM-global system property (CAMEL-24216 bug). When `XsltFromFileExceptionTest` ran afterwards in the same JVM, `example.xsl` — which has 2 XPath operators (`match="/"` and `select="/hello"`) — failed to compile:

```
TransformerConfigurationException: JAXP0801003: the compiler encountered XPath
expressions with an accumulated '2' operators that exceeds the '1' limit set by 'system property'
```

**Already fixed on `main`:**
- Workaround (July 21, commit 1a11849): `@AfterEach` clearing the system property
- Proper fix (July 28, CAMEL-24216, commit f46f5af): set limit per-`TransformerFactory` instance

### Mode B — Exchange timeout (secondary, rare)

```
AssertionFailedError: Exchange should have completed ==> expected: <true> but was: <false>
```

`oneExchangeDone.matchesWaitTime()` times out after 10 seconds — the consumer never completed the exchange within the timeout. After the mode-A workaround, this still occurred at 2/195 (~1%), though those may also be residual mode-A failures.

The prior fix attempt ([CAMEL-24026](https://issues.apache.org/jira/browse/CAMEL-24026), [PR #24625](https://github.com/apache/camel/pull/24625)) reordered assertions but was [reverted](https://github.com/apache/camel/pull/24945) because it didn't help.

## Fix

Eliminate the race between file creation and consumer polling:

1. Override `isUseRouteBuilder()` to return `false`, deferring route addition and context startup
2. Write test files using `Files.writeString()` before starting the context
3. Add the route and start the context — the file consumer's first poll (`initialDelay=0`) immediately finds the file
4. Use Awaitility for file-move assertions (file move is asynchronous relative to mock message delivery)

This makes the test deterministic — the consumer always finds the file on its first poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)