### PR TITLE
CAMEL-24268: Remove write-only resumeInflightExchanges field

### DIFF
--- a/core/camel-support/src/main/java/org/apache/camel/throttling/ThrottlingInflightRoutePolicy.java
+++ b/core/camel-support/src/main/java/org/apache/camel/throttling/ThrottlingInflightRoutePolicy.java
@@ -84,7 +84,7 @@ public class ThrottlingInflightRoutePolicy extends RoutePolicySupport implements
     }
 
     private volatile ThrottlingLimits throttlingLimits
-            = new ThrottlingLimits(1000, Math.max(70 * 1000 / 100, 1));
+            = new ThrottlingLimits(maxInflightExchanges, Math.max(resumePercentOfMax * maxInflightExchanges / 100, 1));
 
     @Metadata(description = "Sets the logging level to report the throttling activity.",
               javaType = "org.apache.camel.LoggingLevel", defaultValue = "INFO", enums = "TRACE,DEBUG,INFO,WARN,ERROR,OFF")

--- a/core/camel-support/src/main/java/org/apache/camel/throttling/ThrottlingInflightRoutePolicy.java
+++ b/core/camel-support/src/main/java/org/apache/camel/throttling/ThrottlingInflightRoutePolicy.java
@@ -78,13 +78,13 @@ public class ThrottlingInflightRoutePolicy extends RoutePolicySupport implements
     @Metadata(description = "Sets at which percentage of the max the throttler should start resuming the route.",
               defaultValue = "70")
     private volatile int resumePercentOfMax = 70;
-    private volatile int resumeInflightExchanges = 700;
 
     // immutable holder for throttling limits that must be visible atomically on routing threads
     private record ThrottlingLimits(int maxInflightExchanges, int resumeInflightExchanges) {
     }
 
-    private volatile ThrottlingLimits throttlingLimits = new ThrottlingLimits(1000, 700);
+    private volatile ThrottlingLimits throttlingLimits
+            = new ThrottlingLimits(1000, Math.max(70 * 1000 / 100, 1));
 
     @Metadata(description = "Sets the logging level to report the throttling activity.",
               javaType = "org.apache.camel.LoggingLevel", defaultValue = "INFO", enums = "TRACE,DEBUG,INFO,WARN,ERROR,OFF")
@@ -191,7 +191,6 @@ public class ThrottlingInflightRoutePolicy extends RoutePolicySupport implements
         this.maxInflightExchanges = maxInflightExchanges;
         // recalculate, must be at least at 1
         int resume = Math.max(resumePercentOfMax * maxInflightExchanges / 100, 1);
-        this.resumeInflightExchanges = resume;
         // atomically publish both values for routing threads
         this.throttlingLimits = new ThrottlingLimits(maxInflightExchanges, resume);
     }
@@ -215,7 +214,6 @@ public class ThrottlingInflightRoutePolicy extends RoutePolicySupport implements
         this.resumePercentOfMax = resumePercentOfMax;
         // recalculate, must be at least at 1
         int resume = Math.max(resumePercentOfMax * maxInflightExchanges / 100, 1);
-        this.resumeInflightExchanges = resume;
         // atomically publish both values for routing threads
         this.throttlingLimits = new ThrottlingLimits(maxInflightExchanges, resume);
     }


### PR DESCRIPTION
_Claude Code on behalf of gnodet_

## Summary

Removes the write-only `resumeInflightExchanges` field from `ThrottlingInflightRoutePolicy` that became dead code after the `ThrottlingLimits` holder refactoring in PR #24985 (CAMEL-24227).

## Problem

After the holder refactoring, the standalone `resumeInflightExchanges` field was:
- **Written** by `setMaxInflightExchanges()` and `setResumePercentOfMax()` setters
- **Never read** — `throttle()` reads from the immutable `ThrottlingLimits` holder record instead
- **No getter** exists, `toString()` doesn't reference it, JMX MBean doesn't expose it
- The default `700` was duplicated between the field initializer and the holder constructor

## Changes

- Remove the dead `resumeInflightExchanges` field
- Remove the two dead writes (`this.resumeInflightExchanges = resume`) in the setter methods
- Derive the initial `ThrottlingLimits` holder default from `maxInflightExchanges` and `resumePercentOfMax` fields instead of duplicating literal values

Net: **−4 lines, +2 lines** in a single file.

## Test plan

- [x] Existing `ThrottlingInflightRoutePolicyTest` passes
- [x] Existing `ManagedThrottlingInflightRoutePolicyTest` passes
- [x] `camel-support` module tests pass
- [x] No other references to the removed field exist in the codebase (verified by grep)