### PR TITLE
docs(datasonnet): update DataSonnet documentation URL

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/datasonnet-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/datasonnet-language.adoc
@@ -9,7 +9,7 @@
 
 *Since Camel {since}*
 
-Camel supports https://datasonnet.com/[DataSonnet] transformations to allow an
+Camel supports https://github.com/datasonnet/datasonnet-mapper[DataSonnet] transformations to allow an
 xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicate] to be
 used in the xref:manual::dsl.adoc[DSL].
 

--- a/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
+++ b/components/camel-datasonnet/src/main/docs/datasonnet-language.adoc
@@ -9,7 +9,7 @@
 
 *Since Camel {since}*
 
-Camel supports https://datasonnet.com/[DataSonnet] transformations to allow an
+Camel supports https://github.com/datasonnet/datasonnet-mapper[DataSonnet] transformations to allow an
 xref:manual::expression.adoc[Expression] or xref:manual::predicate.adoc[Predicate] to be
 used in the xref:manual::dsl.adoc[DSL].
 


### PR DESCRIPTION
### Summary

Updates the DataSonnet documentation link in `datasonnet-language.adoc` from the outdated `https://datasonnet.com/` domain to the official GitHub repository (`https://github.com/datasonnet/datasonnet-mapper`).

### Reason for Change

The domain `datasonnet.com` is no longer the official site for DataSonnet and redirects to an unrelated domain.