### PR TITLE
CAMEL-24266: Add volatile to Delayer.delayValue for JMM visibility

### DIFF
--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/Delayer.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/Delayer.java
@@ -39,7 +39,7 @@ public class Delayer extends DelayProcessorSupport implements Traceable, IdAware
     private String stepId;
     private String id;
     private volatile Expression delay;
-    private long delayValue;
+    private volatile long delayValue;
 
     public Delayer(CamelContext camelContext, Processor processor, Expression delay,
                    ScheduledExecutorService executorService, boolean shutdownExecutorService) {


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

`Delayer.delayValue` is a plain `long` field written by routing threads (in `calculateDelay()`) and read by JMX threads (via `ManagedDelayer.getDelay()` → `getDelayValue()`). This creates a JMM visibility gap:

- On **32-bit JVMs**, reads of a `long` are non-atomic (JLS 17.7), so JMX could observe a torn value
- On **all JVMs**, there is no happens-before guarantee, so stale reads are possible

This was flagged during review of PR #24985 (CAMEL-24227 volatile sweep), which fixed the forward direction (`delay` Expression written by JMX, read by routing threads) but missed the reverse direction (`delayValue` written by routing threads, read by JMX).

### Fix

Add `volatile` to the `delayValue` field. On x86 this compiles to the same `MOV` instruction as a plain load, so there is zero performance cost. No `AtomicLong` is needed because there are no read-modify-write operations — it's pure store/load.

## Test plan

- [x] `DelayerTest`, `DelayerAsyncDelayedTest`, `DelayerPerRouteTest` pass
- [x] `ManagedDelayerTest` (JMX MBean that reads `delayValue`) passes
- [x] `camel-core-processor` module compiles and formats cleanly
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>