### PR TITLE
CAMEL-24360: camel-undertow - use UndertowHeaderFilterStrategy as the endpoint default

### DIFF
--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -134,6 +134,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>jetty-http2-client</artifactId>
             <version>${jetty-version}</version>

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -37,7 +37,6 @@ import org.apache.camel.Producer;
 import org.apache.camel.component.undertow.UndertowConstants.EventType;
 import org.apache.camel.component.undertow.handlers.CamelWebSocketHandler;
 import org.apache.camel.component.undertow.spi.UndertowSecurityProvider;
-import org.apache.camel.http.base.HttpHeaderFilterStrategy;
 import org.apache.camel.http.base.OAuthHttpSecuritySupport;
 import org.apache.camel.http.base.OAuthProfileAwareHttpEndpoint;
 import org.apache.camel.http.base.cookie.CookieHandler;
@@ -85,7 +84,7 @@ public class UndertowEndpoint extends DefaultEndpoint
     @UriParam(label = "advanced")
     private AccessLogReceiver accessLogReceiver;
     @UriParam(label = "advanced")
-    private HeaderFilterStrategy headerFilterStrategy = new HttpHeaderFilterStrategy();
+    private HeaderFilterStrategy headerFilterStrategy = new UndertowHeaderFilterStrategy();
     @UriParam(label = "security")
     private SSLContextParameters sslContextParameters;
     @UriParam(label = "consumer")

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowEndpointTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowEndpointTest.java
@@ -23,10 +23,8 @@ import org.apache.camel.spi.HeaderFilterStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UndertowEndpointTest {
 
@@ -55,23 +53,23 @@ public class UndertowEndpointTest {
 
     @Test
     void defaultHeaderFilterStrategyIsUndertowSpecific() {
-        assertInstanceOf(UndertowHeaderFilterStrategy.class, endpoint.getHeaderFilterStrategy());
+        assertThat(endpoint.getHeaderFilterStrategy()).isInstanceOf(UndertowHeaderFilterStrategy.class);
     }
 
     @Test
     void defaultBindingKeepsUndertowHeaderFilterStrategy() {
         // the endpoint pushes its own strategy into the lazily created binding, so the endpoint default
         // decides which strategy the binding ends up running
-        DefaultUndertowHttpBinding binding
-                = assertInstanceOf(DefaultUndertowHttpBinding.class, endpoint.getUndertowHttpBinding());
-        HeaderFilterStrategy strategy = binding.getHeaderFilterStrategy();
-        assertInstanceOf(UndertowHeaderFilterStrategy.class, strategy);
+        assertThat(endpoint.getUndertowHttpBinding()).isInstanceOf(DefaultUndertowHttpBinding.class);
+        HeaderFilterStrategy strategy
+                = ((DefaultUndertowHttpBinding) endpoint.getUndertowHttpBinding()).getHeaderFilterStrategy();
+        assertThat(strategy).isInstanceOf(UndertowHeaderFilterStrategy.class);
 
         // the undertow-specific prefixes added by CAMEL-23588 must therefore be in effect
-        assertTrue(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null));
-        assertTrue(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY_LIST, "aValue", null));
-        assertTrue(strategy.applyFilterToExternalHeaders(UndertowConstants.SEND_TO_ALL, "aValue", null));
-        assertTrue(strategy.applyFilterToCamelHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null));
+        assertThat(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null)).isTrue();
+        assertThat(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY_LIST, "aValue", null)).isTrue();
+        assertThat(strategy.applyFilterToExternalHeaders(UndertowConstants.SEND_TO_ALL, "aValue", null)).isTrue();
+        assertThat(strategy.applyFilterToCamelHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null)).isTrue();
     }
 
     @Test
@@ -79,8 +77,8 @@ public class UndertowEndpointTest {
         HeaderFilterStrategy custom = new HttpHeaderFilterStrategy();
         endpoint.setHeaderFilterStrategy(custom);
 
-        DefaultUndertowHttpBinding binding
-                = assertInstanceOf(DefaultUndertowHttpBinding.class, endpoint.getUndertowHttpBinding());
-        assertSame(custom, binding.getHeaderFilterStrategy());
+        assertThat(endpoint.getUndertowHttpBinding()).isInstanceOf(DefaultUndertowHttpBinding.class);
+        assertThat(((DefaultUndertowHttpBinding) endpoint.getUndertowHttpBinding()).getHeaderFilterStrategy())
+                .isSameAs(custom);
     }
 }

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowEndpointTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowEndpointTest.java
@@ -18,10 +18,15 @@ package org.apache.camel.component.undertow;
 
 import java.net.URI;
 
+import org.apache.camel.http.base.HttpHeaderFilterStrategy;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UndertowEndpointTest {
 
@@ -46,5 +51,36 @@ public class UndertowEndpointTest {
     public void nonEmptyPathShouldBeKeptSame() {
         endpoint.setHttpURI(withSlash);
         assertEquals(withSlash, endpoint.getHttpURI());
+    }
+
+    @Test
+    void defaultHeaderFilterStrategyIsUndertowSpecific() {
+        assertInstanceOf(UndertowHeaderFilterStrategy.class, endpoint.getHeaderFilterStrategy());
+    }
+
+    @Test
+    void defaultBindingKeepsUndertowHeaderFilterStrategy() {
+        // the endpoint pushes its own strategy into the lazily created binding, so the endpoint default
+        // decides which strategy the binding ends up running
+        DefaultUndertowHttpBinding binding
+                = assertInstanceOf(DefaultUndertowHttpBinding.class, endpoint.getUndertowHttpBinding());
+        HeaderFilterStrategy strategy = binding.getHeaderFilterStrategy();
+        assertInstanceOf(UndertowHeaderFilterStrategy.class, strategy);
+
+        // the undertow-specific prefixes added by CAMEL-23588 must therefore be in effect
+        assertTrue(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null));
+        assertTrue(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY_LIST, "aValue", null));
+        assertTrue(strategy.applyFilterToExternalHeaders(UndertowConstants.SEND_TO_ALL, "aValue", null));
+        assertTrue(strategy.applyFilterToCamelHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null));
+    }
+
+    @Test
+    void explicitHeaderFilterStrategyIsHandedToTheBinding() {
+        HeaderFilterStrategy custom = new HttpHeaderFilterStrategy();
+        endpoint.setHeaderFilterStrategy(custom);
+
+        DefaultUndertowHttpBinding binding
+                = assertInstanceOf(DefaultUndertowHttpBinding.class, endpoint.getUndertowHttpBinding());
+        assertSame(custom, binding.getHeaderFilterStrategy());
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1619,3 +1619,35 @@ only once.
 In a Spring Boot application, Spring AI's auto-configured `ToolCallbackResolver` is built from the
 `ToolCallback` and `ToolCallbackProvider` beans in the context. A bare `@Bean Function<...>` is no
 longer resolvable by bean name; expose such tools as `ToolCallback` or `ToolCallbackProvider` beans.
+
+=== camel-undertow - UndertowHeaderFilterStrategy is now the endpoint default
+
+`UndertowEndpoint` defaulted its `headerFilterStrategy` to the base
+`HttpHeaderFilterStrategy`, and pushed that strategy into the `DefaultUndertowHttpBinding`
+it creates lazily, overwriting the `UndertowHeaderFilterStrategy` that the binding installs
+in its own constructor. The undertow-specific filtering was therefore not applied on
+endpoint-configured routes.
+
+The endpoint now defaults to `UndertowHeaderFilterStrategy`, which makes two already
+documented behaviours take effect:
+
+* The legacy `websocket.*` Exchange-header prefix, added to the in and out filters in
+  4.14.8 / 4.18.3 / 4.21.0 (see the 4.18 upgrade guide), is now filtered at the undertow
+  transport boundary as described there.
+* Header names that undertow does not accept (those for which
+  `io.undertow.util.HttpString.tryFromString` returns `null`) are skipped when mapping
+  external headers in, rather than being mapped onto the message.
+
+Ordinary application headers are unaffected, and Rest DSL consumers already used an
+undertow-specific strategy (`UndertowRestHeaderFilterStrategy`) so their behaviour does not
+change. Routes that relied on `websocket.*` headers crossing the undertow boundary in either
+direction, and routes that relied on undertow-invalid header names being mapped, can restore
+the previous behaviour by configuring `headerFilterStrategy` explicitly on the endpoint:
+
+[source,java]
+----
+from("undertow:http://0.0.0.0:8080/foo?headerFilterStrategy=#myStrategy")
+----
+
+Routes that already supply a custom `headerFilterStrategy` or a custom `undertowHttpBinding`
+are unaffected.


### PR DESCRIPTION
## Description

`DefaultUndertowHttpBinding` installs an `UndertowHeaderFilterStrategy` in its constructor:

```java
public DefaultUndertowHttpBinding(boolean useStreaming) {
    this.headerFilterStrategy = new UndertowHeaderFilterStrategy();
    ...
}
```

but `UndertowEndpoint` defaulted its own field to the base `HttpHeaderFilterStrategy` and pushed that into the binding when creating it lazily, overwriting what the binding had just set:

```java
private HeaderFilterStrategy headerFilterStrategy = new HttpHeaderFilterStrategy();   // line 88

public UndertowHttpBinding getUndertowHttpBinding() {
    if (undertowHttpBinding == null) {
        undertowHttpBinding = new DefaultUndertowHttpBinding(useStreaming);
        undertowHttpBinding.setHeaderFilterStrategy(getHeaderFilterStrategy());        // overwrites it
        ...
```

Unless the user supplied a custom binding or a custom `headerFilterStrategy`, the binding ran the base strategy and the undertow-specific filtering never executed.

## Impact

Two behaviours documented as shipped were inert on endpoint-configured routes:

- the legacy `websocket.*` Exchange-header prefix added to the in/out filters by CAMEL-23588 (released in 4.14.8 / 4.18.3 / 4.21.0 and described in the 4.18 upgrade guide);
- the `io.undertow.util.HttpString.tryFromString` header-name validation in `UndertowHeaderFilterStrategy.applyFilterToExternalHeaders`, which skips header names undertow does not accept.

Documentation and runtime behaviour had therefore diverged since CAMEL-23588.

## Fix

`UndertowEndpoint` now defaults to `UndertowHeaderFilterStrategy`, so both take effect.

- Rest DSL consumers are unchanged: `UndertowComponent` already assigns `UndertowRestHeaderFilterStrategy`, which extends `UndertowHeaderFilterStrategy`.
- Endpoints configuring `headerFilterStrategy` or `undertowHttpBinding` explicitly keep their behaviour.
- Ordinary application headers are unaffected; the two added filters are narrow.

The now-unused `HttpHeaderFilterStrategy` import is removed. No generated metadata changes, since the catalog records only the `HeaderFilterStrategy` interface and not the default implementation class.

## Changes

- `UndertowEndpoint` - default strategy, unused import
- `UndertowEndpointTest` - three cases: the endpoint default is undertow-specific; the lazily created binding keeps it and actually filters `UndertowConstants.CONNECTION_KEY` / `CONNECTION_KEY_LIST` / `SEND_TO_ALL`; an explicitly configured strategy still reaches the binding
- 4.22 upgrade-guide entry, including how to restore the previous behaviour

## Testing

- `camel-undertow` module build green: **191 tests pass, 0 failures, 1 skipped**. The websocket suites (`UndertowWsConsumerRouteTest`, `UndertowWsTwoRoutesToSameEndpointSendToAllHeaderTest`, ...) all still pass, since the producer reads those headers via `in.getHeader(...)`, which does not go through the `HeaderFilterStrategy`.
- Full reactor build from root (`mvn clean install -DskipTests`) green, no regenerated-artifact drift.

## Backport

`UndertowEndpoint` line 88 and `DefaultUndertowHttpBinding` line 86 are identical on `main`, `camel-4.18.x` and `camel-4.14.x`, so this should be backported to both LTS lines (with the matching 4.18 / 4.14 upgrade-guide entries doc-synced back to `main` per the backport policy). Backporting matters here because CAMEL-23588 shipped on those branches and its documented effect is what this restores.


## Review feedback (ff954f9)

The three new `UndertowEndpointTest` methods now use AssertJ (`assertThat(...)`) instead of JUnit assertions, per project convention. The two pre-existing methods keep their JUnit assertions, per the convention that touched code migrates without sweeping the whole file.

`assertj-core` was not on the `camel-undertow` test classpath, so it is also declared as a test dependency (version-less, supplied by the parent `dependencyManagement`). Flagged in the PR thread since the project standards ask that new dependencies be justified.

### Note on the earlier CI failure

The earlier red on this PR was not a regression. `build (17)` failed in `camel-cxf-spring-soap` with `BindException: Address already in use` / `Soap 1.1 endpoint already registered`, and `build (25)` was **cancelled** by matrix fail-fast rather than failing. That module has no `undertow:` endpoint usage in its tests, so `UndertowEndpoint` is not on its code path (it publishes through CXF's own `cxf-rt-transports-http-undertow`). A re-run passed both jobs.
---
_Claude Code on behalf of oscerd_