### PR TITLE
chore: fix ChatScript IT by switching Docker image

### DIFF
--- a/test-infra/camel-test-infra-chatscript/src/main/resources/org/apache/camel/test/infra/chatscript/services/container.properties
+++ b/test-infra/camel-test-infra-chatscript/src/main/resources/org/apache/camel/test/infra/chatscript/services/container.properties
@@ -14,5 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-## tested against 2.1.2, 2.2.0 & 2.3.1
-chatscript.container=mirror.gcr.io/claytantor/chatscript-docker:latest
+chatscript.container=mirror.gcr.io/mniehe/chatscript:latest


### PR DESCRIPTION
## Summary
- The `claytantor/chatscript-docker:latest` image contains a `/dev/agpgart` device node in one of its layers, causing `ContainerFetchException: failed to register layer: openat dev/agpgart: no such device` on CI
- Switch to `mniehe/chatscript:latest` which is Alpine-based, pulls cleanly, and is available on `mirror.gcr.io`

## Test plan
- [x] Verified `mniehe/chatscript` container starts and listens on port 1024
- [x] Ran `ChatScriptComponentIT` locally — 1 test, 0 failures

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)