### PR TITLE
CAMEL-24326: camel-aws-config - throw when pojoRequest=true and the body is the wrong type

### DIFF
--- a/components/camel-aws/camel-aws-config/pom.xml
+++ b/components/camel-aws/camel-aws-config/pom.xml
@@ -84,5 +84,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-aws/camel-aws-config/src/main/java/org/apache/camel/component/aws/config/AWSConfigProducer.java
+++ b/components/camel-aws/camel-aws-config/src/main/java/org/apache/camel/component/aws/config/AWSConfigProducer.java
@@ -109,6 +109,9 @@ public class AWSConfigProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "putConfigRule operation requires PutConfigRuleRequest in POJO mode");
             }
         } else {
             PutConfigRuleRequest.Builder builder = PutConfigRuleRequest.builder();
@@ -155,6 +158,9 @@ public class AWSConfigProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "removeConfigRule operation requires DeleteConfigRuleRequest in POJO mode");
             }
         } else {
             DeleteConfigRuleRequest.Builder builder = DeleteConfigRuleRequest.builder();
@@ -191,6 +197,9 @@ public class AWSConfigProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "describeRuleCompliance operation requires DescribeComplianceByConfigRuleRequest in POJO mode");
             }
         } else {
             DescribeComplianceByConfigRuleRequest.Builder builder = DescribeComplianceByConfigRuleRequest.builder();
@@ -225,6 +234,9 @@ public class AWSConfigProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "putConformancePack operation requires PutConformancePackRequest in POJO mode");
             }
         } else {
             PutConformancePackRequest.Builder builder = PutConformancePackRequest.builder();
@@ -276,6 +288,9 @@ public class AWSConfigProducer extends DefaultProducer {
                 }
                 Message message = getMessageForResponse(exchange);
                 message.setBody(result);
+            } else {
+                throw new IllegalArgumentException(
+                        "removeConformancePack operation requires DeleteConformancePackRequest in POJO mode");
             }
         } else {
             DeleteConformancePackRequest.Builder builder = DeleteConformancePackRequest.builder();

--- a/components/camel-aws/camel-aws-config/src/test/java/org/apache/camel/component/aws/config/AWSConfigProducerPojoRequestTest.java
+++ b/components/camel-aws/camel-aws-config/src/test/java/org/apache/camel/component/aws/config/AWSConfigProducerPojoRequestTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.config;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.awssdk.services.config.ConfigClient;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * When {@code pojoRequest=true}, the producer must fail fast if the body is not the expected request type, rather than
+ * silently doing nothing (see CAMEL-24261).
+ */
+class AWSConfigProducerPojoRequestTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "putConfigRule,putConfigRule operation requires PutConfigRuleRequest in POJO mode",
+            "removeConfigRule,removeConfigRule operation requires DeleteConfigRuleRequest in POJO mode",
+            "describeRuleCompliance,describeRuleCompliance operation requires DescribeComplianceByConfigRuleRequest in POJO mode",
+            "putConformancePack,putConformancePack operation requires PutConformancePackRequest in POJO mode",
+            "removeConformancePack,removeConformancePack operation requires DeleteConformancePackRequest in POJO mode",
+    })
+    void pojoRequestWithWrongBodyTypeThrows(String operation, String expectedMessage) throws Exception {
+        AWSConfigConfiguration configuration = new AWSConfigConfiguration();
+        configuration.setPojoRequest(true);
+        configuration.setOperation(AWSConfigOperations.valueOf(operation));
+
+        AWSConfigEndpoint endpoint = mock(AWSConfigEndpoint.class);
+        when(endpoint.getConfiguration()).thenReturn(configuration);
+        when(endpoint.getConfigClient()).thenReturn(mock(ConfigClient.class));
+
+        AWSConfigProducer producer = new AWSConfigProducer(endpoint);
+
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getIn().setBody("not the expected request type");
+
+        assertThatThrownBy(() -> producer.process(exchange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedMessage);
+    }
+}


### PR DESCRIPTION
Child of CAMEL-24261 (completing CAMEL-23462 across the AWS2 producers).

## Problem

With `pojoRequest=true`, `AWSConfigProducer`'s five operations (`putConfigRule`,
`removeConfigRule`, `describeRuleCompliance`, `putConformancePack`,
`removeConformancePack`) only acted when the body was the matching request type;
any other body fell through the `instanceof` with no `else`, so no AWS call was
made, no response was set, and the original body was returned with no error.

## Fix

Each branch now throws `IllegalArgumentException` naming the required request
type, e.g. `"putConformancePack operation requires PutConformancePackRequest in
POJO mode"`.

## Test

`camel-aws-config` has no producer route/mock harness, so this is covered by a new
Mockito parameterized unit test that mocks the endpoint + client, sends a
wrong-typed body with `pojoRequest=true`, and asserts each `IllegalArgumentException`.
Verified to fail (silent no-op) before the fix. Region-free — no localstack or
real AWS.

## Docs / backport

The shared 4.22 upgrade-guide entry was added with CAMEL-24263. Main only, matching
the CAMEL-23462 precedent (behaviour change, shipped in a minor, not backported).

---
_Claude Code on behalf of oscerd_