### PR TITLE
fix: force LANG=C on MQ 10.0 container to fix JmsReplyToIbmMQTest

### DIFF
--- a/test-infra/camel-test-infra-ibmmq/src/main/java/org/apache/camel/test/infra/ibmmq/services/IbmMQLocalContainerInfraService.java
+++ b/test-infra/camel-test-infra-ibmmq/src/main/java/org/apache/camel/test/infra/ibmmq/services/IbmMQLocalContainerInfraService.java
@@ -70,6 +70,11 @@ public class IbmMQLocalContainerInfraService implements IbmMQInfraService, Conta
                         .withEnv("LICENSE", "accept")
                         .withEnv("MQ_QMGR_NAME", IbmMQProperties.DEFAULT_QMGR_NAME)
                         .withEnv("MQ_APP_PASSWORD", IbmMQProperties.DEFAULT_APP_PASSWORD)
+                        // MQ 10.0 changed the default locale from C to C.utf8, which causes the
+                        // queue manager to use CCSID 1208 (UTF-8) instead of 819 (ISO 8859-1).
+                        // Force C locale to preserve CCSID 819 until the JMS reply-to mechanism
+                        // is confirmed to work correctly with CCSID 1208.
+                        .withEnv("LANG", "C")
                         .withLogConsumer(new Slf4jLogConsumer(LOG))
                         // AND the listener-port and log-message checks; a plain chained waitingFor() would replace,
                         // not combine, the strategies. WITH_INDIVIDUAL_TIMEOUTS_ONLY keeps each strategy's own timeout


### PR DESCRIPTION
## Summary

Fix the `JmsReplyToIbmMQTest.testCustomJMSReplyToInOut` test failure introduced by the IBM MQ 10.0 upgrade in PR #25107.

- IBM MQ 10.0 changed the default locale from `C` to `C.utf8`, causing the queue manager to use **CCSID 1208 (UTF-8)** instead of **CCSID 819 (ISO 8859-1)**
- This change causes the JMS reply-to mechanism to fail silently — the reply message never reaches `DEV.QUEUE.2`
- Force `LANG=C` on the container to preserve the CCSID 819 behavior from MQ 9.4.x

This is a pragmatic fix to validate the CCSID hypothesis. If CI passes with this change, the CCSID locale change is confirmed as the root cause. A proper fix (supporting CCSID 1208 natively) can be investigated as a follow-up.

## Test plan

- [ ] `JmsReplyToIbmMQTest.testCustomJMSReplyToInOut` should pass (currently fails 3/3 runs)
- [ ] `JmsComponentIbmMQTest.testSend` should continue to pass
- [ ] No regressions in other JMS tests

_Claude Code on behalf of gnodet_