### PR TITLE
CAMEL-24357: camel-aws2-s3-vectors - consumer returns no results (topK=0), ignores delay, and can lose vectors

### DIFF
--- a/components/camel-aws/camel-aws2-s3-vectors/pom.xml
+++ b/components/camel-aws/camel-aws2-s3-vectors/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>camel-test-spring-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- test infra -->
         <dependency>

--- a/components/camel-aws/camel-aws2-s3-vectors/src/main/java/org/apache/camel/component/aws2/s3vectors/AWS2S3VectorsConsumer.java
+++ b/components/camel-aws/camel-aws2-s3-vectors/src/main/java/org/apache/camel/component/aws2/s3vectors/AWS2S3VectorsConsumer.java
@@ -83,7 +83,7 @@ public class AWS2S3VectorsConsumer extends ScheduledBatchPollingConsumer {
                     .vectorBucketName(vectorBucketName)
                     .indexName(vectorIndexName)
                     .queryVector(VectorData.builder().float32(queryVector).build())
-                    .topK(Math.min(getMaxMessagesPerPoll(), getConfiguration().getTopK()));
+                    .topK(resolveTopK());
 
             // Add metadata filter if configured
             String metadataFilter = getConfiguration().getConsumerMetadataFilter();
@@ -121,15 +121,18 @@ public class AWS2S3VectorsConsumer extends ScheduledBatchPollingConsumer {
                     message.setHeader(AWS2S3VectorsConstants.VECTOR_BUCKET_NAME, vectorBucketName);
                     message.setHeader(AWS2S3VectorsConstants.VECTOR_INDEX_NAME, vectorIndexName);
 
-                    // Add to processed set
-                    processedVectorIds.add(vectorId);
-
                     // Add delete callback if deleteAfterRead is enabled
                     if (getConfiguration().isDeleteAfterRead()) {
                         exchange.getExchangeExtension().addOnCompletion(
                                 new VectorDeleteSynchronization(
                                         getS3VectorsClient(), vectorBucketName, vectorIndexName,
                                         vectorId));
+                    } else {
+                        // Track for de-duplication only when we are not deleting (a deleted vector cannot be
+                        // returned again). Mark it now to avoid re-delivering it on overlapping polls, but drop it
+                        // again if the exchange fails so it can be retried on a subsequent poll.
+                        processedVectorIds.add(vectorId);
+                        exchange.getExchangeExtension().addOnCompletion(new VectorDedupSynchronization(vectorId));
                     }
 
                     exchanges.add(exchange);
@@ -201,6 +204,18 @@ public class AWS2S3VectorsConsumer extends ScheduledBatchPollingConsumer {
     }
 
     /**
+     * Resolves the number of nearest vectors to request from the similarity search. The configured {@code topK} is
+     * capped by {@code maxMessagesPerPoll} only when that is a positive value; a non-positive
+     * {@code maxMessagesPerPoll} (the "unlimited" default) leaves the configured {@code topK} unchanged. AWS S3 Vectors
+     * requires {@code topK >= 1}.
+     */
+    private int resolveTopK() {
+        int topK = getConfiguration().getTopK();
+        int max = getMaxMessagesPerPoll();
+        return max > 0 ? Math.min(max, topK) : topK;
+    }
+
+    /**
      * Parse comma-separated vector string into List<Float>
      *
      * @param  vectorString comma-separated float values (e.g., "0.1,0.2,0.3")
@@ -266,6 +281,24 @@ public class AWS2S3VectorsConsumer extends ScheduledBatchPollingConsumer {
         @Override
         public void onFailure(Exchange exchange) {
             LOG.trace("Exchange failed, not deleting vector [{}]", vectorId);
+        }
+    }
+
+    /**
+     * Synchronization callback that drops a vector id from the de-duplication set when the exchange fails, so the
+     * vector can be reprocessed on a subsequent poll instead of being skipped forever.
+     */
+    private class VectorDedupSynchronization extends SynchronizationAdapter {
+
+        private final String vectorId;
+
+        VectorDedupSynchronization(String vectorId) {
+            this.vectorId = vectorId;
+        }
+
+        @Override
+        public void onFailure(Exchange exchange) {
+            processedVectorIds.remove(vectorId);
         }
     }
 }

--- a/components/camel-aws/camel-aws2-s3-vectors/src/main/java/org/apache/camel/component/aws2/s3vectors/AWS2S3VectorsEndpoint.java
+++ b/components/camel-aws/camel-aws2-s3-vectors/src/main/java/org/apache/camel/component/aws2/s3vectors/AWS2S3VectorsEndpoint.java
@@ -85,6 +85,10 @@ public class AWS2S3VectorsEndpoint extends ScheduledPollEndpoint implements Endp
     public Consumer createConsumer(Processor processor) throws Exception {
         AWS2S3VectorsConsumer consumer = new AWS2S3VectorsConsumer(this, processor);
         configureConsumer(consumer);
+        consumer.setMaxMessagesPerPoll(configuration.getMaxMessagesPerPoll());
+        // the delay is a configuration option (it would otherwise shadow ScheduledPollEndpoint#delay and be
+        // ignored), so propagate it to the consumer's scheduler
+        consumer.setDelay(configuration.getDelay());
         return consumer;
     }
 

--- a/components/camel-aws/camel-aws2-s3-vectors/src/test/java/org/apache/camel/component/aws2/s3vectors/AWS2S3VectorsConsumerTest.java
+++ b/components/camel-aws/camel-aws2-s3-vectors/src/test/java/org/apache/camel/component/aws2/s3vectors/AWS2S3VectorsConsumerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.s3vectors;
+
+import java.util.List;
+
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
+import software.amazon.awssdk.services.s3vectors.model.QueryVectorsRequest;
+import software.amazon.awssdk.services.s3vectors.model.QueryVectorsResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class AWS2S3VectorsConsumerTest {
+
+    @Test
+    void consumerSendsPositiveTopK() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            S3VectorsClient client = Mockito.mock(S3VectorsClient.class);
+            ArgumentCaptor<QueryVectorsRequest> captor = ArgumentCaptor.forClass(QueryVectorsRequest.class);
+            when(client.queryVectors(captor.capture()))
+                    .thenReturn(QueryVectorsResponse.builder().vectors(List.of()).build());
+
+            AWS2S3VectorsEndpoint endpoint = context.getEndpoint(
+                    "aws2-s3-vectors://test-bucket?vectorIndexName=test-index&accessKey=test&secretKey=test",
+                    AWS2S3VectorsEndpoint.class);
+            endpoint.getConfiguration().setConsumerQueryVector("0.1,0.2,0.3");
+            endpoint.setS3VectorsClient(client);
+
+            AWS2S3VectorsConsumer consumer = (AWS2S3VectorsConsumer) endpoint.createConsumer(exchange -> {
+            });
+
+            consumer.poll();
+
+            // Before the fix the topK was Math.min(maxMessagesPerPoll, topK) where maxMessagesPerPoll was the
+            // unwired base-class field (0), so topK(0) was sent and AWS returned nothing. It must now be >= 1.
+            assertThat(captor.getValue().topK())
+                    .as("topK sent to AWS S3 Vectors must be >= 1")
+                    .isEqualTo(10);
+        }
+    }
+
+    @Test
+    void delayOptionDrivesTheConsumerPollInterval() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            AWS2S3VectorsEndpoint endpoint = context.getEndpoint(
+                    "aws2-s3-vectors://test-bucket?vectorIndexName=test-index&delay=1234&accessKey=test&secretKey=test",
+                    AWS2S3VectorsEndpoint.class);
+
+            AWS2S3VectorsConsumer consumer = (AWS2S3VectorsConsumer) endpoint.createConsumer(exchange -> {
+            });
+
+            // delay used to be ignored (a shadow field on the configuration); it must now drive the actual poll interval
+            assertThat(consumer.getDelay()).isEqualTo(1234L);
+        }
+    }
+}


### PR DESCRIPTION
# CAMEL-24357: camel-aws2-s3-vectors — consumer was non-functional and could lose vectors

The `aws2-s3-vectors` consumer had several defects, all rooted in consumer options that shadow the base scheduled-poll options.

## 1. Consumer always sent `topK(0)` — returned nothing (primary, HIGH)

`AWS2S3VectorsConsumer.poll()` built the query with `topK(Math.min(getMaxMessagesPerPoll(), getConfiguration().getTopK()))`. `getMaxMessagesPerPoll()` is the base `ScheduledBatchPollingConsumer` field, which defaults to **0** and was never wired — `AWS2S3VectorsEndpoint.createConsumer()` only called `configureConsumer(consumer)`, never `setMaxMessagesPerPoll(..)` (unlike `AWS2S3Endpoint`). So the expression was `Math.min(0, topK) = 0` and every poll sent `topK(0)`, which AWS S3 Vectors rejects (`topK >= 1`). **The consumer delivered zero messages out of the box.**

**Fix:** wire `setMaxMessagesPerPoll` from the configuration in `createConsumer`, and resolve `topK` so that a non-positive `maxMessagesPerPoll` (the "unlimited" default) means "use the configured `topK`" instead of capping to zero.

## 2. `delay` option was ignored

`delay` is declared on the configuration, so `?delay=` bound to `configuration.setDelay(..)` — a value the consumer never read; the real poll interval came from the inherited `ScheduledPollEndpoint`. A user setting `?delay=60000` was silently ignored.

**Fix:** propagate `configuration.getDelay()` to the consumer's scheduler in `createConsumer` (same place `maxMessagesPerPoll` is now wired).

## 3. Vectors marked processed before routing → event loss on failure

`poll()` added each vector id to `processedVectorIds` at enqueue time, before the exchange was routed. If routing later failed, the vector stayed in the index but was in the de-dup set, so the fixed similarity query skipped it forever. The set was also cleared only on stop (unbounded growth).

**Fix:** only track `processedVectorIds` when `deleteAfterRead=false` (deletion already prevents re-delivery, so the set no longer grows in that mode), and drop the id again on failure (`VectorDedupSynchronization.onFailure`) so a failed exchange is retried on a later poll.

## Tests

New `AWS2S3VectorsConsumerTest` (Mockito): `consumerSendsPositiveTopK` captures the `QueryVectorsRequest` and asserts `topK` is `>= 1` (fails against the old code), and `delayOptionDrivesTheConsumerPollInterval` asserts the configured `delay` reaches the consumer's scheduler. Existing producer tests still pass; full reactor build is green.

No public API change. `assertj-core` added as a test dependency (project-standard). Targets `main` (4.22.0) and `camel-4.18.x` (the module was added in 4.17.0; it does not exist on 4.14.x).

---
_Claude Code on behalf of oscerd_
