### PR TITLE
Fix flakiness of Eventbridge tests

### DIFF
--- a/components/camel-aws/camel-aws2-eventbridge/pom.xml
+++ b/components/camel-aws/camel-aws2-eventbridge/pom.xml
@@ -96,6 +96,11 @@
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- test infra -->
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeDeleteRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeDeleteRuleIT.java
@@ -44,19 +44,19 @@ public class EventbridgeDeleteRuleIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeDeleteRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDeleteRuleIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgeDeleteRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDeleteRuleIT");
                 Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
@@ -66,22 +66,22 @@ public class EventbridgeDeleteRuleIT extends Aws2EventbridgeBase {
         });
 
         // https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteRule.html before deleting the route, all targets must be removed
-        template.send("direct:evs-removeTarget", new Processor() {
+        template.send("direct:evs-removeTarget-EventbridgeDeleteRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDeleteRuleIT");
                 List<String> targets = new ArrayList<String>();
                 targets.add("sqs-queue");
                 exchange.getIn().setHeader(EventbridgeConstants.TARGETS_IDS, targets);
             }
         });
 
-        Exchange ex = template.send("direct:evs-deleteRule", new Processor() {
+        Exchange ex = template.send("direct:evs-deleteRule-EventbridgeDeleteRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDeleteRuleIT");
             }
         });
 
@@ -100,10 +100,10 @@ public class EventbridgeDeleteRuleIT extends Aws2EventbridgeBase {
                 String target = "aws2-eventbridge://default?operation=putTargets";
                 String removeTarget = "aws2-eventbridge://default?operation=removeTargets";
                 String deleteRule = "aws2-eventbridge://default?operation=deleteRule";
-                from("direct:evs").to(awsEndpoint);
-                from("direct:evs-targets").to(target);
-                from("direct:evs-removeTarget").to(removeTarget);
-                from("direct:evs-deleteRule").to(deleteRule).to("mock:result");
+                from("direct:evs-EventbridgeDeleteRuleIT").to(awsEndpoint);
+                from("direct:evs-targets-EventbridgeDeleteRuleIT").to(target);
+                from("direct:evs-removeTarget-EventbridgeDeleteRuleIT").to(removeTarget);
+                from("direct:evs-deleteRule-EventbridgeDeleteRuleIT").to(deleteRule).to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeDescribeRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeDescribeRuleIT.java
@@ -45,20 +45,21 @@ public class EventbridgeDescribeRuleIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeDescribeRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDescribeRuleIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgeDescribeRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
-                Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDescribeRuleIT");
+                Target target = Target.builder().id("sqs-queue-EventbridgeDescribeRuleIT")
+                        .arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
                 targets.add(target);
@@ -66,16 +67,17 @@ public class EventbridgeDescribeRuleIT extends Aws2EventbridgeBase {
             }
         });
 
-        template.send("direct:describe-rule", new Processor() {
+        template.send("direct:describe-rule-EventbridgeDescribeRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDescribeRuleIT");
             }
         });
         MockEndpoint.assertIsSatisfied(context);
         assertNotNull(result.getExchanges().get(0).getMessage().getBody(DescribeRuleResponse.class).eventPattern());
-        assertEquals("firstrule", result.getExchanges().get(0).getMessage().getBody(DescribeRuleResponse.class).name());
+        assertEquals("firstrule-EventbridgeDescribeRuleIT",
+                result.getExchanges().get(0).getMessage().getBody(DescribeRuleResponse.class).name());
     }
 
     @Override
@@ -87,9 +89,9 @@ public class EventbridgeDescribeRuleIT extends Aws2EventbridgeBase {
                         = "aws2-eventbridge://default?operation=putRule&eventPatternFile=file:src/test/resources/eventpattern.json";
                 String target = "aws2-eventbridge://default?operation=putTargets";
                 String describeRule = "aws2-eventbridge://default?operation=describeRule";
-                from("direct:evs").to(awsEndpoint);
-                from("direct:evs-targets").to(target);
-                from("direct:describe-rule").to(describeRule).to("mock:result");
+                from("direct:evs-EventbridgeDescribeRuleIT").to(awsEndpoint);
+                from("direct:evs-targets-EventbridgeDescribeRuleIT").to(target);
+                from("direct:describe-rule-EventbridgeDescribeRuleIT").to(describeRule).to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeDisableRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeDisableRuleIT.java
@@ -28,9 +28,11 @@ import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.eventbridge.model.ListRulesResponse;
+import software.amazon.awssdk.services.eventbridge.model.Rule;
 import software.amazon.awssdk.services.eventbridge.model.RuleState;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EventbridgeDisableRuleIT extends Aws2EventbridgeBase {
@@ -45,20 +47,21 @@ public class EventbridgeDisableRuleIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeDisableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDisableRuleIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgeDisableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
-                Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDisableRuleIT");
+                Target target = Target.builder().id("sqs-queue-EventbridgeDisableRuleIT")
+                        .arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
                 targets.add(target);
@@ -66,15 +69,15 @@ public class EventbridgeDisableRuleIT extends Aws2EventbridgeBase {
             }
         });
 
-        template.send("direct:evs-disableRule", new Processor() {
+        template.send("direct:evs-disableRule-EventbridgeDisableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeDisableRuleIT");
             }
         });
 
-        Exchange ex = template.request("direct:evs-listRules", new Processor() {
+        Exchange ex = template.request("direct:evs-listRules-EventbridgeDisableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
@@ -83,9 +86,11 @@ public class EventbridgeDisableRuleIT extends Aws2EventbridgeBase {
 
         ListRulesResponse resp = ex.getIn().getBody(ListRulesResponse.class);
         assertEquals(true, resp.hasRules());
-        assertEquals(1, resp.rules().size());
-        assertEquals("firstrule", resp.rules().get(0).name());
-        assertEquals(RuleState.DISABLED, resp.rules().get(0).state());
+        assertThat(resp.rules().stream().map(Rule::name))
+                .contains("firstrule-EventbridgeDisableRuleIT");
+        Rule disabledRule = resp.rules().stream().filter(rule -> "firstrule-EventbridgeDisableRuleIT".equals(rule.name()))
+                .findAny().get();
+        assertEquals(RuleState.DISABLED, disabledRule.state());
         MockEndpoint.assertIsSatisfied(context);
 
     }
@@ -101,10 +106,10 @@ public class EventbridgeDisableRuleIT extends Aws2EventbridgeBase {
                 String listRule = "aws2-eventbridge://default?operation=listRules";
                 String disableRule = "aws2-eventbridge://default?operation=disableRule";
 
-                from("direct:evs").to(putRule);
-                from("direct:evs-targets").to(putTargets);
-                from("direct:evs-listRules").to(listRule);
-                from("direct:evs-disableRule").to(disableRule).log("${body}").to("mock:result");
+                from("direct:evs-EventbridgeDisableRuleIT").to(putRule);
+                from("direct:evs-targets-EventbridgeDisableRuleIT").to(putTargets);
+                from("direct:evs-listRules-EventbridgeDisableRuleIT").to(listRule);
+                from("direct:evs-disableRule-EventbridgeDisableRuleIT").to(disableRule).log("${body}").to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeEnableRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeEnableRuleIT.java
@@ -29,9 +29,11 @@ import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.eventbridge.model.ListRulesResponse;
+import software.amazon.awssdk.services.eventbridge.model.Rule;
 import software.amazon.awssdk.services.eventbridge.model.RuleState;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EventbridgeEnableRuleIT extends Aws2EventbridgeBase {
@@ -46,20 +48,21 @@ public class EventbridgeEnableRuleIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeEnableRuleIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
-                Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeEnableRuleIT");
+                Target target = Target.builder().id("sqs-queue-EventbridgeEnableRuleIT")
+                        .arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
                 targets.add(target);
@@ -67,23 +70,23 @@ public class EventbridgeEnableRuleIT extends Aws2EventbridgeBase {
             }
         });
 
-        template.send("direct:evs-disableRule", new Processor() {
+        template.send("direct:evs-disableRule-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeEnableRuleIT");
             }
         });
 
-        template.send("direct:evs-enableRule", new Processor() {
+        template.send("direct:evs-enableRule-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeEnableRuleIT");
             }
         });
 
-        Exchange ex = template.request("direct:evs-listRules", new Processor() {
+        Exchange ex = template.request("direct:evs-listRules-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
@@ -92,28 +95,30 @@ public class EventbridgeEnableRuleIT extends Aws2EventbridgeBase {
 
         ListRulesResponse resp = ex.getIn().getBody(ListRulesResponse.class);
         assertEquals(true, resp.hasRules());
-        assertEquals(1, resp.rules().size());
-        assertEquals("firstrule", resp.rules().get(0).name());
-        assertEquals(RuleState.ENABLED, resp.rules().get(0).state());
+        assertThat(resp.rules().stream().map(Rule::name))
+                .contains("firstrule-EventbridgeEnableRuleIT");
+        Rule enabledRule = resp.rules().stream().filter(rule -> "firstrule-EventbridgeEnableRuleIT".equals(rule.name()))
+                .findAny().get();
+        assertEquals(RuleState.ENABLED, enabledRule.state());
         MockEndpoint.assertIsSatisfied(context);
 
         // Clean up eventbridge
-        template.send("direct:evs-deleteTargets", new Processor() {
+        template.send("direct:evs-deleteTargets-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeEnableRuleIT");
                 Collection<String> targets = new ArrayList<>();
-                targets.add("sqs-queue");
+                targets.add("sqs-queue-EventbridgeEnableRuleIT");
                 exchange.getIn().setHeader(EventbridgeConstants.TARGETS_IDS, targets);
             }
         });
 
-        template.send("direct:evs-deleteRule", new Processor() {
+        template.send("direct:evs-deleteRule-EventbridgeEnableRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeEnableRuleIT");
             }
         });
     }
@@ -132,13 +137,13 @@ public class EventbridgeEnableRuleIT extends Aws2EventbridgeBase {
                 String enableRule = "aws2-eventbridge://default?operation=enableRule";
                 String deleteRule = "aws2-eventbridge://default?operation=deleteRule";
 
-                from("direct:evs").to(putRule);
-                from("direct:evs-targets").to(putTargets);
-                from("direct:evs-listRules").to(listRule);
-                from("direct:evs-disableRule").to(disableRule);
-                from("direct:evs-deleteRule").to(deleteRule);
-                from("direct:evs-deleteTargets").to(removeTargets);
-                from("direct:evs-enableRule").to(enableRule).log("${body}").to("mock:result");
+                from("direct:evs-EventbridgeEnableRuleIT").to(putRule);
+                from("direct:evs-targets-EventbridgeEnableRuleIT").to(putTargets);
+                from("direct:evs-listRules-EventbridgeEnableRuleIT").to(listRule);
+                from("direct:evs-disableRule-EventbridgeEnableRuleIT").to(disableRule);
+                from("direct:evs-deleteRule-EventbridgeEnableRuleIT").to(deleteRule);
+                from("direct:evs-deleteTargets-EventbridgeEnableRuleIT").to(removeTargets);
+                from("direct:evs-enableRule-EventbridgeEnableRuleIT").to(enableRule).log("${body}").to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeListRulesIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeListRulesIT.java
@@ -28,9 +28,10 @@ import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.eventbridge.model.ListRulesResponse;
+import software.amazon.awssdk.services.eventbridge.model.Rule;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventbridgeListRulesIT extends Aws2EventbridgeBase {
 
@@ -44,20 +45,29 @@ public class EventbridgeListRulesIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeListRulesIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeListRulesIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-EventbridgeListRulesIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
-                Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "secondrule-EventbridgeListRulesIT");
+            }
+        });
+
+        template.send("direct:evs-targets-EventbridgeListRulesIT", new Processor() {
+
+            @Override
+            public void process(Exchange exchange) {
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeListRulesIT");
+                Target target = Target.builder().id("sqs-queue-EventbridgeListRulesIT")
+                        .arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
                 targets.add(target);
@@ -65,7 +75,7 @@ public class EventbridgeListRulesIT extends Aws2EventbridgeBase {
             }
         });
 
-        Exchange ex = template.request("direct:evs-listRules", new Processor() {
+        Exchange ex = template.request("direct:evs-listRules-EventbridgeListRulesIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
@@ -73,9 +83,9 @@ public class EventbridgeListRulesIT extends Aws2EventbridgeBase {
         });
 
         ListRulesResponse resp = ex.getIn().getBody(ListRulesResponse.class);
-        assertEquals(true, resp.hasRules());
-        assertEquals(1, resp.rules().size());
-        assertEquals("firstrule", resp.rules().get(0).name());
+        assertThat(resp.rules().stream().map(Rule::name))
+                .contains("firstrule-EventbridgeListRulesIT")
+                .contains("secondrule-EventbridgeListRulesIT");
         MockEndpoint.assertIsSatisfied(context);
 
     }
@@ -90,9 +100,9 @@ public class EventbridgeListRulesIT extends Aws2EventbridgeBase {
                 String putTargets = "aws2-eventbridge://default?operation=putTargets";
                 String listRule = "aws2-eventbridge://default?operation=listRules";
 
-                from("direct:evs").to(putRule).log("${body}");
-                from("direct:evs-targets").to(putTargets).log("${body}");
-                from("direct:evs-listRules").to(listRule).log("${body}").to("mock:result");
+                from("direct:evs-EventbridgeListRulesIT").to(putRule).log("${body}");
+                from("direct:evs-targets-EventbridgeListRulesIT").to(putTargets).log("${body}");
+                from("direct:evs-listRules-EventbridgeListRulesIT").to(listRule).log("${body}").to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeListTargetsByRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeListTargetsByRuleIT.java
@@ -44,19 +44,19 @@ public class EventbridgeListTargetsByRuleIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeListTargetsByRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeListTargetsByRuleIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgeListTargetsByRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeListTargetsByRuleIT");
                 Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
@@ -65,11 +65,11 @@ public class EventbridgeListTargetsByRuleIT extends Aws2EventbridgeBase {
             }
         });
 
-        template.send("direct:evs-list-targets", new Processor() {
+        template.send("direct:evs-list-targets-EventbridgeListTargetsByRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeListTargetsByRuleIT");
             }
         });
         MockEndpoint.assertIsSatisfied(context);
@@ -88,9 +88,9 @@ public class EventbridgeListTargetsByRuleIT extends Aws2EventbridgeBase {
                         = "aws2-eventbridge://default?operation=putRule&eventPatternFile=file:src/test/resources/eventpattern.json";
                 String target = "aws2-eventbridge://default?operation=putTargets";
                 String listTargets = "aws2-eventbridge://default?operation=listTargetsByRule";
-                from("direct:evs").to(awsEndpoint);
-                from("direct:evs-targets").to(target);
-                from("direct:evs-list-targets").to(listTargets).to("mock:result");
+                from("direct:evs-EventbridgeListTargetsByRuleIT").to(awsEndpoint);
+                from("direct:evs-targets-EventbridgeListTargetsByRuleIT").to(target);
+                from("direct:evs-list-targets-EventbridgeListTargetsByRuleIT").to(listTargets).to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutEventsIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutEventsIT.java
@@ -16,28 +16,18 @@
  */
 package org.apache.camel.component.aws2.eventbridge.localstack;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.aws2.eventbridge.EventbridgeComponent;
 import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.infra.aws.common.services.AWSService;
-import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
-import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
-import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
 
-public class EventbridgePutEventsIT extends CamelTestSupport {
-
-    @RegisterExtension
-    public static AWSService service = AWSServiceFactory.createEventBridgeService();
+public class EventbridgePutEventsIT extends Aws2EventbridgeBase {
 
     @EndpointInject
     private ProducerTemplate template;
@@ -45,19 +35,11 @@ public class EventbridgePutEventsIT extends CamelTestSupport {
     @EndpointInject("mock:result")
     private MockEndpoint result;
 
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext context = super.createCamelContext();
-        EventbridgeComponent eventbridgeComponent = context.getComponent("aws2-eventbridge", EventbridgeComponent.class);
-        eventbridgeComponent.getConfiguration().setEventbridgeClient(AWSSDKClientUtils.newEventBridgeClient());
-        return context;
-    }
-
     @Test
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs-events", new Processor() {
+        template.send("direct:evs-events-EventbridgePutEventsIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
@@ -82,7 +64,7 @@ public class EventbridgePutEventsIT extends CamelTestSupport {
             @Override
             public void configure() {
                 String event = "aws2-eventbridge://default?operation=putEvent";
-                from("direct:evs-events").to(event).log("${body}").to("mock:result");
+                from("direct:evs-events-EventbridgePutEventsIT").to(event).log("${body}").to("mock:result");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutRuleIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgePutRuleIT.java
@@ -27,8 +27,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
+@Isolated
 public class EventbridgePutRuleIT extends Aws2EventbridgeBase {
 
     @EndpointInject
@@ -45,20 +47,21 @@ public class EventbridgePutRuleIT extends Aws2EventbridgeBase {
         result.expectedMessageCount(1);
         result1.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgePutRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgePutRuleIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgePutRuleIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
-                Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgePutRuleIT");
+                Target target = Target.builder().id("sqs-queue")
+                        .arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
                 targets.add(target);
@@ -68,15 +71,15 @@ public class EventbridgePutRuleIT extends Aws2EventbridgeBase {
         MockEndpoint.assertIsSatisfied(context);
 
         // cleanup rule
-        template.send("direct:evs-removeTargets", exchange -> {
-            exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+        template.send("direct:evs-removeTargets-EventbridgePutRuleIT", exchange -> {
+            exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgePutRuleIT");
             List<String> targets = new ArrayList<>();
             targets.add("sqs-queue");
             exchange.getIn().setHeader(EventbridgeConstants.TARGETS_IDS, targets);
         });
 
-        template.send("direct:evs-deleteRule",
-                exchange -> exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule"));
+        template.send("direct:evs-deleteRule-EventbridgePutRuleIT",
+                exchange -> exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgePutRuleIT"));
     }
 
     @Override
@@ -89,10 +92,10 @@ public class EventbridgePutRuleIT extends Aws2EventbridgeBase {
                 String target = "aws2-eventbridge://default?operation=putTargets";
                 String removeTarget = "aws2-eventbridge://default?operation=removeTargets";
                 String deleteRule = "aws2-eventbridge://default?operation=deleteRule";
-                from("direct:evs").to(awsEndpoint).log("${body}").to("mock:result");
-                from("direct:evs-targets").to(target).log("${body}").to("mock:result1");
-                from("direct:evs-removeTargets").to(removeTarget);
-                from("direct:evs-deleteRule").to(deleteRule);
+                from("direct:evs-EventbridgePutRuleIT").to(awsEndpoint).log("${body}").to("mock:result");
+                from("direct:evs-targets-EventbridgePutRuleIT").to(target).log("${body}").to("mock:result1");
+                from("direct:evs-removeTargets-EventbridgePutRuleIT").to(removeTarget);
+                from("direct:evs-deleteRule-EventbridgePutRuleIT").to(deleteRule);
             }
         };
     }

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeRemoveTargetsIT.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/localstack/EventbridgeRemoveTargetsIT.java
@@ -27,10 +27,12 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.eventbridge.EventbridgeConstants;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import software.amazon.awssdk.services.eventbridge.model.Target;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Isolated
 public class EventbridgeRemoveTargetsIT extends Aws2EventbridgeBase {
 
     @EndpointInject
@@ -43,20 +45,21 @@ public class EventbridgeRemoveTargetsIT extends Aws2EventbridgeBase {
     public void sendIn() throws Exception {
         result.expectedMessageCount(1);
 
-        template.send("direct:evs", new Processor() {
+        template.send("direct:evs-EventbridgeRemoveTargetsIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeRemoveTargetsIT");
             }
         });
 
-        template.send("direct:evs-targets", new Processor() {
+        template.send("direct:evs-targets-EventbridgeRemoveTargetsIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
-                Target target = Target.builder().id("sqs-queue").arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeRemoveTargetsIT");
+                Target target = Target.builder().id("sqs-queue-EventbridgeRemoveTargetsIT")
+                        .arn("arn:aws:sqs:eu-west-1:780410022472:camel-connector-test")
                         .build();
                 List<Target> targets = new ArrayList<Target>();
                 targets.add(target);
@@ -64,13 +67,13 @@ public class EventbridgeRemoveTargetsIT extends Aws2EventbridgeBase {
             }
         });
 
-        template.send("direct:evs-remove-targets", new Processor() {
+        template.send("direct:evs-remove-targets-EventbridgeRemoveTargetsIT", new Processor() {
 
             @Override
             public void process(Exchange exchange) {
-                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule");
+                exchange.getIn().setHeader(EventbridgeConstants.RULE_NAME, "firstrule-EventbridgeRemoveTargetsIT");
                 List<String> targets = new ArrayList<String>();
-                targets.add("sqs-queue");
+                targets.add("sqs-queue-EventbridgeRemoveTargetsIT");
                 exchange.getIn().setHeader(EventbridgeConstants.TARGETS_IDS, targets);
             }
         });
@@ -87,9 +90,9 @@ public class EventbridgeRemoveTargetsIT extends Aws2EventbridgeBase {
                         = "aws2-eventbridge://default?operation=putRule&eventPatternFile=file:src/test/resources/eventpattern.json";
                 String target = "aws2-eventbridge://default?operation=putTargets";
                 String removeTargets = "aws2-eventbridge://default?operation=removeTargets";
-                from("direct:evs").to(awsEndpoint);
-                from("direct:evs-targets").to(target);
-                from("direct:evs-remove-targets").to(removeTargets).to("mock:result");
+                from("direct:evs-EventbridgeRemoveTargetsIT").to(awsEndpoint);
+                from("direct:evs-targets-EventbridgeRemoveTargetsIT").to(target);
+                from("direct:evs-remove-targets-EventbridgeRemoveTargetsIT").to(removeTargets).to("mock:result");
             }
         };
     }


### PR DESCRIPTION
flakiness was introduced around 22nd and 23rd of July

Several points:
* one test was not using the same abstract class causing two services to run in //
* all the test classes are sharing the same instance and they were using similar rule names and route names. Some rules can influence the other tests. provided a specific rule id for each of the test classes

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

