### PR TITLE
[backport 4.18.x] upgrade libthrift version to 0.24.0 in upstream 4.18.x

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -322,7 +322,7 @@
         <jgroups-raft-mapdb-version>1.0.8</jgroups-raft-mapdb-version>
         <jira-rest-client-api-version>6.0.2</jira-rest-client-api-version>
         <jline-version>3.30.6</jline-version>
-        <libthrift-version>0.23.0</libthrift-version>
+        <libthrift-version>0.24.0</libthrift-version>
         <jodatime2-version>2.14.0</jodatime2-version>
         <jolokia-version>2.5.0</jolokia-version>
         <jolt-version>0.1.8</jolt-version>


### PR DESCRIPTION
Upgrade libthrift from 0.23.0 to 0.24.0 in 4.18.x
