### PR TITLE
CAMEL-24359: doc-sync backported upgrade-guide entries to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -53,6 +53,27 @@ filtering performed by other components.
 
 Ordinary application headers are unaffected.
 
+=== camel-atmosphere-websocket - potential breaking change
+
+The Exchange header constants in `WebsocketConstants` have been renamed to follow the
+Camel naming convention used across the rest of the component catalog. The Java field
+names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `WebsocketConstants.CONNECTION_KEY`      | `websocket.connectionKey`      | `CamelAtmosphereWebsocketConnectionKey`
+| `WebsocketConstants.CONNECTION_KEY_LIST` | `websocket.connectionKey.list` | `CamelAtmosphereWebsocketConnectionKeyList`
+| `WebsocketConstants.SEND_TO_ALL`         | `websocket.sendToAll`          | `CamelAtmosphereWebsocketSendToAll`
+| `WebsocketConstants.EVENT_TYPE`          | `websocket.eventType`          | `CamelAtmosphereWebsocketEventType`
+| `WebsocketConstants.ERROR_TYPE`          | `websocket.errorType`          | `CamelAtmosphereWebsocketErrorType`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(WebsocketConstants.CONNECTION_KEY, ...)`) continue to work without changes.
+Routes that set the header by its literal string value must be updated to use the new
+value.
+
 == Upgrading from 4.14.3 to 4.14.8
 
 === camel-jackson - potential breaking change

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -89,6 +89,27 @@ filtering performed by other components.
 
 Ordinary application headers are unaffected.
 
+=== camel-atmosphere-websocket - potential breaking change
+
+The Exchange header constants in `WebsocketConstants` have been renamed to follow the
+Camel naming convention used across the rest of the component catalog. The Java field
+names are unchanged; only the header string values have changed:
+
+[options="header"]
+|===
+| Constant | Previous value | New value
+| `WebsocketConstants.CONNECTION_KEY`      | `websocket.connectionKey`      | `CamelAtmosphereWebsocketConnectionKey`
+| `WebsocketConstants.CONNECTION_KEY_LIST` | `websocket.connectionKey.list` | `CamelAtmosphereWebsocketConnectionKeyList`
+| `WebsocketConstants.SEND_TO_ALL`         | `websocket.sendToAll`          | `CamelAtmosphereWebsocketSendToAll`
+| `WebsocketConstants.EVENT_TYPE`          | `websocket.eventType`          | `CamelAtmosphereWebsocketEventType`
+| `WebsocketConstants.ERROR_TYPE`          | `websocket.errorType`          | `CamelAtmosphereWebsocketErrorType`
+|===
+
+Routes that reference the constant symbolically (for example
+`setHeader(WebsocketConstants.CONNECTION_KEY, ...)`) continue to work without changes.
+Routes that set the header by its literal string value must be updated to use the new
+value.
+
 == Upgrading from 4.18.1 to 4.18.3
 
 === camel-jackson - potential breaking change


### PR DESCRIPTION
## Summary

Doc-sync the camel-atmosphere-websocket header rename upgrade-guide entries from the backport PRs back to `main`, per the backport upgrade-guide policy.

- Adds the CAMEL-24359 entry to `camel-4x-upgrade-guide-4_18.adoc` (4.18.3→4.18.4 section)
- Adds the CAMEL-24359 entry to `camel-4x-upgrade-guide-4_14.adoc` (4.14.8→4.14.9 section)

**Related PRs:**
- #25366 (original, merged to `main`)
- #25382 (backport to `camel-4.18.x`)
- #25383 (backport to `camel-4.14.x`)

_Claude Code on behalf of davsclaus_