### PR TITLE
[backport camel-4.18.x] CAMEL-24355: Fix NIOConverter.toByteArray for fully consumed ByteBuffer

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/converter/NIOConverter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/converter/NIOConverter.java
@@ -50,7 +50,11 @@ public final class NIOConverter {
     @Converter(order = 1)
     public static byte[] toByteArray(ByteBuffer buffer) {
         byte[] bArray = new byte[buffer.limit()];
-        buffer.get(bArray);
+        if (bArray.length > 0) {
+            ByteBuffer copy = buffer.duplicate();
+            copy.rewind();
+            copy.get(bArray);
+        }
         return bArray;
     }
 

--- a/core/camel-base/src/main/java/org/apache/camel/converter/NIOConverter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/converter/NIOConverter.java
@@ -50,11 +50,7 @@ public final class NIOConverter {
     @Converter(order = 1)
     public static byte[] toByteArray(ByteBuffer buffer) {
         byte[] bArray = new byte[buffer.limit()];
-        if (bArray.length > 0) {
-            ByteBuffer copy = buffer.duplicate();
-            copy.rewind();
-            copy.get(bArray);
-        }
+        buffer.get(0, bArray);
         return bArray;
     }
 

--- a/core/camel-core/src/test/java/org/apache/camel/converter/NIOConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/NIOConverterTest.java
@@ -25,6 +25,7 @@ import org.apache.camel.ContextTestSupport;
 import org.apache.camel.Exchange;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -51,6 +52,67 @@ public class NIOConverterTest extends ContextTestSupport {
         byte[] out = NIOConverter.toByteArray(bb);
         assertNotNull(out);
         assertEquals(5, out.length);
+    }
+
+    @Test
+    void testToByteArrayFullyConsumedBuffer() {
+        ByteBuffer bb = ByteBuffer.wrap("Hello".getBytes());
+        while (bb.hasRemaining()) {
+            bb.get();
+        }
+        assertThat(bb.position()).isEqualTo(bb.limit());
+
+        byte[] out = NIOConverter.toByteArray(bb);
+
+        assertThat(out).containsExactly("Hello".getBytes());
+        assertThat(bb.position()).isEqualTo(bb.limit());
+    }
+
+    @Test
+    void testToByteArrayPartiallyConsumedBuffer() {
+        ByteBuffer bb = ByteBuffer.allocate(100);
+        bb.put("Hello".getBytes());
+        bb.flip();
+        bb.get();
+        assertThat(bb.position()).isEqualTo(1);
+
+        byte[] out = NIOConverter.toByteArray(bb);
+
+        assertThat(out).containsExactly("Hello".getBytes());
+        assertThat(bb.position()).isEqualTo(1);
+    }
+
+    @Test
+    void testToByteArrayEmptyBuffer() {
+        ByteBuffer bb = ByteBuffer.allocate(0);
+
+        byte[] out = NIOConverter.toByteArray(bb);
+
+        assertThat(out).isEmpty();
+    }
+
+    @Test
+    void testToStringFullyConsumedBuffer() throws Exception {
+        ByteBuffer bb = ByteBuffer.wrap("Hello".getBytes());
+        while (bb.hasRemaining()) {
+            bb.get();
+        }
+
+        String out = NIOConverter.toString(bb, null);
+
+        assertThat(out).isEqualTo("Hello");
+    }
+
+    @Test
+    void testToInputStreamFullyConsumedBuffer() throws Exception {
+        ByteBuffer bb = ByteBuffer.wrap("Hello".getBytes());
+        while (bb.hasRemaining()) {
+            bb.get();
+        }
+
+        InputStream is = NIOConverter.toInputStream(bb);
+
+        assertThat(IOConverter.toString(is, null)).isEqualTo("Hello");
     }
 
     @Test

--- a/core/camel-core/src/test/java/org/apache/camel/converter/NIOConverterTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/NIOConverterTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class NIOConverterTest extends ContextTestSupport {
+class NIOConverterTest extends ContextTestSupport {
     private static final String TEST_FILE_NAME = "hello" + UUID.randomUUID() + ".txt";
 
     @Test
@@ -89,6 +89,18 @@ public class NIOConverterTest extends ContextTestSupport {
         byte[] out = NIOConverter.toByteArray(bb);
 
         assertThat(out).isEmpty();
+    }
+
+    @Test
+    void testToByteArrayReadOnlyFullyConsumedBuffer() {
+        ByteBuffer bb = ByteBuffer.wrap("Hello".getBytes()).asReadOnlyBuffer();
+        while (bb.hasRemaining()) {
+            bb.get();
+        }
+
+        byte[] out = NIOConverter.toByteArray(bb);
+
+        assertThat(out).containsExactly("Hello".getBytes());
     }
 
     @Test


### PR DESCRIPTION
## Backport of #25330

Cherry-pick of #25330 onto `camel-4.18.x`.

**Original PR:** #25330 - CAMEL-24355: Fix NIOConverter.toByteArray for fully consumed ByteBuffer
**Original author:** @atiaomar1978-hub
**Target branch:** `camel-4.18.x`

### Original description

Fixes [CAMEL-24355](https://issues.apache.org/jira/browse/CAMEL-24355): `NIOConverter.toByteArray(ByteBuffer)` threw `BufferUnderflowException` when the buffer was already fully read (`position == limit`), which breaks Kinesis KCL dead-letter-queue conversion and similar flows.

- Read bytes with absolute `buffer.get(0, bArray)` so conversion uses `[0, limit)` regardless of current position
- Preserve the original buffer position (no side effect on the input `ByteBuffer`)
- Add tests for fully consumed, partially consumed, empty, and read-only buffers, plus `toString`/`toInputStream` paths that delegate to `toByteArray`

---
_Claude Code on behalf of davsclaus_