### PR TITLE
ci: fix CamelJfrDevConsoleTest for the registered -> runtimeEvents status rename

### DIFF
--- a/components/camel-jfr/src/test/java/org/apache/camel/runtime/jfr/CamelJfrDevConsoleTest.java
+++ b/components/camel-jfr/src/test/java/org/apache/camel/runtime/jfr/CamelJfrDevConsoleTest.java
@@ -71,7 +71,7 @@ class CamelJfrDevConsoleTest extends CamelTestSupport {
         String text = (String) console.call(DevConsole.MediaType.TEXT, Map.of("command", "status"));
 
         assertThat(text)
-                .contains("registered: false")
+                .contains("runtimeEvents: false")
                 .contains("event route")
                 .contains("event processor")
                 .contains("event exchange")
@@ -92,7 +92,7 @@ class CamelJfrDevConsoleTest extends CamelTestSupport {
 
             String text = (String) resolveConsole(ctx).call(DevConsole.MediaType.TEXT, Map.of("command", "status"));
 
-            assertThat(text).contains("registered: true");
+            assertThat(text).contains("runtimeEvents: true");
         }
     }
 
@@ -180,7 +180,7 @@ class CamelJfrDevConsoleTest extends CamelTestSupport {
         CamelJfrDevConsole console = resolveConsole(context);
         try (Recording recording = startRecordingWithAllEvents()) {
             JsonObject status = (JsonObject) console.call(DevConsole.MediaType.JSON, Map.of("command", "status"));
-            assertThat(status.getBoolean("registered")).isFalse();
+            assertThat(status.getBoolean("runtimeEvents")).isFalse();
             assertThat(status.getJsonObject("events")).containsEntry("route", true);
 
             JsonObject toggle = (JsonObject) console.call(DevConsole.MediaType.JSON,


### PR DESCRIPTION
### Problem

`CamelJfrDevConsoleTest` fails **deterministically on `main`** — 3 of its status tests (`statusReportsNotRegisteredByDefault`, `statusReportsRegisteredWhenRuntimeInstrumentationEnabled`, `jsonStatusAndToggleReflectLiveState`).

`CamelJfrDevConsole` renamed its status field from `registered` to `runtimeEvents` — both the TEXT line (`sb.append("runtimeEvents: ")…`) and the JSON key (`root.put("runtimeEvents", …)`), keeping the same `isInstrumentationRegistered()` value — but the test still asserted the old `registered` name (TEXT `contains("registered: …")` and JSON `getBoolean("registered")`, which now returns null).

Because `camel-jfr` is transitively pulled into the scalpel build of any PR that touches a core module, this was failing the CI of unrelated PRs.

### Fix

Update the three assertions to the new `runtimeEvents` field name. Test-only, no production change. `CamelJfrDevConsoleTest` — **17 tests pass**.

_Claude Code on behalf of Andrea Cosentino (@oscerd)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
