### PR TITLE
[JBANG-IT] Track PID in nohup execution

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -148,7 +148,7 @@ public abstract class JBangTestSupport {
     }
 
     protected String execNohup(final String command) {
-        return containerService.executeGenericCommand("nohup " + getMainCommand() + " " + command + " &");
+        return containerService.executeNohup(command);
     }
 
     protected String mountPoint() {

--- a/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliLocalProcessService.java
+++ b/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliLocalProcessService.java
@@ -192,6 +192,17 @@ public class CliLocalProcessService implements CliService {
     }
 
     @Override
+    public String executeNohup(String command) {
+        String pidOutput = executeGenericCommand("nohup " + getMainCommand() + " " + command + " & echo $!");
+        String pid = pidOutput.trim();
+        if (org.apache.camel.support.ObjectHelper.isNumber(pid)) {
+            backgroundPids.add(pid);
+            LOG.info("Tracking nohup background process with PID: {}", pid);
+        }
+        return pid;
+    }
+
+    @Override
     public String executeGenericCommand(String command) {
         return executeGenericCommand(command, false, false);
     }

--- a/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliService.java
+++ b/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliService.java
@@ -51,6 +51,10 @@ public interface CliService extends BeforeEachCallback, AfterEachCallback, TestS
 
     String executeBackground(String command);
 
+    default String executeNohup(String command) {
+        return executeGenericCommand("nohup " + getMainCommand() + " " + command + " &");
+    }
+
     String executeGenericCommand(String command);
 
     String executeGenericCommand(String command, Boolean getError, Boolean expectFail);


### PR DESCRIPTION
Track PID in nohup execution so that it can be properly cleaned if needed in process-based mode.

