### PR TITLE
CAMEL-24262: camel-aws2 - guard nullable awsErrorDetails() when logging the AWS error code in producer catch blocks

### DIFF
--- a/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agent/BedrockAgentProducer.java
+++ b/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agent/BedrockAgentProducer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -95,7 +96,7 @@ public class BedrockAgentProducer extends DefaultProducer {
                 try {
                     result = bedrockAgentClient.startIngestionJob(startIngestionJobRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Ingestion Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Ingestion Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -143,7 +144,7 @@ public class BedrockAgentProducer extends DefaultProducer {
                 try {
                     result = bedrockAgentClient.listIngestionJobs(listIngestionJobsRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Ingestion Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Ingestion Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -191,7 +192,7 @@ public class BedrockAgentProducer extends DefaultProducer {
                 try {
                     result = bedrockAgentClient.getIngestionJob(getIngestionJobRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Ingestion Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Ingestion Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/BedrockAgentRuntimeProducer.java
+++ b/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/agentruntime/BedrockAgentRuntimeProducer.java
@@ -27,6 +27,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -137,7 +138,7 @@ public class BedrockAgentRuntimeProducer extends DefaultProducer {
                 try {
                     result = bedrockAgentRuntimeClient.retrieveAndGenerate(retrieveAndGenerateRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Retrieve and Generate command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Retrieve and Generate command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -213,7 +214,7 @@ public class BedrockAgentRuntimeProducer extends DefaultProducer {
         try {
             response = bedrockAgentRuntimeClient.retrieve(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Retrieve command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Retrieve command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
 
@@ -311,7 +312,7 @@ public class BedrockAgentRuntimeProducer extends DefaultProducer {
         try {
             asyncClient.invokeFlow(request, handler).join();
         } catch (AwsServiceException ase) {
-            LOG.trace("InvokeFlow command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("InvokeFlow command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         } catch (RuntimeException re) {
             // CompletableFuture.join() wraps checked exceptions in CompletionException; rethrow root cause when it is
@@ -541,7 +542,7 @@ public class BedrockAgentRuntimeProducer extends DefaultProducer {
         try {
             invocation.get().join();
         } catch (AwsServiceException ase) {
-            LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+            LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
             throw ase;
         } catch (RuntimeException re) {
             Throwable cause = re.getCause();

--- a/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/runtime/BedrockProducer.java
+++ b/components/camel-aws/camel-aws-bedrock/src/main/java/org/apache/camel/component/aws2/bedrock/runtime/BedrockProducer.java
@@ -26,6 +26,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.component.aws2.bedrock.runtime.stream.BedrockStreamHandler;
 import org.apache.camel.component.aws2.bedrock.runtime.stream.ConverseStreamHandler;
 import org.apache.camel.support.DefaultProducer;
@@ -142,7 +143,7 @@ public class BedrockProducer extends DefaultProducer {
                 try {
                     result = bedrockRuntimeClient.invokeModel(invokeModelRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Invoke Model command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Invoke Model command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -173,7 +174,7 @@ public class BedrockProducer extends DefaultProducer {
             try {
                 result = bedrockRuntimeClient.invokeModel(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Invoke Model command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Invoke Model command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -189,7 +190,7 @@ public class BedrockProducer extends DefaultProducer {
                 try {
                     result = bedrockRuntimeClient.invokeModel(invokeModelRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Invoke Image Model command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Invoke Image Model command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -220,7 +221,7 @@ public class BedrockProducer extends DefaultProducer {
             try {
                 result = bedrockRuntimeClient.invokeModel(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Invoke Model command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Invoke Model command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -241,7 +242,7 @@ public class BedrockProducer extends DefaultProducer {
                 try {
                     result = bedrockRuntimeClient.invokeModel(invokeModelRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Invoke Image Model command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Invoke Image Model command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -272,7 +273,7 @@ public class BedrockProducer extends DefaultProducer {
             try {
                 result = bedrockRuntimeClient.invokeModel(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Invoke Model command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Invoke Model command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -634,7 +635,7 @@ public class BedrockProducer extends DefaultProducer {
             }
 
         } catch (AwsServiceException ase) {
-            LOG.trace("Invoke Model Streaming command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Invoke Model Streaming command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
     }
@@ -760,7 +761,7 @@ public class BedrockProducer extends DefaultProducer {
             }
 
         } catch (AwsServiceException ase) {
-            LOG.trace("Converse command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Converse command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
     }
@@ -896,7 +897,7 @@ public class BedrockProducer extends DefaultProducer {
             }
 
         } catch (AwsServiceException ase) {
-            LOG.trace("Converse Stream command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Converse Stream command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
     }
@@ -990,7 +991,7 @@ public class BedrockProducer extends DefaultProducer {
             }
 
         } catch (AwsServiceException ase) {
-            LOG.trace("ApplyGuardrail command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("ApplyGuardrail command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
     }

--- a/components/camel-aws/camel-aws-common/pom.xml
+++ b/components/camel-aws/camel-aws-common/pom.xml
@@ -72,6 +72,16 @@
             <artifactId>netty-nio-client</artifactId>
             <version>${aws-java-sdk2-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/camel-aws/camel-aws-common/src/main/java/org/apache/camel/component/aws/common/AwsExceptionUtil.java
+++ b/components/camel-aws/camel-aws-common/src/main/java/org/apache/camel/component/aws/common/AwsExceptionUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.common;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+
+/**
+ * Helpers for working with {@link AwsServiceException} instances.
+ */
+public final class AwsExceptionUtil {
+
+    private AwsExceptionUtil() {
+    }
+
+    /**
+     * Returns the AWS error code of the given exception, or {@code null} when it is not available.
+     * <p>
+     * {@link AwsServiceException#awsErrorDetails()} is nullable, so calling {@code e.awsErrorDetails().errorCode()}
+     * directly can throw a {@link NullPointerException} - and, because it is typically used as a method argument (for
+     * example when logging), the expression is evaluated eagerly regardless of the log level. This helper reads the
+     * error code defensively so a null {@code awsErrorDetails} does not mask the original exception.
+     *
+     * @param  exception the exception, may be {@code null}
+     * @return           the error code, or {@code null} if the exception or its error details are absent
+     */
+    public static String errorCode(AwsServiceException exception) {
+        if (exception == null || exception.awsErrorDetails() == null) {
+            return null;
+        }
+        return exception.awsErrorDetails().errorCode();
+    }
+}

--- a/components/camel-aws/camel-aws-common/src/test/java/org/apache/camel/component/aws/common/AwsExceptionUtilTest.java
+++ b/components/camel-aws/camel-aws-common/src/test/java/org/apache/camel/component/aws/common/AwsExceptionUtilTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.common;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AwsExceptionUtilTest {
+
+    @Test
+    void returnsErrorCodeWhenPresent() {
+        AwsServiceException exception = AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode("AccessDenied").build())
+                .build();
+
+        assertThat(AwsExceptionUtil.errorCode(exception)).isEqualTo("AccessDenied");
+    }
+
+    @Test
+    void returnsNullWhenErrorDetailsAreAbsent() {
+        // awsErrorDetails() is nullable - the helper must not throw
+        AwsServiceException exception = AwsServiceException.builder().message("boom").statusCode(500).build();
+
+        assertThat(AwsExceptionUtil.errorCode(exception)).isNull();
+    }
+
+    @Test
+    void returnsNullForNullException() {
+        assertThat(AwsExceptionUtil.errorCode(null)).isNull();
+    }
+}

--- a/components/camel-aws/camel-aws-config/src/main/java/org/apache/camel/component/aws/config/AWSConfigProducer.java
+++ b/components/camel-aws/camel-aws-config/src/main/java/org/apache/camel/component/aws/config/AWSConfigProducer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -104,7 +105,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 try {
                     result = configClient.putConfigRule(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Put Config rule command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Put Config rule command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -137,7 +138,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 PutConfigRuleRequest request = builder.configRule(configRule.build()).build();
                 result = configClient.putConfigRule(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Put Config Rule command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Put Config Rule command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -153,7 +154,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 try {
                     result = configClient.deleteConfigRule(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Config rule command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Config rule command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -175,7 +176,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 DeleteConfigRuleRequest request = builder.build();
                 result = configClient.deleteConfigRule(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Config Rule command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Config Rule command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -229,7 +230,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 try {
                     result = configClient.putConformancePack(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Put Conformance Pack command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Put Conformance Pack command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -266,7 +267,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 PutConformancePackRequest request = builder.build();
                 result = configClient.putConformancePack(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Put Conformance Pack command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Put Conformance Pack command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -306,7 +307,7 @@ public class AWSConfigProducer extends DefaultProducer {
                 DeleteConformancePackRequest request = builder.build();
                 result = configClient.deleteConformancePack(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Remove Conformance Pack command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Remove Conformance Pack command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws-parameter-store/src/main/java/org/apache/camel/component/aws/parameterstore/ParameterStoreProducer.java
+++ b/components/camel-aws/camel-aws-parameter-store/src/main/java/org/apache/camel/component/aws/parameterstore/ParameterStoreProducer.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -150,7 +151,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.getParameter(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Get Parameter command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Get Parameter command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -184,7 +185,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.getParameters(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Get Parameters command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Get Parameters command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -222,7 +223,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.getParametersByPath(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Get Parameters By Path command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Get Parameters By Path command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -270,7 +271,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.putParameter(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Put Parameter command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Put Parameter command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -299,7 +300,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.deleteParameter(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Delete Parameter command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Delete Parameter command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -326,7 +327,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.deleteParameters(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Delete Parameters command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Delete Parameters command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -350,7 +351,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.describeParameters(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Describe Parameters command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Describe Parameters command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -384,7 +385,7 @@ public class ParameterStoreProducer extends DefaultProducer {
         try {
             result = ssmClient.getParameterHistory(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Get Parameter History command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Get Parameter History command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/SecretsManagerProducer.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/SecretsManagerProducer.java
@@ -25,6 +25,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -140,7 +141,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.listSecrets(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("List Secrets command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("List Secrets command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -176,7 +177,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.createSecret(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Create Secret command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Create Secret command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -202,7 +203,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.getSecretValue(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Get Secret value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Get Secret value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -235,7 +236,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.describeSecret(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Describe Secret value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Describe Secret value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -268,7 +269,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.deleteSecret(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Delete Secret value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Delete Secret value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -299,7 +300,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.rotateSecret(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Rotate Secret value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Rotate Secret value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -335,7 +336,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.updateSecret(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Update Secret command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Update Secret command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -372,7 +373,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.replicateSecretToRegions(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Replicate Secret to region command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Replicate Secret to region command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -398,7 +399,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.restoreSecret(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Restore Secret value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Restore Secret value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -426,7 +427,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.batchGetSecretValue(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Batch Get Secret value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Batch Get Secret value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -483,7 +484,7 @@ public class SecretsManagerProducer extends DefaultProducer {
         try {
             result = secretsManagerClient.putSecretValue(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("Put Secret Value command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("Put Secret Value command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws-security-hub/src/main/java/org/apache/camel/component/aws/securityhub/SecurityHubProducer.java
+++ b/components/camel-aws/camel-aws-security-hub/src/main/java/org/apache/camel/component/aws/securityhub/SecurityHubProducer.java
@@ -26,6 +26,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -398,7 +399,7 @@ public class SecurityHubProducer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -411,7 +412,7 @@ public class SecurityHubProducer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-comprehend/src/main/java/org/apache/camel/component/aws2/comprehend/Comprehend2Producer.java
+++ b/components/camel-aws/camel-aws2-comprehend/src/main/java/org/apache/camel/component/aws2/comprehend/Comprehend2Producer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -137,7 +138,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectDominantLanguage(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Dominant Language command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Dominant Language command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -158,7 +159,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectDominantLanguage(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Dominant Language command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Dominant Language command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -179,7 +180,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectEntities(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Entities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Entities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -196,7 +197,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectEntities(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Entities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Entities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -212,7 +213,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectKeyPhrases(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Key Phrases command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Key Phrases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -229,7 +230,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectKeyPhrases(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Key Phrases command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Key Phrases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -245,7 +246,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectSentiment(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Sentiment command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Sentiment command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -264,7 +265,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectSentiment(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Sentiment command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Sentiment command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -282,7 +283,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectSyntax(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Syntax command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Syntax command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -299,7 +300,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectSyntax(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Syntax command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Syntax command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -315,7 +316,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectPiiEntities(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect PII Entities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect PII Entities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -332,7 +333,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectPiiEntities(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect PII Entities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect PII Entities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -348,7 +349,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.detectToxicContent(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Toxic Content command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Toxic Content command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -366,7 +367,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.detectToxicContent(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Toxic Content command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Toxic Content command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -382,7 +383,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.classifyDocument(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Classify Document command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Classify Document command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -403,7 +404,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.classifyDocument(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Classify Document command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Classify Document command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -419,7 +420,7 @@ public class Comprehend2Producer extends DefaultProducer {
                 try {
                     result = comprehendClient.containsPiiEntities(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Contains PII Entities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Contains PII Entities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -436,7 +437,7 @@ public class Comprehend2Producer extends DefaultProducer {
             try {
                 result = comprehendClient.containsPiiEntities(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Contains PII Entities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Contains PII Entities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-ec2/src/main/java/org/apache/camel/component/aws2/ec2/AWS2EC2Producer.java
+++ b/components/camel-aws/camel-aws2-ec2/src/main/java/org/apache/camel/component/aws2/ec2/AWS2EC2Producer.java
@@ -26,6 +26,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
 import org.apache.camel.support.DefaultProducer;
@@ -154,7 +155,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.runInstances(runInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Run Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Run Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Creating and running instances requests performing");
@@ -229,7 +230,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.runInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Run Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Run Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             LOG.trace("Creating and running instances with ami [{}] and instance type {}", ami, instanceType);
@@ -248,7 +249,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.startInstances(startInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Starting instances with Ids [{}] ", startInstancesRequest.instanceIds());
@@ -270,7 +271,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.startInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -293,7 +294,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.stopInstances(stopInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Stop Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Stop Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Stopping instances with Ids [{}] ", stopInstancesRequest.instanceIds());
@@ -315,7 +316,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.stopInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Stop Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Stop Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -338,7 +339,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.terminateInstances(terminateInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Terminate Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Terminate Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Terminating instances with Ids [{}] ", terminateInstancesRequest.instanceIds());
@@ -360,7 +361,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.terminateInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Terminate Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Terminate Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -443,7 +444,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                     LOG.trace("Rebooting instances with Ids [{}] ", rebootInstancesRequest.instanceIds());
                     ec2Client.rebootInstances(rebootInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Reboot Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Reboot Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -465,7 +466,7 @@ public class AWS2EC2Producer extends DefaultProducer {
 
                 ec2Client.rebootInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Reboot Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Reboot Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }
@@ -481,7 +482,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.monitorInstances(monitorInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Monitor Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Monitor Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Start Monitoring instances with Ids [{}] ", monitorInstancesRequest.instanceIds());
@@ -503,7 +504,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.monitorInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Monitor Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Monitor Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -526,7 +527,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.unmonitorInstances(unmonitorInstancesRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Unmonitor Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Unmonitor Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Stop Monitoring instances with Ids [{}] ", unmonitorInstancesRequest.instanceIds());
@@ -548,7 +549,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.unmonitorInstances(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Unmonitor Instances command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Unmonitor Instances command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -571,7 +572,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.createTags(createTagsRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create tags command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create tags command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Created tags [{}] ", createTagsRequest.tags());
@@ -600,7 +601,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.createTags(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create tags command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create tags command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -623,7 +624,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = ec2Client.deleteTags(deleteTagsRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete tags command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete tags command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("Delete tags [{}]  ", deleteTagsRequest.tags());
@@ -652,7 +653,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = ec2Client.deleteTags(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete tags command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete tags command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
 
@@ -701,7 +702,7 @@ public class AWS2EC2Producer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 LOG.trace("{} request performing", operationName);
@@ -715,7 +716,7 @@ public class AWS2EC2Producer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-ecs/src/main/java/org/apache/camel/component/aws2/ecs/ECS2Producer.java
+++ b/components/camel-aws/camel-aws2-ecs/src/main/java/org/apache/camel/component/aws2/ecs/ECS2Producer.java
@@ -24,6 +24,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -223,7 +224,7 @@ public class ECS2Producer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -236,7 +237,7 @@ public class ECS2Producer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-eks/src/main/java/org/apache/camel/component/aws2/eks/EKS2Producer.java
+++ b/components/camel-aws/camel-aws2-eks/src/main/java/org/apache/camel/component/aws2/eks/EKS2Producer.java
@@ -24,6 +24,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -228,7 +229,7 @@ public class EKS2Producer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -241,7 +242,7 @@ public class EKS2Producer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducer.java
+++ b/components/camel-aws/camel-aws2-eventbridge/src/main/java/org/apache/camel/component/aws2/eventbridge/EventbridgeProducer.java
@@ -29,6 +29,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -149,7 +150,7 @@ public class EventbridgeProducer extends DefaultProducer {
                 try {
                     result = eventbridgeClient.putRule(putRuleRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("PutRule command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("PutRule command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -180,7 +181,7 @@ public class EventbridgeProducer extends DefaultProducer {
             try {
                 result = eventbridgeClient.putRule(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Put Rule command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Put Rule command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -472,7 +473,7 @@ public class EventbridgeProducer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -485,7 +486,7 @@ public class EventbridgeProducer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-iam/src/main/java/org/apache/camel/component/aws2/iam/IAM2Producer.java
+++ b/components/camel-aws/camel-aws2-iam/src/main/java/org/apache/camel/component/aws2/iam/IAM2Producer.java
@@ -24,6 +24,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -970,7 +971,7 @@ public class IAM2Producer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -983,7 +984,7 @@ public class IAM2Producer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/firehose/KinesisFirehose2Producer.java
+++ b/components/camel-aws/camel-aws2-kinesis/src/main/java/org/apache/camel/component/aws2/firehose/KinesisFirehose2Producer.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -241,14 +242,14 @@ public class KinesisFirehose2Producer extends DefaultProducer {
             try {
                 result = pojoExecutor.apply(requestClass.cast(payload));
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         } else if (headerExecutor != null) {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         } else {

--- a/components/camel-aws/camel-aws2-kms/src/main/java/org/apache/camel/component/aws2/kms/KMS2Producer.java
+++ b/components/camel-aws/camel-aws2-kms/src/main/java/org/apache/camel/component/aws2/kms/KMS2Producer.java
@@ -24,6 +24,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -259,7 +260,7 @@ public class KMS2Producer extends DefaultProducer {
                 try {
                     result = pojoExecutor.apply(requestClass.cast(payload));
                 } catch (AwsServiceException ase) {
-                    LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                    LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -272,7 +273,7 @@ public class KMS2Producer extends DefaultProducer {
             try {
                 result = headerExecutor.get();
             } catch (AwsServiceException ase) {
-                LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+                LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }

--- a/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2Producer.java
+++ b/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2Producer.java
@@ -27,6 +27,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -239,7 +240,7 @@ public class Lambda2Producer extends DefaultProducer {
             result = lambdaClient
                     .getFunction(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("getFunction command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("getFunction command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -260,7 +261,7 @@ public class Lambda2Producer extends DefaultProducer {
             result = lambdaClient
                     .deleteFunction(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("deleteFunction command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("deleteFunction command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -287,7 +288,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.listFunctions(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listFunctions command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listFunctions command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -309,7 +310,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.invoke(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("invokeFunction command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("invokeFunction command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -448,7 +449,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.createFunction(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("createFunction command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("createFunction command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
 
@@ -483,7 +484,7 @@ public class Lambda2Producer extends DefaultProducer {
             result = lambdaClient.updateFunctionCode(request);
 
         } catch (AwsServiceException ase) {
-            LOG.trace("updateFunction command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("updateFunction command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
 
@@ -513,7 +514,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.createEventSourceMapping(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("createEventSourceMapping command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("createEventSourceMapping command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -538,7 +539,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.deleteEventSourceMapping(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("deleteEventSourceMapping command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("deleteEventSourceMapping command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -558,7 +559,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.listEventSourceMappings(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listEventSourceMapping command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listEventSourceMapping command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -583,7 +584,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.listTags(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listTags command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listTags command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -615,7 +616,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.tagResource(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listTags command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listTags command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -647,7 +648,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.untagResource(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("untagResource command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("untagResource command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -675,7 +676,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.publishVersion(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("publishVersion command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("publishVersion command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -703,7 +704,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.listVersionsByFunction(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listVersions command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listVersions command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -737,7 +738,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.createAlias(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("createAlias command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("createAlias command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -762,7 +763,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.deleteAlias(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("deleteAlias command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("deleteAlias command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -787,7 +788,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.getAlias(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("getAlias command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("getAlias command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -819,7 +820,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.listAliases(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listAliases command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listAliases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -859,7 +860,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.createFunctionUrlConfig(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("createFunctionUrlConfig command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("createFunctionUrlConfig command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -887,7 +888,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.getFunctionUrlConfig(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("getFunctionUrlConfig command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("getFunctionUrlConfig command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -926,7 +927,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.updateFunctionUrlConfig(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("updateFunctionUrlConfig command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("updateFunctionUrlConfig command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -954,7 +955,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.deleteFunctionUrlConfig(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("deleteFunctionUrlConfig command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("deleteFunctionUrlConfig command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -984,7 +985,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.listFunctionUrlConfigs(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("listFunctionUrlConfigs command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("listFunctionUrlConfigs command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1050,7 +1051,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.getFunctionConfiguration(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("getFunctionConfiguration command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("getFunctionConfiguration command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1109,7 +1110,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.updateFunctionConfiguration(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("updateFunctionConfiguration command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("updateFunctionConfiguration command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1138,7 +1139,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.putFunctionConcurrency(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("putFunctionConcurrency command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("putFunctionConcurrency command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1158,7 +1159,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.deleteFunctionConcurrency(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("deleteFunctionConcurrency command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("deleteFunctionConcurrency command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1178,7 +1179,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.getFunctionConcurrency(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("getFunctionConcurrency command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("getFunctionConcurrency command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1232,7 +1233,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.addPermission(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("addPermission command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("addPermission command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1264,7 +1265,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.removePermission(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("removePermission command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("removePermission command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);
@@ -1290,7 +1291,7 @@ public class Lambda2Producer extends DefaultProducer {
         try {
             result = lambdaClient.getPolicy(request);
         } catch (AwsServiceException ase) {
-            LOG.trace("getPolicy command returned the error code {}", ase.awsErrorDetails().errorCode());
+            LOG.trace("getPolicy command returned the error code {}", AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
         Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2Producer.java
+++ b/components/camel-aws/camel-aws2-mq/src/main/java/org/apache/camel/component/aws2/mq/MQ2Producer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -126,7 +127,7 @@ public class MQ2Producer extends DefaultProducer {
                 try {
                     result = mqClient.listBrokers(listBrokersRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Brokers command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Brokers command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -151,7 +152,7 @@ public class MQ2Producer extends DefaultProducer {
             try {
                 result = mqClient.listBrokers(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Brokers command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Brokers command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -177,7 +178,7 @@ public class MQ2Producer extends DefaultProducer {
                 try {
                     result = mqClient.createBroker(createBrokerRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -234,7 +235,7 @@ public class MQ2Producer extends DefaultProducer {
             try {
                 result = mqClient.createBroker(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -253,7 +254,7 @@ public class MQ2Producer extends DefaultProducer {
                 try {
                     result = mqClient.deleteBroker(deleteBrokerRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -274,7 +275,7 @@ public class MQ2Producer extends DefaultProducer {
             try {
                 result = mqClient.deleteBroker(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -291,7 +292,7 @@ public class MQ2Producer extends DefaultProducer {
                 try {
                     result = mqClient.rebootBroker(rebootBrokerRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Reboot Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Reboot Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -312,7 +313,7 @@ public class MQ2Producer extends DefaultProducer {
             try {
                 result = mqClient.rebootBroker(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Reboot Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Reboot Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -330,7 +331,7 @@ public class MQ2Producer extends DefaultProducer {
                 try {
                     result = mqClient.updateBroker(updateBrokerRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Update Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Update Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -357,7 +358,7 @@ public class MQ2Producer extends DefaultProducer {
             try {
                 result = mqClient.updateBroker(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Update Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Update Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -374,7 +375,7 @@ public class MQ2Producer extends DefaultProducer {
                 try {
                     result = mqClient.describeBroker(describeBrokerRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Reboot Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Reboot Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -395,7 +396,7 @@ public class MQ2Producer extends DefaultProducer {
             try {
                 result = mqClient.describeBroker(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Broker command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Broker command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-msk/src/main/java/org/apache/camel/component/aws2/msk/MSK2Producer.java
+++ b/components/camel-aws/camel-aws2-msk/src/main/java/org/apache/camel/component/aws2/msk/MSK2Producer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -108,7 +109,7 @@ public class MSK2Producer extends DefaultProducer {
                 try {
                     result = mskClient.listClusters(listClustersRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Clusters command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Clusters command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -137,7 +138,7 @@ public class MSK2Producer extends DefaultProducer {
             try {
                 result = mskClient.listClusters(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Clusters command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Clusters command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -155,7 +156,7 @@ public class MSK2Producer extends DefaultProducer {
                 try {
                     response = mskClient.createCluster(createClusterRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Cluster command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Cluster command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -195,7 +196,7 @@ public class MSK2Producer extends DefaultProducer {
             try {
                 response = mskClient.createCluster(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Cluster command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Cluster command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -213,7 +214,7 @@ public class MSK2Producer extends DefaultProducer {
                 try {
                     result = mskClient.deleteCluster(deleteClusterRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Cluster command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Cluster command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -234,7 +235,7 @@ public class MSK2Producer extends DefaultProducer {
             try {
                 result = mskClient.deleteCluster(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Cluster command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Cluster command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -250,7 +251,7 @@ public class MSK2Producer extends DefaultProducer {
                 try {
                     result = mskClient.describeCluster(describeClusterRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Cluster command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Cluster command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -271,7 +272,7 @@ public class MSK2Producer extends DefaultProducer {
             try {
                 result = mskClient.describeCluster(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Cluster command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Cluster command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-polly/src/main/java/org/apache/camel/component/aws2/polly/Polly2Producer.java
+++ b/components/camel-aws/camel-aws2-polly/src/main/java/org/apache/camel/component/aws2/polly/Polly2Producer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -139,7 +140,7 @@ public class Polly2Producer extends DefaultProducer {
                 try {
                     result = pollyClient.synthesizeSpeech(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Synthesize Speech command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Synthesize Speech command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -226,7 +227,7 @@ public class Polly2Producer extends DefaultProducer {
             try {
                 result = pollyClient.synthesizeSpeech(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Synthesize Speech command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Synthesize Speech command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -246,7 +247,7 @@ public class Polly2Producer extends DefaultProducer {
                 try {
                     result = pollyClient.describeVoices(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Voices command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Voices command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -280,7 +281,7 @@ public class Polly2Producer extends DefaultProducer {
             try {
                 result = pollyClient.describeVoices(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Voices command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Voices command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -296,7 +297,7 @@ public class Polly2Producer extends DefaultProducer {
                 try {
                     result = pollyClient.listLexicons(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Lexicons command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Lexicons command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -311,7 +312,7 @@ public class Polly2Producer extends DefaultProducer {
             try {
                 result = pollyClient.listLexicons(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("List Lexicons command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Lexicons command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -327,7 +328,7 @@ public class Polly2Producer extends DefaultProducer {
                 try {
                     result = pollyClient.getLexicon(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Lexicon command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Lexicon command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -349,7 +350,7 @@ public class Polly2Producer extends DefaultProducer {
             try {
                 result = pollyClient.getLexicon(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Lexicon command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Lexicon command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -365,7 +366,7 @@ public class Polly2Producer extends DefaultProducer {
                 try {
                     result = pollyClient.putLexicon(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Put Lexicon command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Put Lexicon command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -400,7 +401,7 @@ public class Polly2Producer extends DefaultProducer {
             try {
                 result = pollyClient.putLexicon(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Put Lexicon command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Put Lexicon command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -416,7 +417,7 @@ public class Polly2Producer extends DefaultProducer {
                 try {
                     result = pollyClient.deleteLexicon(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Lexicon command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Lexicon command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -438,7 +439,7 @@ public class Polly2Producer extends DefaultProducer {
             try {
                 result = pollyClient.deleteLexicon(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Lexicon command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Lexicon command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-redshift/src/main/java/org/apache/camel/component/aws2/redshift/data/RedshiftData2Producer.java
+++ b/components/camel-aws/camel-aws2-redshift/src/main/java/org/apache/camel/component/aws2/redshift/data/RedshiftData2Producer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -97,7 +98,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.listDatabases(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Databases command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Databases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -138,7 +139,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.listDatabases(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Databases command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Databases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -154,7 +155,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.listSchemas(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Schemas command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Schemas command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -202,7 +203,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.listSchemas(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Schemas command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Schemas command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -218,7 +219,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.listStatements(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Statements command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Statements command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -251,7 +252,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.listStatements(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Statements command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Statements command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -267,7 +268,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.listTables(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Tables command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Tables command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -319,7 +320,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.listTables(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Tables command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Tables command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -335,7 +336,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.describeTable(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -388,7 +389,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.describeTable(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -404,7 +405,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.executeStatement(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Execute Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Execute Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -461,7 +462,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.executeStatement(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Execute Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Execute Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -478,7 +479,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.batchExecuteStatement(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Batch Execute Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Batch Execute Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -530,7 +531,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.batchExecuteStatement(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Batch Execute Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Batch Execute Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -546,7 +547,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.cancelStatement(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Cancel Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Cancel Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -566,7 +567,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.cancelStatement(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Cancel Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Cancel Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -582,7 +583,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.describeStatement(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -602,7 +603,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.describeStatement(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Statement command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Statement command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -618,7 +619,7 @@ public class RedshiftData2Producer extends DefaultProducer {
                 try {
                     result = redshiftDataClient.getStatementResult(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Statement Result command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Statement Result command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -638,7 +639,7 @@ public class RedshiftData2Producer extends DefaultProducer {
             try {
                 result = redshiftDataClient.getStatementResult(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Statement Result command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Statement Result command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-rekognition/src/main/java/org/apache/camel/component/aws2/rekognition/Rekognition2Producer.java
+++ b/components/camel-aws/camel-aws2-rekognition/src/main/java/org/apache/camel/component/aws2/rekognition/Rekognition2Producer.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -183,7 +184,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.associateFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Associate Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Associate Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -219,7 +220,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.associateFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Associate Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Associate Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -235,7 +236,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.compareFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Compare Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Compare Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -266,7 +267,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.compareFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Compare Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Compare Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -282,7 +283,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.createCollection(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Collection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Collection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -301,7 +302,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.createCollection(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Collection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Collection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -317,7 +318,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.createUser(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create User command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create User command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -345,7 +346,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.createUser(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create User command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create User command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -361,7 +362,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.deleteCollection(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Collection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Collection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -380,7 +381,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.deleteCollection(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Collection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Collection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -396,7 +397,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.deleteFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -419,7 +420,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.deleteFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -435,7 +436,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.deleteUser(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete User command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete User command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -463,7 +464,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.deleteUser(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete User command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete User command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -479,7 +480,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.describeCollection(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Collection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Collection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -498,7 +499,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.describeCollection(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Collection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Collection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -514,7 +515,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.detectFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -537,7 +538,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.detectFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -553,7 +554,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.detectLabels(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Labels command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Labels command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -590,7 +591,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.detectLabels(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Labels command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Labels command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -606,7 +607,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.detectModerationLabels(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Moderation Labels command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Moderation Labels command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -638,7 +639,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.detectModerationLabels(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Moderation Labels command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Moderation Labels command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -682,7 +683,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.detectProtectiveEquipment(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Protective Equipment command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Protective Equipment command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -698,7 +699,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.detectText(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Text command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Text command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -722,7 +723,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.detectText(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Text command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Text command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -738,7 +739,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.disassociateFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Disassociate Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Disassociate Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -770,7 +771,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.disassociateFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Disassociate Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Disassociate Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -786,7 +787,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.getCelebrityInfo(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Celebrity Info command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Celebrity Info command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -805,7 +806,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.getCelebrityInfo(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Celebrity Info command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Celebrity Info command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -821,7 +822,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.getMediaAnalysisJob(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Media Analysis Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Media Analysis Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -840,7 +841,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.getMediaAnalysisJob(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Media Analysis Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Media Analysis Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -856,7 +857,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.indexFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Index Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Index Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -896,7 +897,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.indexFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Index Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Index Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -912,7 +913,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.listCollections(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Collections command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Collections command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -935,7 +936,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.listCollections(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Collections command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Collections command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -951,7 +952,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.listMediaAnalysisJobs(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Media Analysis Jobs command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Media Analysis Jobs command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -974,7 +975,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.listMediaAnalysisJobs(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Media Analysis Jobs command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Media Analysis Jobs command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -990,7 +991,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.listFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1025,7 +1026,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.listFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1041,7 +1042,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.listUsers(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Users command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Users command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1068,7 +1069,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.listUsers(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Users command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Users command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1084,7 +1085,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.recognizeCelebrities(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Recognize Celebrities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Recognize Celebrities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1103,7 +1104,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.recognizeCelebrities(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Recognize Celebrities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Recognize Celebrities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1119,7 +1120,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.searchFaces(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Search Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Search Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1150,7 +1151,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.searchFaces(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Search Faces command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Search Faces command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1166,7 +1167,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.searchFacesByImage(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Search Faces By Image command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Search Faces By Image command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1201,7 +1202,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.searchFacesByImage(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Search Faces By Image command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Search Faces By Image command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1217,7 +1218,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.searchUsers(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Search Users command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Search Users command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1252,7 +1253,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.searchUsers(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Search Users command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Search Users command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1268,7 +1269,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.searchUsersByImage(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Search Users By Image command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Search Users By Image command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1303,7 +1304,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.searchUsersByImage(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Search Users By Image command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Search Users By Image command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -1319,7 +1320,7 @@ public class Rekognition2Producer extends DefaultProducer {
                 try {
                     result = rekognitionClient.startMediaAnalysisJob(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Media Analysis Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Media Analysis Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -1361,7 +1362,7 @@ public class Rekognition2Producer extends DefaultProducer {
             try {
                 result = rekognitionClient.startMediaAnalysisJob(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Media Analysis Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Media Analysis Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
+++ b/components/camel-aws/camel-aws2-step-functions/src/main/java/org/apache/camel/component/aws2/stepfunctions/StepFunctions2Producer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -106,7 +107,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.createStateMachine(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -146,7 +147,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.createStateMachine(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -162,7 +163,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.deleteStateMachine(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -183,7 +184,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 DeleteStateMachineRequest request = builder.build();
                 result = sfnClient.deleteStateMachine(request);
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -199,7 +200,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.updateStateMachine(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Update State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Update State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -229,7 +230,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.updateStateMachine(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Update State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Update State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -245,7 +246,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.describeStateMachine(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -265,7 +266,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.describeStateMachine(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe State Machine command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe State Machine command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -281,7 +282,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.listStateMachines(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List State Machines command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List State Machines command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -301,7 +302,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.listStateMachines(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List State Machines command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List State Machines command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -317,7 +318,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.createActivity(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Activity command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Activity command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -337,7 +338,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.createActivity(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Activity command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Activity command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -353,7 +354,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.deleteActivity(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Activity command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Activity command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -373,7 +374,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.deleteActivity(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Activity command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Activity command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -389,7 +390,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.describeActivity(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Activity command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Activity command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -409,7 +410,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.describeActivity(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Activity command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Activity command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -425,7 +426,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.getActivityTask(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Activity Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Activity Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -445,7 +446,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.getActivityTask(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Activity Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Activity Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -461,7 +462,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.listActivities(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Activities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Activities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -481,7 +482,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.listActivities(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Activities command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Activities command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -497,7 +498,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.startExecution(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -530,7 +531,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.startExecution(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -546,7 +547,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.startSyncExecution(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Sync Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Sync Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -579,7 +580,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.startSyncExecution(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Sync Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Sync Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -595,7 +596,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.stopExecution(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Stop Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Stop Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -615,7 +616,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.stopExecution(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Stop Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Stop Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -631,7 +632,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.describeExecution(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -651,7 +652,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.describeExecution(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Execution command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Execution command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -667,7 +668,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.listExecutions(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Executions command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Executions command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -691,7 +692,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.listExecutions(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Executions command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Executions command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -707,7 +708,7 @@ public class StepFunctions2Producer extends DefaultProducer {
                 try {
                     result = sfnClient.getExecutionHistory(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Execution History command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Execution History command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -742,7 +743,7 @@ public class StepFunctions2Producer extends DefaultProducer {
             try {
                 result = sfnClient.getExecutionHistory(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Execution History command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Execution History command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-sts/src/main/java/org/apache/camel/component/aws2/sts/STS2Producer.java
+++ b/components/camel-aws/camel-aws2-sts/src/main/java/org/apache/camel/component/aws2/sts/STS2Producer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -98,7 +99,7 @@ public class STS2Producer extends DefaultProducer {
                 try {
                     result = stsClient.assumeRole(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Assume Role command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Assume Role command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -130,7 +131,7 @@ public class STS2Producer extends DefaultProducer {
             try {
                 result = stsClient.assumeRole(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Assume Role command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Assume Role command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -155,7 +156,7 @@ public class STS2Producer extends DefaultProducer {
                 try {
                     result = stsClient.getSessionToken(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Session Token command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Session Token command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -170,7 +171,7 @@ public class STS2Producer extends DefaultProducer {
             try {
                 result = stsClient.getSessionToken(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Session Token command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Session Token command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -192,7 +193,7 @@ public class STS2Producer extends DefaultProducer {
                 try {
                     result = stsClient.getFederationToken(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Federation Token command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Federation Token command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -213,7 +214,7 @@ public class STS2Producer extends DefaultProducer {
             try {
                 result = stsClient.getFederationToken(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Federation Token command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Federation Token command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-textract/src/main/java/org/apache/camel/component/aws2/textract/Textract2Producer.java
+++ b/components/camel-aws/camel-aws2-textract/src/main/java/org/apache/camel/component/aws2/textract/Textract2Producer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -118,7 +119,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.detectDocumentText(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Detect Document Text command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Detect Document Text command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -136,7 +137,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.detectDocumentText(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Detect Document Text command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Detect Document Text command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -152,7 +153,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.analyzeDocument(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Analyze Document command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Analyze Document command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -179,7 +180,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.analyzeDocument(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Analyze Document command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Analyze Document command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -195,7 +196,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.analyzeExpense(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Analyze Expense command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Analyze Expense command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -213,7 +214,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.analyzeExpense(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Analyze Expense command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Analyze Expense command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -265,7 +266,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.startDocumentAnalysis(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Document Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Document Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -291,7 +292,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.startDocumentAnalysis(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Document Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Document Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -307,7 +308,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.startExpenseAnalysis(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Expense Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Expense Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -325,7 +326,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.startExpenseAnalysis(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Expense Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Expense Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -377,7 +378,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.getDocumentTextDetection(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Document Text Detection command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Document Text Detection command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -393,7 +394,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.getDocumentAnalysis(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Document Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Document Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -428,7 +429,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.getDocumentAnalysis(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Document Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Document Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -444,7 +445,7 @@ public class Textract2Producer extends DefaultProducer {
                 try {
                     result = textractClient.getExpenseAnalysis(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Expense Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Expense Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -479,7 +480,7 @@ public class Textract2Producer extends DefaultProducer {
             try {
                 result = textractClient.getExpenseAnalysis(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Expense Analysis command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Expense Analysis command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/query/Timestream2QueryProducer.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.component.aws2.timestream.Timestream2Configuration;
 import org.apache.camel.component.aws2.timestream.Timestream2Constants;
 import org.apache.camel.component.aws2.timestream.Timestream2Operations;
@@ -108,7 +109,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.describeEndpoints(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Endpoints command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Endpoints command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -124,7 +125,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.describeEndpoints(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Endpoints command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Endpoints command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -141,7 +142,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.createScheduledQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -247,7 +248,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.createScheduledQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -264,7 +265,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.deleteScheduledQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -285,7 +286,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.deleteScheduledQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -303,7 +304,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.executeScheduledQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Execute Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Execute Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -335,7 +336,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.executeScheduledQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Execute Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Execute Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -352,7 +353,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.updateScheduledQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Update Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Update Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -378,7 +379,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.updateScheduledQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Update Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Update Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -395,7 +396,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.describeScheduledQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -411,7 +412,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.describeScheduledQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Scheduled Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Scheduled Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -428,7 +429,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.listScheduledQueries(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Scheduled Queries command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Scheduled Queries command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -449,7 +450,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.listScheduledQueries(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Scheduled Queries command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Scheduled Queries command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -465,7 +466,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.prepareQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Prepare Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Prepare Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -491,7 +492,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.prepareQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Prepare Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Prepare Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -507,7 +508,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.query(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -533,7 +534,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.query(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -549,7 +550,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
                 try {
                     result = timestreamQueryClient.cancelQuery(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Cancel Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Cancel Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -570,7 +571,7 @@ public class Timestream2QueryProducer extends DefaultProducer {
             try {
                 result = timestreamQueryClient.cancelQuery(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Cancel Query command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Cancel Query command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducer.java
+++ b/components/camel-aws/camel-aws2-timestream/src/main/java/org/apache/camel/component/aws2/timestream/write/Timestream2WriteProducer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.component.aws2.timestream.Timestream2Configuration;
 import org.apache.camel.component.aws2.timestream.Timestream2Constants;
 import org.apache.camel.component.aws2.timestream.Timestream2Operations;
@@ -114,7 +115,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.describeEndpoints(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Endpoints command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Endpoints command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -130,7 +131,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.describeEndpoints(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Endpoints command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Endpoints command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -147,7 +148,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.createBatchLoadTask(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Batch Load Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Batch Load Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -194,7 +195,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.createBatchLoadTask(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Batch Load Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Batch Load Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -211,7 +212,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.describeBatchLoadTask(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Batch Load Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Batch Load Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -231,7 +232,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.describeBatchLoadTask(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Batch Load Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Batch Load Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -248,7 +249,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.resumeBatchLoadTask(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Resume Batch Load Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Resume Batch Load Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -268,7 +269,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.resumeBatchLoadTask(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Resume Batch Load Task command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Resume Batch Load Task command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -285,7 +286,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.listBatchLoadTasks(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Batch Load Tasks command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Batch Load Tasks command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -309,7 +310,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.listBatchLoadTasks(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Batch Load Tasks command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Batch Load Tasks command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -325,7 +326,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.createDatabase(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -349,7 +350,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.createDatabase(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -365,7 +366,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.deleteDatabase(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -385,7 +386,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.deleteDatabase(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -402,7 +403,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.describeDatabase(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -422,7 +423,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.describeDatabase(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -438,7 +439,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.updateDatabase(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Update Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Update Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -462,7 +463,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.updateDatabase(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Update Database command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Update Database command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -478,7 +479,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.listDatabases(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Databases command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Databases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -498,7 +499,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.listDatabases(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Databases command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Databases command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -514,7 +515,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.createTable(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -552,7 +553,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.createTable(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -568,7 +569,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.deleteTable(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -592,7 +593,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.deleteTable(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -608,7 +609,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.describeTable(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Describe Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Describe Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -632,7 +633,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.describeTable(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Describe Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Describe Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -648,7 +649,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.updateTable(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Update Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Update Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -686,7 +687,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.updateTable(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Update Table command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Update Table command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -702,7 +703,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.listTables(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Tables command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Tables command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -726,7 +727,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.listTables(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Tables command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Tables command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -742,7 +743,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
                 try {
                     result = timestreamWriteClient.writeRecords(request);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Write Records command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Write Records command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -774,7 +775,7 @@ public class Timestream2WriteProducer extends DefaultProducer {
             try {
                 result = timestreamWriteClient.writeRecords(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Write Records command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Write Records command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);

--- a/components/camel-aws/camel-aws2-transcribe/src/main/java/org/apache/camel/component/aws2/transcribe/Transcribe2Producer.java
+++ b/components/camel-aws/camel-aws2-transcribe/src/main/java/org/apache/camel/component/aws2/transcribe/Transcribe2Producer.java
@@ -25,6 +25,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -151,7 +152,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.startTranscriptionJob(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Start Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Start Transcription Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -182,7 +183,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.startTranscriptionJob(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Start Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Start Transcription Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -198,7 +199,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.getTranscriptionJob(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Transcription Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -217,7 +218,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.getTranscriptionJob(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Transcription Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -233,7 +234,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.listTranscriptionJobs(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Transcription Jobs command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Transcription Jobs command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -256,7 +257,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.listTranscriptionJobs(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Transcription Jobs command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Transcription Jobs command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -271,7 +272,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     transcribeClient.deleteTranscriptionJob(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Transcription Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -287,7 +288,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 transcribeClient.deleteTranscriptionJob(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Transcription Job command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Transcription Job command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }
@@ -302,7 +303,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.createVocabulary(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Create Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Create Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -329,7 +330,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.createVocabulary(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Create Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Create Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -345,7 +346,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.getVocabulary(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Get Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Get Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -364,7 +365,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.getVocabulary(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Get Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Get Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -380,7 +381,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.listVocabularies(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("List Vocabularies command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("List Vocabularies command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -399,7 +400,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.listVocabularies(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("List Vocabularies command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("List Vocabularies command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -415,7 +416,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     result = transcribeClient.updateVocabulary(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Update Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Update Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -438,7 +439,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 result = transcribeClient.updateVocabulary(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Update Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Update Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);
@@ -453,7 +454,7 @@ public class Transcribe2Producer extends DefaultProducer {
                 try {
                     transcribeClient.deleteVocabulary(req);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Delete Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Delete Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
             } else {
@@ -469,7 +470,7 @@ public class Transcribe2Producer extends DefaultProducer {
             try {
                 transcribeClient.deleteVocabulary(builder.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Delete Vocabulary command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Delete Vocabulary command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
         }
@@ -930,7 +931,7 @@ public class Transcribe2Producer extends DefaultProducer {
         try {
             return call.get();
         } catch (AwsServiceException ase) {
-            LOG.trace("{} command returned the error code {}", operationName, ase.awsErrorDetails().errorCode());
+            LOG.trace("{} command returned the error code {}", operationName, AwsExceptionUtil.errorCode(ase));
             throw ase;
         }
     }

--- a/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2Producer.java
+++ b/components/camel-aws/camel-aws2-translate/src/main/java/org/apache/camel/component/aws2/translate/Translate2Producer.java
@@ -22,6 +22,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.component.aws.common.AwsExceptionUtil;
 import org.apache.camel.health.HealthCheck;
 import org.apache.camel.health.HealthCheckHelper;
 import org.apache.camel.health.WritableHealthCheckRepository;
@@ -95,7 +96,7 @@ public class Translate2Producer extends DefaultProducer {
                 try {
                     result = translateClient.translateText(translateTextRequest);
                 } catch (AwsServiceException ase) {
-                    LOG.trace("Translate Text command returned the error code {}", ase.awsErrorDetails().errorCode());
+                    LOG.trace("Translate Text command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                     throw ase;
                 }
                 Message message = getMessageForResponse(exchange);
@@ -146,7 +147,7 @@ public class Translate2Producer extends DefaultProducer {
             try {
                 result = translateClient.translateText(request.build());
             } catch (AwsServiceException ase) {
-                LOG.trace("Translate Text command returned the error code {}", ase.awsErrorDetails().errorCode());
+                LOG.trace("Translate Text command returned the error code {}", AwsExceptionUtil.errorCode(ase));
                 throw ase;
             }
             Message message = getMessageForResponse(exchange);


### PR DESCRIPTION
# CAMEL-24262: guard nullable `awsErrorDetails()` when logging the AWS error code

## Motivation

`software.amazon.awssdk.awscore.exception.AwsServiceException#awsErrorDetails()` is **nullable**. Across the `camel-aws` producers, catch blocks log the AWS error code like this:

```java
} catch (AwsServiceException ase) {
    LOG.trace("getFunction command returned the error code {}", ase.awsErrorDetails().errorCode());
    throw ase;
}
```

Because a method argument is evaluated **eagerly, regardless of the configured log level**, `ase.awsErrorDetails().errorCode()` runs even when `TRACE`/`DEBUG` is disabled. When `awsErrorDetails()` returns `null` (e.g. connection/SDK-level failures that are not a modeled service error), this throws a `NullPointerException` from inside the catch block, **masking the original AWS exception** that was about to be rethrown.

## Fix

- Add a small null-safe helper `AwsExceptionUtil.errorCode(AwsServiceException)` in `camel-aws-common` (returns `null` when the exception or its `awsErrorDetails()` is absent).
- Route every producer catch-block error-code log statement across the `camel-aws` components through it, replacing `x.awsErrorDetails().errorCode()` with `AwsExceptionUtil.errorCode(x)`.

This is a defensive robustness fix: behaviour is unchanged on the happy path (the real error code is still logged), but a `null` `awsErrorDetails` can no longer shadow the underlying exception.

## Scope

- New: `AwsExceptionUtil` + unit test in `camel-aws-common`.
- 28 producers updated across 25 `camel-aws` modules (bedrock, comprehend, config, ec2, ecs, eks, eventbridge, iam, kinesis-firehose, kms, lambda, mq, msk, parameter-store, polly, redshift-data, rekognition, secrets-manager, security-hub, step-functions, sts, textract, timestream, transcribe, translate).
- The `*ProducerHealthCheck` classes already guard this inline (CAMEL-24251) and are untouched.

No public API change, no new dependency (the helper lives in the shared `camel-aws-common` that every producer already depends on).

## Testing

- New hermetic unit test `AwsExceptionUtilTest` (3 cases: error code present, `awsErrorDetails` absent → `null`, `null` exception → `null`) — no LocalStack / real AWS.
- Full reactor `mvn clean install -Dquickly` is green.

Only targeting `main` (4.22.0) — low-severity, non-behavioural hardening.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
