### PR TITLE
CAMEL-24289: camel-aws2-textract - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-textract/pom.xml
+++ b/components/camel-aws/camel-aws2-textract/pom.xml
@@ -78,5 +78,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-textract/src/main/java/org/apache/camel/component/aws2/textract/Textract2Producer.java
+++ b/components/camel-aws/camel-aws2-textract/src/main/java/org/apache/camel/component/aws2/textract/Textract2Producer.java
@@ -123,6 +123,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "detectDocumentText operation requires DetectDocumentTextRequest in POJO mode");
             }
         } else {
             DetectDocumentTextRequest.Builder request = DetectDocumentTextRequest.builder();
@@ -154,6 +157,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "analyzeDocument operation requires AnalyzeDocumentRequest in POJO mode");
             }
         } else {
             AnalyzeDocumentRequest.Builder request = AnalyzeDocumentRequest.builder();
@@ -194,6 +200,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "analyzeExpense operation requires AnalyzeExpenseRequest in POJO mode");
             }
         } else {
             AnalyzeExpenseRequest.Builder request = AnalyzeExpenseRequest.builder();
@@ -226,6 +235,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startDocumentTextDetection operation requires StartDocumentTextDetectionRequest in POJO mode");
             }
         } else {
             StartDocumentTextDetectionRequest.Builder request = StartDocumentTextDetectionRequest.builder();
@@ -258,6 +270,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startDocumentAnalysis operation requires StartDocumentAnalysisRequest in POJO mode");
             }
         } else {
             StartDocumentAnalysisRequest.Builder request = StartDocumentAnalysisRequest.builder();
@@ -297,6 +312,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startExpenseAnalysis operation requires StartExpenseAnalysisRequest in POJO mode");
             }
         } else {
             StartExpenseAnalysisRequest.Builder request = StartExpenseAnalysisRequest.builder();
@@ -329,6 +347,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getDocumentTextDetection operation requires GetDocumentTextDetectionRequest in POJO mode");
             }
         } else {
             GetDocumentTextDetectionRequest.Builder request = GetDocumentTextDetectionRequest.builder();
@@ -377,6 +398,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getDocumentAnalysis operation requires GetDocumentAnalysisRequest in POJO mode");
             }
         } else {
             GetDocumentAnalysisRequest.Builder request = GetDocumentAnalysisRequest.builder();
@@ -425,6 +449,9 @@ public class Textract2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getExpenseAnalysis operation requires GetExpenseAnalysisRequest in POJO mode");
             }
         } else {
             GetExpenseAnalysisRequest.Builder request = GetExpenseAnalysisRequest.builder();

--- a/components/camel-aws/camel-aws2-textract/src/test/java/org/apache/camel/component/aws2/textract/Textract2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-textract/src/test/java/org/apache/camel/component/aws2/textract/Textract2ProducerTest.java
@@ -24,11 +24,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.textract.model.DetectDocumentTextRequest;
 import software.amazon.awssdk.services.textract.model.DetectDocumentTextResponse;
 import software.amazon.awssdk.services.textract.model.Document;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -112,6 +115,24 @@ public class Textract2ProducerTest extends CamelTestSupport {
 
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:detectDocumentTextPojo,detectDocumentText operation requires DetectDocumentTextRequest in POJO mode",
+            "direct:analyzeDocumentPojo,analyzeDocument operation requires AnalyzeDocumentRequest in POJO mode",
+            "direct:analyzeExpensePojo,analyzeExpense operation requires AnalyzeExpenseRequest in POJO mode",
+            "direct:startDocumentTextDetectionPojo,startDocumentTextDetection operation requires StartDocumentTextDetectionRequest in POJO mode",
+            "direct:startDocumentAnalysisPojo,startDocumentAnalysis operation requires StartDocumentAnalysisRequest in POJO mode",
+            "direct:startExpenseAnalysisPojo,startExpenseAnalysis operation requires StartExpenseAnalysisRequest in POJO mode",
+            "direct:getDocumentTextDetectionPojo,getDocumentTextDetection operation requires GetDocumentTextDetectionRequest in POJO mode",
+            "direct:getDocumentAnalysisPojo,getDocumentAnalysis operation requires GetDocumentAnalysisRequest in POJO mode",
+            "direct:getExpenseAnalysisPojo,getExpenseAnalysis operation requires GetExpenseAnalysisRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -126,6 +147,22 @@ public class Textract2ProducerTest extends CamelTestSupport {
                 from("direct:detectDocumentTextOptions").to(
                         "aws2-textract://test?textractClient=#amazonTextractClient&operation=detectDocumentText&s3Bucket=testbucket&s3Object=testobject.pdf")
                         .to("mock:result");
+                from("direct:analyzeDocumentPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=analyzeDocument&pojoRequest=true");
+                from("direct:analyzeExpensePojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=analyzeExpense&pojoRequest=true");
+                from("direct:startDocumentTextDetectionPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=startDocumentTextDetection&pojoRequest=true");
+                from("direct:startDocumentAnalysisPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=startDocumentAnalysis&pojoRequest=true");
+                from("direct:startExpenseAnalysisPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=startExpenseAnalysis&pojoRequest=true");
+                from("direct:getDocumentTextDetectionPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=getDocumentTextDetection&pojoRequest=true");
+                from("direct:getDocumentAnalysisPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=getDocumentAnalysis&pojoRequest=true");
+                from("direct:getExpenseAnalysisPojo")
+                        .to("aws2-textract://test?textractClient=#amazonTextractClient&operation=getExpenseAnalysis&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `Textract2Producer`'s nine operations only acted when
the body was the matching request type; any other body fell through the
`instanceof` with no `else`, so no AWS call was made, no response was set, and
the original body was returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"analyzeExpense operation requires AnalyzeExpenseRequest in POJO
mode"`.

## Tests

A `@ParameterizedTest` covers all nine operations, sending a wrong-typed body to
`pojoRequest=true` routes and asserting each message. Verified to fail (silent
no-op) before the fix — with the `analyzeExpense` else removed, exactly that case
reports "Expecting code to raise a throwable". Class 12/12 green. Hermetic unit
tests, region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_