### PR TITLE
 CAMEL-23931: Fix -Dcamel.jbang.quarkus.platform.url system property ignored in export

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 
 import org.apache.camel.dsl.jbang.core.common.CamelJBangConstants;
 import org.apache.camel.dsl.jbang.core.common.PropertyResolver;
+import org.apache.camel.dsl.jbang.core.common.QuarkusHelper;
 import org.apache.camel.dsl.jbang.core.common.RuntimeType;
 import org.apache.camel.dsl.jbang.core.common.RuntimeUtil;
 import org.apache.camel.dsl.jbang.core.common.SourceScheme;
@@ -182,6 +183,8 @@ public class Export extends ExportBaseCommand {
             this.quarkusGroupId = props.getProperty(QUARKUS_GROUP_ID, this.quarkusGroupId);
             this.quarkusArtifactId = props.getProperty(QUARKUS_ARTIFACT_ID, this.quarkusArtifactId);
             this.quarkusVersion = props.getProperty(QUARKUS_VERSION, this.quarkusVersion);
+            this.quarkusPlatformUrl = props.getProperty(
+                    QuarkusHelper.QUARKUS_PLATFORM_URL_PROPERTY, this.quarkusPlatformUrl);
             this.camelSpringBootVersion = props.getProperty(CAMEL_SPRING_BOOT_VERSION, this.camelSpringBootVersion);
             this.springBootVersion = props.getProperty(SPRING_BOOT_VERSION, this.springBootVersion);
             this.mavenWrapper
@@ -209,6 +212,8 @@ public class Export extends ExportBaseCommand {
         this.quarkusGroupId = PropertyResolver.fromSystemProperty(QUARKUS_GROUP_ID, () -> this.quarkusGroupId);
         this.quarkusArtifactId = PropertyResolver.fromSystemProperty(QUARKUS_ARTIFACT_ID, () -> this.quarkusArtifactId);
         this.quarkusVersion = PropertyResolver.fromSystemProperty(QUARKUS_VERSION, () -> this.quarkusVersion);
+        this.quarkusPlatformUrl = PropertyResolver.fromSystemProperty(
+                QuarkusHelper.QUARKUS_PLATFORM_URL_PROPERTY, () -> this.quarkusPlatformUrl);
         this.camelSpringBootVersion
                 = PropertyResolver.fromSystemProperty(CAMEL_SPRING_BOOT_VERSION, () -> this.camelSpringBootVersion);
     }
@@ -247,6 +252,7 @@ public class Export extends ExportBaseCommand {
         cmd.quarkusGroupId = this.quarkusGroupId;
         cmd.quarkusArtifactId = this.quarkusArtifactId;
         cmd.quarkusVersion = this.quarkusVersion;
+        cmd.quarkusPlatformUrl = this.quarkusPlatformUrl;
         cmd.quarkusPackageType = this.quarkusPackageType;
         cmd.springBootVersion = this.springBootVersion;
         cmd.mavenWrapper = this.mavenWrapper;

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -201,6 +201,8 @@ public abstract class ExportBaseCommand extends CamelCommand {
                                       + " (when --download=true), otherwise defaults to " + RuntimeType.QUARKUS_VERSION)
     protected String quarkusVersion;
 
+    protected String quarkusPlatformUrl;
+
     @CommandLine.Option(names = { "--quarkus-package-type" },
                         description = "Quarkus package type (uber-jar or fast-jar)",
                         defaultValue = "fast-jar")

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportQuarkus.java
@@ -74,11 +74,14 @@ class ExportQuarkus extends Export {
         exportBaseDir = exportBaseDir != null ? exportBaseDir : Path.of(".");
         Path profile = exportBaseDir.resolve("application.properties");
 
-        // resolve Quarkus platform version from registry (only when no explicit version was provided)
-        if (quarkusVersion == null) {
-            quarkusVersion = RuntimeType.QUARKUS_VERSION;
+        // resolve Quarkus platform version from registry (only when no explicit version was provided,
+        // or when a custom platform URL is configured — indicating the user wants registry resolution)
+        if (quarkusVersion == null || quarkusPlatformUrl != null) {
+            if (quarkusVersion == null) {
+                quarkusVersion = RuntimeType.QUARKUS_VERSION;
+            }
             if (download) {
-                String resolved = QuarkusHelper.resolveQuarkusPlatformVersion(quarkusVersion);
+                String resolved = QuarkusHelper.resolveQuarkusPlatformVersion(quarkusVersion, quarkusPlatformUrl);
                 if (resolved != null) {
                     quarkusVersion = resolved;
                 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/QuarkusHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/QuarkusHelper.java
@@ -51,7 +51,10 @@ public final class QuarkusHelper {
      * Returns the Quarkus platform registry URL, honoring the system property {@value #QUARKUS_PLATFORM_URL_PROPERTY}
      * if set.
      */
-    public static String getQuarkusPlatformUrl() {
+    public static String getQuarkusPlatformUrl(String userSuppliedUrl) {
+        if (userSuppliedUrl != null) {
+            return userSuppliedUrl;
+        }
         return System.getProperty(QUARKUS_PLATFORM_URL_PROPERTY, DEFAULT_QUARKUS_PLATFORM_URL);
     }
 
@@ -68,7 +71,7 @@ public final class QuarkusHelper {
             Function<T, String> runtimeVersionFunc,
             BiConsumer<T, String> quarkusVersionSetter) {
 
-        JsonArray streams = fetchPlatformStreams();
+        JsonArray streams = fetchPlatformStreams(null);
         if (streams == null) {
             return;
         }
@@ -100,12 +103,12 @@ public final class QuarkusHelper {
      * @return                  the resolved platform BOM version from the registry, or the original buildTimeVersion if
      *                          resolution fails
      */
-    public static String resolveQuarkusPlatformVersion(String buildTimeVersion) {
+    public static String resolveQuarkusPlatformVersion(String buildTimeVersion, String platformUrl) {
         if (buildTimeVersion == null) {
             return null;
         }
 
-        JsonArray streams = fetchPlatformStreams();
+        JsonArray streams = fetchPlatformStreams(platformUrl);
         if (streams == null) {
             return buildTimeVersion;
         }
@@ -120,11 +123,11 @@ public final class QuarkusHelper {
      *
      * @return the streams JsonArray, or null if the registry is unreachable or the response is invalid
      */
-    private static JsonArray fetchPlatformStreams() {
+    private static JsonArray fetchPlatformStreams(String platformUrl) {
         try {
             HttpClient hc = HttpClient.newHttpClient();
             HttpResponse<String> res = hc.send(
-                    HttpRequest.newBuilder(new URI(getQuarkusPlatformUrl()))
+                    HttpRequest.newBuilder(new URI(getQuarkusPlatformUrl(platformUrl)))
                             .timeout(Duration.ofSeconds(2))
                             .build(),
                     HttpResponse.BodyHandlers.ofString());


### PR DESCRIPTION
## Summary
  
  The `-Dcamel.jbang.quarkus.platform.url` system property is ignored when exporting
  with `--runtime quarkus` in Camel 4.18.3, causing the Quarkus platform version to
  not be resolved from the custom registry. This worked correctly in 4.18.1.

   The `-Dcamel.jbang.quarkus.platform.url` system property was ignored when exporting with `--runtime quarkus`.
  As part of the changes in CAMEL-23828, registry resolution could be skipped when quarkusVersion was already set, even if a custom platform URL was configured.

  ## Changes
  - **`Export.java`**: Read `quarkusPlatformUrl` from `application.properties` and
    system properties, and propagate it to `ExportQuarkus`
  - **`ExportBaseCommand.java`**: Added `quarkusPlatformUrl` field
  - **`ExportQuarkus.java`**: Allow registry resolution when a custom platform URL is
    configured (`quarkusPlatformUrl != null`), even if `quarkusVersion` is already set
  - **`QuarkusHelper.java`**: Updated `getQuarkusPlatformUrl()`, `resolveQuarkusPlatformVersion()`,
    and `fetchPlatformStreams()` to accept a user-supplied URL, giving it priority over
    the system property and default

