### PR TITLE
CAMEL-24300: camel-aws2-ec2 - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-ec2/pom.xml
+++ b/components/camel-aws/camel-aws2-ec2/pom.xml
@@ -77,5 +77,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-ec2/src/main/java/org/apache/camel/component/aws2/ec2/AWS2EC2Producer.java
+++ b/components/camel-aws/camel-aws2-ec2/src/main/java/org/apache/camel/component/aws2/ec2/AWS2EC2Producer.java
@@ -160,6 +160,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Creating and running instances requests performing");
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createAndRunInstances operation requires RunInstancesRequest in POJO mode");
             }
         } else {
             RunInstancesRequest.Builder builder = RunInstancesRequest.builder();
@@ -251,6 +254,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Starting instances with Ids [{}] ", startInstancesRequest.instanceIds());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startInstances operation requires StartInstancesRequest in POJO mode");
             }
         } else {
             StartInstancesRequest.Builder builder = StartInstancesRequest.builder();
@@ -293,6 +299,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Stopping instances with Ids [{}] ", stopInstancesRequest.instanceIds());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "stopInstances operation requires StopInstancesRequest in POJO mode");
             }
         } else {
             StopInstancesRequest.Builder builder = StopInstancesRequest.builder();
@@ -335,6 +344,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Terminating instances with Ids [{}] ", terminateInstancesRequest.instanceIds());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "terminateInstances operation requires TerminateInstancesRequest in POJO mode");
             }
         } else {
             TerminateInstancesRequest.Builder builder = TerminateInstancesRequest.builder();
@@ -434,6 +446,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                     LOG.trace("Reboot Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
                     throw ase;
                 }
+            } else {
+                throw new IllegalArgumentException(
+                        "rebootInstances operation requires RebootInstancesRequest in POJO mode");
             }
         } else {
             RebootInstancesRequest.Builder builder = RebootInstancesRequest.builder();
@@ -472,6 +487,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Start Monitoring instances with Ids [{}] ", monitorInstancesRequest.instanceIds());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "monitorInstances operation requires MonitorInstancesRequest in POJO mode");
             }
         } else {
             MonitorInstancesRequest.Builder builder = MonitorInstancesRequest.builder();
@@ -514,6 +532,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Stop Monitoring instances with Ids [{}] ", unmonitorInstancesRequest.instanceIds());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "unmonitorInstances operation requires UnmonitorInstancesRequest in POJO mode");
             }
         } else {
             UnmonitorInstancesRequest.Builder builder = UnmonitorInstancesRequest.builder();
@@ -556,6 +577,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Created tags [{}] ", createTagsRequest.tags());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createTags operation requires CreateTagsRequest in POJO mode");
             }
         } else {
             Collection<Tag> tags;
@@ -605,6 +629,9 @@ public class AWS2EC2Producer extends DefaultProducer {
                 LOG.trace("Delete tags [{}]  ", deleteTagsRequest.tags());
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteTags operation requires DeleteTagsRequest in POJO mode");
             }
         } else {
             Collection<Tag> tags;

--- a/components/camel-aws/camel-aws2-ec2/src/test/java/org/apache/camel/component/aws2/ec2/EC2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-ec2/src/test/java/org/apache/camel/component/aws2/ec2/EC2ProducerTest.java
@@ -27,6 +27,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusResponse;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.InstanceStateName;
@@ -40,6 +42,7 @@ import software.amazon.awssdk.services.ec2.model.StopInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.TerminateInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.UnmonitorInstancesResponse;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -256,6 +259,24 @@ public class EC2ProducerTest extends CamelTestSupport {
         assertEquals(MonitoringState.DISABLED, resultGet.instanceMonitorings().get(0).monitoring().state());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:createAndRunPojo,createAndRunInstances operation requires RunInstancesRequest in POJO mode",
+            "direct:startPojo,startInstances operation requires StartInstancesRequest in POJO mode",
+            "direct:stopPojo,stopInstances operation requires StopInstancesRequest in POJO mode",
+            "direct:terminatePojo,terminateInstances operation requires TerminateInstancesRequest in POJO mode",
+            "direct:rebootPojo,rebootInstances operation requires RebootInstancesRequest in POJO mode",
+            "direct:monitorPojo,monitorInstances operation requires MonitorInstancesRequest in POJO mode",
+            "direct:unmonitorPojo,unmonitorInstances operation requires UnmonitorInstancesRequest in POJO mode",
+            "direct:createTagsPojo,createTags operation requires CreateTagsRequest in POJO mode",
+            "direct:deleteTagsPojo,deleteTags operation requires DeleteTagsRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -288,6 +309,22 @@ public class EC2ProducerTest extends CamelTestSupport {
                         .to("mock:result");
                 from("direct:deleteTags").to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=deleteTags")
                         .to("mock:result");
+                from("direct:startPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=startInstances&pojoRequest=true");
+                from("direct:stopPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=stopInstances&pojoRequest=true");
+                from("direct:terminatePojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=terminateInstances&pojoRequest=true");
+                from("direct:rebootPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=rebootInstances&pojoRequest=true");
+                from("direct:monitorPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=monitorInstances&pojoRequest=true");
+                from("direct:unmonitorPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=unmonitorInstances&pojoRequest=true");
+                from("direct:createTagsPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=createTags&pojoRequest=true");
+                from("direct:deleteTagsPojo")
+                        .to("aws2-ec2://test?amazonEc2Client=#amazonEc2Client&operation=deleteTags&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `AWS2EC2Producer`'s nine operations only acted when the
body was the matching request type; any other body fell through the `instanceof`
with no `else`, so no AWS call was made, no response was set, and the original
body was returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type. The message names the *operation the user configured* — e.g.
`createAndRunInstances` (the enum/URI operation) rather than the internal method
name `createAndRunInstance`.

## Tests

A `@ParameterizedTest` covers all nine operations, sending a wrong-typed body to
`pojoRequest=true` routes and asserting each message. Verified to fail (silent
no-op) before the fix — with the `stopInstances` else removed, exactly that case
reports "Expecting code to raise a throwable". Class 20/20 green. Hermetic unit
tests, region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_