### PR TITLE
CAMEL-23129: Fix CountDownLatch count mismatch in ThreadPerTaskSedaConsumer

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaConsumer.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaConsumer.java
@@ -49,7 +49,7 @@ public class SedaConsumer extends DefaultConsumer implements Runnable, ShutdownA
     private static final Logger LOG = LoggerFactory.getLogger(SedaConsumer.class);
 
     private final AtomicInteger taskCount = new AtomicInteger();
-    private volatile CountDownLatch latch;
+    protected volatile CountDownLatch latch;
     private volatile boolean shutdownPending;
     private volatile boolean forceShutdown;
     private ExecutorService executor;

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/ThreadPerTaskSedaConsumer.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/ThreadPerTaskSedaConsumer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.seda;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -66,6 +67,18 @@ public class ThreadPerTaskSedaConsumer extends SedaConsumer {
         // The actual work is done by taskExecutor
         return getEndpoint().getCamelContext().getExecutorServiceManager()
                 .newSingleThreadExecutor(this, getEndpoint().getEndpointUri() + "-coordinator");
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        // SedaConsumer.doStart() creates the latch with concurrentConsumers count,
+        // but ThreadPerTaskSedaConsumer uses a single coordinator thread that polls
+        // the queue and dispatches each exchange to the task executor.
+        // The concurrentConsumers value is used here as a concurrency limit for the
+        // task executor (via a Semaphore), not as the number of polling threads.
+        // Override the latch to match the actual coordinator thread count (1).
+        latch = new CountDownLatch(1);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/ThreadPerTaskSedaConsumerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/ThreadPerTaskSedaConsumerTest.java
@@ -16,18 +16,22 @@
  */
 package org.apache.camel.component.seda;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Test for the virtualThreadPerTask mode of SEDA consumer
  */
-public class ThreadPerTaskSedaConsumerTest extends ContextTestSupport {
+class ThreadPerTaskSedaConsumerTest extends ContextTestSupport {
 
     @Test
-    public void testVirtualThreadPerTask() throws Exception {
+    void testVirtualThreadPerTask() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:result");
         mock.expectedMessageCount(10);
 
@@ -39,7 +43,7 @@ public class ThreadPerTaskSedaConsumerTest extends ContextTestSupport {
     }
 
     @Test
-    public void testVirtualThreadPerTaskWithConcurrencyLimit() throws Exception {
+    void testVirtualThreadPerTaskWithConcurrencyLimit() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:limited");
         mock.expectedMessageCount(5);
 
@@ -51,7 +55,7 @@ public class ThreadPerTaskSedaConsumerTest extends ContextTestSupport {
     }
 
     @Test
-    public void testVirtualThreadPerTaskHighThroughput() throws Exception {
+    void testVirtualThreadPerTaskHighThroughput() throws Exception {
         int messageCount = 100;
         MockEndpoint mock = getMockEndpoint("mock:throughput");
         mock.expectedMessageCount(messageCount);
@@ -61,6 +65,32 @@ public class ThreadPerTaskSedaConsumerTest extends ContextTestSupport {
         }
 
         mock.assertIsSatisfied();
+    }
+
+    @Test
+    void testShutdownWithConcurrencyLimitCompletesQuickly() throws Exception {
+        // Send messages so the route is actively used
+        for (int i = 0; i < 5; i++) {
+            template.sendBody("seda:limited?virtualThreadPerTask=true&concurrentConsumers=2", "Message " + i);
+        }
+
+        MockEndpoint mock = getMockEndpoint("mock:limited");
+        mock.expectedMessageCount(5);
+        mock.assertIsSatisfied();
+
+        // Stop the context and verify it completes quickly.
+        // Before the fix, the CountDownLatch was initialized with concurrentConsumers
+        // count (2) but only 1 coordinator thread counts down, so prepareShutdown()
+        // would wait the full shutdown timeout before proceeding.
+        long start = System.nanoTime();
+        context.stop();
+        long elapsed = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start);
+
+        // Shutdown should complete well within the default timeout (300s).
+        // Use a generous 30s bound to avoid flakiness, but this is still much less
+        // than the full shutdown strategy timeout that would be hit without the fix.
+        assertTrue(elapsed < 30, "Context stop took " + elapsed + "s, expected < 30s. "
+                                 + "The CountDownLatch count likely does not match the coordinator thread count.");
     }
 
     @Override


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Fix the root cause of the SEDA virtual thread shutdown hang (CAMEL-23129). The previous fix added a timeout to `latch.await()` as a defensive workaround, but the underlying mismatch remained.

**Root cause:** `SedaConsumer.doStart()` creates `latch = new CountDownLatch(concurrentConsumers)`, but `ThreadPerTaskSedaConsumer` uses a single coordinator thread. When `concurrentConsumers > 1` (used as a concurrency limit, e.g., 2), the latch is initialized with count=2 but only 1 coordinator thread ever calls `countDown()` — so `prepareShutdown()` always waits the full shutdown timeout before proceeding.

**Fix:** Override `doStart()` in `ThreadPerTaskSedaConsumer` to set `latch = new CountDownLatch(1)`, matching the single coordinator thread. The `concurrentConsumers` value continues to serve as the task executor concurrency limit via the `Semaphore`. The task executor shutdown is handled separately in `ThreadPerTaskSedaConsumer.prepareShutdown()`.

### Changes
- `SedaConsumer`: Change `latch` field visibility from `private` to `protected` so subclasses can override the count
- `ThreadPerTaskSedaConsumer`: Override `doStart()` to set latch count to 1
- `ThreadPerTaskSedaConsumerTest`: Add test verifying shutdown with concurrency limit completes quickly (no full timeout wait); apply JUnit 5 conventions (drop `public`)

## Test plan

- [x] Existing `ThreadPerTaskSedaConsumerTest` tests pass (virtualThreadPerTask basic, concurrency limit, high throughput)
- [x] New `testShutdownWithConcurrencyLimitCompletesQuickly` verifies context stop completes in < 30s with `concurrentConsumers=2`
- [ ] CI validation