### PR TITLE
chore(deps): Upgrade Citrus test framework to 5.0.0

### DIFF
--- a/dsl/camel-jbang/camel-jbang-plugin-test/src/main/java/org/apache/camel/dsl/jbang/core/commands/test/TestInit.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-test/src/main/java/org/apache/camel/dsl/jbang/core/commands/test/TestInit.java
@@ -18,84 +18,41 @@
 package org.apache.camel.dsl.jbang.core.commands.test;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Stack;
 
-import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.catalog.VersionHelper;
 import org.apache.camel.dsl.jbang.core.commands.ExportHelper;
 import org.apache.camel.util.IOHelper;
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.CitrusVersion;
-import org.citrusframework.jbang.CitrusJBangMain;
-import org.citrusframework.jbang.commands.CitrusCommand;
-import org.citrusframework.util.ClassLoaderHelper;
-import org.citrusframework.util.FileUtils;
+import org.citrusframework.jbang.cli.CitrusJBangMain;
+import org.citrusframework.jbang.cli.commands.Init;
 import picocli.CommandLine;
-
-import static java.nio.file.Files.writeString;
 
 /**
  * Automatically uses test subfolder as a working directory for creating new tests. Automatically adds a
  * citrus-application.properties configuration if not present.
  */
 @CommandLine.Command(name = "init", description = "Creates a new Citrus test")
-public class TestInit extends CitrusCommand {
-
-    @CommandLine.Parameters(description = "Name of test file (or a github link)", arity = "1",
-                            paramLabel = "<file>", parameterConsumer = TestInit.FileConsumer.class)
-    private Path filePath; // Defined only for file path completion; the field never used
-
-    private String file;
-
-    @CommandLine.Option(names = { "--directory" },
-                        description = "Directory where the files will be created", defaultValue = TestPlugin.TEST_DIR)
-    private String directory;
+public class TestInit extends Init {
 
     public TestInit(CitrusJBangMain citrus) {
         super(citrus);
     }
 
     @Override
-    public Integer call() throws Exception {
-        String ext = FileUtils.getFileExtension(file);
-        String name = FileUtils.getBaseName(file);
-        String content;
-        try (InputStream is = ClassLoaderHelper.getClassLoader().getResourceAsStream("templates/" + ext + ".tmpl")) {
-            if (is == null) {
-                printer().println("Error: Unsupported file type: " + ext);
-                return 1;
-            }
-            content = FileUtils.readToString(is, StandardCharsets.UTF_8);
+    protected String resolveTargetDirectory(String directory) {
+        if (directory == null || ".".equals(directory)) {
+            return TestPlugin.TEST_DIR;
         }
 
-        Path currentDir = Paths.get(".");
-        Path workingDir;
-        String currentDirName = Paths.get("").toAbsolutePath().getFileName().toString();
-        if (directory.equals(currentDirName)) {
-            // current directory is already the target subfolder
-            workingDir = currentDir;
-        } else if (currentDir.resolve(directory).toFile().exists()) {
-            // navigate to existing target subfolder
-            workingDir = currentDir.resolve(directory);
-            System.setProperty(CitrusSettings.RESOURCES_WORKDIR_PROPERTY, workingDir.toString());
-        } else if (currentDir.resolve(directory).toFile().mkdirs()) {
-            // create target subfolder and navigate to it
-            workingDir = currentDir.resolve(directory);
-            System.setProperty(CitrusSettings.RESOURCES_WORKDIR_PROPERTY, workingDir.toString());
-        } else {
-            throw new RuntimeCamelException("Failed to create working directory in: " + currentDir);
-        }
+        return super.resolveTargetDirectory(directory);
+    }
 
-        File target = workingDir.resolve(file).toFile();
-        content = content.replaceFirst("\\{\\{ \\.Name }}", name);
-
-        writeString(target.toPath(), content);
-
+    @Override
+    protected void initAdditionalFiles(Path workingDir) {
         // Create Citrus application properties if not present
         if (!workingDir.resolve(CitrusSettings.getApplicationPropertiesFile()).toFile().exists()) {
             Path citrusApplicationProperties = workingDir.resolve(CitrusSettings.getApplicationPropertiesFile());
@@ -110,18 +67,9 @@ public class TestInit extends CitrusCommand {
                 ExportHelper.safeCopy(new ByteArrayInputStream(context.getBytes(StandardCharsets.UTF_8)),
                         citrusApplicationProperties);
             } catch (Exception e) {
-                getMain().getOut().println("Failed to create %s for tests in: %s"
+                printer().println("Error: Failed to create '%s' in: %s"
                         .formatted(CitrusSettings.getApplicationPropertiesFile(), citrusApplicationProperties));
             }
-        }
-
-        return 0;
-    }
-
-    static class FileConsumer extends ParameterConsumer<TestInit> {
-        @Override
-        protected void doConsumeParameters(Stack<String> args, TestInit cmd) {
-            cmd.file = args.pop();
         }
     }
 }

--- a/dsl/camel-jbang/camel-jbang-plugin-test/src/main/java/org/apache/camel/dsl/jbang/core/commands/test/TestPlugin.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-test/src/main/java/org/apache/camel/dsl/jbang/core/commands/test/TestPlugin.java
@@ -25,15 +25,15 @@ import org.apache.camel.dsl.jbang.core.common.Plugin;
 import org.apache.camel.dsl.jbang.core.common.PluginExporter;
 import org.apache.camel.dsl.jbang.core.common.Printer;
 import org.citrusframework.CitrusVersion;
-import org.citrusframework.jbang.CitrusJBangMain;
-import org.citrusframework.jbang.commands.Agent;
-import org.citrusframework.jbang.commands.AgentRun;
-import org.citrusframework.jbang.commands.AgentStart;
-import org.citrusframework.jbang.commands.AgentStop;
-import org.citrusframework.jbang.commands.CitrusCommand;
-import org.citrusframework.jbang.commands.Inspect;
-import org.citrusframework.jbang.commands.ListTests;
-import org.citrusframework.jbang.commands.Run;
+import org.citrusframework.jbang.cli.CitrusJBangMain;
+import org.citrusframework.jbang.cli.commands.Agent;
+import org.citrusframework.jbang.cli.commands.AgentRun;
+import org.citrusframework.jbang.cli.commands.AgentStart;
+import org.citrusframework.jbang.cli.commands.AgentStop;
+import org.citrusframework.jbang.cli.commands.CitrusCommand;
+import org.citrusframework.jbang.cli.commands.Inspect;
+import org.citrusframework.jbang.cli.commands.ListTests;
+import org.citrusframework.jbang.cli.commands.Run;
 import picocli.CommandLine;
 
 @CamelJBangPlugin(name = "camel-jbang-plugin-test", firstVersion = "4.14.0")
@@ -129,7 +129,7 @@ public class TestPlugin implements Plugin {
      *
      * @param delegate the Camel printer.
      */
-    private record PipedPrinter(Printer delegate) implements org.citrusframework.jbang.Printer {
+    private record PipedPrinter(Printer delegate) implements org.citrusframework.jbang.cli.Printer {
         @Override
         public void println() {
             delegate.println();

--- a/dsl/camel-jbang/camel-jbang-plugin-test/src/main/resources/templates/junit-test.tmpl
+++ b/dsl/camel-jbang/camel-jbang-plugin-test/src/main/resources/templates/junit-test.tmpl
@@ -1,4 +1,6 @@
-{{ .PackageDeclaration }}import org.citrusframework.annotations.CitrusTestSource;
+{{ .PackageDeclaration }}
+
+import org.citrusframework.annotations.CitrusTestSource;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 
 import org.junit.jupiter.api.Test;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -103,7 +103,7 @@
         <clickhouse-client-version>0.9.8</clickhouse-client-version>
         <jta-api-1.2-version>1.2</jta-api-1.2-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
-        <citrus-version>5.0.0-M2</citrus-version>
+        <citrus-version>5.0.0</citrus-version>
         <classgraph-version>4.8.186</classgraph-version>
         <cloudant-version>0.10.20</cloudant-version>
         <com-ibm-mq-jakarta-client-version>10.0.0.0</com-ibm-mq-jakarta-client-version>


### PR DESCRIPTION
## Summary

- Upgrade Citrus test framework from `5.0.0-M2` to `5.0.0` GA release
- Adapt `camel-jbang-plugin-test` to Citrus 5.0.0 API changes: package rename from `org.citrusframework.jbang` to `org.citrusframework.jbang.cli`
- Refactor `TestInit` to extend the new `Init` base class, delegating file creation logic to the parent and only overriding target directory resolution and additional file initialization

## Test plan

- [x] Module compiles successfully (`mvn -DskipTests install` on `camel-jbang-plugin-test`)
- [ ] CI passes on all platforms

_Claude Code on behalf of christophd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)