### PR TITLE
CAMEL-24284: Reset recoverTask after successful SJMS connection recovery

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/consumer/SimpleMessageListenerContainer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/consumer/SimpleMessageListenerContainer.java
@@ -205,6 +205,16 @@ public class SimpleMessageListenerContainer extends ServiceSupport
         try {
             refreshConnection();
             initConsumers();
+            connectionLock.lock();
+            try {
+                if (recoverFuture != null) {
+                    recoverFuture.cancel(false);
+                }
+                recoverTask = null;
+                recoverFuture = null;
+            } finally {
+                connectionLock.unlock();
+            }
             LOG.debug("Successfully recovered JMS Connection (attempt: {})", task.iteration());
             // success so do not try again
             return true;


### PR DESCRIPTION
# Description

Fix a bug where the SJMS consumer becomes permanently dead after recovering from a JMS connection failure once — any subsequent connection failure cannot trigger recovery.

**Root cause**

[CAMEL-23646](https://issues.apache.org/jira/browse/CAMEL-23646) added a !recoverTask.isRunning() guard in scheduleConnectionRecovery() to allow re-scheduling after a completed task. However, BackgroundTask.schedule() sets running=true but never resets it (running is only cleared in waitForTaskCompletion(), which is the run() path, not the schedule() path).

  After the first successful recovery:
  1. recoverTask is non-null and isRunning() returns true forever
  2. The guard recoverTask == null || !recoverTask.isRunning() is permanently false
  3. If onException() fires again (transient broker event, Artemis internal cleanup), consumers/sessions are nulled with no recovery path
  4. Consumer is permanently dead

 **Fix**

Reset recoverTask and recoverFuture to null (and cancel the scheduled future) after successful recovery. This re-arms the recovery mechanism so subsequent failures can schedule a new recovery  task.

Claude Code on behalf of gansheer