### PR TITLE
CAMEL-24317: camel-aws2-eventbridge - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducer.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducer.java
@@ -157,7 +157,9 @@ public class EventbridgeProducer extends DefaultProducer {
                 message.setHeader(EventbridgeConstants.RULE_ARN, result.ruleArn());
             } else {
                 throw new IllegalArgumentException(
-                        "putRule operation requires PutRuleRequest in POJO mode");
+                        String.format("Expected body of type %s but was %s",
+                                PutRuleRequest.class.getName(),
+                                ObjectHelper.isNotEmpty(payload) ? payload.getClass().getName() : "null"));
             }
         } else {
             PutRuleRequest.Builder builder = PutRuleRequest.builder();

--- a/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducer.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducer.java
@@ -155,6 +155,9 @@ public class EventbridgeProducer extends DefaultProducer {
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
                 message.setHeader(EventbridgeConstants.RULE_ARN, result.ruleArn());
+            } else {
+                throw new IllegalArgumentException(
+                        "putRule operation requires PutRuleRequest in POJO mode");
             }
         } else {
             PutRuleRequest.Builder builder = PutRuleRequest.builder();

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducerPojoRequestTest.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducerPojoRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.eventbridge;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * When {@code pojoRequest=true}, the producer must fail fast if the body is not the expected request type, rather than
+ * silently doing nothing (see CAMEL-24261).
+ */
+class EventbridgeProducerPojoRequestTest {
+
+    @Test
+    void putRuleWithPojoRequestAndWrongBodyTypeThrows() {
+        EventbridgeConfiguration configuration = new EventbridgeConfiguration();
+        configuration.setPojoRequest(true);
+        configuration.setOperation(EventbridgeOperations.putRule);
+
+        EventbridgeEndpoint endpoint = mock(EventbridgeEndpoint.class);
+        when(endpoint.getConfiguration()).thenReturn(configuration);
+        when(endpoint.getEventbridgeClient()).thenReturn(mock(EventBridgeClient.class));
+
+        EventbridgeProducer producer = new EventbridgeProducer(endpoint);
+
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getIn().setBody("not a PutRuleRequest");
+
+        assertThatThrownBy(() -> producer.process(exchange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("putRule operation requires PutRuleRequest in POJO mode");
+    }
+}

--- a/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducerPojoRequestTest.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/test/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducerPojoRequestTest.java
@@ -49,6 +49,8 @@ class EventbridgeProducerPojoRequestTest {
 
         assertThatThrownBy(() -> producer.process(exchange))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("putRule operation requires PutRuleRequest in POJO mode");
+                .hasMessageContaining("Expected body of type")
+                .hasMessageContaining("PutRuleRequest")
+                .hasMessageContaining("java.lang.String");
     }
 }


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `EventbridgeProducer.putRule` only acted when the body
was a `PutRuleRequest`; any other body fell through the `instanceof` with no
`else`, so no AWS call was made, no response was set, and the original body was
returned with no error. (The other Eventbridge operations already build their
request from headers and don't have a pojo branch.)

## Fix

```java
} else {
    throw new IllegalArgumentException(
            "putRule operation requires PutRuleRequest in POJO mode");
}
```

## Test

`camel-aws2-eventbridge` has no producer route/mock harness, so this is covered
by a new Mockito unit test (`EventbridgeProducerPojoRequestTest`) that mocks the
endpoint + client, sends a wrong-typed body with `pojoRequest=true`, and asserts
the `IllegalArgumentException`. Verified to fail (silent no-op) before the fix.
Region-free — no localstack or real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_