### PR TITLE
CAMEL-24316: camel-aws2-transcribe - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-transcribe/src/main/java/org/apache/camel/component/aws2/transcribe/Transcribe2Producer.java
+++ b/components/camel-aws/camel-aws2-transcribe/src/main/java/org/apache/camel/component/aws2/transcribe/Transcribe2Producer.java
@@ -156,6 +156,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "startTranscriptionJob operation requires StartTranscriptionJobRequest in POJO mode");
             }
         } else {
             StartTranscriptionJobRequest.Builder builder = StartTranscriptionJobRequest.builder();
@@ -200,6 +203,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getTranscriptionJob operation requires GetTranscriptionJobRequest in POJO mode");
             }
         } else {
             GetTranscriptionJobRequest.Builder builder = GetTranscriptionJobRequest.builder();
@@ -232,6 +238,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listTranscriptionJobs operation requires ListTranscriptionJobsRequest in POJO mode");
             }
         } else {
             ListTranscriptionJobsRequest.Builder builder = ListTranscriptionJobsRequest.builder();
@@ -265,6 +274,9 @@ public class Transcribe2Producer extends DefaultProducer {
                     LOG.trace("Delete Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
                     throw ase;
                 }
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteTranscriptionJob operation requires DeleteTranscriptionJobRequest in POJO mode");
             }
         } else {
             DeleteTranscriptionJobRequest.Builder builder = DeleteTranscriptionJobRequest.builder();
@@ -295,6 +307,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "createVocabulary operation requires CreateVocabularyRequest in POJO mode");
             }
         } else {
             CreateVocabularyRequest.Builder builder = CreateVocabularyRequest.builder();
@@ -335,6 +350,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "getVocabulary operation requires GetVocabularyRequest in POJO mode");
             }
         } else {
             GetVocabularyRequest.Builder builder = GetVocabularyRequest.builder();
@@ -367,6 +385,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "listVocabularies operation requires ListVocabulariesRequest in POJO mode");
             }
         } else {
             ListVocabulariesRequest.Builder builder = ListVocabulariesRequest.builder();
@@ -399,6 +420,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "updateVocabulary operation requires UpdateVocabularyRequest in POJO mode");
             }
         } else {
             UpdateVocabularyRequest.Builder builder = UpdateVocabularyRequest.builder();
@@ -432,6 +456,9 @@ public class Transcribe2Producer extends DefaultProducer {
                     LOG.trace("Delete Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
                     throw ase;
                 }
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteVocabulary operation requires DeleteVocabularyRequest in POJO mode");
             }
         } else {
             DeleteVocabularyRequest.Builder builder = DeleteVocabularyRequest.builder();
@@ -454,6 +481,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof CreateVocabularyFilterRequest req) {
                 setResponse(exchange, execute("Create Vocabulary Filter", () -> transcribeClient.createVocabularyFilter(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "createVocabularyFilter operation requires CreateVocabularyFilterRequest in POJO mode");
             }
         } else {
             CreateVocabularyFilterRequest.Builder builder = CreateVocabularyFilterRequest.builder();
@@ -475,6 +505,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof GetVocabularyFilterRequest req) {
                 setResponse(exchange, execute("Get Vocabulary Filter", () -> transcribeClient.getVocabularyFilter(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "getVocabularyFilter operation requires GetVocabularyFilterRequest in POJO mode");
             }
         } else {
             GetVocabularyFilterRequest.Builder builder = GetVocabularyFilterRequest.builder();
@@ -489,6 +522,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof ListVocabularyFiltersRequest req) {
                 setResponse(exchange, execute("List Vocabulary Filters", () -> transcribeClient.listVocabularyFilters(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "listVocabularyFilters operation requires ListVocabularyFiltersRequest in POJO mode");
             }
         } else {
             ListVocabularyFiltersRequest.Builder builder = ListVocabularyFiltersRequest.builder();
@@ -506,6 +542,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof UpdateVocabularyFilterRequest req) {
                 setResponse(exchange, execute("Update Vocabulary Filter", () -> transcribeClient.updateVocabularyFilter(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "updateVocabularyFilter operation requires UpdateVocabularyFilterRequest in POJO mode");
             }
         } else {
             UpdateVocabularyFilterRequest.Builder builder = UpdateVocabularyFilterRequest.builder();
@@ -527,6 +566,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof DeleteVocabularyFilterRequest req) {
                 setResponse(exchange, execute("Delete Vocabulary Filter", () -> transcribeClient.deleteVocabularyFilter(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteVocabularyFilter operation requires DeleteVocabularyFilterRequest in POJO mode");
             }
         } else {
             DeleteVocabularyFilterRequest.Builder builder = DeleteVocabularyFilterRequest.builder();
@@ -541,6 +583,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof CreateLanguageModelRequest req) {
                 setResponse(exchange, execute("Create Language Model", () -> transcribeClient.createLanguageModel(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "createLanguageModel operation requires CreateLanguageModelRequest in POJO mode");
             }
         } else {
             CreateLanguageModelRequest.Builder builder = CreateLanguageModelRequest.builder();
@@ -562,6 +607,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof DescribeLanguageModelRequest req) {
                 setResponse(exchange, execute("Describe Language Model", () -> transcribeClient.describeLanguageModel(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "describeLanguageModel operation requires DescribeLanguageModelRequest in POJO mode");
             }
         } else {
             DescribeLanguageModelRequest.Builder builder = DescribeLanguageModelRequest.builder();
@@ -576,6 +624,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof ListLanguageModelsRequest req) {
                 setResponse(exchange, execute("List Language Models", () -> transcribeClient.listLanguageModels(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "listLanguageModels operation requires ListLanguageModelsRequest in POJO mode");
             }
         } else {
             ListLanguageModelsRequest.Builder builder = ListLanguageModelsRequest.builder();
@@ -592,6 +643,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof DeleteLanguageModelRequest req) {
                 setResponse(exchange, execute("Delete Language Model", () -> transcribeClient.deleteLanguageModel(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteLanguageModel operation requires DeleteLanguageModelRequest in POJO mode");
             }
         } else {
             DeleteLanguageModelRequest.Builder builder = DeleteLanguageModelRequest.builder();
@@ -608,6 +662,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof CreateMedicalVocabularyRequest req) {
                 setResponse(exchange,
                         execute("Create Medical Vocabulary", () -> transcribeClient.createMedicalVocabulary(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "createMedicalVocabulary operation requires CreateMedicalVocabularyRequest in POJO mode");
             }
         } else {
             CreateMedicalVocabularyRequest.Builder builder = CreateMedicalVocabularyRequest.builder();
@@ -624,6 +681,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof GetMedicalVocabularyRequest req) {
                 setResponse(exchange, execute("Get Medical Vocabulary", () -> transcribeClient.getMedicalVocabulary(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "getMedicalVocabulary operation requires GetMedicalVocabularyRequest in POJO mode");
             }
         } else {
             GetMedicalVocabularyRequest.Builder builder = GetMedicalVocabularyRequest.builder();
@@ -640,6 +700,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof ListMedicalVocabulariesRequest req) {
                 setResponse(exchange,
                         execute("List Medical Vocabularies", () -> transcribeClient.listMedicalVocabularies(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "listMedicalVocabularies operation requires ListMedicalVocabulariesRequest in POJO mode");
             }
         } else {
             ListMedicalVocabulariesRequest.Builder builder = ListMedicalVocabulariesRequest.builder();
@@ -659,6 +722,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof UpdateMedicalVocabularyRequest req) {
                 setResponse(exchange,
                         execute("Update Medical Vocabulary", () -> transcribeClient.updateMedicalVocabulary(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "updateMedicalVocabulary operation requires UpdateMedicalVocabularyRequest in POJO mode");
             }
         } else {
             UpdateMedicalVocabularyRequest.Builder builder = UpdateMedicalVocabularyRequest.builder();
@@ -677,6 +743,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof DeleteMedicalVocabularyRequest req) {
                 setResponse(exchange,
                         execute("Delete Medical Vocabulary", () -> transcribeClient.deleteMedicalVocabulary(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteMedicalVocabulary operation requires DeleteMedicalVocabularyRequest in POJO mode");
             }
         } else {
             DeleteMedicalVocabularyRequest.Builder builder = DeleteMedicalVocabularyRequest.builder();
@@ -694,6 +763,9 @@ public class Transcribe2Producer extends DefaultProducer {
                 setResponse(exchange,
                         execute("Start Medical Transcription Job",
                                 () -> transcribeClient.startMedicalTranscriptionJob(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "startMedicalTranscriptionJob operation requires StartMedicalTranscriptionJobRequest in POJO mode");
             }
         } else {
             StartMedicalTranscriptionJobRequest.Builder builder = StartMedicalTranscriptionJobRequest.builder();
@@ -720,6 +792,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof GetMedicalTranscriptionJobRequest req) {
                 setResponse(exchange,
                         execute("Get Medical Transcription Job", () -> transcribeClient.getMedicalTranscriptionJob(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "getMedicalTranscriptionJob operation requires GetMedicalTranscriptionJobRequest in POJO mode");
             }
         } else {
             GetMedicalTranscriptionJobRequest.Builder builder = GetMedicalTranscriptionJobRequest.builder();
@@ -737,6 +812,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof ListMedicalTranscriptionJobsRequest req) {
                 setResponse(exchange,
                         execute("List Medical Transcription Jobs", () -> transcribeClient.listMedicalTranscriptionJobs(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "listMedicalTranscriptionJobs operation requires ListMedicalTranscriptionJobsRequest in POJO mode");
             }
         } else {
             ListMedicalTranscriptionJobsRequest.Builder builder = ListMedicalTranscriptionJobsRequest.builder();
@@ -756,6 +834,9 @@ public class Transcribe2Producer extends DefaultProducer {
             if (payload instanceof DeleteMedicalTranscriptionJobRequest req) {
                 setResponse(exchange, execute("Delete Medical Transcription Job",
                         () -> transcribeClient.deleteMedicalTranscriptionJob(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "deleteMedicalTranscriptionJob operation requires DeleteMedicalTranscriptionJobRequest in POJO mode");
             }
         } else {
             DeleteMedicalTranscriptionJobRequest.Builder builder = DeleteMedicalTranscriptionJobRequest.builder();
@@ -771,6 +852,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof TagResourceRequest req) {
                 setResponse(exchange, execute("Tag Resource", () -> transcribeClient.tagResource(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "tagResource operation requires TagResourceRequest in POJO mode");
             }
         } else {
             TagResourceRequest.Builder builder = TagResourceRequest.builder();
@@ -790,6 +874,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof UntagResourceRequest req) {
                 setResponse(exchange, execute("Untag Resource", () -> transcribeClient.untagResource(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "untagResource operation requires UntagResourceRequest in POJO mode");
             }
         } else {
             UntagResourceRequest.Builder builder = UntagResourceRequest.builder();
@@ -807,6 +894,9 @@ public class Transcribe2Producer extends DefaultProducer {
             Object payload = exchange.getIn().getMandatoryBody();
             if (payload instanceof ListTagsForResourceRequest req) {
                 setResponse(exchange, execute("List Tags For Resource", () -> transcribeClient.listTagsForResource(req)));
+            } else {
+                throw new IllegalArgumentException(
+                        "listTagsForResource operation requires ListTagsForResourceRequest in POJO mode");
             }
         } else {
             ListTagsForResourceRequest.Builder builder = ListTagsForResourceRequest.builder();

--- a/components/camel-aws/camel-aws2-transcribe/src/test/java/org/apache/camel/component/aws2/transcribe/Transcribe2ProducerPojoRequestTest.java
+++ b/components/camel-aws/camel-aws2-transcribe/src/test/java/org/apache/camel/component/aws2/transcribe/Transcribe2ProducerPojoRequestTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.transcribe;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Transcribe2ProducerPojoRequestTest extends CamelTestSupport {
+
+    @BindToRegistry("amazonTranscribeClient")
+    AmazonAWSTranscribeMock clientMock = new AmazonAWSTranscribeMock();
+
+    @ParameterizedTest
+    @CsvSource({
+            "direct:startTranscriptionJob,startTranscriptionJob operation requires StartTranscriptionJobRequest in POJO mode",
+            "direct:getTranscriptionJob,getTranscriptionJob operation requires GetTranscriptionJobRequest in POJO mode",
+            "direct:listTranscriptionJobs,listTranscriptionJobs operation requires ListTranscriptionJobsRequest in POJO mode",
+            "direct:deleteTranscriptionJob,deleteTranscriptionJob operation requires DeleteTranscriptionJobRequest in POJO mode",
+            "direct:createVocabulary,createVocabulary operation requires CreateVocabularyRequest in POJO mode",
+            "direct:getVocabulary,getVocabulary operation requires GetVocabularyRequest in POJO mode",
+            "direct:listVocabularies,listVocabularies operation requires ListVocabulariesRequest in POJO mode",
+            "direct:updateVocabulary,updateVocabulary operation requires UpdateVocabularyRequest in POJO mode",
+            "direct:deleteVocabulary,deleteVocabulary operation requires DeleteVocabularyRequest in POJO mode",
+            "direct:createVocabularyFilter,createVocabularyFilter operation requires CreateVocabularyFilterRequest in POJO mode",
+            "direct:getVocabularyFilter,getVocabularyFilter operation requires GetVocabularyFilterRequest in POJO mode",
+            "direct:listVocabularyFilters,listVocabularyFilters operation requires ListVocabularyFiltersRequest in POJO mode",
+            "direct:updateVocabularyFilter,updateVocabularyFilter operation requires UpdateVocabularyFilterRequest in POJO mode",
+            "direct:deleteVocabularyFilter,deleteVocabularyFilter operation requires DeleteVocabularyFilterRequest in POJO mode",
+            "direct:createLanguageModel,createLanguageModel operation requires CreateLanguageModelRequest in POJO mode",
+            "direct:describeLanguageModel,describeLanguageModel operation requires DescribeLanguageModelRequest in POJO mode",
+            "direct:listLanguageModels,listLanguageModels operation requires ListLanguageModelsRequest in POJO mode",
+            "direct:deleteLanguageModel,deleteLanguageModel operation requires DeleteLanguageModelRequest in POJO mode",
+            "direct:createMedicalVocabulary,createMedicalVocabulary operation requires CreateMedicalVocabularyRequest in POJO mode",
+            "direct:getMedicalVocabulary,getMedicalVocabulary operation requires GetMedicalVocabularyRequest in POJO mode",
+            "direct:listMedicalVocabularies,listMedicalVocabularies operation requires ListMedicalVocabulariesRequest in POJO mode",
+            "direct:updateMedicalVocabulary,updateMedicalVocabulary operation requires UpdateMedicalVocabularyRequest in POJO mode",
+            "direct:deleteMedicalVocabulary,deleteMedicalVocabulary operation requires DeleteMedicalVocabularyRequest in POJO mode",
+            "direct:startMedicalTranscriptionJob,startMedicalTranscriptionJob operation requires StartMedicalTranscriptionJobRequest in POJO mode",
+            "direct:getMedicalTranscriptionJob,getMedicalTranscriptionJob operation requires GetMedicalTranscriptionJobRequest in POJO mode",
+            "direct:listMedicalTranscriptionJobs,listMedicalTranscriptionJobs operation requires ListMedicalTranscriptionJobsRequest in POJO mode",
+            "direct:deleteMedicalTranscriptionJob,deleteMedicalTranscriptionJob operation requires DeleteMedicalTranscriptionJobRequest in POJO mode",
+            "direct:tagResource,tagResource operation requires TagResourceRequest in POJO mode",
+            "direct:untagResource,untagResource operation requires UntagResourceRequest in POJO mode",
+            "direct:listTagsForResource,listTagsForResource operation requires ListTagsForResourceRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String route, String expectedMessage) {
+        assertThatThrownBy(() -> template.requestBody(route, "not the expected request type"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(expectedMessage);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:startTranscriptionJob")
+                        .to("aws2-transcribe://transcribe?operation=startTranscriptionJob&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:getTranscriptionJob")
+                        .to("aws2-transcribe://transcribe?operation=getTranscriptionJob&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listTranscriptionJobs")
+                        .to("aws2-transcribe://transcribe?operation=listTranscriptionJobs&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:deleteTranscriptionJob")
+                        .to("aws2-transcribe://transcribe?operation=deleteTranscriptionJob&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:createVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=createVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:getVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=getVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listVocabularies")
+                        .to("aws2-transcribe://transcribe?operation=listVocabularies&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:updateVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=updateVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:deleteVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=deleteVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:createVocabularyFilter")
+                        .to("aws2-transcribe://transcribe?operation=createVocabularyFilter&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:getVocabularyFilter")
+                        .to("aws2-transcribe://transcribe?operation=getVocabularyFilter&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listVocabularyFilters")
+                        .to("aws2-transcribe://transcribe?operation=listVocabularyFilters&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:updateVocabularyFilter")
+                        .to("aws2-transcribe://transcribe?operation=updateVocabularyFilter&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:deleteVocabularyFilter")
+                        .to("aws2-transcribe://transcribe?operation=deleteVocabularyFilter&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:createLanguageModel")
+                        .to("aws2-transcribe://transcribe?operation=createLanguageModel&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:describeLanguageModel")
+                        .to("aws2-transcribe://transcribe?operation=describeLanguageModel&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listLanguageModels")
+                        .to("aws2-transcribe://transcribe?operation=listLanguageModels&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:deleteLanguageModel")
+                        .to("aws2-transcribe://transcribe?operation=deleteLanguageModel&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:createMedicalVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=createMedicalVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:getMedicalVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=getMedicalVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listMedicalVocabularies")
+                        .to("aws2-transcribe://transcribe?operation=listMedicalVocabularies&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:updateMedicalVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=updateMedicalVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:deleteMedicalVocabulary")
+                        .to("aws2-transcribe://transcribe?operation=deleteMedicalVocabulary&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:startMedicalTranscriptionJob")
+                        .to("aws2-transcribe://transcribe?operation=startMedicalTranscriptionJob&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:getMedicalTranscriptionJob")
+                        .to("aws2-transcribe://transcribe?operation=getMedicalTranscriptionJob&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listMedicalTranscriptionJobs")
+                        .to("aws2-transcribe://transcribe?operation=listMedicalTranscriptionJobs&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:deleteMedicalTranscriptionJob")
+                        .to("aws2-transcribe://transcribe?operation=deleteMedicalTranscriptionJob&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:tagResource")
+                        .to("aws2-transcribe://transcribe?operation=tagResource&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:untagResource")
+                        .to("aws2-transcribe://transcribe?operation=untagResource&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+                from("direct:listTagsForResource")
+                        .to("aws2-transcribe://transcribe?operation=listTagsForResource&transcribeClient=#amazonTranscribeClient&pojoRequest=true");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `Transcribe2Producer`'s 30 operations only acted when
the body was the matching request type; any other body fell through the
`instanceof` with no `else`, so no AWS call was made, no response was set, and
the original body was returned with no error.

This is distinct from CAMEL-24207, which implemented the previously-empty
operation stubs — here the operations work, but the pojo-mode path silently
dropped a wrong-typed body.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"createVocabulary operation requires CreateVocabularyRequest in POJO
mode"`.

## Tests

A new `Transcribe2ProducerPojoRequestTest` uses a `@ParameterizedTest` covering
all 30 operations, sending a wrong-typed body to `pojoRequest=true` routes and
asserting each message. Verified to fail (silent no-op) before the fix — with the
`createVocabulary` else removed, exactly that case reports "Expecting code to
raise a throwable". 30/30 green. Hermetic unit tests, region-free — no localstack
or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_