### PR TITLE
CAMEL-24293: Strip path segments from externally-derived filenames before setting CamelFileName

### DIFF
--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumer.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumer.java
@@ -540,7 +540,10 @@ public class VertxPlatformHttpConsumer extends DefaultConsumer
                 if (uploads.size() == 1) {
                     message.setHeader(Exchange.FILE_PATH, localFile.getAbsolutePath());
                     message.setHeader(Exchange.FILE_LENGTH, upload.size());
-                    message.setHeader(Exchange.FILE_NAME, upload.fileName());
+                    // FILE_NAME is a Camel control header consumed by file/ftp producers; the raw
+                    // client-supplied multipart filename may contain path segments, so reduce it to a
+                    // leaf name (CAMEL-24293)
+                    message.setHeader(Exchange.FILE_NAME, FileUtil.stripPath(upload.fileName()));
                     String ct = MimeTypeHelper.probeMimeType(upload.fileName());
                     if (ct == null) {
                         ct = upload.contentType();

--- a/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarFileDataFormat.java
+++ b/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarFileDataFormat.java
@@ -30,6 +30,7 @@ import org.apache.camel.spi.DataFormatName;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.apache.camel.support.builder.OutputStreamBuilder;
 import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
@@ -113,7 +114,7 @@ public class TarFileDataFormat extends ServiceSupport implements DataFormat, Dat
             try {
                 TarArchiveEntry entry = tis.getNextEntry();
                 if (entry != null) {
-                    exchange.getMessage().setHeader(FILE_NAME, entry.getName());
+                    exchange.getMessage().setHeader(FILE_NAME, FileUtil.stripPath(entry.getName()));
                     IOHelper.copy(tis, osb, IOHelper.DEFAULT_BUFFER_SIZE, false, maxDecompressedSize);
                 } else {
                     throw new IllegalStateException("Unable to untar the file, it may be corrupted.");

--- a/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarIterator.java
+++ b/components/camel-tarfile/src/main/java/org/apache/camel/dataformat/tarfile/TarIterator.java
@@ -27,6 +27,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.support.DefaultMessage;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -132,7 +133,10 @@ public class TarIterator implements Iterator<Message>, Closeable {
                 Message answer = new DefaultMessage(exchange.getContext());
                 answer.getHeaders().putAll(exchange.getIn().getHeaders());
                 answer.setHeader(TARFILE_ENTRY_NAME_HEADER, current.getName());
-                answer.setHeader(Exchange.FILE_NAME, current.getName());
+                // CAMEL-24293: the entry name is attacker-influenced archive content, so reduce the
+                // CamelFileName control header to the leaf name (Tar Slip). The full path stays on
+                // CamelTarFileEntryName.
+                answer.setHeader(Exchange.FILE_NAME, FileUtil.stripPath(current.getName()));
                 if (current.getSize() > 0) {
                     if (maxDecompressedSize > 0) {
                         answer.setBody(BoundedInputStream.builder()

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileDataFormatTest.java
@@ -364,7 +364,9 @@ class TarFileDataFormatTest extends CamelTestSupport {
                                 InputStream is = new FileInputStream("src/test/resources/data/hello.tar");
 
                                 TarArchiveEntry entry
-                                        = new TarArchiveEntry((String) exchange.getIn().getHeader(Exchange.FILE_NAME));
+                                        // CamelFileName is now the stripped basename (Tar Slip prevention); rebuild structure from the full entry name
+                                        = new TarArchiveEntry(
+                                                (String) exchange.getIn().getHeader(TarIterator.TARFILE_ENTRY_NAME_HEADER));
                                 File outputFile = new File("hello_out", entry.getName());
                                 if (entry.isDirectory()) {
                                     outputFile.mkdirs();

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileNameStripPathTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileNameStripPathTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.tarfile;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.Exchange.FILE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The TAR entry name is attacker-influenced archive content, so when it is promoted to the CamelFileName control header
+ * it must be reduced to a leaf name (no path segments). See CAMEL-24293.
+ */
+class TarFileNameStripPathTest extends CamelTestSupport {
+
+    private static byte[] tarWithEntry(String entryName) throws Exception {
+        byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tos = new TarArchiveOutputStream(bos)) {
+            TarArchiveEntry entry = new TarArchiveEntry(entryName);
+            entry.setSize(payload.length);
+            tos.putArchiveEntry(entry);
+            tos.write(payload);
+            tos.closeArchiveEntry();
+        }
+        return bos.toByteArray();
+    }
+
+    @Test
+    void entryNameWithPathIsStrippedToLeaf() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", tarWithEntry("subdir/evil.txt"));
+
+        mock.assertIsSatisfied();
+        assertEquals("evil.txt", mock.getReceivedExchanges().get(0).getIn().getHeader(FILE_NAME, String.class));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").unmarshal(new TarFileDataFormat()).to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileNameStripPathTest.java
+++ b/components/camel-tarfile/src/test/java/org/apache/camel/dataformat/tarfile/TarFileNameStripPathTest.java
@@ -31,7 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The TAR entry name is attacker-influenced archive content, so when it is promoted to the CamelFileName control header
- * it must be reduced to a leaf name (no path segments). See CAMEL-24293.
+ * it must be reduced to a leaf name (no path segments) - for both the data format {@code unmarshal} and the
+ * iterator/splitter ({@link TarSplitter}) modes. See CAMEL-24293.
  */
 class TarFileNameStripPathTest extends CamelTestSupport {
 
@@ -59,12 +60,29 @@ class TarFileNameStripPathTest extends CamelTestSupport {
         assertEquals("evil.txt", mock.getReceivedExchanges().get(0).getIn().getHeader(FILE_NAME, String.class));
     }
 
+    @Test
+    void iteratorEntryNameWithPathIsStrippedToLeaf() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:iterated");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:iterate", tarWithEntry("subdir/evil.txt"));
+
+        mock.assertIsSatisfied();
+        // the splitter path reduces CamelFileName to the leaf name too ...
+        assertEquals("evil.txt",
+                mock.getReceivedExchanges().get(0).getIn().getHeader(FILE_NAME, String.class));
+        // ... while the full entry name stays available on the dedicated header
+        assertEquals("subdir/evil.txt",
+                mock.getReceivedExchanges().get(0).getIn().getHeader(TarIterator.TARFILE_ENTRY_NAME_HEADER, String.class));
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:start").unmarshal(new TarFileDataFormat()).to("mock:result");
+                from("direct:iterate").split(new TarSplitter()).streaming().to("mock:iterated");
             }
         };
     }

--- a/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipFileDataFormat.java
+++ b/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipFileDataFormat.java
@@ -30,6 +30,7 @@ import org.apache.camel.spi.DataFormatName;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.apache.camel.support.builder.OutputStreamBuilder;
 import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
@@ -116,7 +117,7 @@ public class ZipFileDataFormat extends ServiceSupport implements DataFormat, Dat
             try {
                 ZipArchiveEntry entry = zis.getNextEntry();
                 if (entry != null) {
-                    exchange.getMessage().setHeader(FILE_NAME, entry.getName());
+                    exchange.getMessage().setHeader(FILE_NAME, FileUtil.stripPath(entry.getName()));
                     IOHelper.copy(zis, osb, IOHelper.DEFAULT_BUFFER_SIZE, false, maxDecompressedSize);
                 } else {
                     throw new IllegalStateException("Unable to unzip the file, it may be corrupted.");

--- a/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipIterator.java
+++ b/components/camel-zipfile/src/main/java/org/apache/camel/dataformat/zipfile/ZipIterator.java
@@ -31,6 +31,7 @@ import org.apache.camel.Message;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.converter.stream.CachedOutputStream;
 import org.apache.camel.support.DefaultMessage;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.IOHelper;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -145,7 +146,9 @@ public class ZipIterator implements Iterator<Message>, Closeable {
                 Message answer = new DefaultMessage(exchange.getContext());
                 answer.getHeaders().putAll(exchange.getIn().getHeaders());
                 answer.setHeader("zipFileName", zipFileName);
-                answer.setHeader(Exchange.FILE_NAME, zipFileName);
+                // CAMEL-24293: the entry name is attacker-influenced archive content, so reduce the
+                // CamelFileName control header to the leaf name (Zip Slip). The full path stays on zipFileName.
+                answer.setHeader(Exchange.FILE_NAME, FileUtil.stripPath(zipFileName));
                 if (currentEntry.isDirectory()) {
                     if (allowEmptyDirectory) {
                         answer.setBody(new ByteArrayInputStream(new byte[0]));

--- a/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileDataFormatTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileDataFormatTest.java
@@ -318,7 +318,9 @@ public class ZipFileDataFormatTest extends CamelTestSupport {
                             @Override
                             public void process(Exchange exchange) throws Exception {
                                 ZipFile zfile = new ZipFile(new File("src/test/resources/hello.odt"));
-                                ZipEntry entry = new ZipEntry((String) exchange.getIn().getHeader(Exchange.FILE_NAME));
+                                // CamelFileName is now the stripped basename (Zip Slip prevention); rebuild structure from the full entry name
+                                ZipEntry entry
+                                        = new ZipEntry((String) exchange.getIn().getHeader("zipFileName"));
                                 File file = new File("hello_out", entry.getName());
                                 if (entry.isDirectory()) {
                                     file.mkdirs();

--- a/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileNameStripPathTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileNameStripPathTest.java
@@ -31,7 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The ZIP entry name is attacker-influenced archive content, so when it is promoted to the CamelFileName control header
- * it must be reduced to a leaf name (no path segments). See CAMEL-24293.
+ * it must be reduced to a leaf name (no path segments) - for both the data format {@code unmarshal} and the
+ * iterator/splitter ({@link ZipSplitter}) modes. See CAMEL-24293.
  */
 class ZipFileNameStripPathTest extends CamelTestSupport {
 
@@ -56,12 +57,29 @@ class ZipFileNameStripPathTest extends CamelTestSupport {
         assertEquals("evil.txt", mock.getReceivedExchanges().get(0).getIn().getHeader(FILE_NAME, String.class));
     }
 
+    @Test
+    void iteratorEntryNameWithPathIsStrippedToLeaf() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:iterated");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:iterate", zipWithEntry("subdir/evil.txt"));
+
+        mock.assertIsSatisfied();
+        // the splitter path reduces CamelFileName to the leaf name too ...
+        assertEquals("evil.txt",
+                mock.getReceivedExchanges().get(0).getIn().getHeader(FILE_NAME, String.class));
+        // ... while the full entry name stays available on the dedicated header
+        assertEquals("subdir/evil.txt",
+                mock.getReceivedExchanges().get(0).getIn().getHeader("zipFileName", String.class));
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             @Override
             public void configure() {
                 from("direct:start").unmarshal(new ZipFileDataFormat()).to("mock:result");
+                from("direct:iterate").split(new ZipSplitter()).streaming().to("mock:iterated");
             }
         };
     }

--- a/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileNameStripPathTest.java
+++ b/components/camel-zipfile/src/test/java/org/apache/camel/dataformat/zipfile/ZipFileNameStripPathTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dataformat.zipfile;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.Exchange.FILE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The ZIP entry name is attacker-influenced archive content, so when it is promoted to the CamelFileName control header
+ * it must be reduced to a leaf name (no path segments). See CAMEL-24293.
+ */
+class ZipFileNameStripPathTest extends CamelTestSupport {
+
+    private static byte[] zipWithEntry(String entryName) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(bos)) {
+            zos.putNextEntry(new ZipEntry(entryName));
+            zos.write("payload".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return bos.toByteArray();
+    }
+
+    @Test
+    void entryNameWithPathIsStrippedToLeaf() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:start", zipWithEntry("subdir/evil.txt"));
+
+        mock.assertIsSatisfied();
+        assertEquals("evil.txt", mock.getReceivedExchanges().get(0).getIn().getHeader(FILE_NAME, String.class));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").unmarshal(new ZipFileDataFormat()).to("mock:result");
+            }
+        };
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1360,3 +1360,15 @@ and/or the audience that tokens are expected to carry.
 If a deployment genuinely wants signature and expiry validation only, set
 `camel.server.jwtAllowMissingIssuerAndAudience=true` (or `camel.management.jwtAllowMissingIssuerAndAudience=true`)
 to keep the previous behaviour.
+
+=== camel-tarfile / camel-zipfile - CamelFileName is stripped to the entry base name on unmarshal
+
+When unmarshalling a tar or zip archive, the `CamelFileName` header was previously set to the
+raw archive entry name, which for a crafted archive can contain path segments (e.g.
+`../../etc/passwd`). If a downstream route wrote the message to disk using that header, the
+entry name could escape the intended directory (Tar Slip / Zip Slip).
+
+`CamelFileName` is now set to the entry's base name only (path segments stripped) for both the
+data format and the iterator/splitter modes. The full, unmodified entry name remains available
+so routes that intentionally recreate the archive's directory structure keep working — read it
+from `CamelTarFileEntryName` for tar and from `zipFileName` for zip instead of `CamelFileName`.


### PR DESCRIPTION
Reduces externally-derived filenames to a leaf name (`FileUtil.stripPath`) before they are placed in the `CamelFileName` control header, so path segments carried by an archive/multipart name are not propagated to downstream file/ftp producers. This aligns these paths with the normalisation other file-producing paths already apply.

### What

`CamelFileName` (`Exchange.FILE_NAME`) is consumed by file/ftp producers to choose the output filename. These paths set it from an externally-derived name that may contain path segments — each now applies `FileUtil.stripPath(...)`:

- **camel-platform-http-vertx** — `VertxPlatformHttpConsumer`, from the raw multipart `Content-Disposition` filename (`upload.fileName()`).
- **camel-zipfile** — `ZipFileDataFormat` (unmarshal) **and `ZipIterator`** (the `.split(new ZipSplitter())` path), from the raw ZIP entry name.
- **camel-tarfile** — `TarFileDataFormat` (unmarshal) **and `TarIterator`** (the `.split(new TarSplitter())` path), from the raw TAR entry name.

The full, unmodified entry name remains available on the dedicated `zipFileName` / `CamelTarFileEntryName` headers, so routes that intentionally recreate the archive's directory structure keep working. The **marshal** paths (`ZipFileDataFormat` / `TarFileDataFormat` output-filename headers, which are route-author-controlled) are intentionally left unchanged.

### Tests

`ZipFileNameStripPathTest` and `TarFileNameStripPathTest` assert that an entry name with a directory prefix (`subdir/evil.txt`) yields `CamelFileName = evil.txt` — for **both** the data-format `unmarshal` path and the iterator/splitter (`ZipSplitter` / `TarSplitter`) path, while the dedicated header keeps the full `subdir/evil.txt`. The vertx multipart path uses the identical `FileUtil.stripPath` call. Existing empty-directory splitter tests remain green.

### Notes

- Non-breaking: legitimate leaf filenames are unaffected.
- Improvement / consistency hardening — **not backported** (main only).
- Full reactor build (`mvn clean install -DskipTests`) succeeds with no generated-file drift.

---
_Claude Code on behalf of Andrea Cosentino (@oscerd)_
