### PR TITLE
CAMEL-24323: Fix MongoDB TLS test-infra cert copy for Testcontainers 2.x

### DIFF
--- a/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/integration/MongoDbSslConnectionIT.java
+++ b/components/camel-mongodb/src/test/java/org/apache/camel/component/mongodb/integration/MongoDbSslConnectionIT.java
@@ -47,8 +47,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration test that validates TLS connectivity to MongoDB using Camel's SSLContextParameters.
@@ -114,23 +114,34 @@ public class MongoDbSslConnectionIT implements ConfigurableContext, Configurable
     }
 
     @Test
-    public void testInsertOverTls() {
+    void testInsertOverTls() {
         ProducerTemplate template = contextExtension.getProducerTemplate();
 
         Document doc = new Document("scientist", "Einstein").append("tls", true);
         Object result = template.requestBody("direct:insert", doc);
         assertNotNull(result, "Insert result should not be null");
 
-        assertEquals(1L, testCollection.countDocuments(),
-                "Test collection should contain 1 document after insert");
+        assertEquals(1L, testCollection.countDocuments());
     }
 
     @Test
-    public void testCountOverTls() {
+    void testInsertAndCountOverTls() {
+        ProducerTemplate template = contextExtension.getProducerTemplate();
+
+        Document doc = new Document("scientist", "Curie").append("tls", true);
+        template.requestBody("direct:insert", doc);
+
+        Object count = template.requestBody("direct:count", "irrelevantBody");
+        assertInstanceOf(Long.class, count);
+        assertEquals(1L, count);
+    }
+
+    @Test
+    void testCountOverTls() {
         ProducerTemplate template = contextExtension.getProducerTemplate();
 
         Object result = template.requestBody("direct:count", "irrelevantBody");
-        assertTrue(result instanceof Long, "Count result should be of type Long");
+        assertInstanceOf(Long.class, result);
     }
 
     @AfterEach

--- a/test-infra/camel-test-infra-mongodb/src/main/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerTLSService.java
+++ b/test-infra/camel-test-infra-mongodb/src/main/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerTLSService.java
@@ -24,19 +24,23 @@ import org.apache.camel.test.infra.common.services.ContainerService;
 import org.apache.camel.test.infra.mongodb.common.MongoDBProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * A TLS-enabled MongoDB container service using a standalone mongod with --tlsMode requireTLS. Uses pre-generated
- * self-signed certificates mounted from classpath resources.
+ * self-signed certificates copied from classpath resources (individual files, not a directory mount, for Testcontainers
+ * 2.x portability).
  */
 public class MongoDBLocalContainerTLSService implements MongoDBService, ContainerService<GenericContainer<?>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBLocalContainerTLSService.class);
     private static final int DEFAULT_MONGODB_PORT = 27017;
-    private static final String CERT_RESOURCE_PATH = "org/apache/camel/test/infra/mongodb/services/ssl";
+    static final String CERT_RESOURCE_PATH = "org/apache/camel/test/infra/mongodb/services/ssl";
+    static final String CONTAINER_SSL_DIR = "/etc/mongodb/ssl";
+    static final String SERVER_CERT_RESOURCE = CERT_RESOURCE_PATH + "/server.pem";
+    static final String CA_CERT_RESOURCE = CERT_RESOURCE_PATH + "/ca.pem";
 
     private final GenericContainer<?> container;
 
@@ -55,12 +59,17 @@ public class MongoDBLocalContainerTLSService implements MongoDBService, Containe
         boolean fixedPort = ContainerEnvironmentUtil.isFixedPort(this.getClass());
         ContainerEnvironmentUtil.configurePort(c, fixedPort, DEFAULT_MONGODB_PORT);
 
-        c.withClasspathResourceMapping(CERT_RESOURCE_PATH, "/etc/mongodb/ssl", BindMode.READ_ONLY)
+        c.withCopyFileToContainer(
+                MountableFile.forClasspathResource(SERVER_CERT_RESOURCE),
+                CONTAINER_SSL_DIR + "/server.pem")
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource(CA_CERT_RESOURCE),
+                        CONTAINER_SSL_DIR + "/ca.pem")
                 .withCommand(
                         "mongod",
                         "--tlsMode", "requireTLS",
-                        "--tlsCertificateKeyFile", "/etc/mongodb/ssl/server.pem",
-                        "--tlsCAFile", "/etc/mongodb/ssl/ca.pem",
+                        "--tlsCertificateKeyFile", CONTAINER_SSL_DIR + "/server.pem",
+                        "--tlsCAFile", CONTAINER_SSL_DIR + "/ca.pem",
                         "--tlsAllowConnectionsWithoutCertificates",
                         "--bind_ip_all",
                         "--port", String.valueOf(DEFAULT_MONGODB_PORT))

--- a/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerTLSServiceTest.java
+++ b/test-infra/camel-test-infra-mongodb/src/test/java/org/apache/camel/test/infra/mongodb/services/MongoDBLocalContainerTLSServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.test.infra.mongodb.services;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MongoDBLocalContainerTLSServiceTest {
+
+    @Test
+    void tlsClasspathResourcesExist() {
+        ClassLoader loader = MongoDBLocalContainerTLSService.class.getClassLoader();
+
+        assertNotNull(loader.getResource(MongoDBLocalContainerTLSService.SERVER_CERT_RESOURCE));
+        assertNotNull(loader.getResource(MongoDBLocalContainerTLSService.CA_CERT_RESOURCE));
+        assertNotNull(loader.getResource(MongoDBLocalContainerTLSService.CERT_RESOURCE_PATH + "/ca-truststore.jks"));
+    }
+
+    @Test
+    void mountableFilesResolveToNonEmptyTlsCertificates() throws Exception {
+        MountableFile serverCert = MountableFile.forClasspathResource(MongoDBLocalContainerTLSService.SERVER_CERT_RESOURCE);
+        MountableFile caCert = MountableFile.forClasspathResource(MongoDBLocalContainerTLSService.CA_CERT_RESOURCE);
+
+        Path serverPath = Path.of(serverCert.getFilesystemPath());
+        Path caPath = Path.of(caCert.getFilesystemPath());
+
+        assertTrue(Files.exists(serverPath));
+        assertTrue(Files.exists(caPath));
+        assertTrue(Files.size(serverPath) > 0);
+        assertTrue(Files.size(caPath) > 0);
+    }
+
+    @Test
+    void initContainerConfiguresIndividualCertCopyAndTlsCommand() {
+        MongoDBLocalContainerTLSService service = new MongoDBLocalContainerTLSService("mirror.gcr.io/mongo:7.0.31-jammy");
+        GenericContainer<?> container = service.getContainer();
+
+        String[] commandParts = container.getCommandParts();
+
+        assertTrue(Arrays.asList(commandParts).contains("--tlsMode"));
+        assertTrue(Arrays.asList(commandParts).contains("requireTLS"));
+        assertTrue(Arrays.asList(commandParts).contains(MongoDBLocalContainerTLSService.CONTAINER_SSL_DIR + "/server.pem"));
+        assertTrue(Arrays.asList(commandParts).contains(MongoDBLocalContainerTLSService.CONTAINER_SSL_DIR + "/ca.pem"));
+
+        // Directory classpath mapping breaks on Testcontainers 2.x copy strategy (CAMEL-24323).
+        assertDoesNotThrow(() -> MountableFile.forClasspathResource(MongoDBLocalContainerTLSService.SERVER_CERT_RESOURCE));
+        assertDoesNotThrow(() -> MountableFile.forClasspathResource(MongoDBLocalContainerTLSService.CA_CERT_RESOURCE));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24323](https://issues.apache.org/jira/browse/CAMEL-24323): `MongoDbSslConnectionIT` fails to start the TLS MongoDB Testcontainer with:

`Could not find the file / in container`

**Root cause:** `MongoDBLocalContainerTLSService` mapped an entire classpath **directory** via `withClasspathResourceMapping`. Testcontainers 2.x uses a copy strategy for read-only classpath mappings that breaks on directory mounts in CI.

**Fix:** Copy TLS cert files individually with `MountableFile.forClasspathResource` + `withCopyFileToContainer` (same approach as other Camel test-infra services, e.g. Kafka JAAS config).

## Changes

- `MongoDBLocalContainerTLSService` — per-file cert copy for `server.pem` and `ca.pem`
- `MongoDBLocalContainerTLSServiceTest` — classpath resource + MountableFile + TLS command config coverage (3 tests)
- `MongoDbSslConnectionIT` — added `testInsertAndCountOverTls` round-trip assertion

## Test plan

- [x] `mvn test -pl test-infra/camel-test-infra-mongodb -Dtest=MongoDBLocalContainerTLSServiceTest`
- [x] `mvn test -pl components/camel-mongodb -am -Dtest=MongoDbSslConnectionIT` (Docker)

_AI-generated PR description on behalf of [atiaomar1978-hub](https://github.com/atiaomar1978-hub)_

Made with [Cursor](https://cursor.com)