### PR TITLE
Enable SjmsConnectionRecoveryTest for s390x by adding s390x container image configuration for Artemis

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
@@ -35,7 +35,6 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,8 +53,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Uses a real Artemis broker over TCP (via Testcontainers) so that connection close truly kills sessions and consumers,
  * matching the behavior of Oracle AQ and other remote JMS providers.
  */
-@DisabledOnOs(architectures = { "s390x" },
-              disabledReason = "The container image cannot be started for this test. Maybe because it is using the ArtemisContainer instead fo the service.")
 public class SjmsConnectionRecoveryTest extends CamelTestSupport {
 
     private static final String SJMS_QUEUE_NAME = "sjms:queue:SjmsConnectionRecoveryTest";

--- a/test-infra/camel-test-infra-artemis/src/main/resources/org/apache/camel/test/infra/artemis/services/container.properties
+++ b/test-infra/camel-test-infra-artemis/src/main/resources/org/apache/camel/test/infra/artemis/services/container.properties
@@ -16,4 +16,5 @@
 ## ---------------------------------------------------------------------------
 artemis.container=quay.io/artemiscloud/activemq-artemis-broker:latest
 artemis.container.ppc64le=icr.io/ppc64le-oss/activemq-artemis-broker-ppc64le:2.0.2
+artemis.container.s390x=icr.io/s390x-oss/activemq-artemis-broker-s390x:2.0.2
 artemis.container.version.exclude=dev,latest


### PR DESCRIPTION
# Description

- The test was disabled on s390x because the public Artemis broker image
([quay.io/artemiscloud/activemq-artemis-broker:latest](http://quay.io/artemiscloud/activemq-artemis-broker:latest)) is amd64-only and
fails with "exec format error" on IBM Z hardware.

- A native s390x image is available at [icr.io/s390x-oss/](http://icr.io/s390x-oss/) — the same IBM
Cloud Registry used for ppc64le ([icr.io/ppc64le-oss/...](http://icr.io/ppc64le-oss/...)).

Changes:
- container.properties: add artemis.container.s390x pointing to the
  native s390x image on ICR, mirroring the existing ppc64le entry
- SjmsConnectionRecoveryTest: remove @DisabledOnOs for s390x


# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

