### PR TITLE
CAMEL-24035: Fix flaky camel-core tests with timed mock assertions

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerTest.java
@@ -25,14 +25,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TwoSchedulerTest extends ContextTestSupport {
+class TwoSchedulerTest extends ContextTestSupport {
+
+    private static final long TIMEOUT_SECONDS = 30;
 
     @Test
-    public void testTwoScheduler() throws Exception {
+    void testTwoScheduler() throws Exception {
         getMockEndpoint("mock:a").expectedMinimumMessageCount(4);
         getMockEndpoint("mock:b").expectedMinimumMessageCount(2);
 
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // should use same thread as they share the same scheduler
         String tn1 = getMockEndpoint("mock:a").getReceivedExchanges().get(0).getMessage().getHeader("tn", String.class);

--- a/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/scheduler/TwoSchedulerTest.java
@@ -25,16 +25,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class TwoSchedulerTest extends ContextTestSupport {
-
-    private static final long TIMEOUT_SECONDS = 30;
+public class TwoSchedulerTest extends ContextTestSupport {
 
     @Test
-    void testTwoScheduler() throws Exception {
+    public void testTwoScheduler() throws Exception {
         getMockEndpoint("mock:a").expectedMinimumMessageCount(4);
         getMockEndpoint("mock:b").expectedMinimumMessageCount(2);
 
-        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
 
         // should use same thread as they share the same scheduler
         String tn1 = getMockEndpoint("mock:a").getReceivedExchanges().get(0).getMessage().getHeader("tn", String.class);

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
@@ -30,7 +30,9 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DistributedTimeoutTest extends AbstractDistributedTest {
+class DistributedTimeoutTest extends AbstractDistributedTest {
+
+    private static final long TIMEOUT_SECONDS = 30;
 
     private final MemoryAggregationRepository sharedAggregationRepository = new MemoryAggregationRepository(true);
 
@@ -41,7 +43,7 @@ public class DistributedTimeoutTest extends AbstractDistributedTest {
     private volatile long receivedTimeout;
 
     @Test
-    public void testAggregateTimeout() throws Exception {
+    void testAggregateTimeout() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:aggregated");
         MockEndpoint mock2 = getMockEndpoint2("mock:aggregated");
         mock.expectedMessageCount(0);
@@ -50,11 +52,11 @@ public class DistributedTimeoutTest extends AbstractDistributedTest {
         template.sendBodyAndHeader("direct:start", "A", "id", 123);
         template2.sendBodyAndHeader("direct:start", "B", "id", 123);
 
-        // wait a bit until the timeout was triggered
-        await().atMost(10, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
+        // wait until the timeout was triggered
+        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
 
-        mock.assertIsSatisfied();
-        mock2.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context2, TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         assertNotNull(receivedExchange);
         assertEquals("AB", receivedExchange.getIn().getBody());
@@ -72,8 +74,8 @@ public class DistributedTimeoutTest extends AbstractDistributedTest {
         template2.sendBodyAndHeader("direct:start", "B", "id", 123);
         template2.sendBodyAndHeader("direct:start", "C", "id", 123);
 
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
-        MockEndpoint.assertIsSatisfied(context2, 30, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context2, TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // should have not invoked the timeout method anymore
         assertEquals(1, invoked.get());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/aggregator/DistributedTimeoutTest.java
@@ -53,10 +53,10 @@ class DistributedTimeoutTest extends AbstractDistributedTest {
         template2.sendBodyAndHeader("direct:start", "B", "id", 123);
 
         // wait until the timeout was triggered
-        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> invoked.get() == 1);
 
-        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        MockEndpoint.assertIsSatisfied(context2, TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        mock.assertIsSatisfied();
+        mock2.assertIsSatisfied();
 
         assertNotNull(receivedExchange);
         assertEquals("AB", receivedExchange.getIn().getBody());

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
 
-public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTestSupport {
+class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTestSupport {
+
+    private static final long TIMEOUT_SECONDS = 30;
 
     private final String url = "seda:foo?concurrentConsumers=20";
     private MockEndpoint result;
@@ -55,7 +57,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
     }
 
     @Test
-    public void testThrottlingRoutePolicyStartWithAlwaysOpenOffThenToggle() throws Exception {
+    void testThrottlingRoutePolicyStartWithAlwaysOpenOffThenToggle() throws Exception {
         final ServiceSupport consumer = (ServiceSupport) context.getRoute("foo").getConsumer();
 
         // send first set of messages
@@ -65,7 +67,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
             template.sendBody(url, "MessageRound1 " + i);
         }
         result.expectedMessageCount(size);
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // set keepOpen to true
         policy.setKeepOpen(true);
@@ -75,7 +77,7 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
         template.sendBody(url, "MessageTrigger");
 
         // wait for the circuit to open (consumer suspended)
-        await().atMost(10, TimeUnit.SECONDS).until(consumer::isSuspended);
+        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS).until(consumer::isSuspended);
 
         // send next set of messages
         // should NOT go through b/c circuit is open
@@ -85,17 +87,17 @@ public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTest
 
         // should not close b/c keepOpen is true
         result.expectedMessageCount(size + 1);
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // set keepOpen to false
         policy.setKeepOpen(false);
 
         // wait for the consumer to resume since keepOpen is now false
-        await().atMost(10, TimeUnit.SECONDS).until(consumer::isStarted);
+        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS).until(consumer::isStarted);
 
         // it should close b/c keepOpen is false — queued messages should now arrive
         result.expectedMessageCount(size * 2 + 1);
-        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
+        MockEndpoint.assertIsSatisfied(context, TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/throttle/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
@@ -77,7 +77,7 @@ class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTestSupport
         template.sendBody(url, "MessageTrigger");
 
         // wait for the circuit to open (consumer suspended)
-        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS).until(consumer::isSuspended);
+        await().atMost(10, TimeUnit.SECONDS).until(consumer::isSuspended);
 
         // send next set of messages
         // should NOT go through b/c circuit is open
@@ -93,7 +93,7 @@ class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends ContextTestSupport
         policy.setKeepOpen(false);
 
         // wait for the consumer to resume since keepOpen is now false
-        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS).until(consumer::isStarted);
+        await().atMost(10, TimeUnit.SECONDS).until(consumer::isStarted);
 
         // it should close b/c keepOpen is false — queued messages should now arrive
         result.expectedMessageCount(size * 2 + 1);


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24035](https://issues.apache.org/jira/browse/CAMEL-24035): flaky `camel-core` tests due to timing issues in mock assertions.

**Note:** The core fixes for all three tests were already merged via [CAMEL-24037](https://issues.apache.org/jira/browse/CAMEL-24037) (#24635) and [CAMEL-24042](https://issues.apache.org/jira/browse/CAMEL-24042) (#24650). This PR completes the remaining polish:

- `DistributedTimeoutTest` — extract `TIMEOUT_SECONDS` constant for second-phase timed assertions; drop `public` modifier; keep bare `mock.assertIsSatisfied()` for count-0 first phase (timed assert adds no value there)
- `ThrottlingExceptionRoutePolicyOpenViaConfigTest` — extract `TIMEOUT_SECONDS` constant; drop `public` modifier; keep 10s Awaitility for consumer suspend/resume waits

`TwoSchedulerTest` unchanged — already fixed in CAMEL-24037.

## Test plan

- [x] `./mvnw -pl core/camel-core -am test -Dtest=TwoSchedulerTest,DistributedTimeoutTest,ThrottlingExceptionRoutePolicyOpenViaConfigTest`

---
_AI-generated PR description on behalf of atiaomar1978-hub_