### PR TITLE
CAMEL-24324: camel-aws-bedrock - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agent/BedrockAgentProducer.java
+++ b/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agent/BedrockAgentProducer.java
@@ -100,6 +100,9 @@ public class BedrockAgentProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 prepareIngestionJobResponse(result, message);
+            } else {
+                throw new IllegalArgumentException(
+                        "startIngestionJob operation requires a StartIngestionJobRequest body when pojoRequest=true");
             }
         } else {
             String knowledgeBaseId;
@@ -145,6 +148,9 @@ public class BedrockAgentProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 prepareListIngestionJobsResponse(result, message);
+            } else {
+                throw new IllegalArgumentException(
+                        "listIngestionJobs operation requires a ListIngestionJobsRequest body when pojoRequest=true");
             }
         } else {
             String knowledgeBaseId;
@@ -190,6 +196,9 @@ public class BedrockAgentProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 prepareGetIngestionJobResponse(result, message);
+            } else {
+                throw new IllegalArgumentException(
+                        "getIngestionJob operation requires a GetIngestionJobRequest body when pojoRequest=true");
             }
         } else {
             String knowledgeBaseId;

--- a/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/BedrockAgentRuntimeProducer.java
+++ b/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/BedrockAgentRuntimeProducer.java
@@ -142,6 +142,9 @@ public class BedrockAgentRuntimeProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 prepareResponse(result, message);
+            } else {
+                throw new IllegalArgumentException(
+                        "retrieveAndGenerate operation requires a RetrieveAndGenerateRequest body when pojoRequest=true");
             }
         } else {
             String inputText = exchange.getMessage().getMandatoryBody(String.class);

--- a/components/camel-aws/camel-aws-bedrock/src/test/java/org/apache/camel/component/aws2/bedrock/agent/BedrockAgentProducerPojoRequestTest.java
+++ b/components/camel-aws/camel-aws-bedrock/src/test/java/org/apache/camel/component/aws2/bedrock/agent/BedrockAgentProducerPojoRequestTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.bedrock.agent;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.awssdk.services.bedrockagent.BedrockAgentClient;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * When {@code pojoRequest=true}, the producer must fail fast if the body is not the expected request type, rather than
+ * silently doing nothing (see CAMEL-24261).
+ */
+class BedrockAgentProducerPojoRequestTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "startIngestionJob,startIngestionJob operation requires a StartIngestionJobRequest body when pojoRequest=true",
+            "listIngestionJobs,listIngestionJobs operation requires a ListIngestionJobsRequest body when pojoRequest=true",
+            "getIngestionJob,getIngestionJob operation requires a GetIngestionJobRequest body when pojoRequest=true",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String operation, String expectedMessage) throws Exception {
+        BedrockAgentConfiguration configuration = new BedrockAgentConfiguration();
+        configuration.setPojoRequest(true);
+        configuration.setOperation(BedrockAgentOperations.valueOf(operation));
+
+        BedrockAgentEndpoint endpoint = mock(BedrockAgentEndpoint.class);
+        when(endpoint.getConfiguration()).thenReturn(configuration);
+        when(endpoint.getBedrockAgentClient()).thenReturn(mock(BedrockAgentClient.class));
+
+        BedrockAgentProducer producer = new BedrockAgentProducer(endpoint);
+
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getIn().setBody("not the expected request type");
+
+        assertThatThrownBy(() -> producer.process(exchange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedMessage);
+    }
+}

--- a/components/camel-aws/camel-aws-bedrock/src/test/java/org/apache/camel/component/aws2/bedrock/agentruntime/BedrockAgentRuntimeProducerPojoRequestTest.java
+++ b/components/camel-aws/camel-aws-bedrock/src/test/java/org/apache/camel/component/aws2/bedrock/agentruntime/BedrockAgentRuntimeProducerPojoRequestTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.bedrock.agentruntime;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * When {@code pojoRequest=true}, the producer must fail fast if the body is not the expected request type, rather than
+ * silently doing nothing (see CAMEL-24261). The invoke and retrieve operations already did this; this covers the
+ * remaining retrieveAndGenerate operation.
+ */
+class BedrockAgentRuntimeProducerPojoRequestTest {
+
+    @Test
+    void retrieveAndGenerateWithPojoRequestAndWrongBodyTypeThrows() throws Exception {
+        BedrockAgentRuntimeConfiguration configuration = new BedrockAgentRuntimeConfiguration();
+        configuration.setPojoRequest(true);
+        configuration.setOperation(BedrockAgentRuntimeOperations.retrieveAndGenerate);
+
+        BedrockAgentRuntimeEndpoint endpoint = mock(BedrockAgentRuntimeEndpoint.class);
+        when(endpoint.getConfiguration()).thenReturn(configuration);
+        when(endpoint.getBedrockAgentRuntimeClient()).thenReturn(mock(BedrockAgentRuntimeClient.class));
+
+        BedrockAgentRuntimeProducer producer = new BedrockAgentRuntimeProducer(endpoint);
+
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getIn().setBody("not the expected request type");
+
+        assertThatThrownBy(() -> producer.process(exchange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("retrieveAndGenerate operation requires a RetrieveAndGenerateRequest body when pojoRequest=true");
+    }
+}


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

Most `BedrockAgent` / `BedrockAgentRuntime` operations already fail fast when
`pojoRequest=true` and the body is not the expected request type. Four did not —
they fell through the `instanceof` with no `else`, so no AWS call was made, no
response was set, and the original body was returned with no error:

- `BedrockAgentProducer`: `startIngestionJob`, `listIngestionJobs`, `getIngestionJob`
- `BedrockAgentRuntimeProducer`: `retrieveAndGenerate`

(`BedrockProducer` in the runtime package is already covered by CAMEL-23462.)

## Fix

Each of the four branches now throws `IllegalArgumentException`, matching the
wording the sibling operations in the same module already use, e.g.
`"retrieveAndGenerate operation requires a RetrieveAndGenerateRequest body when
pojoRequest=true"`.

## Tests

`camel-aws-bedrock` has no producer route/mock harness, so this is covered by two
new Mockito unit tests that mock the endpoint + client, send a wrong-typed body
with `pojoRequest=true`, and assert the `IllegalArgumentException`. Each was
verified to fail (silent no-op) before the fix. Region-free — no localstack or
real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_