### PR TITLE
CAMEL-24026: Fix flaky XsltFromFileExceptionTest

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
@@ -39,7 +39,8 @@ class XsltFromFileExceptionTest extends ContextTestSupport {
 
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello>", Exchange.FILE_NAME, "hello.xml");
 
-        // Wait for the file consumer route to finish — producer write alone is not enough.
+        // Do not use oneExchangeDone here: the producer write to fileUri() can satisfy
+        // the global whenDone(1) notify before the file consumer route runs.
         assertMockEndpointsSatisfied(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // File move happens after route processing; poll until the consumer has moved the file.
@@ -59,6 +60,8 @@ class XsltFromFileExceptionTest extends ContextTestSupport {
         // the last tag is not ended properly
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello", Exchange.FILE_NAME, "hello2.xml");
 
+        // Do not use oneExchangeDone here: the producer write to fileUri() can satisfy
+        // the global whenDone(1) notify before the file consumer route runs.
         assertMockEndpointsSatisfied(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/xslt/XsltFromFileExceptionTest.java
@@ -16,45 +16,57 @@
  */
 package org.apache.camel.component.xslt;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
+
 /**
  *
  */
-public class XsltFromFileExceptionTest extends ContextTestSupport {
+class XsltFromFileExceptionTest extends ContextTestSupport {
+
+    private static final long TIMEOUT_SECONDS = 30;
 
     @Test
-    public void testXsltFromFileExceptionOk() throws Exception {
+    void testXsltFromFileExceptionOk() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(1);
         getMockEndpoint("mock:error").expectedMessageCount(0);
 
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello>", Exchange.FILE_NAME, "hello.xml");
 
-        assertMockEndpointsSatisfied();
+        // Wait for the file consumer route to finish — producer write alone is not enough.
+        assertMockEndpointsSatisfied(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        oneExchangeDone.matchesWaitTime();
-
-        assertFileNotExists(testFile("hello.xml"));
-        assertFileExists(testFile("ok/hello.xml"));
+        // File move happens after route processing; poll until the consumer has moved the file.
+        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertFileNotExists(testFile("hello.xml"));
+                    assertFileExists(testFile("ok/hello.xml"));
+                });
     }
 
     @Test
-    public void testXsltFromFileExceptionFail() throws Exception {
+    void testXsltFromFileExceptionFail() throws Exception {
         getMockEndpoint("mock:result").expectedMessageCount(0);
         getMockEndpoint("mock:error").expectedMessageCount(1);
 
         // the last tag is not ended properly
         template.sendBodyAndHeader(fileUri(), "<hello>world!</hello", Exchange.FILE_NAME, "hello2.xml");
 
-        assertMockEndpointsSatisfied();
+        assertMockEndpointsSatisfied(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        oneExchangeDone.matchesWaitTime();
-
-        assertFileNotExists(testFile("hello2.xml"));
-        assertFileExists(testFile("error/hello2.xml"));
+        await().atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertFileNotExists(testFile("hello2.xml"));
+                    assertFileExists(testFile("error/hello2.xml"));
+                });
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24026](https://issues.apache.org/jira/browse/CAMEL-24026): `XsltFromFileExceptionTest` is flaky on slow CI when the file consumer has not finished before assertions run.

**Why #24625 was reverted:** reordering to wait on `oneExchangeDone` first still failed — the default 10s notify latch timed out (`Exchange should have completed` was false). Simply swapping assertion order was insufficient.

**This fix (different approach):**
- Use `assertMockEndpointsSatisfied(30, SECONDS)` so mock waits generously for the file consumer route to complete
- Poll file move completion with Awaitility (`ok/` / `error/` directories) instead of `oneExchangeDone`
- Drop reliance on the global `oneExchangeDone` notify latch, which races with producer vs consumer exchanges

## Test plan

- [x] `./mvnw -pl core/camel-core -am test -Dtest=XsltFromFileExceptionTest`

---
_AI-generated PR description on behalf of atiaomar1978-hub_