### PR TITLE
[backport camel-4.18.x] CAMEL-24354: camel-aws2-lambda - updateFunction never sets the code source

### DIFF
--- a/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2Producer.java
+++ b/components/camel-aws/camel-aws2-lambda/src/main/java/org/apache/camel/component/aws2/lambda/Lambda2Producer.java
@@ -468,8 +468,35 @@ public class Lambda2Producer extends DefaultProducer {
 
             if (ObjectHelper.isEmpty(exchange.getIn().getBody())
                     && ObjectHelper.isEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_BUCKET))
-                    && ObjectHelper.isEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_KEY))) {
+                    && ObjectHelper.isEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_KEY))
+                    && ObjectHelper.isEmpty(exchange.getIn().getHeader(Lambda2Constants.ZIP_FILE))) {
                 throw new IllegalArgumentException("At least S3 bucket/S3 key or zip file must be specified");
+            }
+
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_BUCKET))) {
+                String s3Bucket = exchange.getIn().getHeader(Lambda2Constants.S3_BUCKET, String.class);
+                builder.s3Bucket(s3Bucket);
+            }
+
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_KEY))) {
+                String s3Key = exchange.getIn().getHeader(Lambda2Constants.S3_KEY, String.class);
+                builder.s3Key(s3Key);
+            }
+
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.S3_OBJECT_VERSION))) {
+                String s3ObjectVersion = exchange.getIn().getHeader(Lambda2Constants.S3_OBJECT_VERSION, String.class);
+                builder.s3ObjectVersion(s3ObjectVersion);
+            }
+
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.ZIP_FILE))) {
+                String zipFile = exchange.getIn().getHeader(Lambda2Constants.ZIP_FILE, String.class);
+                File fileLocalPath = new File(zipFile);
+                try (FileInputStream inputStream = new FileInputStream(fileLocalPath)) {
+                    builder.zipFile(SdkBytes.fromInputStream(inputStream));
+                }
+            }
+            if (ObjectHelper.isNotEmpty(exchange.getIn().getBody())) {
+                builder.zipFile(SdkBytes.fromByteBuffer(exchange.getIn().getBody(ByteBuffer.class)));
             }
 
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.PUBLISH))) {
@@ -530,7 +557,7 @@ public class Lambda2Producer extends DefaultProducer {
             if (ObjectHelper.isNotEmpty(exchange.getIn().getHeader(Lambda2Constants.EVENT_SOURCE_UUID))) {
                 builder.uuid(exchange.getIn().getHeader(Lambda2Constants.EVENT_SOURCE_UUID, String.class));
             } else {
-                throw new IllegalArgumentException("Event Source Arn must be specified");
+                throw new IllegalArgumentException("Event Source UUID must be specified");
             }
             request = builder.build();
         }

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/AmazonLambdaClientMock.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/AmazonLambdaClientMock.java
@@ -101,6 +101,8 @@ import software.amazon.awssdk.services.lambda.model.UpdateFunctionUrlConfigRespo
 
 public class AmazonLambdaClientMock implements LambdaClient {
 
+    public UpdateFunctionCodeRequest updateFunctionCodeRequest;
+
     public AmazonLambdaClientMock() {
     }
 
@@ -319,6 +321,7 @@ public class AmazonLambdaClientMock implements LambdaClient {
 
     @Override
     public UpdateFunctionCodeResponse updateFunctionCode(UpdateFunctionCodeRequest updateFunctionCodeRequest) {
+        this.updateFunctionCodeRequest = updateFunctionCodeRequest;
         UpdateFunctionCodeResponse.Builder result = UpdateFunctionCodeResponse.builder();
 
         result.functionName(updateFunctionCodeRequest.functionName());

--- a/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/LambdaProducerTest.java
+++ b/components/camel-aws/camel-aws2-lambda/src/test/java/org/apache/camel/component/aws2/lambda/LambdaProducerTest.java
@@ -103,6 +103,29 @@ public class LambdaProducerTest extends CamelTestSupport {
     }
 
     @Test
+    public void lambdaUpdateFunctionTest() throws Exception {
+
+        Exchange exchange = template.send("direct:updateFunction", ExchangePattern.InOut, new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                ClassLoader classLoader = getClass().getClassLoader();
+                File file = new File(
+                        classLoader.getResource("org/apache/camel/component/aws2/lambda/function/node/GetHelloWithName.zip")
+                                .getFile());
+                FileInputStream inputStream = new FileInputStream(file);
+                exchange.getIn().setBody(inputStream);
+            }
+        });
+
+        assertNotNull(exchange.getMessage().getBody());
+        // the fix: the code source (the zip taken from the body) must actually reach the request,
+        // otherwise AWS rejects UpdateFunctionCode with "Please provide a source for function code."
+        assertNotNull(clientMock.updateFunctionCodeRequest);
+        assertEquals("GetHelloWithName", clientMock.updateFunctionCodeRequest.functionName());
+        assertNotNull(clientMock.updateFunctionCodeRequest.zipFile());
+    }
+
+    @Test
     public void lambdaDeleteFunctionTest() {
 
         Exchange exchange = template.send("direct:deleteFunction", ExchangePattern.InOut, new Processor() {


### PR DESCRIPTION
Backport of #25343 to camel-4.18.x.

`Lambda2Producer.updateFunction()` validated that a body / S3 bucket / S3 key was present, then discarded them and built an `UpdateFunctionCodeRequest` with only `functionName` (+ optional `publish`). AWS `UpdateFunctionCode` requires a code source, so every call failed and the operation was unusable in the default (non-pojoRequest) mode. Now the code source (S3 bucket/key/object-version, ZIP_FILE header path, message body) is assembled on the request, mirroring `createFunction`. Also fixes the misleading `deleteEventSourceMapping` validation message (said "Arn" but validates the UUID).

Adds `LambdaProducerTest.lambdaUpdateFunctionTest`; full `LambdaProducerTest` green (32 tests) on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)