### PR TITLE
CAMEL-24304: camel-aws2-step-functions - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-step-functions/pom.xml
+++ b/components/camel-aws/camel-aws2-step-functions/pom.xml
@@ -80,6 +80,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
@@ -111,6 +111,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createStateMachine operation requires CreateStateMachineRequest in POJO mode");
             }
         } else {
             CreateStateMachineRequest.Builder builder = CreateStateMachineRequest.builder();
@@ -164,6 +167,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteStateMachine operation requires DeleteStateMachineRequest in POJO mode");
             }
         } else {
             DeleteStateMachineRequest.Builder builder = DeleteStateMachineRequest.builder();
@@ -198,6 +204,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "updateStateMachine operation requires UpdateStateMachineRequest in POJO mode");
             }
         } else {
             UpdateStateMachineRequest.Builder builder = UpdateStateMachineRequest.builder();
@@ -241,6 +250,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeStateMachine operation requires DescribeStateMachineRequest in POJO mode");
             }
         } else {
             DescribeStateMachineRequest.Builder builder = DescribeStateMachineRequest.builder();
@@ -274,6 +286,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listStateMachines operation requires ListStateMachinesRequest in POJO mode");
             }
         } else {
             ListStateMachinesRequest.Builder builder = ListStateMachinesRequest.builder();
@@ -307,6 +322,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createActivity operation requires CreateActivityRequest in POJO mode");
             }
         } else {
             CreateActivityRequest.Builder builder = CreateActivityRequest.builder();
@@ -340,6 +358,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteActivity operation requires DeleteActivityRequest in POJO mode");
             }
         } else {
             DeleteActivityRequest.Builder builder = DeleteActivityRequest.builder();
@@ -373,6 +394,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeActivity operation requires DescribeActivityRequest in POJO mode");
             }
         } else {
             DescribeActivityRequest.Builder builder = DescribeActivityRequest.builder();
@@ -406,6 +430,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getActivityTask operation requires GetActivityTaskRequest in POJO mode");
             }
         } else {
             GetActivityTaskRequest.Builder builder = GetActivityTaskRequest.builder();
@@ -439,6 +466,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listActivities operation requires ListActivitiesRequest in POJO mode");
             }
         } else {
             ListActivitiesRequest.Builder builder = ListActivitiesRequest.builder();
@@ -472,6 +502,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startExecution operation requires StartExecutionRequest in POJO mode");
             }
         } else {
             StartExecutionRequest.Builder builder = StartExecutionRequest.builder();
@@ -518,6 +551,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startSyncExecution operation requires StartSyncExecutionRequest in POJO mode");
             }
         } else {
             StartSyncExecutionRequest.Builder builder = StartSyncExecutionRequest.builder();
@@ -564,6 +600,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "stopExecution operation requires StopExecutionRequest in POJO mode");
             }
         } else {
             StopExecutionRequest.Builder builder = StopExecutionRequest.builder();
@@ -597,6 +636,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeExecution operation requires DescribeExecutionRequest in POJO mode");
             }
         } else {
             DescribeExecutionRequest.Builder builder = DescribeExecutionRequest.builder();
@@ -630,6 +672,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listExecutions operation requires ListExecutionsRequest in POJO mode");
             }
         } else {
             ListExecutionsRequest.Builder builder = ListExecutionsRequest.builder();
@@ -667,6 +712,9 @@ public class StepFunctions2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getExecutionHistory operation requires GetExecutionHistoryRequest in POJO mode");
             }
         } else {
             GetExecutionHistoryRequest.Builder builder = GetExecutionHistoryRequest.builder();

--- a/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/test/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2ProducerTest.java
@@ -26,8 +26,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.sfn.model.*;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -339,6 +342,31 @@ public class StepFunctions2ProducerTest extends CamelTestSupport {
         assertEquals(1L, resultGet.events().get(0).id());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:createStateMachinePojo,createStateMachine operation requires CreateStateMachineRequest in POJO mode",
+            "direct:deleteStateMachinePojo,deleteStateMachine operation requires DeleteStateMachineRequest in POJO mode",
+            "direct:updateStateMachinePojo,updateStateMachine operation requires UpdateStateMachineRequest in POJO mode",
+            "direct:describeStateMachinePojo,describeStateMachine operation requires DescribeStateMachineRequest in POJO mode",
+            "direct:listStateMachinesPojo,listStateMachines operation requires ListStateMachinesRequest in POJO mode",
+            "direct:createPojoActivity,createActivity operation requires CreateActivityRequest in POJO mode",
+            "direct:deleteActivityPojo,deleteActivity operation requires DeleteActivityRequest in POJO mode",
+            "direct:describeActivityPojo,describeActivity operation requires DescribeActivityRequest in POJO mode",
+            "direct:getActivityTaskPojo,getActivityTask operation requires GetActivityTaskRequest in POJO mode",
+            "direct:listActivitiesPojo,listActivities operation requires ListActivitiesRequest in POJO mode",
+            "direct:startExecutionPojo,startExecution operation requires StartExecutionRequest in POJO mode",
+            "direct:startSyncExecutionPojo,startSyncExecution operation requires StartSyncExecutionRequest in POJO mode",
+            "direct:stopExecutionPojo,stopExecution operation requires StopExecutionRequest in POJO mode",
+            "direct:describeExecutionPojo,describeExecution operation requires DescribeExecutionRequest in POJO mode",
+            "direct:listExecutionsPojo,listExecutions operation requires ListExecutionsRequest in POJO mode",
+            "direct:getExecutionHistoryPojo,getExecutionHistory operation requires GetExecutionHistoryRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -394,6 +422,36 @@ public class StepFunctions2ProducerTest extends CamelTestSupport {
                 from("direct:describeStateMachine")
                         .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=describeStateMachine")
                         .to("mock:result");
+                from("direct:createStateMachinePojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=createStateMachine&pojoRequest=true");
+                from("direct:deleteStateMachinePojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=deleteStateMachine&pojoRequest=true");
+                from("direct:updateStateMachinePojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=updateStateMachine&pojoRequest=true");
+                from("direct:describeStateMachinePojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=describeStateMachine&pojoRequest=true");
+                from("direct:listStateMachinesPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=listStateMachines&pojoRequest=true");
+                from("direct:deleteActivityPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=deleteActivity&pojoRequest=true");
+                from("direct:describeActivityPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=describeActivity&pojoRequest=true");
+                from("direct:getActivityTaskPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=getActivityTask&pojoRequest=true");
+                from("direct:listActivitiesPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=listActivities&pojoRequest=true");
+                from("direct:startExecutionPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=startExecution&pojoRequest=true");
+                from("direct:startSyncExecutionPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=startSyncExecution&pojoRequest=true");
+                from("direct:stopExecutionPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=stopExecution&pojoRequest=true");
+                from("direct:describeExecutionPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=describeExecution&pojoRequest=true");
+                from("direct:listExecutionsPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=listExecutions&pojoRequest=true");
+                from("direct:getExecutionHistoryPojo")
+                        .to("aws2-step-functions://test?awsSfnClient=#awsSfnClient&operation=getExecutionHistory&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `StepFunctions2Producer`'s sixteen operations (state
machines, activities, executions) only acted when the body was the matching
request type; any other body fell through the `instanceof` with no `else`, so no
AWS call was made, no response was set, and the original body was returned with
no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"startExecution operation requires StartExecutionRequest in POJO
mode"`.

## Tests

A `@ParameterizedTest` covers all sixteen operations, sending a wrong-typed body
to `pojoRequest=true` routes and asserting each message. Verified to fail (silent
no-op) before the fix — with the `startExecution` else removed, exactly that case
reports "Expecting code to raise a throwable". Class 33/33 green. Hermetic unit
tests, region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_