### PR TITLE
CAMEL-24302: camel-aws2-timestream - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-timestream/pom.xml
+++ b/components/camel-aws/camel-aws2-timestream/pom.xml
@@ -85,6 +85,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
@@ -113,6 +113,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeEndpoints operation requires DescribeEndpointsRequest in POJO mode");
             }
         } else {
             DescribeEndpointsRequest.Builder builder = DescribeEndpointsRequest.builder();
@@ -143,6 +146,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createScheduledQuery operation requires CreateScheduledQueryRequest in POJO mode");
             }
         } else {
             CreateScheduledQueryRequest.Builder builder = CreateScheduledQueryRequest.builder();
@@ -263,6 +269,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteScheduledQuery operation requires DeleteScheduledQueryRequest in POJO mode");
             }
         } else {
             DeleteScheduledQueryRequest.Builder builder = DeleteScheduledQueryRequest.builder();
@@ -299,6 +308,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "executeScheduledQuery operation requires ExecuteScheduledQueryRequest in POJO mode");
             }
         } else {
             ExecuteScheduledQueryRequest.Builder builder = ExecuteScheduledQueryRequest.builder();
@@ -345,6 +357,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "updateScheduledQuery operation requires UpdateScheduledQueryRequest in POJO mode");
             }
         } else {
             UpdateScheduledQueryRequest.Builder builder = UpdateScheduledQueryRequest.builder();
@@ -385,6 +400,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeScheduledQuery operation requires DescribeScheduledQueryRequest in POJO mode");
             }
         } else {
             DescribeScheduledQueryRequest.Builder builder = DescribeScheduledQueryRequest.builder();
@@ -415,6 +433,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listScheduledQueries operation requires ListScheduledQueriesRequest in POJO mode");
             }
         } else {
             ListScheduledQueriesRequest.Builder builder = ListScheduledQueriesRequest.builder();
@@ -449,6 +470,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "prepareQuery operation requires PrepareQueryRequest in POJO mode");
             }
         } else {
             PrepareQueryRequest.Builder builder = PrepareQueryRequest.builder();
@@ -488,6 +512,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "query operation requires QueryRequest in POJO mode");
             }
         } else {
             QueryRequest.Builder builder = QueryRequest.builder();
@@ -527,6 +554,9 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "cancelQuery operation requires CancelQueryRequest in POJO mode");
             }
         } else {
             CancelQueryRequest.Builder builder = CancelQueryRequest.builder();

--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducer.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducer.java
@@ -119,6 +119,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeEndpoints operation requires DescribeEndpointsRequest in POJO mode");
             }
         } else {
             DescribeEndpointsRequest.Builder builder = DescribeEndpointsRequest.builder();
@@ -149,6 +152,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createBatchLoadTask operation requires CreateBatchLoadTaskRequest in POJO mode");
             }
         } else {
             CreateBatchLoadTaskRequest.Builder builder = CreateBatchLoadTaskRequest.builder();
@@ -210,6 +216,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeBatchLoadTask operation requires DescribeBatchLoadTaskRequest in POJO mode");
             }
         } else {
             DescribeBatchLoadTaskRequest.Builder builder = DescribeBatchLoadTaskRequest.builder();
@@ -244,6 +253,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "resumeBatchLoadTask operation requires ResumeBatchLoadTaskRequest in POJO mode");
             }
         } else {
             ResumeBatchLoadTaskRequest.Builder builder = ResumeBatchLoadTaskRequest.builder();
@@ -278,6 +290,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listBatchLoadTasks operation requires ListBatchLoadTasksRequest in POJO mode");
             }
         } else {
             ListBatchLoadTasksRequest.Builder builder = ListBatchLoadTasksRequest.builder();
@@ -315,6 +330,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createDatabase operation requires CreateDatabaseRequest in POJO mode");
             }
         } else {
             CreateDatabaseRequest.Builder builder = CreateDatabaseRequest.builder();
@@ -352,6 +370,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteDatabase operation requires DeleteDatabaseRequest in POJO mode");
             }
         } else {
             DeleteDatabaseRequest.Builder builder = DeleteDatabaseRequest.builder();
@@ -386,6 +407,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeDatabase operation requires DescribeDatabaseRequest in POJO mode");
             }
         } else {
             DescribeDatabaseRequest.Builder builder = DescribeDatabaseRequest.builder();
@@ -419,6 +443,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "updateDatabase operation requires UpdateDatabaseRequest in POJO mode");
             }
         } else {
             UpdateDatabaseRequest.Builder builder = UpdateDatabaseRequest.builder();
@@ -456,6 +483,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listDatabases operation requires ListDatabasesRequest in POJO mode");
             }
         } else {
             ListDatabasesRequest.Builder builder = ListDatabasesRequest.builder();
@@ -489,6 +519,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createTable operation requires CreateTableRequest in POJO mode");
             }
         } else {
             CreateTableRequest.Builder builder = CreateTableRequest.builder();
@@ -540,6 +573,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteTable operation requires DeleteTableRequest in POJO mode");
             }
         } else {
             DeleteTableRequest.Builder builder = DeleteTableRequest.builder();
@@ -577,6 +613,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeTable operation requires DescribeTableRequest in POJO mode");
             }
         } else {
             DescribeTableRequest.Builder builder = DescribeTableRequest.builder();
@@ -614,6 +653,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "updateTable operation requires UpdateTableRequest in POJO mode");
             }
         } else {
             UpdateTableRequest.Builder builder = UpdateTableRequest.builder();
@@ -665,6 +707,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listTables operation requires ListTablesRequest in POJO mode");
             }
         } else {
             ListTablesRequest.Builder builder = ListTablesRequest.builder();
@@ -702,6 +747,9 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "writeRecords operation requires WriteRecordsRequest in POJO mode");
             }
         } else {
             WriteRecordsRequest.Builder builder = WriteRecordsRequest.builder();

--- a/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerTest.java
+++ b/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducerTest.java
@@ -29,8 +29,11 @@ import org.apache.camel.component.aws2.timestream.Timestream2Operations;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.timestreamquery.model.*;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -253,6 +256,25 @@ public class Timestream2QueryProducerTest extends CamelTestSupport {
         assertEquals("Query Cancelled", resultGet.cancellationMessage());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:describeQueryEndpointsPojo,describeEndpoints operation requires DescribeEndpointsRequest in POJO mode",
+            "direct:createScheduledQueryPojo,createScheduledQuery operation requires CreateScheduledQueryRequest in POJO mode",
+            "direct:deleteScheduledQueryPojo,deleteScheduledQuery operation requires DeleteScheduledQueryRequest in POJO mode",
+            "direct:executeScheduledQueryPojo,executeScheduledQuery operation requires ExecuteScheduledQueryRequest in POJO mode",
+            "direct:updateScheduledQueryPojo,updateScheduledQuery operation requires UpdateScheduledQueryRequest in POJO mode",
+            "direct:describeScheduledQueryPojo,describeScheduledQuery operation requires DescribeScheduledQueryRequest in POJO mode",
+            "direct:listScheduledQueriesPojo,listScheduledQueries operation requires ListScheduledQueriesRequest in POJO mode",
+            "direct:prepareQueryPojo,prepareQuery operation requires PrepareQueryRequest in POJO mode",
+            "direct:queryPojo,query operation requires QueryRequest in POJO mode",
+            "direct:cancelQueryPojo,cancelQuery operation requires CancelQueryRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -291,7 +313,24 @@ public class Timestream2QueryProducerTest extends CamelTestSupport {
                 from("direct:cancelQuery")
                         .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=cancelQuery")
                         .to("mock:result");
-
+                from("direct:createScheduledQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=createScheduledQuery&pojoRequest=true");
+                from("direct:deleteScheduledQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=deleteScheduledQuery&pojoRequest=true");
+                from("direct:executeScheduledQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=executeScheduledQuery&pojoRequest=true");
+                from("direct:updateScheduledQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=updateScheduledQuery&pojoRequest=true");
+                from("direct:describeScheduledQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=describeScheduledQuery&pojoRequest=true");
+                from("direct:listScheduledQueriesPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=listScheduledQueries&pojoRequest=true");
+                from("direct:prepareQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=prepareQuery&pojoRequest=true");
+                from("direct:queryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=query&pojoRequest=true");
+                from("direct:cancelQueryPojo")
+                        .to("aws2-timestream://query:test?awsTimestreamQueryClient=#awsTimestreamQueryClient&operation=cancelQuery&pojoRequest=true");
             }
         };
     }

--- a/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducerTest.java
+++ b/components/camel-aws/camel-aws2-timestream/src/test/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducerTest.java
@@ -26,8 +26,11 @@ import org.apache.camel.component.aws2.timestream.Timestream2Operations;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.timestreamwrite.model.*;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -334,6 +337,31 @@ public class Timestream2WriteProducerTest extends CamelTestSupport {
         assertEquals(5, resultGet.recordsIngested().total());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:describeWriteEndpointsPojo,describeEndpoints operation requires DescribeEndpointsRequest in POJO mode",
+            "direct:createBatchLoadTaskPojo,createBatchLoadTask operation requires CreateBatchLoadTaskRequest in POJO mode",
+            "direct:describeBatchLoadTaskPojo,describeBatchLoadTask operation requires DescribeBatchLoadTaskRequest in POJO mode",
+            "direct:resumeBatchLoadTaskPojo,resumeBatchLoadTask operation requires ResumeBatchLoadTaskRequest in POJO mode",
+            "direct:listBatchLoadTasksPojo,listBatchLoadTasks operation requires ListBatchLoadTasksRequest in POJO mode",
+            "direct:createDatabasePojo,createDatabase operation requires CreateDatabaseRequest in POJO mode",
+            "direct:deleteDatabasePojo,deleteDatabase operation requires DeleteDatabaseRequest in POJO mode",
+            "direct:describeDatabasePojo,describeDatabase operation requires DescribeDatabaseRequest in POJO mode",
+            "direct:updateDatabasePojo,updateDatabase operation requires UpdateDatabaseRequest in POJO mode",
+            "direct:listDatabasesPojo,listDatabases operation requires ListDatabasesRequest in POJO mode",
+            "direct:createTablePojo,createTable operation requires CreateTableRequest in POJO mode",
+            "direct:deleteTablePojo,deleteTable operation requires DeleteTableRequest in POJO mode",
+            "direct:describeTablePojo,describeTable operation requires DescribeTableRequest in POJO mode",
+            "direct:updateTablePojo,updateTable operation requires UpdateTableRequest in POJO mode",
+            "direct:listTablesPojo,listTables operation requires ListTablesRequest in POJO mode",
+            "direct:writeRecordsPojo,writeRecords operation requires WriteRecordsRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -390,7 +418,36 @@ public class Timestream2WriteProducerTest extends CamelTestSupport {
                 from("direct:writeRecords")
                         .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=writeRecords")
                         .to("mock:result");
-
+                from("direct:createBatchLoadTaskPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=createBatchLoadTask&pojoRequest=true");
+                from("direct:describeBatchLoadTaskPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=describeBatchLoadTask&pojoRequest=true");
+                from("direct:resumeBatchLoadTaskPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=resumeBatchLoadTask&pojoRequest=true");
+                from("direct:listBatchLoadTasksPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=listBatchLoadTasks&pojoRequest=true");
+                from("direct:createDatabasePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=createDatabase&pojoRequest=true");
+                from("direct:deleteDatabasePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=deleteDatabase&pojoRequest=true");
+                from("direct:describeDatabasePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=describeDatabase&pojoRequest=true");
+                from("direct:updateDatabasePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=updateDatabase&pojoRequest=true");
+                from("direct:listDatabasesPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=listDatabases&pojoRequest=true");
+                from("direct:createTablePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=createTable&pojoRequest=true");
+                from("direct:deleteTablePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=deleteTable&pojoRequest=true");
+                from("direct:describeTablePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=describeTable&pojoRequest=true");
+                from("direct:updateTablePojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=updateTable&pojoRequest=true");
+                from("direct:listTablesPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=listTables&pojoRequest=true");
+                from("direct:writeRecordsPojo")
+                        .to("aws2-timestream://write:test?awsTimestreamWriteClient=#awsTimestreamWriteClient&operation=writeRecords&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, both timestream producers only acted when the body was
the matching request type; any other body fell through the `instanceof` with no
`else`, so no AWS call was made, no response was set, and the original body was
returned with no error. This covers **26** operations:

* `Timestream2WriteProducer` — 16 (databases, tables, batch-load tasks, writeRecords, describeEndpoints)
* `Timestream2QueryProducer` — 10 (scheduled queries, prepareQuery, query, cancelQuery, describeEndpoints)

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"writeRecords operation requires WriteRecordsRequest in POJO mode"`.

## Tests

A `@ParameterizedTest` in each producer's test class covers every operation,
sending a wrong-typed body to `pojoRequest=true` routes and asserting each
message. Verified to fail (silent no-op) before the fix — with `writeRecords`
(write) and `cancelQuery` (query) elses removed, exactly those cases report
"Expecting code to raise a throwable". Write 33/33, Query 21/21 green. Hermetic
unit tests, region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_