### PR TITLE
CAMEL-24307: camel-aws2-rekognition - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-rekognition/pom.xml
+++ b/components/camel-aws/camel-aws2-rekognition/pom.xml
@@ -80,6 +80,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-aws/camel-aws2-rekognition/src/main/java/org/apache/camel/component/aws2/rekognition/Rekognition2Producer.java
+++ b/components/camel-aws/camel-aws2-rekognition/src/main/java/org/apache/camel/component/aws2/rekognition/Rekognition2Producer.java
@@ -188,6 +188,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "associateFaces operation requires AssociateFacesRequest in POJO mode");
             }
         } else {
             AssociateFacesRequest.Builder builder = AssociateFacesRequest.builder();
@@ -237,6 +240,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "compareFaces operation requires CompareFacesRequest in POJO mode");
             }
         } else {
             CompareFacesRequest.Builder builder = CompareFacesRequest.builder();
@@ -281,6 +287,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createCollection operation requires CreateCollectionRequest in POJO mode");
             }
         } else {
             CreateCollectionRequest.Builder builder = CreateCollectionRequest.builder();
@@ -313,6 +322,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createUser operation requires CreateUserRequest in POJO mode");
             }
         } else {
             CreateUserRequest.Builder builder = CreateUserRequest.builder();
@@ -354,6 +366,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteCollection operation requires DeleteCollectionRequest in POJO mode");
             }
         } else {
             DeleteCollectionRequest.Builder builder = DeleteCollectionRequest.builder();
@@ -386,6 +401,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteFaces operation requires DeleteFacesRequest in POJO mode");
             }
         } else {
             DeleteFacesRequest.Builder builder = DeleteFacesRequest.builder();
@@ -422,6 +440,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteUser operation requires DeleteUserRequest in POJO mode");
             }
         } else {
             DeleteUserRequest.Builder builder = DeleteUserRequest.builder();
@@ -463,6 +484,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeCollection operation requires DescribeCollectionRequest in POJO mode");
             }
         } else {
             DescribeCollectionRequest.Builder builder = DescribeCollectionRequest.builder();
@@ -495,6 +519,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "detectFaces operation requires DetectFacesRequest in POJO mode");
             }
         } else {
             DetectFacesRequest.Builder builder = DetectFacesRequest.builder();
@@ -531,6 +558,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "detectLabels operation requires DetectLabelsRequest in POJO mode");
             }
         } else {
             DetectLabelsRequest.Builder builder = DetectLabelsRequest.builder();
@@ -581,6 +611,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "detectModerationLabels operation requires DetectModerationLabelsRequest in POJO mode");
             }
         } else {
             DetectModerationLabelsRequest.Builder builder = DetectModerationLabelsRequest.builder();
@@ -628,6 +661,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "detectProtectiveEquipment operation requires DetectProtectiveEquipmentRequest in POJO mode");
             }
         } else {
             DetectProtectiveEquipmentRequest.Builder builder = DetectProtectiveEquipmentRequest.builder();
@@ -667,6 +703,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "detectText operation requires DetectTextRequest in POJO mode");
             }
         } else {
             DetectTextRequest.Builder builder = DetectTextRequest.builder();
@@ -704,6 +743,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "disassociateFaces operation requires DisassociateFacesRequest in POJO mode");
             }
         } else {
             DisassociateFacesRequest.Builder builder = DisassociateFacesRequest.builder();
@@ -749,6 +791,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getCelebrityInfo operation requires GetCelebrityInfoRequest in POJO mode");
             }
         } else {
             GetCelebrityInfoRequest.Builder builder = GetCelebrityInfoRequest.builder();
@@ -781,6 +826,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getMediaAnalysisJob operation requires GetMediaAnalysisJobRequest in POJO mode");
             }
         } else {
             GetMediaAnalysisJobRequest.Builder builder = GetMediaAnalysisJobRequest.builder();
@@ -813,6 +861,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "indexFaces operation requires IndexFacesRequest in POJO mode");
             }
         } else {
             IndexFacesRequest.Builder builder = IndexFacesRequest.builder();
@@ -866,6 +917,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listCollections operation requires ListCollectionsRequest in POJO mode");
             }
         } else {
             ListCollectionsRequest.Builder builder = ListCollectionsRequest.builder();
@@ -902,6 +956,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listMediaAnalysisJobs operation requires ListMediaAnalysisJobsRequest in POJO mode");
             }
         } else {
             ListMediaAnalysisJobsRequest.Builder builder = ListMediaAnalysisJobsRequest.builder();
@@ -938,6 +995,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listFaces operation requires ListFacesRequest in POJO mode");
             }
         } else {
             ListFacesRequest.Builder builder = ListFacesRequest.builder();
@@ -986,6 +1046,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listUsers operation requires ListUsersRequest in POJO mode");
             }
         } else {
             ListUsersRequest.Builder builder = ListUsersRequest.builder();
@@ -1026,6 +1089,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "recognizeCelebrities operation requires RecognizeCelebritiesRequest in POJO mode");
             }
         } else {
             RecognizeCelebritiesRequest.Builder builder = RecognizeCelebritiesRequest.builder();
@@ -1058,6 +1124,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "searchFaces operation requires SearchFacesRequest in POJO mode");
             }
         } else {
             SearchFacesRequest.Builder builder = SearchFacesRequest.builder();
@@ -1102,6 +1171,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "searchFacesByImage operation requires SearchFacesByImageRequest in POJO mode");
             }
         } else {
             SearchFacesByImageRequest.Builder builder = SearchFacesByImageRequest.builder();
@@ -1150,6 +1222,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "searchUsers operation requires SearchUsersRequest in POJO mode");
             }
         } else {
             SearchUsersRequest.Builder builder = SearchUsersRequest.builder();
@@ -1198,6 +1273,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "searchUsersByImage operation requires SearchUsersByImageRequest in POJO mode");
             }
         } else {
             SearchUsersByImageRequest.Builder builder = SearchUsersByImageRequest.builder();
@@ -1246,6 +1324,9 @@ public class Rekognition2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startMediaAnalysisJob operation requires StartMediaAnalysisJobRequest in POJO mode");
             }
         } else {
             StartMediaAnalysisJobRequest.Builder builder = StartMediaAnalysisJobRequest.builder();

--- a/components/camel-aws/camel-aws2-rekognition/src/test/java/org/apache/camel/component/aws2/rekognition/Rekognition2ProducerTest.java
+++ b/components/camel-aws/camel-aws2-rekognition/src/test/java/org/apache/camel/component/aws2/rekognition/Rekognition2ProducerTest.java
@@ -24,8 +24,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.awssdk.services.rekognition.model.*;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -496,6 +499,42 @@ public class Rekognition2ProducerTest extends CamelTestSupport {
         assertEquals("new-job-id", result.jobId());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "direct:associateFacesPojo,associateFaces operation requires AssociateFacesRequest in POJO mode",
+            "direct:compareFacesPojo,compareFaces operation requires CompareFacesRequest in POJO mode",
+            "direct:createCollectionPojo,createCollection operation requires CreateCollectionRequest in POJO mode",
+            "direct:createUserPojo,createUser operation requires CreateUserRequest in POJO mode",
+            "direct:deleteCollectionPojo,deleteCollection operation requires DeleteCollectionRequest in POJO mode",
+            "direct:deleteFacesPojo,deleteFaces operation requires DeleteFacesRequest in POJO mode",
+            "direct:deleteUserPojo,deleteUser operation requires DeleteUserRequest in POJO mode",
+            "direct:describeCollectionPojo,describeCollection operation requires DescribeCollectionRequest in POJO mode",
+            "direct:detectFacesPojo,detectFaces operation requires DetectFacesRequest in POJO mode",
+            "direct:detectLabelsPojo,detectLabels operation requires DetectLabelsRequest in POJO mode",
+            "direct:detectModerationLabelsPojo,detectModerationLabels operation requires DetectModerationLabelsRequest in POJO mode",
+            "direct:detectProtectiveEquipmentPojo,detectProtectiveEquipment operation requires DetectProtectiveEquipmentRequest in POJO mode",
+            "direct:detectTextPojo,detectText operation requires DetectTextRequest in POJO mode",
+            "direct:disassociateFacesPojo,disassociateFaces operation requires DisassociateFacesRequest in POJO mode",
+            "direct:getCelebrityInfoPojo,getCelebrityInfo operation requires GetCelebrityInfoRequest in POJO mode",
+            "direct:getMediaAnalysisJobPojo,getMediaAnalysisJob operation requires GetMediaAnalysisJobRequest in POJO mode",
+            "direct:indexFacesPojo,indexFaces operation requires IndexFacesRequest in POJO mode",
+            "direct:listCollectionsPojo,listCollections operation requires ListCollectionsRequest in POJO mode",
+            "direct:listMediaAnalysisJobsPojo,listMediaAnalysisJobs operation requires ListMediaAnalysisJobsRequest in POJO mode",
+            "direct:listFacesPojo,listFaces operation requires ListFacesRequest in POJO mode",
+            "direct:listUsersPojo,listUsers operation requires ListUsersRequest in POJO mode",
+            "direct:recognizeCelebritiesPojo,recognizeCelebrities operation requires RecognizeCelebritiesRequest in POJO mode",
+            "direct:searchFacesPojo,searchFaces operation requires SearchFacesRequest in POJO mode",
+            "direct:searchFacesByImagePojo,searchFacesByImage operation requires SearchFacesByImageRequest in POJO mode",
+            "direct:searchUsersPojo,searchUsers operation requires SearchUsersRequest in POJO mode",
+            "direct:searchUsersByImagePojo,searchUsersByImage operation requires SearchUsersByImageRequest in POJO mode",
+            "direct:startMediaAnalysisJobPojo,startMediaAnalysisJob operation requires StartMediaAnalysisJobRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -582,6 +621,60 @@ public class Rekognition2ProducerTest extends CamelTestSupport {
                 from("direct:startMediaAnalysisJob")
                         .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=startMediaAnalysisJob")
                         .to("mock:result");
+                from("direct:associateFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=associateFaces&pojoRequest=true");
+                from("direct:compareFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=compareFaces&pojoRequest=true");
+                from("direct:createCollectionPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=createCollection&pojoRequest=true");
+                from("direct:createUserPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=createUser&pojoRequest=true");
+                from("direct:deleteCollectionPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=deleteCollection&pojoRequest=true");
+                from("direct:deleteFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=deleteFaces&pojoRequest=true");
+                from("direct:deleteUserPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=deleteUser&pojoRequest=true");
+                from("direct:describeCollectionPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=describeCollection&pojoRequest=true");
+                from("direct:detectFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=detectFaces&pojoRequest=true");
+                from("direct:detectLabelsPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=detectLabels&pojoRequest=true");
+                from("direct:detectModerationLabelsPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=detectModerationLabels&pojoRequest=true");
+                from("direct:detectProtectiveEquipmentPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=detectProtectiveEquipment&pojoRequest=true");
+                from("direct:detectTextPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=detectText&pojoRequest=true");
+                from("direct:disassociateFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=disassociateFaces&pojoRequest=true");
+                from("direct:getCelebrityInfoPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=getCelebrityInfo&pojoRequest=true");
+                from("direct:getMediaAnalysisJobPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=getMediaAnalysisJob&pojoRequest=true");
+                from("direct:indexFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=indexFaces&pojoRequest=true");
+                from("direct:listCollectionsPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=listCollections&pojoRequest=true");
+                from("direct:listMediaAnalysisJobsPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=listMediaAnalysisJobs&pojoRequest=true");
+                from("direct:listFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=listFaces&pojoRequest=true");
+                from("direct:listUsersPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=listUsers&pojoRequest=true");
+                from("direct:recognizeCelebritiesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=recognizeCelebrities&pojoRequest=true");
+                from("direct:searchFacesPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=searchFaces&pojoRequest=true");
+                from("direct:searchFacesByImagePojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=searchFacesByImage&pojoRequest=true");
+                from("direct:searchUsersPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=searchUsers&pojoRequest=true");
+                from("direct:searchUsersByImagePojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=searchUsersByImage&pojoRequest=true");
+                from("direct:startMediaAnalysisJobPojo")
+                        .to("aws2-rekognition://test?awsRekognitionClient=#awsRekognitionClient&operation=startMediaAnalysisJob&pojoRequest=true");
             }
         };
     }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `Rekognition2Producer`'s 27 operations only acted when
the body was the matching request type; any other body fell through the
`instanceof` with no `else`, so no AWS call was made, no response was set, and
the original body was returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"detectText operation requires DetectTextRequest in POJO mode"`.

## Tests

A `@ParameterizedTest` covers all 27 operations, sending a wrong-typed body to
`pojoRequest=true` routes and asserting each message. Verified to fail (silent
no-op) before the fix — with the `detectText` else removed, exactly that case
reports "Expecting code to raise a throwable". Class 54/54 green. Hermetic unit
tests, region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_