### PR TITLE
CAMEL-24286: Release the latch and unregister when a BackgroundTask supplier throws

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/support/task/task/BackgroundTaskRegistryTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/task/task/BackgroundTaskRegistryTest.java
@@ -128,6 +128,49 @@ class BackgroundTaskRegistryTest {
         assertThat(registry.getTasks()).isEmpty();
     }
 
+    @DisplayName("Test that run() returns and unregisters when the supplier throws (CAMEL-24286)")
+    @Test
+    @Timeout(15)
+    void testRunReturnsAndUnregistersWhenSupplierThrows() throws Exception {
+        AtomicBoolean runReturned = new AtomicBoolean(false);
+        AtomicBoolean completed = new AtomicBoolean(true);
+
+        // an unlimited-duration task: before CAMEL-24286 a thrown supplier exception left the latch
+        // un-counted, so run() blocked forever here and the task leaked in the registry
+        BackgroundTask task = Tasks.backgroundTask()
+                .withScheduledExecutor(Executors.newSingleThreadScheduledExecutor())
+                .withBudget(Budgets.iterationTimeBudget()
+                        .withInterval(Duration.ofMillis(100))
+                        .withInitialDelay(Duration.ZERO)
+                        .withUnlimitedDuration()
+                        .build())
+                .build();
+
+        // daemon so a regression (run() hanging forever) cannot keep the JVM alive
+        Thread runner = new Thread(() -> {
+            boolean result = task.run(camelContext, () -> {
+                throw new IllegalStateException("boom");
+            });
+            completed.set(result);
+            runReturned.set(true);
+        });
+        runner.setDaemon(true);
+        runner.start();
+
+        runner.join(TimeUnit.SECONDS.toMillis(10));
+
+        assertThat(runReturned.get())
+                .as("run() must return when the supplier throws, not block forever")
+                .isTrue();
+        assertThat(completed.get())
+                .as("run() should report the task as not completed after a thrown exception")
+                .isFalse();
+        await().atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(registry.getTasks())
+                        .as("the failed task must not leak in the registry")
+                        .isEmpty());
+    }
+
     @DisplayName("Test that task is removed from registry after supplier succeeds")
     @Test
     @Timeout(10)

--- a/core/camel-support/src/main/java/org/apache/camel/support/task/BackgroundTask.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/task/BackgroundTask.java
@@ -130,7 +130,14 @@ public class BackgroundTask extends AbstractTask implements BlockingTask {
             }
         } catch (Exception e) {
             status = Status.Failed;
+            completed.set(false);
             cause = e;
+            // release the blocking run() caller and unregister; without this a task built with
+            // withUnlimitedDuration() would await() forever and stay in the registry (CAMEL-24286)
+            if (!registeredByRun && registry != null) {
+                registry.removeTask(this);
+            }
+            latch.countDown();
             throw e;
         }
         // scheduleWithFixedDelay waits interval after this run finishes, so compute from now
@@ -196,20 +203,20 @@ public class BackgroundTask extends AbstractTask implements BlockingTask {
                     LOG.debug("The task has finished the execution and it is ready to continue");
                 }
             }
-
-            TaskManagerRegistry registry = null;
-            if (camelContext != null) {
-                registry = PluginHelper.getTaskManagerRegistry(camelContext.getCamelContextExtension());
-            }
-            if (registry != null) {
-                registry.removeTask(this);
-            }
-
-            task.cancel(true);
         } catch (InterruptedException e) {
             LOG.warn("Interrupted while waiting for the repeatable task to execute: {}", e.getMessage(), e);
             Thread.currentThread().interrupt();
         } finally {
+            // unregister and cancel even if the await was interrupted, otherwise the task leaks in
+            // the registry and the scheduled future keeps running (CAMEL-24286)
+            if (camelContext != null) {
+                TaskManagerRegistry registry
+                        = PluginHelper.getTaskManagerRegistry(camelContext.getCamelContextExtension());
+                if (registry != null) {
+                    registry.removeTask(this);
+                }
+            }
+            task.cancel(true);
             elapsed = budget.elapsed();
             running.set(false);
         }


### PR DESCRIPTION
## The bug

`BackgroundTask.runTaskWrapper` rethrows a supplier exception on the scheduler thread without counting down the completion latch or unregistering the task:

```java
try {
    if (doRun(supplier)) {
        ...
        latch.countDown();
    }
} catch (Exception e) {          // no countDown, no removeTask
    status = Status.Failed;
    cause = e;
    throw e;
}
```

`doRun` only catches `TaskRunFailureException`, so any *other* exception reaches this path. `scheduleWithFixedDelay` then suppresses all further executions, and for a task built with `withUnlimitedDuration()` `waitForTaskCompletion` calls `latch.await()` with **no timeout** — so the calling thread **blocks forever** and the task **leaks in the `TaskManagerRegistry`**.

The interrupt path has a smaller sibling of the same gap: in `waitForTaskCompletion`, `removeTask` sits inside the `try`, so an `InterruptedException` from `latch.await()` also leaves the task registered.

## Reachability on `main`

CAMEL-24272 now routes two *unlimited-duration* reconnection loops through `BackgroundTask.run()`:

- **camel-ftp SFTP** — `SftpOperations.java` uses `withUnlimitedDuration()`; `tryConnect` catches only `JSchException`. A non-JSch `RuntimeException` on the connect path escapes into the throw path.
- **camel-mongodb-gridfs** — `GridFsConsumer` uses `withUnlimitedDuration()` + `run()`. In `processCollection`, the inner `catch (Exception) { // ignore }` wraps only `getProcessor().process(...)`; the cursor acquisition and the pre-process `findOneAndUpdate` are **outside** any catch, so a transient `MongoException` escapes.

Bounded tasks (`withMaxDuration`, e.g. Infinispan) don't hang — `latch.await(maxDuration)` times out — but they still fail slow and lose the cause.

## The fix

In the `catch`, mark the task not-completed, unregister it, and count down the latch **before** rethrowing, so the blocking `run()` caller unblocks and observes the failure. The rethrow is kept so the `schedule()` path (no latch waiter) still surfaces the error to the executor.

Also move `removeTask` + `task.cancel` into the `finally` of `waitForTaskCompletion`, so an interrupted `await()` no longer leaves the task registered.

## Test

`BackgroundTaskRegistryTest.testRunReturnsAndUnregistersWhenSupplierThrows` builds an unlimited-duration task whose supplier throws, runs it on a **daemon** thread (so a regression can't wedge the JVM), and asserts `run()` returns, reports not-completed, and the registry ends empty.

Verified both directions locally:
- **without the fix** — the new test fails (`run()` hangs on the 10s join); the three existing tests pass.
- **with the fix** — all four pass.

## Notes

Found while reviewing the task-manager PR cluster (CAMEL-24271/24272/24278). It is the residual foreground→background porting gap, not attributable to a single PR. The rethrow is deliberately preserved in case surfacing the error to the executor on the `schedule()` path is intended — only the latch-release/unregister omission is fixed.

---

_Claude Code on behalf of @oscerd_
