### PR TITLE
CAMEL-23382: deprecate camel-langchain4j-tools, replaced by ai-tool + langchain4j-agent

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/langchain4j-tools.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/components/langchain4j-tools.json
@@ -4,7 +4,7 @@
     "name": "langchain4j-tools",
     "title": "LangChain4j Tools",
     "description": "LangChain4j Tools and Function Calling Features",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "4.8.0",
     "label": "ai",
     "javaType": "org.apache.camel.component.langchain4j.tools.LangChain4jToolsComponent",

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-tools-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-tools-component.adoc
@@ -17,7 +17,7 @@
 
 [WARNING]
 ====
-This component is deprecated since Camel 4.22. Use xref:ai-tool-component.adoc[camel-ai-tool] to define tools and the https://docs.langchain4j.dev/tutorials/ai-services#tools-function-calling[LangChain4j AiServices tool-calling] (via `camel-langchain4j-agent`) to invoke them.
+This component is deprecated since Camel 4.22. Use xref:ai-tool-component.adoc[camel-ai-tool] to define tools and xref:langchain4j-agent-component.adoc[camel-langchain4j-agent] to invoke them.
 ====
 
 The LangChain4j Tools Component allows you to use function calling features from Large Language Models (LLMs) supported by https://github.com/langchain4j/langchain4j[LangChain4j].

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-tools-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-tools-component.adoc
@@ -1,10 +1,11 @@
-= LangChain4j Tools Component
+= LangChain4j Tools Component (deprecated)
 :doctitle: LangChain4j Tools
 :shortname: langchain4j-tools
 :artifactid: camel-langchain4j-tools
 :description: LangChain4j Tools and Function Calling Features
 :since: 4.8
-:supportlevel: Preview
+:supportlevel: Preview-deprecated
+:deprecated: *deprecated*
 :tabs-sync-option:
 :component-header: Both producer and consumer are supported
 //Manually maintained attributes
@@ -13,6 +14,11 @@
 *Since Camel {since}*
 
 *{component-header}*
+
+[WARNING]
+====
+This component is deprecated since Camel 4.22. Use xref:ai-tool-component.adoc[camel-ai-tool] to define tools and the https://docs.langchain4j.dev/tutorials/ai-services#tools-function-calling[LangChain4j AiServices tool-calling] (via `camel-langchain4j-agent`) to invoke them.
+====
 
 The LangChain4j Tools Component allows you to use function calling features from Large Language Models (LLMs) supported by https://github.com/langchain4j/langchain4j[LangChain4j].
 

--- a/components/camel-ai/camel-langchain4j-tools/pom.xml
+++ b/components/camel-ai/camel-langchain4j-tools/pom.xml
@@ -30,7 +30,7 @@
 
     <artifactId>camel-langchain4j-tools</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: AI :: LangChain4j :: Tools</name>
+    <name>Camel :: AI :: LangChain4j :: Tools (deprecated)</name>
     <description>LangChain4j Tools and Function Calling Features</description>
 
     <properties>

--- a/components/camel-ai/camel-langchain4j-tools/src/generated/resources/META-INF/org/apache/camel/component/langchain4j/tools/langchain4j-tools.json
+++ b/components/camel-ai/camel-langchain4j-tools/src/generated/resources/META-INF/org/apache/camel/component/langchain4j/tools/langchain4j-tools.json
@@ -4,7 +4,7 @@
     "name": "langchain4j-tools",
     "title": "LangChain4j Tools",
     "description": "LangChain4j Tools and Function Calling Features",
-    "deprecated": false,
+    "deprecated": true,
     "firstVersion": "4.8.0",
     "label": "ai",
     "javaType": "org.apache.camel.component.langchain4j.tools.LangChain4jToolsComponent",

--- a/components/camel-ai/camel-langchain4j-tools/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/components/camel-ai/camel-langchain4j-tools/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -3,5 +3,5 @@ components=langchain4j-tools
 groupId=org.apache.camel
 artifactId=camel-langchain4j-tools
 version=4.22.0-SNAPSHOT
-projectName=Camel :: AI :: LangChain4j :: Tools
+projectName=Camel :: AI :: LangChain4j :: Tools (deprecated)
 projectDescription=LangChain4j Tools and Function Calling Features

--- a/components/camel-ai/camel-langchain4j-tools/src/main/docs/langchain4j-tools-component.adoc
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/docs/langchain4j-tools-component.adoc
@@ -17,7 +17,7 @@
 
 [WARNING]
 ====
-This component is deprecated since Camel 4.22. Use xref:ai-tool-component.adoc[camel-ai-tool] to define tools and the https://docs.langchain4j.dev/tutorials/ai-services#tools-function-calling[LangChain4j AiServices tool-calling] (via `camel-langchain4j-agent`) to invoke them.
+This component is deprecated since Camel 4.22. Use xref:ai-tool-component.adoc[camel-ai-tool] to define tools and xref:langchain4j-agent-component.adoc[camel-langchain4j-agent] to invoke them.
 ====
 
 The LangChain4j Tools Component allows you to use function calling features from Large Language Models (LLMs) supported by https://github.com/langchain4j/langchain4j[LangChain4j].

--- a/components/camel-ai/camel-langchain4j-tools/src/main/docs/langchain4j-tools-component.adoc
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/docs/langchain4j-tools-component.adoc
@@ -1,10 +1,11 @@
-= LangChain4j Tools Component
+= LangChain4j Tools Component (deprecated)
 :doctitle: LangChain4j Tools
 :shortname: langchain4j-tools
 :artifactid: camel-langchain4j-tools
 :description: LangChain4j Tools and Function Calling Features
 :since: 4.8
-:supportlevel: Preview
+:supportlevel: Preview-deprecated
+:deprecated: *deprecated*
 :tabs-sync-option:
 :component-header: Both producer and consumer are supported
 //Manually maintained attributes
@@ -13,6 +14,11 @@
 *Since Camel {since}*
 
 *{component-header}*
+
+[WARNING]
+====
+This component is deprecated since Camel 4.22. Use xref:ai-tool-component.adoc[camel-ai-tool] to define tools and the https://docs.langchain4j.dev/tutorials/ai-services#tools-function-calling[LangChain4j AiServices tool-calling] (via `camel-langchain4j-agent`) to invoke them.
+====
 
 The LangChain4j Tools Component allows you to use function calling features from Large Language Models (LLMs) supported by https://github.com/langchain4j/langchain4j[LangChain4j].
 

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jTools.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jTools.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.langchain4j.tools;
 
+@Deprecated(since = "4.22.0")
 public final class LangChain4jTools {
 
     public static final String SCHEME = "langchain4j-tools";

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsComponent.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsComponent.java
@@ -31,6 +31,7 @@ import org.apache.camel.util.StringHelper;
 import static org.apache.camel.component.langchain4j.tools.LangChain4jTools.SCHEME;
 
 @Component(SCHEME)
+@Deprecated(since = "4.22.0")
 public class LangChain4jToolsComponent extends DefaultComponent {
 
     @Metadata

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsConfiguration.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.camel.spi.UriParams;
 
 @Configurer
 @UriParams
+@Deprecated(since = "4.22.0")
 public class LangChain4jToolsConfiguration implements Cloneable {
 
     @UriParam(label = "advanced")

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsConsumer.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsConsumer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.support.DefaultConsumer;
 
+@Deprecated(since = "4.22.0")
 public class LangChain4jToolsConsumer extends DefaultConsumer {
 
     public LangChain4jToolsConsumer(Endpoint endpoint, Processor processor) {

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsEndpoint.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsEndpoint.java
@@ -53,6 +53,7 @@ import static org.apache.camel.component.langchain4j.tools.LangChain4jTools.SCHE
              syntax = "langchain4j-tools:toolId",
              category = { Category.AI },
              headersClass = LangChain4jToolsHeaders.class)
+@Deprecated(since = "4.22.0")
 public class LangChain4jToolsEndpoint extends DefaultEndpoint {
 
     private static final Logger LOG = LoggerFactory.getLogger(LangChain4jToolsEndpoint.class);

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsHeaders.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsHeaders.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.langchain4j.tools;
 
 import org.apache.camel.spi.Metadata;
 
+@Deprecated(since = "4.22.0")
 public class LangChain4jToolsHeaders {
 
     @Metadata(description = "The Finish Reason.", javaType = "dev.langchain4j.model.output.FinishReason")

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/LangChain4jToolsProducer.java
@@ -55,6 +55,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(since = "4.22.0")
 public class LangChain4jToolsProducer extends DefaultProducer {
     private static final Logger LOG = LoggerFactory.getLogger(LangChain4jToolsProducer.class);
 

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/TagsHelper.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/TagsHelper.java
@@ -17,6 +17,7 @@
 
 package org.apache.camel.component.langchain4j.tools;
 
+@Deprecated(since = "4.22.0")
 final class TagsHelper {
     private TagsHelper() {
     }

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/ToolSearchTool.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/ToolSearchTool.java
@@ -30,6 +30,7 @@ import org.apache.camel.component.langchain4j.tools.spec.CamelToolSpecification;
  * Native tool that allows LLMs to search for available tools without consuming the context window. This tool is
  * automatically exposed when there are searchable (non-exposed) tools registered.
  */
+@Deprecated(since = "4.22.0")
 public class ToolSearchTool {
 
     public static final String TOOL_NAME = "toolSearchTool";

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/CamelSimpleToolParameter.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/CamelSimpleToolParameter.java
@@ -26,6 +26,7 @@ import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
  * langchain4j Simple Tool parameter implementation, this class can be used to provide multiple properties/input
  * parameters to the tool itself, the NamedJsonSchemaProperty can be then found as headers into the consumer route
  */
+@Deprecated(since = "4.22.0")
 public class CamelSimpleToolParameter {
 
     private final String description;

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/CamelToolExecutorCache.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/CamelToolExecutorCache.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Caches Tools Specification and Consumer route reference by the chatId, so that different chats can have different
  * Tool implementation. Also maintains a separate cache for searchable (non-exposed) tools.
  */
+@Deprecated(since = "4.22.0")
 public final class CamelToolExecutorCache {
 
     private Map<String, Set<CamelToolSpecification>> tools;

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/CamelToolSpecification.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/CamelToolSpecification.java
@@ -25,6 +25,7 @@ import org.apache.camel.component.langchain4j.tools.LangChain4jToolsConsumer;
  * Holds ToolSpecification needed by langchain4j and the associated Camel Consumer. In this way, a specific route can be
  * invoked by a specific Tool
  */
+@Deprecated(since = "4.22.0")
 public class CamelToolSpecification {
 
     private ToolSpecification toolSpecification;

--- a/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/NamedJsonSchemaProperty.java
+++ b/components/camel-ai/camel-langchain4j-tools/src/main/java/org/apache/camel/component/langchain4j/tools/spec/NamedJsonSchemaProperty.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.langchain4j.tools.spec;
 
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 
+@Deprecated(since = "4.22.0")
 public class NamedJsonSchemaProperty {
 
     private final String name;

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -312,40 +312,41 @@ They were not wired into the component; the `chatModel` is autowired instead.
 If you used these helpers directly, configure your `ChatModel` with LangChain4j's own builders or Spring Boot starters
 and inject it into the component.
 
-=== camel-langchain4j-tools
+=== camel-langchain4j-tools (deprecated)
 
-==== Tool-calling round trips now bounded by default
+The `camel-langchain4j-tools` component is deprecated. Use `camel-ai-tool` to define tools
+and `camel-langchain4j-agent` for tool-calling with LangChain4j models.
 
-The `langchain4j-tools` producer now limits the number of tool-calling round trips to 10 by default
-(previously the loop was unbounded and could run indefinitely if the LLM kept requesting tools).
-Each round trip consists of one LLM call and the execution of all tools requested in that call.
+Migrate your tool definition routes from `langchain4j-tools:` to `ai-tool:`:
 
-If your LLM interaction legitimately requires more than 10 iterations, increase the
-`maxToolCallingRoundTrips` endpoint option. Set to `0` for unlimited (not recommended).
-Negative values are rejected with `IllegalArgumentException`.
+[source,java]
+----
+// Before
+from("langchain4j-tools:weather?tags=weather&description=Get weather&parameter.city=string")
+    .setBody(constant("{\"city\": \"Paris\", \"temp\": \"22C\"}"));
 
-When the limit is reached, the producer throws a `RuntimeCamelException` with a message indicating
-the maximum was exceeded.
+// After
+from("ai-tool:weather?tags=weather&description=Get weather&parameter.city=string")
+    .setBody(constant("{\"city\": \"Paris\", \"temp\": \"22C\"}"));
+----
 
-==== Hallucinated tool names no longer crash the producer
+Use `langchain4j-agent` with matching tags to invoke tools:
 
-When the LLM requests a tool name that does not exist among the registered tools, the producer
-now sends an error message back to the LLM listing the available tools, giving it a chance to
-self-correct. Previously this caused a `NoSuchElementException` crash.
+[source,java]
+----
+from("direct:chat")
+    .to("langchain4j-agent:assistant?agent=#myAgent&tags=weather");
+----
 
-==== Tool execution errors sent to LLM instead of propagating to the route
+Add the `camel-ai-tool` dependency to your project:
 
-When a tool route throws an exception, the error is now sent back to the LLM as a
-`ToolExecutionResultMessage`, allowing the LLM to handle it gracefully (e.g., retry with different
-parameters or answer directly). Previously the exception was set on the tool exchange and
-`ExchangeHelper.copyResults` propagated it onto the main exchange, but the loop continued anyway,
-leaving the exchange in an inconsistent state.
-
-This is a behavior change: routes that used `onException(...)` to catch tool execution failures
-will no longer see those exceptions, since the error is now handled within the producer and sent
-back to the LLM. The previous behavior was unreliable — a later successful tool call would
-overwrite the exception via `copyResults` — but if you relied on it, be aware that tool errors
-are now consumed by the producer.
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>camel-ai-tool</artifactId>
+</dependency>
+----
 
 === camel-langchain4j-web-search
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -348,6 +348,39 @@ Add the `camel-ai-tool` dependency to your project:
 </dependency>
 ----
 
+==== Tool-calling round trips now bounded by default
+
+The `langchain4j-tools` producer now limits the number of tool-calling round trips to 10 by default
+(previously the loop was unbounded and could run indefinitely if the LLM kept requesting tools).
+Each round trip consists of one LLM call and the execution of all tools requested in that call.
+
+If your LLM interaction legitimately requires more than 10 iterations, increase the
+`maxToolCallingRoundTrips` endpoint option. Set to `0` for unlimited (not recommended).
+Negative values are rejected with `IllegalArgumentException`.
+
+When the limit is reached, the producer throws a `RuntimeCamelException` with a message indicating
+the maximum was exceeded.
+
+==== Hallucinated tool names no longer crash the producer
+
+When the LLM requests a tool name that does not exist among the registered tools, the producer
+now sends an error message back to the LLM listing the available tools, giving it a chance to
+self-correct. Previously this caused a `NoSuchElementException` crash.
+
+==== Tool execution errors sent to LLM instead of propagating to the route
+
+When a tool route throws an exception, the error is now sent back to the LLM as a
+`ToolExecutionResultMessage`, allowing the LLM to handle it gracefully (e.g., retry with different
+parameters or answer directly). Previously the exception was set on the tool exchange and
+`ExchangeHelper.copyResults` propagated it onto the main exchange, but the loop continued anyway,
+leaving the exchange in an inconsistent state.
+
+This is a behavior change: routes that used `onException(...)` to catch tool execution failures
+will no longer see those exceptions, since the error is now handled within the producer and sent
+back to the LLM. The previous behavior was unreliable — a later successful tool call would
+overwrite the exception via `copyResults` — but if you relied on it, be aware that tool errors
+are now consumed by the producer.
+
 === camel-langchain4j-web-search
 
 The `safeSearch` endpoint option is now correctly propagated to the LangChain4j `WebSearchRequest`.

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/EndpointHeaderBuilders.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/EndpointHeaderBuilders.java
@@ -2611,6 +2611,7 @@ public class EndpointHeaderBuilders {
      * 
      * @return the dsl builder for the headers' name.
      */
+    @Deprecated
     public static LangChain4jToolsEndpointBuilderFactory.LangChain4jToolsHeaderNameBuilder langchain4jTools() {
         return LangChain4jToolsEndpointBuilderFactory.LangChain4jToolsHeaderNameBuilder.INSTANCE;
     }

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/StaticEndpointBuilders.java
@@ -10920,6 +10920,7 @@ public class StaticEndpointBuilders {
      * @param path toolId
      * @return the dsl builder
      */
+    @Deprecated
     public static LangChain4jToolsEndpointBuilderFactory.LangChain4jToolsEndpointBuilder langchain4jTools(String path) {
         return langchain4jTools("langchain4j-tools", path);
     }
@@ -10941,6 +10942,7 @@ public class StaticEndpointBuilders {
      * @param path toolId
      * @return the dsl builder
      */
+    @Deprecated
     public static LangChain4jToolsEndpointBuilderFactory.LangChain4jToolsEndpointBuilder langchain4jTools(String componentName, String path) {
         return LangChain4jToolsEndpointBuilderFactory.endpointBuilder(componentName, path);
     }

--- a/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/LangChain4jToolsEndpointBuilderFactory.java
+++ b/dsl/camel-endpointdsl/src/generated/java/org/apache/camel/builder/endpoint/dsl/LangChain4jToolsEndpointBuilderFactory.java
@@ -594,6 +594,7 @@ public interface LangChain4jToolsEndpointBuilderFactory {
          * 
          * @return the dsl builder for the headers' name.
          */
+        @Deprecated
         default LangChain4jToolsHeaderNameBuilder langchain4jTools() {
             return LangChain4jToolsHeaderNameBuilder.INSTANCE;
         }
@@ -613,6 +614,7 @@ public interface LangChain4jToolsEndpointBuilderFactory {
          * @param path toolId
          * @return the dsl builder
          */
+        @Deprecated
         default LangChain4jToolsEndpointBuilder langchain4jTools(String path) {
             return LangChain4jToolsEndpointBuilderFactory.endpointBuilder("langchain4j-tools", path);
         }
@@ -634,6 +636,7 @@ public interface LangChain4jToolsEndpointBuilderFactory {
          * @param path toolId
          * @return the dsl builder
          */
+        @Deprecated
         default LangChain4jToolsEndpointBuilder langchain4jTools(String componentName, String path) {
             return LangChain4jToolsEndpointBuilderFactory.endpointBuilder(componentName, path);
         }


### PR DESCRIPTION
### Description

 Step 4: Deprecate Langchain4j tools

 ## Summary

  - Deprecate `camel-langchain4j-tools` (`@Deprecated(since = "4.22.0")` on all classes, `(deprecated)` in pom.xml name and doc title)
  - Add deprecation warning in component docs pointing to `camel-ai-tool` + `camel-langchain4j-agent`
  - Update upgrade guide with migration example

  ## Migration

  Replace `langchain4j-tools:` consumer routes with `ai-tool:`:

  ```java
  // Before
  from("langchain4j-tools:weather?tags=weather&description=Get weather&parameter.city=string")

  // After
  from("ai-tool:weather?tags=weather&description=Get weather&parameter.city=string")

  Use langchain4j-agent with matching tags for tool-calling:

 ```java
  from("direct:chat")
      .to("langchain4j-agent:assistant?agent=#myAgent&tags=weather");

  ```

  ## Roadmap

  - [x] Step 1: Create the new camel-ai-tool module - PR #24473
  - [x] Step 2: Wire camel-langchain4j-agent producer to AiToolRegistry - PR #24988
  - [x] Step 3: Wire camel-spring-ai-chat producer to AiToolRegistry - PR #24862
  - [ ] Step 4 (this PR): Deprecate camel-langchain4j-tools
  - [ ] Step 5: Remove or deprecate camel-spring-ai-tools - PR https://github.com/apache/camel/pull/25276
  - [ ] Step 6: Add tool support to camel-openai ([CAMEL-24322](https://issues.apache.org/jira/browse/CAMEL-24322))