### PR TITLE
docs(jms): update JMS API references to Jakarta and fix stale content

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/jms-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/jms-component.adoc
@@ -95,7 +95,7 @@ You append query options to the URI by using the following format,
 
 === Using ActiveMQ
 
-The JMS component reuses Spring 2's `JmsTemplate` for sending messages.
+The JMS component reuses Spring's `JmsTemplate` for sending messages.
 This is not ideal for use in a non-J2EE container and typically requires
 some caching in the JMS provider to avoid
 http://activemq.apache.org/jmstemplate-gotchas.html[poor performance].
@@ -359,7 +359,7 @@ Channel], using a JMS queue as the Dead Letter Queue, then normally the
 caused Exception is not stored in the JMS message. You can, however, use
 the `transferExchange` option on the JMS dead letter queue to instruct
 Camel to store the entire Exchange in the queue as a
-`javax.jms.ObjectMessage` that holds a
+`jakarta.jms.ObjectMessage` that holds a
 `org.apache.camel.support.DefaultExchangeHolder`. This allows you to
 consume from the Dead Letter Queue and retrieve the caused exception
 from the Exchange property with the key `Exchange.EXCEPTION_CAUGHT`. The
@@ -444,7 +444,7 @@ a custom processor.
 
 === Message Mapping between JMS and Camel
 
-Camel automatically maps messages between `javax.jms.Message` and
+Camel automatically maps messages between `jakarta.jms.Message` and
 `org.apache.camel.Message`.
 
 When sending a JMS message, Camel converts the message body to the
@@ -453,25 +453,37 @@ following JMS message types:
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================
 |Body Type |JMS Message |Comment
-|`String` |`javax.jms.TextMessage` | 
+|`String` |`jakarta.jms.TextMessage` | 
 
-|`org.w3c.dom.Node` |`javax.jms.TextMessage` |The DOM will be converted
+|`org.w3c.dom.Node` |`jakarta.jms.TextMessage` |The DOM will be converted
 to `String`.
 
-|`Map` |`javax.jms.MapMessage` | 
+|`Map` |`jakarta.jms.MapMessage` | 
 
-|`java.io.Serializable` |`javax.jms.ObjectMessage` | 
+|`java.io.Serializable` |`jakarta.jms.ObjectMessage` | 
 
-|`byte[]` |`javax.jms.BytesMessage` | 
+|`byte[]` |`jakarta.jms.BytesMessage` | 
 
-|`java.io.File` |`javax.jms.BytesMessage` | 
+|`java.io.File` |`jakarta.jms.BytesMessage` | 
 
-|`java.io.Reader` |`javax.jms.BytesMessage` | 
+|`java.io.Reader` |`jakarta.jms.BytesMessage` | 
 
-|`java.io.InputStream` |`javax.jms.BytesMessage` | 
+|`java.io.InputStream` |`jakarta.jms.BytesMessage` |
 
-|`java.nio.ByteBuffer` |`javax.jms.BytesMessage` | 
+|`org.apache.camel.WrappedFile` |`jakarta.jms.BytesMessage` |
+
+|`org.apache.camel.StreamCache` |`jakarta.jms.BytesMessage` |
+
+|`java.nio.ByteBuffer` |`jakarta.jms.BytesMessage` |
 |=======================================================================
+
+NOTE: When the `streamMessageTypeEnabled` option is enabled, bodies of type
+`java.io.File`, `java.io.Reader`, `java.io.InputStream`,
+`org.apache.camel.WrappedFile` and `org.apache.camel.StreamCache` are sent as
+`jakarta.jms.StreamMessage` instead of `jakarta.jms.BytesMessage`. When
+`artemisStreamingEnabled` is in effect, Camel enforces
+`jakarta.jms.BytesMessage` even then, because ActiveMQ Artemis has an
+optimised streaming mode that requires bytes messages.
 
 When receiving a JMS message, Camel converts the JMS message to the
 following body type:
@@ -479,10 +491,11 @@ following body type:
 [width="100%",cols="50%,50%",options="header",]
 |=============================================
 |JMS Message |Body Type
-|`javax.jms.TextMessage` |`String`
-|`javax.jms.BytesMessage` |`byte[]`
-|`javax.jms.MapMessage` |`Map<String, Object>`
-|`javax.jms.ObjectMessage` |`Object`
+|`jakarta.jms.TextMessage` |`String`
+|`jakarta.jms.BytesMessage` |`byte[]`
+|`jakarta.jms.MapMessage` |`Map<String, Object>`
+|`jakarta.jms.ObjectMessage` |`Object`
+|`jakarta.jms.StreamMessage` |`java.io.InputStream`
 |=============================================
 
 === Disabling auto-mapping of JMS messages
@@ -491,7 +504,7 @@ You can use the `mapJmsMessage` option to disable the auto-mapping
 above. If disabled, Camel will not try to map the received JMS message,
 but instead uses it directly as the payload. This allows you to avoid
 the overhead of mapping and let Camel just pass through the JMS message.
-For instance, it even allows you to route `javax.jms.ObjectMessage` JMS
+For instance, it even allows you to route `jakarta.jms.ObjectMessage` JMS
 messages with classes you do *not* have on the classpath.
 
 === Using a custom MessageConverter
@@ -546,7 +559,7 @@ You can use the `jmsMessageType` option on the endpoint URL to force a
 specific message type for all messages.
 
 In the route below, we poll files from a folder and send them as
-`javax.jms.TextMessage` as we have forced the JMS producer endpoint to
+`jakarta.jms.TextMessage` as we have forced the JMS producer endpoint to
 use text messages:
 
 [tabs]
@@ -640,7 +653,7 @@ message:
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================
 |Property |Type |Description
-|`org.apache.camel.jms.replyDestination` |`javax.jms.Destination` |The
+|`org.apache.camel.jms.replyDestination` |`jakarta.jms.Destination` |The
 reply destination.
 |=======================================================================
 
@@ -654,7 +667,7 @@ it receives a JMS message:
 
 |`JMSDeliveryMode` |`int` |The JMS delivery mode.
 
-|`JMSDestination` |`javax.jms.Destination` |The JMS destination.
+|`JMSDestination` |`jakarta.jms.Destination` |The JMS destination.
 
 |`JMSExpiration` |`long` |The JMS expiration.
 
@@ -665,7 +678,7 @@ and 9 as the highest).
 
 |`JMSRedelivered` |`boolean` |Whether the JMS message is redelivered.
 
-|`JMSReplyTo` |`javax.jms.Destination` |The JMS reply-to destination.
+|`JMSReplyTo` |`jakarta.jms.Destination` |The JMS reply-to destination.
 
 |`JMSTimestamp` |`long` |The JMS timestamp.
 
@@ -716,9 +729,9 @@ the specified `JMSReplyTo` queue.
 |_InOnly_ |`JMSReplyTo` is set |By default, Camel discards the
 `JMSReplyTo` destination and clears the `JMSReplyTo` header before
 sending the message. Camel then sends the message and does *not* expect
-a reply. Camel logs this in the log at `WARN` level (changed to `DEBUG`
-level from *Camel 2.6* onwards. You can use `preserveMessageQuo=true` to
-instruct Camel to keep the `JMSReplyTo`. In all situations the
+a reply. Camel logs this in the log at `DEBUG` level. You can use
+`preserveMessageQos=true` to instruct Camel to keep the `JMSReplyTo`.
+In all situations the
 `JmsProducer` does *not* expect any reply and thus continue after
 sending the message.
 |=======================================================================
@@ -799,7 +812,7 @@ You can specify the destination in the following headers:
 [width="100%",cols="10%,10%,80%",options="header",]
 |=====================================================================
 |Header |Type |Description
-|`CamelJmsDestination` |`javax.jms.Destination` |A destination object.
+|`CamelJmsDestination` |`jakarta.jms.Destination` |A destination object.
 |`CamelJmsDestinationName` |`String` |The destination name.
 |=====================================================================
 
@@ -1385,7 +1398,7 @@ http://forum.springsource.org/showthread.php?123631-JMS-DMLC-not-caching%20conne
 === Using JMSReplyTo for late replies
 
 When using Camel as a JMS listener, it sets an Exchange property with
-the value of the ReplyTo `javax.jms.Destination` object, having the key
+the value of the ReplyTo `jakarta.jms.Destination` object, having the key
 `ReplyTo`. You can obtain this `Destination` as follows:
 
 ._Java-only: uses JMS `Destination` object and Camel Java API_

--- a/components/camel-jms/src/main/docs/jms-component.adoc
+++ b/components/camel-jms/src/main/docs/jms-component.adoc
@@ -95,7 +95,7 @@ You append query options to the URI by using the following format,
 
 === Using ActiveMQ
 
-The JMS component reuses Spring 2's `JmsTemplate` for sending messages.
+The JMS component reuses Spring's `JmsTemplate` for sending messages.
 This is not ideal for use in a non-J2EE container and typically requires
 some caching in the JMS provider to avoid
 http://activemq.apache.org/jmstemplate-gotchas.html[poor performance].
@@ -359,7 +359,7 @@ Channel], using a JMS queue as the Dead Letter Queue, then normally the
 caused Exception is not stored in the JMS message. You can, however, use
 the `transferExchange` option on the JMS dead letter queue to instruct
 Camel to store the entire Exchange in the queue as a
-`javax.jms.ObjectMessage` that holds a
+`jakarta.jms.ObjectMessage` that holds a
 `org.apache.camel.support.DefaultExchangeHolder`. This allows you to
 consume from the Dead Letter Queue and retrieve the caused exception
 from the Exchange property with the key `Exchange.EXCEPTION_CAUGHT`. The
@@ -444,7 +444,7 @@ a custom processor.
 
 === Message Mapping between JMS and Camel
 
-Camel automatically maps messages between `javax.jms.Message` and
+Camel automatically maps messages between `jakarta.jms.Message` and
 `org.apache.camel.Message`.
 
 When sending a JMS message, Camel converts the message body to the
@@ -453,25 +453,37 @@ following JMS message types:
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================
 |Body Type |JMS Message |Comment
-|`String` |`javax.jms.TextMessage` | 
+|`String` |`jakarta.jms.TextMessage` | 
 
-|`org.w3c.dom.Node` |`javax.jms.TextMessage` |The DOM will be converted
+|`org.w3c.dom.Node` |`jakarta.jms.TextMessage` |The DOM will be converted
 to `String`.
 
-|`Map` |`javax.jms.MapMessage` | 
+|`Map` |`jakarta.jms.MapMessage` | 
 
-|`java.io.Serializable` |`javax.jms.ObjectMessage` | 
+|`java.io.Serializable` |`jakarta.jms.ObjectMessage` | 
 
-|`byte[]` |`javax.jms.BytesMessage` | 
+|`byte[]` |`jakarta.jms.BytesMessage` | 
 
-|`java.io.File` |`javax.jms.BytesMessage` | 
+|`java.io.File` |`jakarta.jms.BytesMessage` | 
 
-|`java.io.Reader` |`javax.jms.BytesMessage` | 
+|`java.io.Reader` |`jakarta.jms.BytesMessage` | 
 
-|`java.io.InputStream` |`javax.jms.BytesMessage` | 
+|`java.io.InputStream` |`jakarta.jms.BytesMessage` |
 
-|`java.nio.ByteBuffer` |`javax.jms.BytesMessage` | 
+|`org.apache.camel.WrappedFile` |`jakarta.jms.BytesMessage` |
+
+|`org.apache.camel.StreamCache` |`jakarta.jms.BytesMessage` |
+
+|`java.nio.ByteBuffer` |`jakarta.jms.BytesMessage` |
 |=======================================================================
+
+NOTE: When the `streamMessageTypeEnabled` option is enabled, bodies of type
+`java.io.File`, `java.io.Reader`, `java.io.InputStream`,
+`org.apache.camel.WrappedFile` and `org.apache.camel.StreamCache` are sent as
+`jakarta.jms.StreamMessage` instead of `jakarta.jms.BytesMessage`. When
+`artemisStreamingEnabled` is in effect, Camel enforces
+`jakarta.jms.BytesMessage` even then, because ActiveMQ Artemis has an
+optimised streaming mode that requires bytes messages.
 
 When receiving a JMS message, Camel converts the JMS message to the
 following body type:
@@ -479,10 +491,11 @@ following body type:
 [width="100%",cols="50%,50%",options="header",]
 |=============================================
 |JMS Message |Body Type
-|`javax.jms.TextMessage` |`String`
-|`javax.jms.BytesMessage` |`byte[]`
-|`javax.jms.MapMessage` |`Map<String, Object>`
-|`javax.jms.ObjectMessage` |`Object`
+|`jakarta.jms.TextMessage` |`String`
+|`jakarta.jms.BytesMessage` |`byte[]`
+|`jakarta.jms.MapMessage` |`Map<String, Object>`
+|`jakarta.jms.ObjectMessage` |`Object`
+|`jakarta.jms.StreamMessage` |`java.io.InputStream`
 |=============================================
 
 === Disabling auto-mapping of JMS messages
@@ -491,7 +504,7 @@ You can use the `mapJmsMessage` option to disable the auto-mapping
 above. If disabled, Camel will not try to map the received JMS message,
 but instead uses it directly as the payload. This allows you to avoid
 the overhead of mapping and let Camel just pass through the JMS message.
-For instance, it even allows you to route `javax.jms.ObjectMessage` JMS
+For instance, it even allows you to route `jakarta.jms.ObjectMessage` JMS
 messages with classes you do *not* have on the classpath.
 
 === Using a custom MessageConverter
@@ -546,7 +559,7 @@ You can use the `jmsMessageType` option on the endpoint URL to force a
 specific message type for all messages.
 
 In the route below, we poll files from a folder and send them as
-`javax.jms.TextMessage` as we have forced the JMS producer endpoint to
+`jakarta.jms.TextMessage` as we have forced the JMS producer endpoint to
 use text messages:
 
 [tabs]
@@ -640,7 +653,7 @@ message:
 [width="100%",cols="10%,10%,80%",options="header",]
 |=======================================================================
 |Property |Type |Description
-|`org.apache.camel.jms.replyDestination` |`javax.jms.Destination` |The
+|`org.apache.camel.jms.replyDestination` |`jakarta.jms.Destination` |The
 reply destination.
 |=======================================================================
 
@@ -654,7 +667,7 @@ it receives a JMS message:
 
 |`JMSDeliveryMode` |`int` |The JMS delivery mode.
 
-|`JMSDestination` |`javax.jms.Destination` |The JMS destination.
+|`JMSDestination` |`jakarta.jms.Destination` |The JMS destination.
 
 |`JMSExpiration` |`long` |The JMS expiration.
 
@@ -665,7 +678,7 @@ and 9 as the highest).
 
 |`JMSRedelivered` |`boolean` |Whether the JMS message is redelivered.
 
-|`JMSReplyTo` |`javax.jms.Destination` |The JMS reply-to destination.
+|`JMSReplyTo` |`jakarta.jms.Destination` |The JMS reply-to destination.
 
 |`JMSTimestamp` |`long` |The JMS timestamp.
 
@@ -716,9 +729,9 @@ the specified `JMSReplyTo` queue.
 |_InOnly_ |`JMSReplyTo` is set |By default, Camel discards the
 `JMSReplyTo` destination and clears the `JMSReplyTo` header before
 sending the message. Camel then sends the message and does *not* expect
-a reply. Camel logs this in the log at `WARN` level (changed to `DEBUG`
-level from *Camel 2.6* onwards. You can use `preserveMessageQuo=true` to
-instruct Camel to keep the `JMSReplyTo`. In all situations the
+a reply. Camel logs this in the log at `DEBUG` level. You can use
+`preserveMessageQos=true` to instruct Camel to keep the `JMSReplyTo`.
+In all situations the
 `JmsProducer` does *not* expect any reply and thus continue after
 sending the message.
 |=======================================================================
@@ -799,7 +812,7 @@ You can specify the destination in the following headers:
 [width="100%",cols="10%,10%,80%",options="header",]
 |=====================================================================
 |Header |Type |Description
-|`CamelJmsDestination` |`javax.jms.Destination` |A destination object.
+|`CamelJmsDestination` |`jakarta.jms.Destination` |A destination object.
 |`CamelJmsDestinationName` |`String` |The destination name.
 |=====================================================================
 
@@ -1385,7 +1398,7 @@ http://forum.springsource.org/showthread.php?123631-JMS-DMLC-not-caching%20conne
 === Using JMSReplyTo for late replies
 
 When using Camel as a JMS listener, it sets an Exchange property with
-the value of the ReplyTo `javax.jms.Destination` object, having the key
+the value of the ReplyTo `jakarta.jms.Destination` object, having the key
 `ReplyTo`. You can obtain this `Destination` as follows:
 
 ._Java-only: uses JMS `Destination` object and Camel Java API_

--- a/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camelcontext.adoc
@@ -198,7 +198,7 @@ A producer is the Camel abstraction that refers to an entity capable of sending 
 an endpoint. When a message is sent to an endpoint, the producer handles the details of getting
 the message data compatible with that particular endpoint. For example, `FileProducer`
 will write the message body to a `java.io.File`. `JmsProducer`, on the other hand, will map
-the Camel message to `javax.jms.Message` before sending it to a JMS destination. This
+the Camel message to `jakarta.jms.Message` before sending it to a JMS destination. This
 is an important feature in Camel, because it hides the complexity of interacting with
 particular transports. All you need to do is route a message to an endpoint, and the producer
 does the heavy lifting.


### PR DESCRIPTION
### What

Updates the `camel-jms` documentation to reference the Jakarta Messaging API, and fixes several factual defects found in the same pages while doing so.

**1. `javax.jms` -> `jakarta.jms` (23 references)**

`camel-jms` has run on Jakarta Messaging since Camel 4. `components/camel-jms/src/main/java` contains 111 `jakarta.jms` imports and zero `javax.jms`, and `pom.xml` depends on `jakarta.jms:jakarta.jms-api` 3.1.0. The documentation, however, still described `javax.jms` throughout, including the normative type-mapping tables that readers copy type names from.

Renamed 22 references in `jms-component.adoc` and 1 in `camelcontext.adoc`. Every type named (`Message`, `TextMessage`, `MapMessage`, `BytesMessage`, `ObjectMessage`, `Destination`) exists unchanged in `jakarta.jms-api` 3.1.0, so this is a pure package rename.

The two `http://java.sun.com/.../javax/jms/Message.html` URLs are intentionally left as-is: they are historical links, not package references.

**2. `preserveMessageQuo` -> `preserveMessageQos`**

There is no option named `preserveMessageQuo`. The real option is `preserveMessageQos` (`JmsConfiguration.java`). A reader copying the documented name would get a silent no-op. The surrounding sentence also had an unbalanced parenthesis and a stale "from *Camel 2.6* onwards" qualifier, both cleaned up.

**3. "Spring 2's `JmsTemplate`"**

The build is on Spring 7. Changed to "Spring's `JmsTemplate`" so it does not go stale again.

**4. Type-mapping tables were incomplete and unconditional**

`JmsBinding.getJMSMessageTypeForBody` maps `File`, `Reader`, `InputStream`, `WrappedFile` and `StreamCache` to `StreamMessage` when `streamMessageTypeEnabled` is set, and forces `BytesMessage` when `artemisStreamingEnabled` is in effect. The tables stated the `BytesMessage` mapping unconditionally and did not mention `StreamMessage` at all, even on the receive side where `extractBodyFromJms` returns an `InputStream` for it.

Added the missing `StreamMessage` receive row, the `WrappedFile` and `StreamCache` send rows, and a NOTE describing the `streamMessageTypeEnabled` / `artemisStreamingEnabled` behaviour.

### Why

These are user-facing correctness problems rather than cosmetics. The package rename affects the tables people copy from, and `preserveMessageQuo` is an option name that does not exist.

### Testing

Documentation-only change; no production code is modified. The regenerated catalog copy is included, as is the convention for component doc changes.

---
_Generated by Claude Code on behalf of @stn1slv_
