### PR TITLE
CAMEL-24344: camel-google-mail - return a body for raw and non-multipart messages

### DIFF
--- a/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumer.java
+++ b/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumer.java
@@ -92,7 +92,8 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
 
         if (c.getMessages() != null) {
             for (Message message : c.getMessages()) {
-                Message mess = getClient().users().messages().get("me", message.getId()).setFormat("FULL").execute();
+                Message mess
+                        = getClient().users().messages().get("me", message.getId()).setFormat(messageFormat()).execute();
                 Exchange exchange = createExchange(getEndpoint().getExchangePattern(), mess);
                 answer.add(exchange);
             }
@@ -167,8 +168,13 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
      * Strategy when processing the exchange failed.
      */
     protected void processRollback(Exchange exchange, String unreadLabelId) {
+        if (!getConfiguration().isMarkAsRead()) {
+            // the mail was never marked as read, so there is nothing to roll back
+            LOG.warn("Exchange failed: {}", exchange);
+            return;
+        }
         try {
-            LOG.warn("Exchange failed, so rolling back mail {} to un {}", exchange, unreadLabelId);
+            LOG.warn("Exchange failed, so marking mail {} as unread again", exchange);
 
             List<String> add = new ArrayList<>();
             add.add(unreadLabelId);
@@ -176,7 +182,8 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
             getClient().users().messages()
                     .modify("me", exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_ID, String.class), mods).execute();
         } catch (Exception e) {
-            getExceptionHandler().handleException("Error occurred mark as read mail. This exception is ignored.", exchange, e);
+            getExceptionHandler().handleException("Error occurred marking the mail as unread. This exception is ignored.",
+                    exchange, e);
         }
     }
 
@@ -190,15 +197,50 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
         if (getConfiguration().isRaw()) {
             message.setBody(mail.getRaw());
         } else {
-            List<MessagePart> parts = mail.getPayload().getParts();
-            if (parts != null && parts.get(0).getBody().getData() != null) {
-                byte[] bodyBytes = Base64.decodeBase64(parts.get(0).getBody().getData().trim());
-                String body = new String(bodyBytes, StandardCharsets.UTF_8);
+            String body = extractBody(mail.getPayload());
+            if (body != null) {
                 message.setBody(body);
             }
         }
-        configureHeaders(message, mail.getPayload().getHeaders());
+        if (mail.getPayload() != null && mail.getPayload().getHeaders() != null) {
+            configureHeaders(message, mail.getPayload().getHeaders());
+        }
         return exchange;
+    }
+
+    /**
+     * The message format the consumer has to ask for. The raw field of a message is only populated when the RAW format
+     * is requested, the payload only when the FULL format is.
+     */
+    String messageFormat() {
+        return getConfiguration().isRaw() ? "RAW" : "FULL";
+    }
+
+    /**
+     * Returns the decoded content of the first part carrying data, walking into nested multiparts. A message that is
+     * not multipart at all keeps its content directly on the payload.
+     */
+    private String extractBody(MessagePart part) {
+        if (part == null) {
+            return null;
+        }
+
+        if (part.getBody() != null && part.getBody().getData() != null) {
+            byte[] bodyBytes = Base64.decodeBase64(part.getBody().getData().trim());
+            return new String(bodyBytes, StandardCharsets.UTF_8);
+        }
+
+        List<MessagePart> parts = part.getParts();
+        if (parts != null) {
+            for (MessagePart child : parts) {
+                String body = extractBody(child);
+                if (body != null) {
+                    return body;
+                }
+            }
+        }
+
+        return null;
     }
 
     private void configureHeaders(org.apache.camel.Message message, List<MessagePartHeader> headers) {

--- a/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumer.java
+++ b/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumer.java
@@ -170,7 +170,6 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
     protected void processRollback(Exchange exchange, String unreadLabelId) {
         if (!getConfiguration().isMarkAsRead()) {
             // the mail was never marked as read, so there is nothing to roll back
-            LOG.warn("Exchange failed: {}", exchange);
             return;
         }
         try {

--- a/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerBodyTest.java
+++ b/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerBodyTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.mail.stream;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import com.google.api.client.util.Base64;
+import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.MessagePart;
+import com.google.api.services.gmail.model.MessagePartBody;
+import com.google.api.services.gmail.model.MessagePartHeader;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Verifies how the stream consumer turns a Gmail message into an exchange: which format it asks the API for, and where
+ * it picks the body up from.
+ */
+class GoogleMailStreamConsumerBodyTest {
+
+    private DefaultCamelContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    private GoogleMailStreamConsumer consumer(boolean raw) throws Exception {
+        context = new DefaultCamelContext();
+        context.start();
+        GoogleMailStreamEndpoint endpoint = context.getEndpoint(
+                "google-mail-stream://index?clientId=id&clientSecret=secret&raw=" + raw,
+                GoogleMailStreamEndpoint.class);
+        return new GoogleMailStreamConsumer(endpoint, exchange -> {
+        }, "UNREAD", List.of());
+    }
+
+    private static MessagePartBody body(String content) {
+        return new MessagePartBody().setData(Base64.encodeBase64URLSafeString(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void theRawOptionAsksForTheRawFormat() throws Exception {
+        // the raw field of a message is only returned for the RAW format, asking for FULL always left it null
+        assertThat(consumer(true).messageFormat()).isEqualTo("RAW");
+        assertThat(consumer(false).messageFormat()).isEqualTo("FULL");
+    }
+
+    @Test
+    void aNonMultipartMessageKeepsItsBody() throws Exception {
+        Message mail = new Message().setId("1").setThreadId("t1")
+                .setPayload(new MessagePart().setMimeType("text/plain").setBody(body("plain content")));
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getBody()).isEqualTo("plain content");
+    }
+
+    @Test
+    void aMultipartMessageUsesTheFirstPartCarryingData() throws Exception {
+        Message mail = new Message().setId("2").setPayload(new MessagePart().setMimeType("multipart/alternative")
+                .setParts(List.of(
+                        new MessagePart().setMimeType("multipart/mixed")
+                                .setParts(List.of(new MessagePart().setMimeType("text/plain").setBody(body("nested")))),
+                        new MessagePart().setMimeType("text/html").setBody(body("<p>html</p>")))));
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getBody()).isEqualTo("nested");
+    }
+
+    @Test
+    void aMessageWithoutPayloadIsNotAFailure() throws Exception {
+        Message mail = new Message().setId("3");
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getBody()).isNull();
+        assertThat(exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_ID)).isEqualTo("3");
+    }
+
+    @Test
+    void headersAreMappedWhenPresent() throws Exception {
+        Message mail = new Message().setId("4").setPayload(new MessagePart()
+                .setBody(body("content"))
+                .setHeaders(List.of(
+                        new MessagePartHeader().setName("Subject").setValue("a subject"),
+                        new MessagePartHeader().setName("From").setValue("someone@example.org"))));
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_SUBJECT)).isEqualTo("a subject");
+        assertThat(exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_FROM)).isEqualTo("someone@example.org");
+    }
+
+    @Test
+    void aPayloadWithoutHeadersIsNotAFailure() throws Exception {
+        Message mail = new Message().setId("5").setPayload(new MessagePart().setBody(body("content")));
+
+        assertThatCode(() -> consumer(false).createExchange(ExchangePattern.InOnly, mail)).doesNotThrowAnyException();
+    }
+}

--- a/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerBodyTest.java
+++ b/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerBodyTest.java
@@ -49,6 +49,9 @@ class GoogleMailStreamConsumerBodyTest {
     }
 
     private GoogleMailStreamConsumer consumer(boolean raw) throws Exception {
+        if (context != null) {
+            context.stop();
+        }
         context = new DefaultCamelContext();
         context.start();
         GoogleMailStreamEndpoint endpoint = context.getEndpoint(

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1710,3 +1710,15 @@ transport `from` and the `atmosphere-websocket:` `to`. Allowing untrusted sender
 drive `WebsocketConstants.CONNECTION_KEY_LIST`, which selects the target peers and
 takes precedence over `CONNECTION_KEY`, without such a mapping step is not the intended
 use of the component.
+
+=== camel-google-mail - the raw option now returns the message
+
+The `google-mail-stream` consumer always asked the Gmail API for the `FULL` message format, but the
+`raw` field is only populated for the `RAW` format, so `raw=true` produced a `null` body. The consumer
+now requests the format that matches the option.
+
+Because the Gmail API does not return the parsed `payload` for the `RAW` format, a route running with
+`raw=true` no longer receives the `CamelGoogleMailStreamSubject`, `...From`, `...To`, `...Cc`, `...Bcc`
+and `...MessageId` headers — those values are part of the RFC 2822 content that is now in the body.
+`CamelGoogleMailStreamId`, `...ThreadId` and `...LabelIds` are still set. Routes that need the parsed
+headers should keep the default `raw=false`.


### PR DESCRIPTION
Three body-related defects in the `google-mail-stream` consumer.

**1. `raw=true` always produced a `null` body.** The consumer asked for the `FULL` format:

```java
Message mess = getClient().users().messages().get("me", message.getId()).setFormat("FULL").execute();
...
if (getConfiguration().isRaw()) { message.setBody(mail.getRaw()); }
```

but Gmail only populates `raw` for `format=RAW`
([API reference](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages):
_"Returned in messages.get and drafts.get responses when the format=RAW parameter is supplied."_).
The requested format now follows the option.

Since the `RAW` format does not return the parsed `payload`, a route with `raw=true` no longer gets
the subject/from/to/cc/bcc/message-id headers — they are part of the RFC 2822 content that is now in
the body. That is covered by an upgrade-guide entry.

**2. Messages that are not multipart arrived with no body.** The old code only looked at
`getPayload().getParts()`, which is `null` for a plain message — its content sits directly on
`payload.body.data`. Nested multiparts (a `multipart/mixed` inside a `multipart/alternative`) were
also skipped, because `parts.get(0).getBody().getData()` is `null` for a part that only holds other
parts. The body is now taken from the first part that actually carries data, descending into nested
parts.

**3. `getPayload()` and `getPayload().getHeaders()` were dereferenced unguarded** — both are absent
for some message formats and metadata-only responses.

Also: `processRollback` re-added the `UNREAD` label even when `markAsRead` was never enabled, so a
failed exchange mutated the mailbox for routes that had not asked for it; and its catch block
reported "Error occurred mark as read mail" for a rollback failure.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)