### PR TITLE
CAMEL-24342: camel-google-storage - fix wrong blob metadata and missing object handling

### DIFF
--- a/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageConsumer.java
+++ b/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageConsumer.java
@@ -94,6 +94,14 @@ public class GoogleCloudStorageConsumer extends ScheduledBatchPollingConsumer {
 
             Blob blob = getStorageClient().get(bucketName, fileName);
 
+            // okay we have some response from Google so lets mark the consumer as ready
+            forceConsumerAsReady();
+
+            if (blob == null) {
+                LOG.trace("No object found in bucket [{}] with file name [{}]", bucketName, fileName);
+                return 0;
+            }
+
             exchanges = createExchanges(blob, fileName);
         } else {
             LOG.trace("Queueing objects in bucket [{}]...", bucketName);

--- a/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageProducer.java
+++ b/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageProducer.java
@@ -23,7 +23,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.google.cloud.storage.Blob;
@@ -36,6 +40,7 @@ import com.google.cloud.storage.Storage.CopyRequest;
 import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.WrappedFile;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.IOHelper;
@@ -136,7 +141,7 @@ public class GoogleCloudStorageProducer extends DefaultProducer {
         }
         String ce = objectMetadata.remove("Content-Encoding");
         if (ce != null) {
-            builder.setContentEncoding(ct);
+            builder.setContentEncoding(ce);
         }
         String md5 = objectMetadata.remove("Content-Md5");
         if (md5 != null) {
@@ -144,7 +149,7 @@ public class GoogleCloudStorageProducer extends DefaultProducer {
         }
         String cc = objectMetadata.remove("Cache-Control");
         if (cc != null) {
-            builder.setCacheControl(ct);
+            builder.setCacheControl(cc);
         }
         BlobInfo blobInfo = builder.setMetadata(objectMetadata).build();
         // According to documentation, this internally uses a WriteChannel
@@ -231,18 +236,12 @@ public class GoogleCloudStorageProducer extends DefaultProducer {
     private void createDownloadLink(Storage storage, Exchange exchange) {
         final String bucketName = determineBucketName(exchange);
         final String objectName = determineObjectName(exchange);
-        Long expirationMillis
+        long expirationMillis
                 = exchange.getIn().getHeader(GoogleCloudStorageConstants.DOWNLOAD_LINK_EXPIRATION_TIME, 300000L, Long.class);
-        long milliSeconds = 0;
-        if (expirationMillis != null) {
-            milliSeconds += expirationMillis;
-        } else {
-            milliSeconds += 1000 * 60 * 60;
-        }
 
         BlobId blobId = BlobId.of(bucketName, objectName);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
-        URL url = storage.signUrl(blobInfo, milliSeconds, TimeUnit.MILLISECONDS);
+        URL url = storage.signUrl(blobInfo, expirationMillis, TimeUnit.MILLISECONDS);
 
         Message message = getMessageForResponse(exchange);
         message.setBody(url.toString());
@@ -326,6 +325,10 @@ public class GoogleCloudStorageProducer extends DefaultProducer {
         final String objectName = determineObjectName(exchange);
 
         Blob blob = storage.get(BlobId.of(bucketName, objectName));
+        if (blob == null) {
+            throw new RuntimeCamelException(
+                    "Object " + objectName + " does not exist in bucket " + bucketName);
+        }
         Message message = getMessageForResponse(exchange);
         message.setBody(blob.getContent(Blob.BlobSourceOption.generationMatch()));
         message.setHeader(GoogleCloudStorageConstants.OBJECT_NAME, blob.getName());
@@ -372,6 +375,8 @@ public class GoogleCloudStorageProducer extends DefaultProducer {
     }
 
     private String determineObjectName(Exchange exchange) {
+        // the configured objectName deliberately wins over the header, see CAMEL-20998: a consumer in the
+        // same route sets the object name header, which would otherwise hijack the producer destination
         String key = getConfiguration().getObjectName();
         if (ObjectHelper.isEmpty(key)) {
             key = exchange.getIn().getHeader(GoogleCloudStorageConstants.OBJECT_NAME, String.class);

--- a/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/GoogleCloudStorageConsumerMissingObjectTest.java
+++ b/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/GoogleCloudStorageConsumerMissingObjectTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.storage;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.google.storage.localstorage.LocalStorageHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Verifies that polling for a configured object name that does not exist in the bucket is a no-op instead of failing.
+ */
+class GoogleCloudStorageConsumerMissingObjectTest extends CamelTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        GoogleCloudStorageComponent component = context.getComponent("google-storage", GoogleCloudStorageComponent.class);
+        component.getConfiguration().setStorageClient(LocalStorageHelper.getOptions().getService());
+        return context;
+    }
+
+    private GoogleCloudStorageConsumer createConsumer(String objectName) throws Exception {
+        GoogleCloudStorageEndpoint endpoint = context.getEndpoint(
+                "google-storage://myCamelBucket?autoCreateBucket=true&objectName=" + objectName,
+                GoogleCloudStorageEndpoint.class);
+        GoogleCloudStorageConsumer consumer = (GoogleCloudStorageConsumer) endpoint.createConsumer(exchange -> {
+        });
+        endpoint.start();
+        return consumer;
+    }
+
+    @Test
+    void pollingAMissingObjectYieldsNoExchange() throws Exception {
+        GoogleCloudStorageConsumer consumer = createConsumer("there-is-no-such-object.txt");
+
+        // the object is not in the bucket, so the storage client hands back a null blob
+        assertThatNoException().isThrownBy(consumer::poll);
+        assertThat(consumer.poll()).isZero();
+    }
+}

--- a/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/unit/ProducerBlobMetadataTest.java
+++ b/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/unit/ProducerBlobMetadataTest.java
@@ -26,10 +26,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.google.storage.GoogleCloudStorageConstants;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProducerBlobMetadataTest extends GoogleCloudStorageBaseTest {
+class ProducerBlobMetadataTest extends GoogleCloudStorageBaseTest {
 
     private static final String FILE_NAME = "metadata.txt";
 
@@ -48,7 +47,7 @@ public class ProducerBlobMetadataTest extends GoogleCloudStorageBaseTest {
     }
 
     @Test
-    public void contentEncodingAndCacheControlAreStoredAsSent() {
+    void contentEncodingAndCacheControlAreStoredAsSent() {
         Exchange exchange = template.request("direct:store", e -> {
             e.getIn().setHeader(GoogleCloudStorageConstants.OBJECT_NAME, FILE_NAME);
             e.getIn().setHeader(GoogleCloudStorageConstants.CONTENT_TYPE, "text/plain");
@@ -57,24 +56,24 @@ public class ProducerBlobMetadataTest extends GoogleCloudStorageBaseTest {
             e.getIn().setBody(new ByteArrayInputStream("Hi, How are you ?".getBytes()));
         });
 
-        assertNotNull(exchange);
+        assertThat(exchange).isNotNull();
         Blob blob = exchange.getMessage().getBody(Blob.class);
-        assertNotNull(blob);
+        assertThat(blob).isNotNull();
         // each field has to carry its own header value, they used to be overwritten with the content type
-        assertEquals("text/plain", blob.getContentType());
-        assertEquals("gzip", blob.getContentEncoding());
-        assertEquals("max-age=3600", blob.getCacheControl());
+        assertThat(blob.getContentType()).isEqualTo("text/plain");
+        assertThat(blob.getContentEncoding()).isEqualTo("gzip");
+        assertThat(blob.getCacheControl()).isEqualTo("max-age=3600");
     }
 
     @Test
-    public void getObjectOnAMissingObjectReportsTheObjectName() {
+    void getObjectOnAMissingObjectReportsTheObjectName() {
         Exchange exchange = template.request("direct:getObject",
                 e -> e.getIn().setHeader(GoogleCloudStorageConstants.OBJECT_NAME, "there-is-no-such-object.txt"));
 
-        assertNotNull(exchange);
+        assertThat(exchange).isNotNull();
         Exception exception = exchange.getException();
-        assertNotNull(exception, "a missing object must fail the exchange");
-        assertEquals("Object there-is-no-such-object.txt does not exist in bucket myCamelBucket",
-                exception.getMessage());
+        assertThat(exception).as("a missing object must fail the exchange").isNotNull();
+        assertThat(exception.getMessage())
+                .isEqualTo("Object there-is-no-such-object.txt does not exist in bucket myCamelBucket");
     }
 }

--- a/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/unit/ProducerBlobMetadataTest.java
+++ b/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/unit/ProducerBlobMetadataTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.storage.unit;
+
+import java.io.ByteArrayInputStream;
+
+import com.google.cloud.storage.Blob;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.google.storage.GoogleCloudStorageConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ProducerBlobMetadataTest extends GoogleCloudStorageBaseTest {
+
+    private static final String FILE_NAME = "metadata.txt";
+
+    @EndpointInject
+    private ProducerTemplate template;
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:store").to("google-storage://myCamelBucket?autoCreateBucket=true");
+                from("direct:getObject")
+                        .to("google-storage://myCamelBucket?autoCreateBucket=true&operation=getObject");
+            }
+        };
+    }
+
+    @Test
+    public void contentEncodingAndCacheControlAreStoredAsSent() {
+        Exchange exchange = template.request("direct:store", e -> {
+            e.getIn().setHeader(GoogleCloudStorageConstants.OBJECT_NAME, FILE_NAME);
+            e.getIn().setHeader(GoogleCloudStorageConstants.CONTENT_TYPE, "text/plain");
+            e.getIn().setHeader(GoogleCloudStorageConstants.CONTENT_ENCODING, "gzip");
+            e.getIn().setHeader(GoogleCloudStorageConstants.CACHE_CONTROL, "max-age=3600");
+            e.getIn().setBody(new ByteArrayInputStream("Hi, How are you ?".getBytes()));
+        });
+
+        assertNotNull(exchange);
+        Blob blob = exchange.getMessage().getBody(Blob.class);
+        assertNotNull(blob);
+        // each field has to carry its own header value, they used to be overwritten with the content type
+        assertEquals("text/plain", blob.getContentType());
+        assertEquals("gzip", blob.getContentEncoding());
+        assertEquals("max-age=3600", blob.getCacheControl());
+    }
+
+    @Test
+    public void getObjectOnAMissingObjectReportsTheObjectName() {
+        Exchange exchange = template.request("direct:getObject",
+                e -> e.getIn().setHeader(GoogleCloudStorageConstants.OBJECT_NAME, "there-is-no-such-object.txt"));
+
+        assertNotNull(exchange);
+        Exception exception = exchange.getException();
+        assertNotNull(exception, "a missing object must fail the exchange");
+        assertEquals("Object there-is-no-such-object.txt does not exist in bucket myCamelBucket",
+                exception.getMessage());
+    }
+}


### PR DESCRIPTION
Three defects in `camel-google-storage`, all covered by new tests.

**1. Uploads stored the content type in two other blob fields.** `processFile` read the
`Content-Encoding` and `Cache-Control` entries from the metadata map but then passed the *content
type* variable to the builder:

```java
String ce = objectMetadata.remove("Content-Encoding");
if (ce != null) { builder.setContentEncoding(ct); }   // ct == Content-Type
...
String cc = objectMetadata.remove("Cache-Control");
if (cc != null) { builder.setCacheControl(ct); }      // ct == Content-Type
```

So an upload sending those headers ended up with the content type in both fields — or `null`, when
no `Content-Type` header was sent at all.

**2. `getObject` NPE'd on a missing object.** `storage.get(BlobId)` returns `null` when the object
is not there, and the result was dereferenced straight away. It now fails with a message naming the
object and the bucket.

**3. The consumer NPE'd on every poll when the configured `objectName` was missing.** Same null
blob, this time handed to `createExchange`. The poll now logs and yields no exchange. That path also
never called `forceConsumerAsReady()`, so the consumer health check stayed not-ready when
`objectName` was configured; it is now marked ready as soon as the storage client answers, like on
the list path.

Two cleanups in the touched file: the `else` branch in `createDownloadLink` was unreachable (the
header lookup already supplies the `300000L` default), and the `java.util.*` wildcard import is
replaced with explicit ones.

**Not changed:** the audit that produced this issue also flagged that the `objectName` endpoint
option wins over the `CamelGoogleCloudStorageObjectName` header. That is deliberate — CAMEL-20998
made it so, because a consumer in the same route sets that header and would otherwise hijack the
producer destination. Only a comment recording the reason was added, and the item was withdrawn in a
comment on the JIRA issue.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)