### PR TITLE
CAMEL-23952: Support executeToolsConcurrently for langchain4j-agent

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-agent-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-agent-component.adoc
@@ -158,6 +158,25 @@ Agents are configured using the `AgentConfiguration` class which provides a flue
 * Chat Memory Provider (for memory-enabled agents)
 * Retrieval Augmentor (for RAG functionality)
 * Input and Output Guardrails
+* Concurrent tool execution (`withExecuteToolsConcurrently`) for parallel Camel route tools and MCP tools within one LLM round trip
+
+==== Concurrent tool execution
+
+When the LLM requests multiple tools in a single turn, LangChain4j can invoke them in parallel via `AgentConfiguration.withExecuteToolsConcurrently()`. Camel route tools (`ai-tool:` consumers discovered through `tags`) run each invocation on an isolated exchange copy, so concurrent execution does not corrupt the producer exchange.
+
+._Java-only: enable parallel tool calls with a managed Camel executor_
+[source,java]
+----
+AgentConfiguration configuration = new AgentConfiguration()
+    .withChatModel(chatModel)
+    .withExecuteToolsConcurrently();
+
+// When created through langchain4j-agent (agentConfiguration on the endpoint),
+// Camel registers a managed thread pool from ExecutorServiceManager automatically.
+// Pass your own Executor with withExecuteToolsConcurrently(executor) to override.
+----
+
+Tool-route header side-effects are not merged back onto the main exchange when tools run concurrently; only the tool result text is returned to the LLM.
 
 ==== Creating an Agent without Memory
 

--- a/components/camel-ai/camel-langchain4j-agent-api/pom.xml
+++ b/components/camel-ai/camel-langchain4j-agent-api/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AbstractAgent.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AbstractAgent.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.langchain4j.agent.api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.function.BiPredicate;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -183,6 +184,14 @@ public abstract class AbstractAgent<S> implements Agent {
         }
         if (configuration.getCompensateOnToolErrors() != null) {
             builder.compensateOnToolErrors(configuration.getCompensateOnToolErrors());
+        }
+        if (Boolean.TRUE.equals(configuration.getExecuteToolsConcurrently())) {
+            Executor executor = configuration.getExecuteToolsExecutor();
+            if (executor != null) {
+                builder.executeToolsConcurrently(executor);
+            } else {
+                builder.executeToolsConcurrently();
+            }
         }
 
         // Custom AiServices builder customizer (escape hatch for any builder option not directly exposed)

--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AgentConfiguration.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AgentConfiguration.java
@@ -512,6 +512,34 @@ public class AgentConfiguration {
     }
 
     /**
+     * Creates a shallow copy of this configuration. Used by the langchain4j-agent producer to attach a managed tool
+     * executor without mutating registry-held configuration beans.
+     *
+     * @return a new configuration instance with the same settings
+     * @since  4.22
+     */
+    public AgentConfiguration duplicate() {
+        AgentConfiguration copy = new AgentConfiguration();
+        copy.chatModel = chatModel;
+        copy.chatMemoryProvider = chatMemoryProvider;
+        copy.retrievalAugmentor = retrievalAugmentor;
+        copy.inputGuardrailClasses = inputGuardrailClasses;
+        copy.outputGuardrailClasses = outputGuardrailClasses;
+        copy.customTools = customTools;
+        copy.mcpClients = mcpClients;
+        copy.mcpToolProviderFilter = mcpToolProviderFilter;
+        copy.maxToolCallingRoundTrips = maxToolCallingRoundTrips;
+        copy.hallucinatedToolNameStrategy = hallucinatedToolNameStrategy;
+        copy.toolExecutionErrorHandler = toolExecutionErrorHandler;
+        copy.toolArgumentsErrorHandler = toolArgumentsErrorHandler;
+        copy.compensateOnToolErrors = compensateOnToolErrors;
+        copy.executeToolsConcurrently = executeToolsConcurrently;
+        copy.executeToolsExecutor = executeToolsExecutor;
+        copy.aiServicesCustomizer = aiServicesCustomizer;
+        return copy;
+    }
+
+    /**
      * Gets the custom AiServices builder customizer.
      *
      * @return the customizer, or {@code null} if not configured

--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AgentConfiguration.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AgentConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.camel.component.langchain4j.agent.api;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
@@ -502,12 +503,14 @@ public class AgentConfiguration {
     /**
      * Enables parallel tool execution using the given executor.
      *
-     * @param  executeToolsExecutor the executor for concurrent tool invocations
+     * @param  executeToolsExecutor the executor for concurrent tool invocations (must not be {@code null}; use
+     *                              {@link #withExecuteToolsConcurrently()} for the managed executor)
      * @return                      this configuration instance for method chaining
+     * @throws NullPointerException if {@code executeToolsExecutor} is {@code null}
      */
     public AgentConfiguration withExecuteToolsConcurrently(Executor executeToolsExecutor) {
         this.executeToolsConcurrently = true;
-        this.executeToolsExecutor = executeToolsExecutor;
+        this.executeToolsExecutor = Objects.requireNonNull(executeToolsExecutor, "executeToolsExecutor");
         return this;
     }
 

--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AgentConfiguration.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/AgentConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.camel.component.langchain4j.agent.api;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -79,6 +80,8 @@ public class AgentConfiguration {
     private ToolExecutionErrorHandler toolExecutionErrorHandler;
     private ToolArgumentsErrorHandler toolArgumentsErrorHandler;
     private Boolean compensateOnToolErrors;
+    private Boolean executeToolsConcurrently;
+    private Executor executeToolsExecutor;
     private Consumer<AiServices<?>> aiServicesCustomizer;
 
     /**
@@ -460,6 +463,51 @@ public class AgentConfiguration {
      */
     public AgentConfiguration withCompensateOnToolErrors(Boolean compensateOnToolErrors) {
         this.compensateOnToolErrors = compensateOnToolErrors;
+        return this;
+    }
+
+    /**
+     * Gets whether concurrent tool execution is enabled for this agent.
+     *
+     * @return {@code true} if enabled, {@code false} if explicitly disabled, or {@code null} if not configured
+     */
+    public Boolean getExecuteToolsConcurrently() {
+        return executeToolsConcurrently;
+    }
+
+    /**
+     * Gets the executor used for concurrent tool execution, if configured.
+     *
+     * @return the executor, or {@code null} if not configured
+     */
+    public Executor getExecuteToolsExecutor() {
+        return executeToolsExecutor;
+    }
+
+    /**
+     * Enables parallel execution of all tool calls within a single LLM round trip via LangChain4j's
+     * {@code executeToolsConcurrently()} mode. Requires Camel route tools to run on isolated exchange copies (see
+     * {@code LangChain4jAgentProducer}).
+     * <p>
+     * When no explicit executor is supplied, the langchain4j-agent component resolves a managed thread pool from the
+     * Camel {@code ExecutorServiceManager} at startup.
+     *
+     * @return this configuration instance for method chaining
+     */
+    public AgentConfiguration withExecuteToolsConcurrently() {
+        this.executeToolsConcurrently = true;
+        return this;
+    }
+
+    /**
+     * Enables parallel tool execution using the given executor.
+     *
+     * @param  executeToolsExecutor the executor for concurrent tool invocations
+     * @return                      this configuration instance for method chaining
+     */
+    public AgentConfiguration withExecuteToolsConcurrently(Executor executeToolsExecutor) {
+        this.executeToolsConcurrently = true;
+        this.executeToolsExecutor = executeToolsExecutor;
         return this;
     }
 

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.langchain4j.agent.api;
 import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -29,6 +30,7 @@ import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -334,36 +336,43 @@ public class AgentConfigurationTest {
     }
 
     @Test
-    public void testDuplicateCopiesExecuteToolsConcurrentlySettings() {
+    void testDuplicateCopiesExecuteToolsConcurrentlySettings() {
         Executor executor = Executors.newSingleThreadExecutor();
-        AgentConfiguration original = new AgentConfiguration()
-                .withExecuteToolsConcurrently(executor)
-                .withMaxToolCallingRoundTrips(3);
+        try {
+            AgentConfiguration original = new AgentConfiguration()
+                    .withExecuteToolsConcurrently(executor)
+                    .withMaxToolCallingRoundTrips(3);
 
-        AgentConfiguration copy = original.duplicate();
+            AgentConfiguration copy = original.duplicate();
 
-        assertTrue(copy.getExecuteToolsConcurrently());
-        assertSame(executor, copy.getExecuteToolsExecutor());
-        assertEquals(3, copy.getMaxToolCallingRoundTrips());
-        assertSame(original.getMaxToolCallingRoundTrips(), copy.getMaxToolCallingRoundTrips());
+            assertThat(copy.getExecuteToolsConcurrently()).isTrue();
+            assertThat(copy.getExecuteToolsExecutor()).isSameAs(executor);
+            assertThat(copy.getMaxToolCallingRoundTrips()).isEqualTo(3);
+        } finally {
+            ((ExecutorService) executor).shutdownNow();
+        }
     }
 
     @Test
-    public void testExecuteToolsConcurrently() {
+    void testExecuteToolsConcurrently() {
         AgentConfiguration config = new AgentConfiguration();
-        assertNull(config.getExecuteToolsConcurrently());
-        assertNull(config.getExecuteToolsExecutor());
+        assertThat(config.getExecuteToolsConcurrently()).isNull();
+        assertThat(config.getExecuteToolsExecutor()).isNull();
 
         AgentConfiguration enabled = config.withExecuteToolsConcurrently();
-        assertSame(config, enabled);
-        assertTrue(config.getExecuteToolsConcurrently());
-        assertNull(config.getExecuteToolsExecutor());
+        assertThat(enabled).isSameAs(config);
+        assertThat(config.getExecuteToolsConcurrently()).isTrue();
+        assertThat(config.getExecuteToolsExecutor()).isNull();
 
         Executor executor = Executors.newSingleThreadExecutor();
-        AgentConfiguration withExecutor = config.withExecuteToolsConcurrently(executor);
-        assertSame(config, withExecutor);
-        assertTrue(config.getExecuteToolsConcurrently());
-        assertSame(executor, config.getExecuteToolsExecutor());
+        try {
+            AgentConfiguration withExecutor = config.withExecuteToolsConcurrently(executor);
+            assertThat(withExecutor).isSameAs(config);
+            assertThat(config.getExecuteToolsConcurrently()).isTrue();
+            assertThat(config.getExecuteToolsExecutor()).isSameAs(executor);
+        } finally {
+            ((ExecutorService) executor).shutdownNow();
+        }
     }
 
     @Test

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
@@ -334,6 +334,21 @@ public class AgentConfigurationTest {
     }
 
     @Test
+    public void testDuplicateCopiesExecuteToolsConcurrentlySettings() {
+        Executor executor = Executors.newSingleThreadExecutor();
+        AgentConfiguration original = new AgentConfiguration()
+                .withExecuteToolsConcurrently(executor)
+                .withMaxToolCallingRoundTrips(3);
+
+        AgentConfiguration copy = original.duplicate();
+
+        assertTrue(copy.getExecuteToolsConcurrently());
+        assertSame(executor, copy.getExecuteToolsExecutor());
+        assertEquals(3, copy.getMaxToolCallingRoundTrips());
+        assertSame(original.getMaxToolCallingRoundTrips(), copy.getMaxToolCallingRoundTrips());
+    }
+
+    @Test
     public void testExecuteToolsConcurrently() {
         AgentConfiguration config = new AgentConfiguration();
         assertNull(config.getExecuteToolsConcurrently());

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.langchain4j.agent.api;
 
 import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -31,13 +33,14 @@ import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AgentConfigurationTest {
+class AgentConfigurationTest {
 
     @Test
     public void testParseGuardrailClasses_WithValidClasses() {
@@ -333,6 +336,50 @@ public class AgentConfigurationTest {
 
         assertSame(config, result);
         assertNotNull(config.getAiServicesCustomizer());
+    }
+
+    @Test
+    void duplicateCopiesAllDeclaredInstanceFields() throws Exception {
+        Executor executor = Executors.newSingleThreadExecutor();
+        try {
+            Function<ToolExecutionRequest, ToolExecutionResultMessage> strategy
+                    = request -> ToolExecutionResultMessage.from(request, "unknown");
+            ToolExecutionErrorHandler execHandler = (error, context) -> null;
+            ToolArgumentsErrorHandler argsHandler = (error, context) -> null;
+
+            AgentConfiguration original = new AgentConfiguration()
+                    .withMaxToolCallingRoundTrips(11)
+                    .withHallucinatedToolNameStrategy(strategy)
+                    .withToolExecutionErrorHandler(execHandler)
+                    .withToolArgumentsErrorHandler(argsHandler)
+                    .withCompensateOnToolErrors(true)
+                    .withExecuteToolsConcurrently(executor)
+                    .withInputGuardrailClassesArray(new String[] { "java.lang.String" })
+                    .withAiServicesCustomizer(builder -> {
+                    });
+
+            AgentConfiguration copy = original.duplicate();
+
+            for (Field field : AgentConfiguration.class.getDeclaredFields()) {
+                int modifiers = field.getModifiers();
+                if (Modifier.isStatic(modifiers)) {
+                    continue;
+                }
+                field.setAccessible(true);
+                assertThat(field.get(copy))
+                        .as("duplicate() should copy field %s", field.getName())
+                        .isEqualTo(field.get(original));
+            }
+        } finally {
+            ((ExecutorService) executor).shutdownNow();
+        }
+    }
+
+    @Test
+    void withExecuteToolsConcurrentlyRejectsNullExecutor() {
+        assertThatThrownBy(() -> new AgentConfiguration().withExecuteToolsConcurrently((Executor) null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("executeToolsExecutor");
     }
 
     @Test

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
@@ -27,7 +27,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import org.junit.jupiter.api.Test;
@@ -342,12 +346,19 @@ class AgentConfigurationTest {
     void duplicateCopiesAllDeclaredInstanceFields() throws Exception {
         Executor executor = Executors.newSingleThreadExecutor();
         try {
+            ChatModel chatModel = new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                    return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+                }
+            };
             Function<ToolExecutionRequest, ToolExecutionResultMessage> strategy
                     = request -> ToolExecutionResultMessage.from(request, "unknown");
             ToolExecutionErrorHandler execHandler = (error, context) -> null;
             ToolArgumentsErrorHandler argsHandler = (error, context) -> null;
 
             AgentConfiguration original = new AgentConfiguration()
+                    .withChatModel(chatModel)
                     .withMaxToolCallingRoundTrips(11)
                     .withHallucinatedToolNameStrategy(strategy)
                     .withToolExecutionErrorHandler(execHandler)
@@ -355,6 +366,8 @@ class AgentConfigurationTest {
                     .withCompensateOnToolErrors(true)
                     .withExecuteToolsConcurrently(executor)
                     .withInputGuardrailClassesArray(new String[] { "java.lang.String" })
+                    .withOutputGuardrailClassesArray(new String[] { "java.io.Serializable" })
+                    .withCustomTools(List.of("custom-tool"))
                     .withAiServicesCustomizer(builder -> {
                     });
 

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/AgentConfigurationTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.component.langchain4j.agent.api;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -329,6 +331,24 @@ public class AgentConfigurationTest {
 
         assertSame(config, result);
         assertNotNull(config.getAiServicesCustomizer());
+    }
+
+    @Test
+    public void testExecuteToolsConcurrently() {
+        AgentConfiguration config = new AgentConfiguration();
+        assertNull(config.getExecuteToolsConcurrently());
+        assertNull(config.getExecuteToolsExecutor());
+
+        AgentConfiguration enabled = config.withExecuteToolsConcurrently();
+        assertSame(config, enabled);
+        assertTrue(config.getExecuteToolsConcurrently());
+        assertNull(config.getExecuteToolsExecutor());
+
+        Executor executor = Executors.newSingleThreadExecutor();
+        AgentConfiguration withExecutor = config.withExecuteToolsConcurrently(executor);
+        assertSame(config, withExecutor);
+        assertTrue(config.getExecuteToolsConcurrently());
+        assertSame(executor, config.getExecuteToolsExecutor());
     }
 
     @Test

--- a/components/camel-ai/camel-langchain4j-agent/src/main/docs/langchain4j-agent-component.adoc
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/docs/langchain4j-agent-component.adoc
@@ -158,6 +158,25 @@ Agents are configured using the `AgentConfiguration` class which provides a flue
 * Chat Memory Provider (for memory-enabled agents)
 * Retrieval Augmentor (for RAG functionality)
 * Input and Output Guardrails
+* Concurrent tool execution (`withExecuteToolsConcurrently`) for parallel Camel route tools and MCP tools within one LLM round trip
+
+==== Concurrent tool execution
+
+When the LLM requests multiple tools in a single turn, LangChain4j can invoke them in parallel via `AgentConfiguration.withExecuteToolsConcurrently()`. Camel route tools (`ai-tool:` consumers discovered through `tags`) run each invocation on an isolated exchange copy, so concurrent execution does not corrupt the producer exchange.
+
+._Java-only: enable parallel tool calls with a managed Camel executor_
+[source,java]
+----
+AgentConfiguration configuration = new AgentConfiguration()
+    .withChatModel(chatModel)
+    .withExecuteToolsConcurrently();
+
+// When created through langchain4j-agent (agentConfiguration on the endpoint),
+// Camel registers a managed thread pool from ExecutorServiceManager automatically.
+// Pass your own Executor with withExecuteToolsConcurrently(executor) to override.
+----
+
+Tool-route header side-effects are not merged back onto the main exchange when tools run concurrently; only the tool result text is returned to the LLM.
 
 ==== Creating an Agent without Memory
 

--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
@@ -61,6 +62,7 @@ import org.apache.camel.component.langchain4j.agent.api.AgentWithoutMemory;
 import org.apache.camel.component.langchain4j.agent.api.AiAgentBody;
 import org.apache.camel.component.langchain4j.agent.api.CompositeToolProvider;
 import org.apache.camel.component.langchain4j.agent.api.Headers;
+import org.apache.camel.spi.ThreadPoolProfile;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.ResourceHelper;
@@ -76,6 +78,7 @@ public class LangChain4jAgentProducer extends DefaultProducer {
     private AgentFactory agentFactory;
     private Agent agent;
     private List<McpClient> materializedMcpClients;
+    private ExecutorService managedToolExecutionExecutor;
 
     public LangChain4jAgentProducer(LangChain4jAgentEndpoint endpoint) {
         super(endpoint);
@@ -115,6 +118,7 @@ public class LangChain4jAgentProducer extends DefaultProducer {
             agent = endpoint.getConfiguration().getAgent();
         } else if (endpoint.getConfiguration().getAgentConfiguration() != null) {
             AgentConfiguration agentConfiguration = endpoint.getConfiguration().getAgentConfiguration();
+            resolveExecuteToolsConcurrentlyExecutor(agentConfiguration);
             agent = agentConfiguration.getChatMemoryProvider() != null
                     ? new AgentWithMemory(agentConfiguration)
                     : new AgentWithoutMemory(agentConfiguration);
@@ -162,6 +166,24 @@ public class LangChain4jAgentProducer extends DefaultProducer {
         if (result.toolExecutions() != null && !result.toolExecutions().isEmpty()) {
             message.setHeader(Headers.TOOL_EXECUTIONS, result.toolExecutions());
         }
+    }
+
+    /**
+     * When concurrent tool execution is enabled without an explicit executor, register a Camel-managed thread pool so
+     * tool parallelism uses the framework lifecycle and naming conventions.
+     */
+    private void resolveExecuteToolsConcurrentlyExecutor(AgentConfiguration agentConfiguration) {
+        if (!Boolean.TRUE.equals(agentConfiguration.getExecuteToolsConcurrently())) {
+            return;
+        }
+        if (agentConfiguration.getExecuteToolsExecutor() != null) {
+            return;
+        }
+        ThreadPoolProfile profile = endpoint.getCamelContext().getExecutorServiceManager().getDefaultThreadPoolProfile();
+        managedToolExecutionExecutor = endpoint.getCamelContext().getExecutorServiceManager()
+                .newThreadPool(this, "LangChain4jAgentToolExecution", profile);
+        agentConfiguration.withExecuteToolsConcurrently(managedToolExecutionExecutor);
+        LOG.debug("Registered Camel-managed executor for concurrent LangChain4j tool execution");
     }
 
     /**
@@ -579,6 +601,10 @@ public class LangChain4jAgentProducer extends DefaultProducer {
                 }
             }
             materializedMcpClients = null;
+        }
+        if (managedToolExecutionExecutor != null) {
+            endpoint.getCamelContext().getExecutorServiceManager().shutdownGraceful(managedToolExecutionExecutor);
+            managedToolExecutionExecutor = null;
         }
         super.doStop();
     }

--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -117,7 +117,7 @@ public class LangChain4jAgentProducer extends DefaultProducer {
         if (endpoint.getConfiguration().getAgent() != null) {
             agent = endpoint.getConfiguration().getAgent();
         } else if (endpoint.getConfiguration().getAgentConfiguration() != null) {
-            AgentConfiguration agentConfiguration = endpoint.getConfiguration().getAgentConfiguration();
+            AgentConfiguration agentConfiguration = endpoint.getConfiguration().getAgentConfiguration().duplicate();
             resolveExecuteToolsConcurrentlyExecutor(agentConfiguration);
             agent = agentConfiguration.getChatMemoryProvider() != null
                     ? new AgentWithMemory(agentConfiguration)

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentExecuteToolsConcurrentlyTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentExecuteToolsConcurrentlyTest.java
@@ -26,10 +26,12 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
 import org.apache.camel.component.langchain4j.agent.api.AiAgentBody;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.Registry;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +77,7 @@ class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
     }
 
     @Override
-    protected void bindToRegistry(org.apache.camel.spi.Registry registry) {
+    protected void bindToRegistry(Registry registry) {
         registry.bind("agentConfig", new AgentConfiguration()
                 .withChatModel(chatModel)
                 .withExecuteToolsConcurrently()
@@ -138,7 +140,7 @@ class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
         assertThat(response).isEqualTo("done");
     }
 
-    private void recordConcurrentEntry(String label, org.apache.camel.Exchange exchange) throws InterruptedException {
+    private void recordConcurrentEntry(String label, Exchange exchange) throws InterruptedException {
         int concurrent = inFlight.incrementAndGet();
         maxConcurrent.updateAndGet(current -> Math.max(current, concurrent));
         bothToolsEntered.countDown();

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentExecuteToolsConcurrentlyTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentExecuteToolsConcurrentlyTest.java
@@ -18,8 +18,6 @@ package org.apache.camel.component.langchain4j.agent;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,6 +43,7 @@ class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
 
     private static final String TAG = "concurrent-tools";
 
+    private final TwoToolRoundTripChatModel chatModel = new TwoToolRoundTripChatModel();
     private final AtomicInteger chatRound = new AtomicInteger();
     private CountDownLatch bothToolsEntered = new CountDownLatch(2);
     private final AtomicInteger inFlight = new AtomicInteger();
@@ -77,15 +76,10 @@ class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
 
     @Override
     protected void bindToRegistry(org.apache.camel.spi.Registry registry) {
-        ExecutorService toolPool = Executors.newFixedThreadPool(4);
-        registry.bind("toolPool", toolPool);
-
-        ChatModel chatModel = new TwoToolRoundTripChatModel();
-        AgentConfiguration agentConfig = new AgentConfiguration()
+        registry.bind("agentConfig", new AgentConfiguration()
                 .withChatModel(chatModel)
-                .withExecuteToolsConcurrently(toolPool)
-                .withMaxToolCallingRoundTrips(5);
-        registry.bind("agentConfig", agentConfig);
+                .withExecuteToolsConcurrently()
+                .withMaxToolCallingRoundTrips(5));
     }
 
     @Test
@@ -104,14 +98,14 @@ class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
     @Test
     void producerResolvesCamelManagedExecutorWhenNoneConfigured() throws Exception {
         try (DefaultCamelContext ctx = new DefaultCamelContext()) {
-            ChatModel chatModel = new ChatModel() {
+            ChatModel noopModel = new ChatModel() {
                 @Override
                 public ChatResponse doChat(ChatRequest request) {
                     return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
                 }
             };
             AgentConfiguration config = new AgentConfiguration()
-                    .withChatModel(chatModel)
+                    .withChatModel(noopModel)
                     .withExecuteToolsConcurrently();
             ctx.getRegistry().bind("cfg", config);
 
@@ -125,9 +119,23 @@ class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
             ctx.start();
 
             assertThat(config.getExecuteToolsExecutor())
-                    .as("producer should register a Camel-managed executor")
-                    .isNotNull();
+                    .as("registry AgentConfiguration must not be mutated with a managed executor")
+                    .isNull();
         }
+    }
+
+    @Test
+    void managedExecutorWorksAfterContextStopAndRestart() throws Exception {
+        context.stop();
+        context.getRegistry().bind("agentConfig", new AgentConfiguration()
+                .withChatModel(chatModel)
+                .withExecuteToolsConcurrently()
+                .withMaxToolCallingRoundTrips(5));
+        context.start();
+
+        String response = template.requestBody("direct:agent", new AiAgentBody<>("run tools"), String.class);
+
+        assertThat(response).isEqualTo("done");
     }
 
     private void recordConcurrentEntry(String label, org.apache.camel.Exchange exchange) throws InterruptedException {

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentExecuteToolsConcurrentlyTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentExecuteToolsConcurrentlyTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.langchain4j.agent;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
+import org.apache.camel.component.langchain4j.agent.api.AiAgentBody;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for CAMEL-23952: {@link AgentConfiguration#withExecuteToolsConcurrently()} and exchange-safe Camel route tools.
+ */
+class LangChain4jAgentExecuteToolsConcurrentlyTest extends CamelTestSupport {
+
+    private static final String TAG = "concurrent-tools";
+
+    private final AtomicInteger chatRound = new AtomicInteger();
+    private CountDownLatch bothToolsEntered = new CountDownLatch(2);
+    private final AtomicInteger inFlight = new AtomicInteger();
+    private final AtomicInteger maxConcurrent = new AtomicInteger();
+
+    @BeforeEach
+    void resetConcurrencyState() {
+        chatRound.set(0);
+        bothToolsEntered = new CountDownLatch(2);
+        maxConcurrent.set(0);
+        inFlight.set(0);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:agent")
+                        .to("langchain4j-agent:test?agentConfiguration=#agentConfig&tags=" + TAG);
+
+                from("ai-tool:slowToolA?tags=" + TAG + "&description=Slow tool A")
+                        .process(exchange -> recordConcurrentEntry("A", exchange));
+
+                from("ai-tool:slowToolB?tags=" + TAG + "&description=Slow tool B")
+                        .process(exchange -> recordConcurrentEntry("B", exchange));
+            }
+        };
+    }
+
+    @Override
+    protected void bindToRegistry(org.apache.camel.spi.Registry registry) {
+        ExecutorService toolPool = Executors.newFixedThreadPool(4);
+        registry.bind("toolPool", toolPool);
+
+        ChatModel chatModel = new TwoToolRoundTripChatModel();
+        AgentConfiguration agentConfig = new AgentConfiguration()
+                .withChatModel(chatModel)
+                .withExecuteToolsConcurrently(toolPool)
+                .withMaxToolCallingRoundTrips(5);
+        registry.bind("agentConfig", agentConfig);
+    }
+
+    @Test
+    void concurrentToolExecutionRunsBothToolsInParallel() throws Exception {
+        String response = template.requestBody("direct:agent", new AiAgentBody<>("run tools"), String.class);
+
+        assertThat(response).isEqualTo("done");
+        assertThat(bothToolsEntered.await(10, TimeUnit.SECONDS))
+                .as("both tools should be invoked")
+                .isTrue();
+        assertThat(maxConcurrent.get())
+                .as("tools should overlap when executeToolsConcurrently is enabled")
+                .isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void producerResolvesCamelManagedExecutorWhenNoneConfigured() throws Exception {
+        try (DefaultCamelContext ctx = new DefaultCamelContext()) {
+            ChatModel chatModel = new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                    return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+                }
+            };
+            AgentConfiguration config = new AgentConfiguration()
+                    .withChatModel(chatModel)
+                    .withExecuteToolsConcurrently();
+            ctx.getRegistry().bind("cfg", config);
+
+            ctx.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("direct:x").to("langchain4j-agent:test?agentConfiguration=#cfg");
+                }
+            });
+
+            ctx.start();
+
+            assertThat(config.getExecuteToolsExecutor())
+                    .as("producer should register a Camel-managed executor")
+                    .isNotNull();
+        }
+    }
+
+    private void recordConcurrentEntry(String label, org.apache.camel.Exchange exchange) throws InterruptedException {
+        int concurrent = inFlight.incrementAndGet();
+        maxConcurrent.updateAndGet(current -> Math.max(current, concurrent));
+        bothToolsEntered.countDown();
+        assertThat(bothToolsEntered.await(10, TimeUnit.SECONDS))
+                .as("both tools should enter before either completes")
+                .isTrue();
+        inFlight.decrementAndGet();
+        exchange.getMessage().setBody(label);
+    }
+
+    private final class TwoToolRoundTripChatModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            if (chatRound.getAndIncrement() == 0) {
+                List<ToolExecutionRequest> requests = List.of(
+                        ToolExecutionRequest.builder().id("a").name("slowToolA").arguments("{}").build(),
+                        ToolExecutionRequest.builder().id("b").name("slowToolB").arguments("{}").build());
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.builder().toolExecutionRequests(requests).build())
+                        .build();
+            }
+            return ChatResponse.builder().aiMessage(AiMessage.from("done")).build();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

_AI-generated on behalf of atiaomar1978-hub_

- Exposes `AgentConfiguration.withExecuteToolsConcurrently()` and `withExecuteToolsConcurrently(Executor)`, wired into `AbstractAgent.configureBuilder()` for LangChain4j `AiServices`.
- When concurrent execution is enabled without an explicit executor, `LangChain4jAgentProducer` registers a Camel-managed thread pool via `ExecutorServiceManager` (on a **duplicated** configuration so registry beans are not mutated) and shuts it down on component stop.
- Builds on exchange-isolated Camel route tool execution (CAMEL-23944) so parallel tool calls are safe.
- Documents concurrent tool mode in the langchain4j-agent component guide.

## Review follow-up (Bugbot / Grok)

- **Fixed:** Managed executor is no longer written into shared `#agentConfiguration` registry beans; producer uses `AgentConfiguration.duplicate()` for the build-time copy.
- **Added:** Context stop/restart test for managed executor path; `duplicate()` unit test.

## Test plan

- [x] `AgentConfigurationTest` (executeToolsConcurrently + duplicate)
- [x] `LangChain4jAgentExecuteToolsConcurrentlyTest` (parallel overlap, registry not mutated, restart)
- [x] `mvn test -pl components/camel-ai/camel-langchain4j-agent -am -Dtest=LangChain4jAgentExecuteToolsConcurrentlyTest,AgentConfigurationTest`