### PR TITLE
CAMEL-24365: Copy attachment trait from IN when creating a fresh OUT message

### DIFF
--- a/components/camel-attachments/src/test/java/org/apache/camel/attachment/AttachmentOnOutMessageTest.java
+++ b/components/camel-attachments/src/test/java/org/apache/camel/attachment/AttachmentOnOutMessageTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.attachment;
+
+import jakarta.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test that attachments on the IN message survive when a producer creates a fresh OUT message via exchange.getOut().
+ * This is a regression test for CAMEL-24365.
+ */
+class AttachmentOnOutMessageTest extends CamelTestSupport {
+
+    @Test
+    void testAttachmentSurvivesOutMessage() throws Exception {
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        template.sendBody("direct:start", "Hello");
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        Exchange received = getMockEndpoint("mock:result").getReceivedExchanges().get(0);
+        AttachmentMessage am = received.getMessage(AttachmentMessage.class);
+        assertTrue(am.hasAttachments());
+        assertEquals(1, am.getAttachmentNames().size());
+        assertTrue(am.getAttachmentNames().contains("test.txt"));
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .process(exchange -> {
+                            AttachmentMessage msg = exchange.getMessage(AttachmentMessage.class);
+                            msg.addAttachment("test.txt", new DataHandler("content", "text/plain"));
+                        })
+                        .process(exchange -> {
+                            // simulate what HttpProducer does: create a fresh OUT message
+                            exchange.getOut().setBody("response");
+                        })
+                        .process(exchange -> {
+                            // after pipeline promotes OUT to IN, attachments must still be present
+                            AttachmentMessage msg = exchange.getMessage(AttachmentMessage.class);
+                            exchange.getMessage().setHeader("attachmentCount", msg.getAttachmentNames().size());
+                        })
+                        .to("mock:result");
+            }
+        };
+    }
+}

--- a/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
+++ b/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessage.java
@@ -17,7 +17,6 @@
 package org.apache.camel.component.jms;
 
 import java.io.File;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import jakarta.jms.Destination;
@@ -120,12 +119,6 @@ public class JmsMessage extends DefaultMessage {
         // we have already cleared the headers
         if (that.hasHeaders()) {
             getHeaders().putAll(that.getHeaders());
-        }
-
-        // copy attachments
-        Map<String, Object> attachments = (Map<String, Object>) that.getPayloadForTrait(MessageTrait.ATTACHMENTS);
-        if (attachments != null) {
-            setPayloadForTrait(MessageTrait.ATTACHMENTS, new LinkedHashMap<>(attachments));
         }
     }
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/AbstractExchange.java
@@ -19,6 +19,7 @@ package org.apache.camel.support;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -514,10 +515,19 @@ abstract class AbstractExchange implements Exchange, ExchangeExtension {
         return out;
     }
 
+    @SuppressWarnings("unchecked")
     private Message newOutMessage() {
         if (in != null) {
             Message answer = in.newInstance();
             CamelContextAware.trySetCamelContext(answer, getContext());
+            // copy attachments from IN so they survive when a producer swaps in a fresh OUT
+            if (in.hasTrait(MessageTrait.ATTACHMENTS)) {
+                Map<String, Object> attachments
+                        = (Map<String, Object>) in.getPayloadForTrait(MessageTrait.ATTACHMENTS);
+                if (attachments != null) {
+                    answer.setPayloadForTrait(MessageTrait.ATTACHMENTS, new LinkedHashMap<>(attachments));
+                }
+            }
             return answer;
         } else {
             return new DefaultMessage(getContext());

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -70,6 +70,14 @@ allow-list must pass an explicit filter pattern to the new
 `CamelObjectInputStream(InputStream, CamelContext, String)` constructor (or configure
 `jdk.serialFilter`) to permit them.
 
+==== Attachments preserved when a producer creates a fresh OUT message
+
+Since Camel 4.10.1, message attachments were silently lost when a producer (such as `camel-http`)
+created a fresh OUT message via `exchange.getOut()`. The attachment trait is now copied from the
+IN message to the new OUT message, restoring the pre-4.10.1 behavior where attachments survived
+across the exchange. If you added a workaround (for example, stashing and restoring attachments
+in exchange properties around a producer call), it can be removed.
+
 === camel-jbang
 
 The Camel JBang CLI (Camel CLI) and TUI have been promoted from _Preview_ to _Stable_ support level.


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

Since [CAMEL-21755](https://issues.apache.org/jira/browse/CAMEL-21755) (released in 4.10.1) moved attachment storage from Exchange-level safe-copy properties to Message-level traits (`MessageTrait.ATTACHMENTS`), any producer that creates a fresh OUT message via `exchange.getOut()` silently drops attachments. This affects camel-http (reported in [CAMEL-24364](https://issues.apache.org/jira/browse/CAMEL-24364)) and ~127 other producers across 30+ components.

**Root cause:** `AbstractExchange.newOutMessage()` calls `in.newInstance()` which returns a blank message with no traits. Before 4.10.1, attachments lived on the Exchange and were naturally shared; after the trait migration, they're silently lost.

**Fix:**
- Copy the `ATTACHMENTS` trait from IN to the new OUT message in `AbstractExchange.newOutMessage()`, restoring the pre-4.10.1 semantics
- Remove the per-component workaround added in [CAMEL-23193](https://issues.apache.org/jira/browse/CAMEL-23193) for `JmsMessage.copyFrom()`
- Add a regression test that reproduces the exact bug
- Add upgrade guide note for 4.22

## Test plan

- [x] New `AttachmentOnOutMessageTest` reproduces the bug (attachment on IN, fresh OUT via `exchange.getOut()`, verify attachment survives)
- [x] All existing camel-attachments tests pass
- [x] camel-jms compiles cleanly after removing workaround