### PR TITLE
CAMEL-24303: camel-aws2-redshift - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-redshift/pom.xml
+++ b/components/camel-aws/camel-aws2-redshift/pom.xml
@@ -74,5 +74,10 @@
             <artifactId>camel-test-spring-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws2-redshift/src/main/java/org/apache/camel/component/aws2/redshift/data/RedshiftData2Producer.java
+++ b/components/camel-aws/camel-aws2-redshift/src/main/java/org/apache/camel/component/aws2/redshift/data/RedshiftData2Producer.java
@@ -102,6 +102,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listDatabases operation requires ListDatabasesRequest in POJO mode");
             }
         } else {
             ListDatabasesRequest.Builder builder = ListDatabasesRequest.builder();
@@ -156,6 +159,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listSchemas operation requires ListSchemasRequest in POJO mode");
             }
         } else {
             ListSchemasRequest.Builder builder = ListSchemasRequest.builder();
@@ -217,6 +223,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listStatements operation requires ListStatementsRequest in POJO mode");
             }
         } else {
             ListStatementsRequest.Builder builder = ListStatementsRequest.builder();
@@ -263,6 +272,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listTables operation requires ListTablesRequest in POJO mode");
             }
         } else {
             ListTablesRequest.Builder builder = ListTablesRequest.builder();
@@ -328,6 +340,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeTable operation requires DescribeTableRequest in POJO mode");
             }
         } else {
             DescribeTableRequest.Builder builder = DescribeTableRequest.builder();
@@ -394,6 +409,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "executeStatement operation requires ExecuteStatementRequest in POJO mode");
             }
         } else {
             ExecuteStatementRequest.Builder builder = ExecuteStatementRequest.builder();
@@ -465,6 +483,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "batchExecuteStatement operation requires BatchExecuteStatementRequest in POJO mode");
             }
         } else {
             BatchExecuteStatementRequest.Builder builder = BatchExecuteStatementRequest.builder();
@@ -530,6 +551,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "cancelStatement operation requires CancelStatementRequest in POJO mode");
             }
         } else {
             CancelStatementRequest.Builder builder = CancelStatementRequest.builder();
@@ -563,6 +587,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeStatement operation requires DescribeStatementRequest in POJO mode");
             }
         } else {
             DescribeStatementRequest.Builder builder = DescribeStatementRequest.builder();
@@ -596,6 +623,9 @@ public class RedshiftData2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getStatementResult operation requires GetStatementResultRequest in POJO mode");
             }
         } else {
             GetStatementResultRequest.Builder builder = GetStatementResultRequest.builder();

--- a/components/camel-aws/camel-aws2-redshift/src/test/java/org/apache/camel/component/aws2/redshift/data/RedshiftData2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-redshift/src/test/java/org/apache/camel/component/aws2/redshift/data/RedshiftData2ProducerTest.java
@@ -27,6 +27,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.redshiftdata.model.BatchExecuteStatementResponse;
 import software.amazon.awssdk.services.redshiftdata.model.CancelStatementResponse;
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementResponse;
@@ -38,6 +40,7 @@ import software.amazon.awssdk.services.redshiftdata.model.ListSchemasResponse;
 import software.amazon.awssdk.services.redshiftdata.model.ListStatementsResponse;
 import software.amazon.awssdk.services.redshiftdata.model.ListTablesResponse;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RedshiftData2ProducerTest extends CamelTestSupport {
@@ -222,6 +225,25 @@ public class RedshiftData2ProducerTest extends CamelTestSupport {
         assertEquals(10, resultGet.totalNumRows());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:listDatabasesPojo,listDatabases operation requires ListDatabasesRequest in POJO mode",
+            "direct:listSchemasPojo,listSchemas operation requires ListSchemasRequest in POJO mode",
+            "direct:listStatementsPojo,listStatements operation requires ListStatementsRequest in POJO mode",
+            "direct:listTablesPojo,listTables operation requires ListTablesRequest in POJO mode",
+            "direct:describeTablePojo,describeTable operation requires DescribeTableRequest in POJO mode",
+            "direct:executeStatementPojo,executeStatement operation requires ExecuteStatementRequest in POJO mode",
+            "direct:batchExecuteStatementPojo,batchExecuteStatement operation requires BatchExecuteStatementRequest in POJO mode",
+            "direct:cancelStatementPojo,cancelStatement operation requires CancelStatementRequest in POJO mode",
+            "direct:describeStatementPojo,describeStatement operation requires DescribeStatementRequest in POJO mode",
+            "direct:getStatementResultPojo,getStatementResult operation requires GetStatementResultRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -260,6 +282,24 @@ public class RedshiftData2ProducerTest extends CamelTestSupport {
                 from("direct:getStatementResult")
                         .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=getStatementResult")
                         .to("mock:result");
+                from("direct:listSchemasPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=listSchemas&pojoRequest=true");
+                from("direct:listStatementsPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=listStatements&pojoRequest=true");
+                from("direct:listTablesPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=listTables&pojoRequest=true");
+                from("direct:describeTablePojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=describeTable&pojoRequest=true");
+                from("direct:executeStatementPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=executeStatement&pojoRequest=true");
+                from("direct:batchExecuteStatementPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=batchExecuteStatement&pojoRequest=true");
+                from("direct:cancelStatementPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=cancelStatement&pojoRequest=true");
+                from("direct:describeStatementPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=describeStatement&pojoRequest=true");
+                from("direct:getStatementResultPojo")
+                        .to("aws2-redshift-data://test?awsRedshiftDataClient=#awsRedshiftDataClient&operation=getStatementResult&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `RedshiftData2Producer`'s ten operations only acted when
the body was the matching request type; any other body fell through the
`instanceof` with no `else`, so no AWS call was made, no response was set, and
the original body was returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"executeStatement operation requires ExecuteStatementRequest in POJO
mode"`.

## Tests

A `@ParameterizedTest` covers all ten operations, sending a wrong-typed body to
`pojoRequest=true` routes and asserting each message. Verified to fail (silent
no-op) before the fix — with the `executeStatement` else removed, exactly that
case reports "Expecting code to raise a throwable". Class 20/20 green. Hermetic
unit tests, region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_