### PR TITLE
CAMEL-24345: camel-google-vertexai - do not require credentials in GoogleVertexAIProducerOptionsTest

### DIFF
--- a/components/camel-google/camel-google-vertexai/src/test/java/org/apache/camel/component/google/vertexai/GoogleVertexAIProducerOptionsTest.java
+++ b/components/camel-google/camel-google-vertexai/src/test/java/org/apache/camel/component/google/vertexai/GoogleVertexAIProducerOptionsTest.java
@@ -43,8 +43,10 @@ class GoogleVertexAIProducerOptionsTest {
 
     private GoogleVertexAIProducer producer(String query) throws Exception {
         context = new DefaultCamelContext();
-        context.start();
-        GoogleVertexAIEndpoint endpoint = context.getEndpoint(BASE + query, GoogleVertexAIEndpoint.class);
+        // the endpoint is deliberately created without starting it: starting it builds the Vertex AI client,
+        // which looks up Application Default Credentials and fails wherever none are configured
+        GoogleVertexAIComponent component = context.getComponent("google-vertexai", GoogleVertexAIComponent.class);
+        GoogleVertexAIEndpoint endpoint = (GoogleVertexAIEndpoint) component.createEndpoint(BASE + query);
         return new GoogleVertexAIProducer(endpoint);
     }
 


### PR DESCRIPTION
Follow-up to #25362, which turned `main` red: `GoogleVertexAIProducerOptionsTest` fails in CI with

```
ResolveEndpointFailed ... due to: java.io.IOException: Your default credentials were not found.
```

The test resolved its endpoint from a **started** `CamelContext`. Camel starts endpoints created on a
started context, and `GoogleVertexAIEndpoint.doStart()` builds the Vertex AI client, which falls back
to Application Default Credentials. My workstation has ADC configured, so the test passed locally and
failed on every machine that has none.

The endpoint is now created through the component and never started — the same pattern the existing
`GoogleVertexAIProducerOperationsTest` uses. `buildConfig` and `determineStreamOutputMode` only read
the configuration, so no client is needed.

Verified by reproducing the CI failure locally with `CLOUDSDK_CONFIG` pointed at an empty directory
and `GOOGLE_APPLICATION_CREDENTIALS` cleared: 4 errors before the change, 13/13 module tests green
after it.

Sorry for the breakage — the fix is test-only, no production code is touched.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)