### PR TITLE
[backport camel-4.18.x] CAMEL-24284: Reset recoverTask after successful SJMS connection recovery

### DIFF
--- a/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/consumer/SimpleMessageListenerContainer.java
+++ b/components/camel-sjms/src/main/java/org/apache/camel/component/sjms/consumer/SimpleMessageListenerContainer.java
@@ -203,6 +203,16 @@ public class SimpleMessageListenerContainer extends ServiceSupport
         try {
             refreshConnection();
             initConsumers();
+            connectionLock.lock();
+            try {
+                if (recoverFuture != null) {
+                    recoverFuture.cancel(false);
+                }
+                recoverTask = null;
+                recoverFuture = null;
+            } finally {
+                connectionLock.unlock();
+            }
             LOG.debug("Successfully recovered JMS Connection (attempt: {})", task.iteration());
             // success so do not try again
             return true;


### PR DESCRIPTION
## Backport of #25283

Cherry-pick of #25283 onto `camel-4.18.x`.

**Original PR:** #25283 - CAMEL-24284: Reset recoverTask after successful SJMS connection recovery
**Original author:** @gansheer
**Target branch:** `camel-4.18.x`

### Original description

Fix a bug where the SJMS consumer becomes permanently dead after recovering from a JMS connection failure once — any subsequent connection failure cannot trigger recovery.

**Root cause:** BackgroundTask.schedule() sets running=true but never resets it, so the re-scheduling guard permanently blocks after the first successful recovery.

**Fix:** Reset recoverTask and recoverFuture to null (and cancel the scheduled future) after successful recovery to re-arm the mechanism for subsequent failures.