### PR TITLE
CAMEL-23932: Auto-delete stale branches and enforce fork usage for AI agents

### DIFF
--- a/.github/workflows/pr-cleanup-branches.yml
+++ b/.github/workflows/pr-cleanup-branches.yml
@@ -32,6 +32,7 @@ jobs:
       && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
       && github.event.pull_request.head.ref != 'main'
       && !startsWith(github.event.pull_request.head.ref, 'camel-')
+      && !startsWith(github.event.pull_request.head.ref, 'regen_bot_')
     runs-on: ubuntu-latest
     steps:
       - name: Delete branch

--- a/.github/workflows/pr-cleanup-branches.yml
+++ b/.github/workflows/pr-cleanup-branches.yml
@@ -26,11 +26,12 @@ permissions:
 
 jobs:
   cleanup:
-    name: Delete automated branch
+    name: Delete PR branch
     if: >-
       github.repository == 'apache/camel'
       && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
-      && startsWith(github.event.pull_request.head.ref, 'automated/upgrade')
+      && github.event.pull_request.head.ref != 'main'
+      && !startsWith(github.event.pull_request.head.ref, 'camel-')
     runs-on: ubuntu-latest
     steps:
       - name: Delete branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,14 @@ These rules apply to ALL AI agents working on this codebase.
 - An agent MUST NEVER push commits to a branch it did not create.
 - If a contributor's PR needs changes, the agent may suggest changes via review comments,
   but must not push to their branch without explicit permission.
-- An agent should prefer to use his own fork to push branches instead of the main apache/camel repository. It avoids to fill the main repository with a long list of uncleaned branches.
+- An agent MUST use its own fork to push branches instead of the main apache/camel repository.
+  Pushing directly to the upstream repo fills it with stale branches that waste CI time and disk
+  space for all contributors. A `pr-cleanup-branches.yml` workflow deletes non-protected branches
+  when their PR is closed, but using a fork avoids the problem entirely.
 - An agent must provide a useful name for the git branch. It should contain the global topic and issue number if possible.
-- After a Pull Request is merged or rejected, the branch should be deleted.
+- After a Pull Request is merged or rejected, the branch MUST be deleted. The
+  `pr-cleanup-branches.yml` workflow handles this automatically for branches pushed directly to
+  `apache/camel`, but agents using forks must delete their remote branch manually.
 
 ### JIRA Ticket Ownership
 


### PR DESCRIPTION
## Summary

Addresses [CAMEL-23932](https://issues.apache.org/jira/browse/CAMEL-23932) — AI agents push branches directly to `apache/camel` and fail to clean them up after PRs are merged or closed.

### Changes

1. **Expanded `pr-cleanup-branches.yml`**: The workflow now deletes **any** non-protected branch pushed directly to `apache/camel` when its PR is merged or closed. Previously it only matched `automated/upgrade*`, leaving `backport/*`, `feature/*`, `fix/*`, `investigate-and-fix-*`, `dependabot/*`, `dependency/*`, `ci/*`, and ad-hoc AI agent branches to accumulate indefinitely.

   Protected patterns excluded from cleanup:
   - `main`
   - `camel-*` (all maintenance branches like `camel-4.14.x`, `camel-4.18.x`, plus legacy `camel-1.x`/`camel-2.x`/`camel-3.x`)
   - `regen_bot_*` (persistent branches reused by the regen bot across multiple PRs)

2. **Strengthened CLAUDE.md/AGENTS.md**: Changed fork-preference from advisory "should prefer" to mandatory "MUST use". Also upgraded branch deletion from "should be deleted" to "MUST be deleted", with a note that the workflow handles it automatically for upstream branches.

### Stale branches found during investigation

These branches exist on `apache/camel` with their PRs already merged or closed:

| Branch | PR | State |
|--------|-----|-------|
| `backport/25036-to-camel-4.14.x` | #25068 | MERGED |
| `backport/25036-to-camel-4.18.x` | #25067 | MERGED |
| `feature/CAMEL-24259-tui-tabs-and-inline-docs` | #25114 | MERGED |
| `regen_bot_3x` | #12263 | MERGED (2023!) |
| `fix-camel-24227-add-volatile-to-jmx-writable-fiel` | #24985 | MERGED |
| `fix/CAMEL-24140` | #24820 | MERGED |
| `investigate-and-fix-flaky-aws-eventbridge-localsta` | #25148 | CLOSED |

These will need to be deleted manually (the workflow only triggers on future PR close events).

## Test plan

- [ ] Verify YAML syntax is valid (workflow passes `actionlint` or GitHub Actions validation)
- [ ] Merge or close a test PR from a non-protected branch on `apache/camel` and verify the branch is auto-deleted
- [ ] Verify that `main`, `camel-*.x`, and `regen_bot_*` branches are never affected
- [ ] Review the AGENTS.md language change for clarity

_Claude Code on behalf of gnodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)