### PR TITLE
[backport camel-4.14.x] CAMEL-24360: camel-undertow - use UndertowHeaderFilterStrategy as the endpoint default

### DIFF
--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -140,6 +140,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>jetty-http2-client</artifactId>
             <version>${jetty-version}</version>

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowEndpoint.java
@@ -39,7 +39,6 @@ import org.apache.camel.cloud.ServiceDefinition;
 import org.apache.camel.component.undertow.UndertowConstants.EventType;
 import org.apache.camel.component.undertow.handlers.CamelWebSocketHandler;
 import org.apache.camel.component.undertow.spi.UndertowSecurityProvider;
-import org.apache.camel.http.base.HttpHeaderFilterStrategy;
 import org.apache.camel.http.base.cookie.CookieHandler;
 import org.apache.camel.spi.EndpointServiceLocation;
 import org.apache.camel.spi.HeaderFilterStrategy;
@@ -85,7 +84,7 @@ public class UndertowEndpoint extends DefaultEndpoint
     @UriParam(label = "advanced")
     private AccessLogReceiver accessLogReceiver;
     @UriParam(label = "advanced")
-    private HeaderFilterStrategy headerFilterStrategy = new HttpHeaderFilterStrategy();
+    private HeaderFilterStrategy headerFilterStrategy = new UndertowHeaderFilterStrategy();
     @UriParam(label = "security")
     private SSLContextParameters sslContextParameters;
     @UriParam(label = "consumer")

--- a/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowEndpointTest.java
+++ b/components/camel-undertow/src/test/java/org/apache/camel/component/undertow/UndertowEndpointTest.java
@@ -18,9 +18,12 @@ package org.apache.camel.component.undertow;
 
 import java.net.URI;
 
+import org.apache.camel.http.base.HttpHeaderFilterStrategy;
+import org.apache.camel.spi.HeaderFilterStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UndertowEndpointTest {
@@ -46,5 +49,36 @@ public class UndertowEndpointTest {
     public void nonEmptyPathShouldBeKeptSame() {
         endpoint.setHttpURI(withSlash);
         assertEquals(withSlash, endpoint.getHttpURI());
+    }
+
+    @Test
+    void defaultHeaderFilterStrategyIsUndertowSpecific() {
+        assertThat(endpoint.getHeaderFilterStrategy()).isInstanceOf(UndertowHeaderFilterStrategy.class);
+    }
+
+    @Test
+    void defaultBindingKeepsUndertowHeaderFilterStrategy() {
+        // the endpoint pushes its own strategy into the lazily created binding, so the endpoint default
+        // decides which strategy the binding ends up running
+        assertThat(endpoint.getUndertowHttpBinding()).isInstanceOf(DefaultUndertowHttpBinding.class);
+        HeaderFilterStrategy strategy
+                = ((DefaultUndertowHttpBinding) endpoint.getUndertowHttpBinding()).getHeaderFilterStrategy();
+        assertThat(strategy).isInstanceOf(UndertowHeaderFilterStrategy.class);
+
+        // the undertow-specific prefixes added by CAMEL-23588 must therefore be in effect
+        assertThat(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null)).isTrue();
+        assertThat(strategy.applyFilterToExternalHeaders(UndertowConstants.CONNECTION_KEY_LIST, "aValue", null)).isTrue();
+        assertThat(strategy.applyFilterToExternalHeaders(UndertowConstants.SEND_TO_ALL, "aValue", null)).isTrue();
+        assertThat(strategy.applyFilterToCamelHeaders(UndertowConstants.CONNECTION_KEY, "aValue", null)).isTrue();
+    }
+
+    @Test
+    void explicitHeaderFilterStrategyIsHandedToTheBinding() {
+        HeaderFilterStrategy custom = new HttpHeaderFilterStrategy();
+        endpoint.setHeaderFilterStrategy(custom);
+
+        assertThat(endpoint.getUndertowHttpBinding()).isInstanceOf(DefaultUndertowHttpBinding.class);
+        assertThat(((DefaultUndertowHttpBinding) endpoint.getUndertowHttpBinding()).getHeaderFilterStrategy())
+                .isSameAs(custom);
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -1129,6 +1129,37 @@ Routes that intentionally relied on undertow mapping `websocket.*` wire
 headers in or out can supply a custom `headerFilterStrategy` endpoint option
 to restore the previous behaviour.
 
+=== camel-undertow - UndertowHeaderFilterStrategy is now the endpoint default
+
+`UndertowEndpoint` defaulted its `headerFilterStrategy` to the base
+`HttpHeaderFilterStrategy`, and pushed that strategy into the `DefaultUndertowHttpBinding`
+it creates lazily, overwriting the `UndertowHeaderFilterStrategy` that the binding installs
+in its own constructor. The undertow-specific filtering was therefore not applied on
+endpoint-configured routes.
+
+The endpoint now defaults to `UndertowHeaderFilterStrategy`, which makes two already
+documented behaviours take effect:
+
+* The legacy `websocket.*` Exchange-header prefix, added to the in and out filters in
+  4.14.8 / 4.18.3 / 4.21.0 (see above), is now filtered at the undertow
+  transport boundary as described there.
+* Header names that undertow does not accept (those for which
+  `io.undertow.util.HttpString.tryFromString` returns `null`) are skipped when mapping
+  external headers in, rather than being mapped onto the message.
+
+Ordinary application headers are unaffected, and Rest DSL consumers already used an
+undertow-specific strategy (`UndertowRestHeaderFilterStrategy`) so their behaviour does not
+change. Routes that relied on `websocket.*` headers crossing the undertow boundary in either
+direction, and routes that relied on undertow-invalid header names being mapped, can restore
+the previous behaviour by configuring `headerFilterStrategy` explicitly on the endpoint:
+
+[source,java]
+----
+from("undertow:http://0.0.0.0:8080/foo?headerFilterStrategy=#myStrategy")
+----
+
+Routes that already supply a custom `headerFilterStrategy` or a custom `undertowHttpBinding`
+are unaffected.
 
 === camel-aws2-sqs
 


### PR DESCRIPTION
## Backport of #25367

Cherry-pick of #25367 onto `camel-4.14.x`.

**Original PR:** #25367 - CAMEL-24360: camel-undertow - use UndertowHeaderFilterStrategy as the endpoint default
**Original author:** @oscerd
**Target branch:** `camel-4.14.x`

### Original description

See #25367 for full details. The `UndertowEndpoint` defaulted its `headerFilterStrategy` to the base `HttpHeaderFilterStrategy`, overwriting the `UndertowHeaderFilterStrategy` the binding installs. This made the undertow-specific filtering (websocket.* prefix filtering, HttpString header-name validation) inert on endpoint-configured routes.

Conflicts resolved: import conflict (OAuth imports from main not present on 4.14.x), upgrade guide placed in 4.14 guide instead of 4.22.

---
_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>