### PR TITLE
CAMEL-24335: update Artemis dependency groupId to org.apache.artemis

### DIFF
--- a/test-infra/camel-test-infra-artemis/pom.xml
+++ b/test-infra/camel-test-infra-artemis/pom.xml
@@ -42,22 +42,22 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-server</artifactId>
             <version>${activemq-artemis-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-server</artifactId>
             <version>${activemq-artemis-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
             <version>${activemq-artemis-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-amqp-protocol</artifactId>
             <version>${activemq-artemis-version}</version>
         </dependency>

--- a/tests/camel-itest/pom.xml
+++ b/tests/camel-itest/pom.xml
@@ -220,13 +220,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-server</artifactId>
             <version>${activemq-artemis-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
             <version>${activemq-artemis-version}</version>
             <scope>test</scope>


### PR DESCRIPTION
# Description

Since Artemis 2.5.0, the following artifacts relocated from groupId `org.apache.activemq` to
`org.apache.artemis` (see https://artemis.apache.org/artemis-tlp-groupid-migration):

- `artemis-server`
- `artemis-jakarta-server`
- `artemis-jakarta-client`
- `artemis-amqp-protocol`

`activemq-artemis-version` was already bumped to 2.55.0 (via Dependabot), but the `groupId` in the
dependency declarations was never updated, so the build emitted Maven relocation warnings:

```
[WARNING] The artifact org.apache.activemq:artemis-jakarta-server:jar:2.55.0 has been relocated to org.apache.artemis:artemis-jakarta-server:jar:2.55.0
[WARNING] The artifact org.apache.activemq:artemis-jakarta-client:jar:2.55.0 has been relocated to org.apache.artemis:artemis-jakarta-client:jar:2.55.0
[WARNING] The artifact org.apache.activemq:artemis-server:jar:2.55.0 has been relocated to org.apache.artemis:artemis-server:jar:2.55.0
[WARNING] The artifact org.apache.activemq:artemis-amqp-protocol:jar:2.55.0 has been relocated to org.apache.artemis:artemis-amqp-protocol:jar:2.55.0
```

This updates the `groupId` to `org.apache.artemis` for these four dependencies in:

- `test-infra/camel-test-infra-artemis/pom.xml`
- `tests/camel-itest/pom.xml`

`components/camel-paho/pom.xml` already used `org.apache.artemis` for `artemis-mqtt-protocol`, confirming
the new groupId is correct.

Verified with `mvnd clean install -Dquickly -Dci.env.name=local`: build succeeds and the relocation
warnings are gone.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL-24335) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code on behalf of ammachado_