### PR TITLE
[backport camel-4.18.x] CAMEL-24299: disable DTD support in XmlStreamDetector for consistency with other XML parsers

### DIFF
--- a/core/camel-xml-io-util/src/main/java/org/apache/camel/xml/io/util/XmlStreamDetector.java
+++ b/core/camel-xml-io-util/src/main/java/org/apache/camel/xml/io/util/XmlStreamDetector.java
@@ -67,6 +67,8 @@ public class XmlStreamDetector {
             XMLInputFactory factory = XMLInputFactory.newInstance();
             factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
             factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+            // disable DTD support for consistency with XmlConverter / StaxConverter (defends against DTD-based attacks)
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
             reader = factory.createXMLStreamReader(xmlStream);
         } catch (XMLStreamException e) {
             information.problem = e;

--- a/core/camel-xml-io-util/src/test/java/org/apache/camel/xml/io/util/XmlStreamDetectorTest.java
+++ b/core/camel-xml-io-util/src/test/java/org/apache/camel/xml/io/util/XmlStreamDetectorTest.java
@@ -133,4 +133,16 @@ public class XmlStreamDetectorTest {
         assertEquals("http://www.w3.org/2001/XMLSchema-instance", info.getNamespaces().get("xsi"));
     }
 
+    @Test
+    void documentWithDoctypeIsRejected() throws IOException {
+        // SUPPORT_DTD=false: a DOCTYPE declaration is not processed, so the stream is reported invalid rather than
+        // expanding any DTD-defined entities (CAMEL-24299)
+        String xml = "<?xml version=\"1.0\"?>\n"
+                     + "<!DOCTYPE root [ <!ENTITY x \"expanded\"> ]>\n"
+                     + "<root>&x;</root>";
+        XmlStreamDetector detector
+                = new XmlStreamDetector(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        assertFalse(detector.information().isValid());
+    }
+
 }


### PR DESCRIPTION
## Backport of #25279

Cherry-pick of #25279 onto `camel-4.18.x` (clean, no conflicts).

**Original PR:** #25279 — CAMEL-24299: disable DTD support in XmlStreamDetector for consistency with other XML parsers
**Original author:** @oscerd
**Target branch:** `camel-4.18.x`

### What

`XmlStreamDetector` created its StAX `XMLInputFactory` with `IS_SUPPORTING_EXTERNAL_ENTITIES=false` but left `SUPPORT_DTD` at its default. This adds `factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE)`, for consistency with `XmlConverter` / `StaxConverter`, as defence-in-depth against DTD-based attacks (e.g. entity-expansion DoS). Non-breaking: Camel route XML does not use DTDs.

Sanity build: full-reactor `mvn clean install -DskipTests` green on `camel-4.18.x`; `XmlStreamDetectorTest` (7 tests incl. the DTD-rejection case) passes.
