### PR TITLE
Fix IBM MQ 10.0 upgrade: handle reserved JMS vendor properties

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -293,7 +293,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
   "version" : "4.22.0-SNAPSHOT",
-  "serviceVersion" : "9.4.5.0-r2",
+  "serviceVersion" : "10.0.0.0-r2",
   "uiSupported" : true
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
@@ -471,14 +471,19 @@ public class JmsBinding {
                     // set the property
                     JmsMessageHelper.setProperty(jmsMessage, key, value);
                 } catch (JMSException e) {
-                    // Some JMS providers (e.g. IBM MQ) mark certain vendor-specific properties
-                    // as read-only/reserved (set by the provider, not the application). When Camel
-                    // copies headers from an incoming message to an outgoing reply or forwarded
-                    // message, these reserved properties cause an exception. We skip them gracefully
-                    // since they are provider-assigned metadata that should not be propagated.
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Could not set JMS property '{}' on outgoing message, skipping ({})",
+                    // JMS vendor-specific properties (JMS_<vendor>_xxx per JMS spec section 3.5.1)
+                    // may be read-only/reserved — set by the provider, not the application.
+                    // There is no standard JMS API to query which vendor properties are reserved,
+                    // and the set can change between provider versions (e.g. IBM MQ 10.0 made
+                    // JMS_IBM_MsgToken read-only). We skip them gracefully since they are
+                    // provider-assigned metadata that should not be propagated.
+                    // For non-vendor properties, we re-throw the exception as it likely indicates
+                    // a real problem (e.g. invalid value type, message not writable).
+                    if (key.startsWith("JMS_")) {
+                        LOG.warn("Could not set JMS vendor property '{}' on outgoing message, skipping: {}",
                                 key, e.getMessage());
+                    } else {
+                        throw e;
                     }
                 }
             } else if (LOG.isDebugEnabled()) {

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsBinding.java
@@ -467,8 +467,20 @@ public class JmsBinding {
             if (value != null) {
                 // must encode to safe JMS header name before setting property on jmsMessage
                 String key = jmsKeyFormatStrategy.encodeKey(headerName);
-                // set the property
-                JmsMessageHelper.setProperty(jmsMessage, key, value);
+                try {
+                    // set the property
+                    JmsMessageHelper.setProperty(jmsMessage, key, value);
+                } catch (JMSException e) {
+                    // Some JMS providers (e.g. IBM MQ) mark certain vendor-specific properties
+                    // as read-only/reserved (set by the provider, not the application). When Camel
+                    // copies headers from an incoming message to an outgoing reply or forwarded
+                    // message, these reserved properties cause an exception. We skip them gracefully
+                    // since they are provider-assigned metadata that should not be propagated.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Could not set JMS property '{}' on outgoing message, skipping ({})",
+                                key, e.getMessage());
+                    }
+                }
             } else if (LOG.isDebugEnabled()) {
                 // okay the value is not a primitive or string so we cannot sent it over the wire
                 LOG.debug("Ignoring non primitive header: {} of class: {} with value: {}",

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
@@ -30,23 +30,23 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisabledOnOs(architectures = { "aarch64", "aarch_64" }, disabledReason = "IBM MQ has no Linux ARM64 native image")
-public class JmsReplyToIbmMQTest extends CamelTestSupport {
+class JmsReplyToIbmMQTest extends CamelTestSupport {
 
     @RegisterExtension
-    public static IbmMQService service = IbmMQServiceFactory.createService();
+    static IbmMQService service = IbmMQServiceFactory.createService();
 
     @Test
-    public void testCustomJMSReplyToInOut() {
+    void testCustomJMSReplyToInOut() {
         JmsTestHelper.waitForJmsConsumerRoutes(context, "request");
 
         template.sendBody("jms:queue:DEV.QUEUE.1", "What is your name?");
 
         String reply
                 = consumer.receiveBody("jms:queue:DEV.QUEUE.2", 20000, String.class);
-        assertEquals("My name is Camel", reply);
+        assertThat(reply).isEqualTo("My name is Camel");
     }
 
     @Override

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1177,6 +1177,26 @@ New JMX attributes have been added for live call monitoring:
 A new `transitionToCloseState` JMX operation resets the circuit breaker to CLOSED and clears
 the call counters.
 
+=== camel-jms - IBM MQ client upgraded to 10.0
+
+The IBM MQ client library (`com.ibm.mq:com.ibm.mq.jakarta.client`) has been upgraded from 9.4.x to 10.0.0.0,
+and the IBM MQ test container image from 9.4.x to 10.0.0.0.
+
+IBM MQ 10.0 marks the `JMS_IBM_MsgToken` vendor property as read-only. When Camel copies headers from an
+incoming JMS message to an outgoing reply or forwarded message, this reserved property previously caused a
+`MessageFormatException` that silently prevented the reply from being sent.
+
+=== camel-jms - vendor-specific JMS properties skipped when read-only
+
+When setting JMS properties on an outgoing message, Camel now catches `JMSException` for JMS vendor-specific
+properties (those with a `JMS_` prefix, per JMS spec section 3.5.1) and logs a `WARN` instead of propagating
+the exception. There is no standard JMS API to query which vendor properties are reserved, and the set can
+change between provider versions. Non-vendor properties still throw on failure as before.
+
+This change is necessary for IBM MQ 10.0 compatibility but applies to all JMS providers. If you relied on
+exceptions from vendor-specific property failures propagating through `JmsBinding.appendJmsProperty()`, be
+aware that they are now caught and logged at `WARN` level for `JMS_`-prefixed properties only.
+
 === camel-clickhouse (new component)
 
 A new `camel-clickhouse` producer component has been added. It integrates with

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,7 @@
         <citrus-version>5.0.0-M2</citrus-version>
         <classgraph-version>4.8.186</classgraph-version>
         <cloudant-version>0.10.20</cloudant-version>
-        <com-ibm-mq-jakarta-client-version>9.4.5.1</com-ibm-mq-jakarta-client-version>
+        <com-ibm-mq-jakarta-client-version>10.0.0.0</com-ibm-mq-jakarta-client-version>
         <cometd-java-client-version>9.0.1</cometd-java-client-version>
         <cometd-java-server-version>9.0.1</cometd-java-server-version>
         <commons-beanutils-version>1.11.0</commons-beanutils-version>

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -293,7 +293,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
   "version" : "4.22.0-SNAPSHOT",
-  "serviceVersion" : "9.4.5.0-r2",
+  "serviceVersion" : "10.0.0.0-r2",
   "uiSupported" : true
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-ibmmq/src/main/resources/org/apache/camel/test/infra/ibmmq/services/container.properties
+++ b/test-infra/camel-test-infra-ibmmq/src/main/resources/org/apache/camel/test/infra/ibmmq/services/container.properties
@@ -14,5 +14,5 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-ibm.mq.container=icr.io/ibm-messaging/mq:9.4.5.0-r2
+ibm.mq.container=icr.io/ibm-messaging/mq:10.0.0.0-r2
 ibm.mq.container.version.exclude=amd64,arm64,ppc64le,s390x,x86_64


### PR DESCRIPTION
_Claude Code on behalf of Guillaume Nodet_

## Summary

Upgrade IBM MQ client library and container image to version 10.0, and fix a compatibility issue where IBM MQ 10.0 marks the `JMS_IBM_MsgToken` vendor property as read-only.

This is a follow-up to #25107 which identified the upgrade but had test failures.

## Changes

- **`parent/pom.xml`**: Upgrade `com.ibm.mq:com.ibm.mq.jakarta.client` from 9.4.5.1 to 10.0.0.0
- **`test-infra/camel-test-infra-ibmmq/src/test/resources/container.properties`**: Upgrade container image from `icr.io/ibm-messaging/mq:9.4.5.0-r2` to `icr.io/ibm-messaging/mq:10.0.0.0-r2`
- **`components/camel-jms/src/main/java/.../JmsBinding.java`**: Add defensive try-catch in `appendJmsProperty()` for JMS vendor-specific properties (`JMS_*` prefix per JMS spec section 3.5.1) that the provider marks as reserved/read-only. Non-vendor properties still throw on failure as before.
- **`components/camel-jms/src/test/java/.../JmsReplyToIbmMQTest.java`**: Modernized test (dropped `public`, switched to AssertJ assertions)
- **`docs/.../camel-4x-upgrade-guide-4_22.adoc`**: Added upgrade guide entries for the IBM MQ 10.0 upgrade and the behavioral change
- **Generated metadata files**: Updated `serviceVersion` in IBM MQ test-infra JSON files

## Root Cause

IBM MQ 10.0 marks `JMS_IBM_MsgToken` as a reserved property that cannot be set by applications. When Camel copies all headers from an incoming JMS message to an outgoing reply, `JmsBinding.appendJmsProperty()` attempted to set this reserved property, causing a `MessageFormatException`. This exception propagated up through Spring's `DefaultMessageListenerContainer`, preventing the reply from being sent — resulting in the test receiving `null` instead of the expected response.

The fix catches `JMSException` only for JMS vendor-specific properties (`JMS_*` prefix) and logs at WARN level, while re-throwing for non-vendor properties. There is no standard JMS API to query which vendor properties are reserved, and the set can change between provider versions.

## Test Plan

- [x] `JmsReplyToIbmMQTest.testCustomJMSReplyToInOut` passes with IBM MQ 10.0
- [x] Full CI green