### PR TITLE
CAMEL-24305: Fix autowiring of KafkaClientFactory via addComponent()

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaComponent.java
@@ -298,21 +298,19 @@ public class KafkaComponent extends HealthCheckComponent implements SSLContextPa
     }
 
     @Override
-    protected void doInit() throws Exception {
-        super.doInit();
+    protected void doStart() throws Exception {
+        super.doStart();
 
         // if a factory was not autowired then create a default factory
+        // NOTE: must be done in doStart() rather than doInit(), because when a component is
+        // registered via addComponent() (the path used by Spring Boot), doInit() runs before
+        // the autowiring lifecycle strategy has a chance to inject a custom factory.
         if (kafkaClientFactory == null) {
             kafkaClientFactory = new DefaultKafkaClientFactory();
         }
         if (configuration.isAllowManualCommit() && kafkaManualCommitFactory == null) {
             LOG.warn("The component was setup for allowing manual commits, but a manual commit factory was not set");
         }
-    }
-
-    @Override
-    protected void doStart() throws Exception {
-        super.doStart();
 
         Map<String, Object> map = new HashMap<>();
         // resolve parameter values from the values (#bean / #class etc)

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaEndpoint.java
@@ -132,6 +132,9 @@ public class KafkaEndpoint extends DefaultEndpoint implements MultipleConsumersS
         if (kafkaClientFactory == null) {
             kafkaClientFactory = getComponent().getKafkaClientFactory();
         }
+        if (kafkaClientFactory == null) {
+            kafkaClientFactory = new DefaultKafkaClientFactory();
+        }
         if (kafkaManualCommitFactory == null) {
             kafkaManualCommitFactory = getComponent().getKafkaManualCommitFactory();
         }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaAutowireTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaAutowireTest.java
@@ -18,14 +18,16 @@ package org.apache.camel.component.kafka;
 
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.infra.core.CamelContextExtension;
 import org.apache.camel.test.infra.core.DefaultCamelContextExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class KafkaAutowireTest {
+class KafkaAutowireTest {
 
     @RegisterExtension
     protected static CamelContextExtension contextExtension = new DefaultCamelContextExtension();
@@ -36,12 +38,55 @@ public class KafkaAutowireTest {
     private final KafkaClientFactory clientFactory = new TestKafkaClientFactory();
 
     @Test
-    public void testKafkaComponentAutowiring() {
+    void testKafkaComponentAutowiring() {
         KafkaComponent component = context.getComponent("kafka", KafkaComponent.class);
         assertSame(clientFactory, component.getKafkaClientFactory());
 
         KafkaEndpoint endpoint = context.getEndpoint("kafka:foo", KafkaEndpoint.class);
         assertSame(clientFactory, endpoint.getKafkaClientFactory());
+    }
+
+    /**
+     * Verifies that autowiring works when the component is registered via
+     * {@link CamelContext#addComponent(String, org.apache.camel.Component)}, which is the path used by Spring Boot. In
+     * this path, the component is added before the context is started, so {@code doInit()} runs before the autowiring
+     * lifecycle strategy. The default factory must not be created until {@code doStart()} to give autowiring a chance
+     * to inject a custom factory.
+     *
+     * This is a regression test for <a href="https://issues.apache.org/jira/browse/CAMEL-24305">CAMEL-24305</a>.
+     */
+    @Test
+    void testKafkaComponentAutowiringViaAddComponent() throws Exception {
+        // Simulate the Spring Boot path: addComponent() is called before the context is started
+        try (DefaultCamelContext ctx = new DefaultCamelContext()) {
+            KafkaClientFactory customFactory = new TestKafkaClientFactory();
+            ctx.getRegistry().bind("kafkaClientFactory", customFactory);
+
+            KafkaComponent component = new KafkaComponent();
+            ctx.addComponent("kafka", component);
+
+            ctx.start();
+
+            assertSame(customFactory, component.getKafkaClientFactory(),
+                    "Custom KafkaClientFactory should be autowired when using addComponent()");
+        }
+    }
+
+    /**
+     * Verifies that when no custom KafkaClientFactory is registered, the component creates a
+     * {@link DefaultKafkaClientFactory} as the default.
+     */
+    @Test
+    void testKafkaComponentDefaultFactoryWhenNoneRegistered() throws Exception {
+        try (DefaultCamelContext ctx = new DefaultCamelContext()) {
+            KafkaComponent component = new KafkaComponent();
+            ctx.addComponent("kafka", component);
+
+            ctx.start();
+
+            assertInstanceOf(DefaultKafkaClientFactory.class, component.getKafkaClientFactory(),
+                    "Default KafkaClientFactory should be created when none is registered");
+        }
     }
 
     static final class TestKafkaClientFactory extends DefaultKafkaClientFactory {


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fixes [CAMEL-24305](https://issues.apache.org/jira/browse/CAMEL-24305): `KafkaComponent` does not autowire a custom `KafkaClientFactory` bean when the component is registered via `addComponent()` (the path used by Spring Boot).

### Root Cause

When a component is registered via `CamelContext.addComponent()`, the lifecycle order is:

1. `ServiceHelper.initService(component)` — calls `doBuild()` + `doInit()`
2. `postInitComponent()` — triggers autowiring via `LifecycleStrategySupport.doAutoWire()`

Since `KafkaComponent.doInit()` was creating a `DefaultKafkaClientFactory` in step 1, the field was already non-null when autowiring checked it in step 2, and the custom factory was silently skipped.

This is a regression from [CAMEL-17262](https://issues.apache.org/jira/browse/CAMEL-17262) (commit `74c5a4ad2a7`), which reintroduced the bug originally fixed in [CAMEL-16500](https://issues.apache.org/jira/browse/CAMEL-16500) (commit `5ae05407c02`).

### Fix

- **KafkaComponent**: Move default `KafkaClientFactory` creation from `doInit()` to `doStart()`, giving the autowiring lifecycle strategy time to inject a custom factory before the default is created. This follows the same pattern used by `MapstructComponent` and `VertxHttpComponent`.
- **KafkaEndpoint**: Restore the `DefaultKafkaClientFactory` fallback in `doBuild()` (originally from CAMEL-16500) for resilience when the endpoint builds before the component starts.

### Tests

- Added `testKafkaComponentAutowiringViaAddComponent()` — exercises the `addComponent()` path with a custom `KafkaClientFactory` registered in the registry, verifying autowiring works
- Added `testKafkaComponentDefaultFactoryWhenNoneRegistered()` — verifies the default factory is still created when no custom factory is available
- Existing `testKafkaComponentAutowiring()` continues to pass (exercises the `getComponent()` path)
- All 196 unit tests in `camel-kafka` pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)