### PR TITLE
CAMEL-24346: camel-google-sheets - number every range and tolerate a range without values

### DIFF
--- a/components/camel-google/camel-google-sheets/pom.xml
+++ b/components/camel-google/camel-google-sheets/pom.xml
@@ -149,6 +149,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
             <scope>test</scope>

--- a/components/camel-google/camel-google-sheets/src/main/java/org/apache/camel/component/google/sheets/stream/GoogleSheetsStreamConsumer.java
+++ b/components/camel-google/camel-google-sheets/src/main/java/org/apache/camel/component/google/sheets/stream/GoogleSheetsStreamConsumer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.BatchGetValuesResponse;
@@ -84,39 +85,7 @@ public class GoogleSheetsStreamConsumer extends ScheduledBatchPollingConsumer {
             forceConsumerAsReady();
 
             if (response.getValueRanges() != null) {
-                if (getConfiguration().isSplitResults()) {
-                    for (ValueRange valueRange : response.getValueRanges()) {
-                        AtomicInteger rangeIndex = new AtomicInteger(1);
-                        AtomicInteger valueIndex = new AtomicInteger();
-                        if (getConfiguration().getMaxResults() > 0) {
-                            valueRange.getValues().stream()
-                                    .limit(getConfiguration().getMaxResults())
-                                    .map(values -> createExchange(rangeIndex.get(), valueIndex.incrementAndGet(),
-                                            valueRange.getRange(), valueRange.getMajorDimension(), values))
-                                    .forEach(answer::add);
-                        } else {
-                            valueRange.getValues().stream()
-                                    .map(values -> createExchange(rangeIndex.get(), valueIndex.incrementAndGet(),
-                                            valueRange.getRange(), valueRange.getMajorDimension(), values))
-                                    .forEach(answer::add);
-                        }
-                        rangeIndex.incrementAndGet();
-                    }
-                } else {
-                    AtomicInteger rangeIndex = new AtomicInteger();
-                    response.getValueRanges()
-                            .stream()
-                            .peek(valueRange -> {
-                                if (getConfiguration().getMaxResults() > 0) {
-                                    valueRange.setValues(valueRange.getValues()
-                                            .stream()
-                                            .limit(getConfiguration().getMaxResults())
-                                            .collect(Collectors.toList()));
-                                }
-                            })
-                            .map(valueRange -> createExchange(rangeIndex.incrementAndGet(), valueRange))
-                            .forEach(answer::add);
-                }
+                answer.addAll(createExchanges(response.getValueRanges()));
             }
         } else {
             Sheets.Spreadsheets.Get request = getClient().spreadsheets().get(getConfiguration().getSpreadsheetId());
@@ -124,10 +93,58 @@ public class GoogleSheetsStreamConsumer extends ScheduledBatchPollingConsumer {
             request.setIncludeGridData(getConfiguration().isIncludeGridData());
 
             Spreadsheet spreadsheet = request.execute();
+
+            // okay we have some response from Google so lets mark the consumer as ready
+            forceConsumerAsReady();
+
             answer.add(createExchange(spreadsheet));
         }
 
         return processBatch(CastUtils.cast(answer));
+    }
+
+    /**
+     * Builds one exchange per value when the results are split, one per range otherwise. The range index counts the
+     * ranges of the whole response, not of a single range.
+     */
+    Queue<Exchange> createExchanges(List<ValueRange> valueRanges) {
+        Queue<Exchange> answer = new ArrayDeque<>();
+        AtomicInteger rangeIndex = new AtomicInteger();
+
+        if (getConfiguration().isSplitResults()) {
+            for (ValueRange valueRange : valueRanges) {
+                int currentRange = rangeIndex.incrementAndGet();
+                AtomicInteger valueIndex = new AtomicInteger();
+                Stream<List<Object>> values = valuesOf(valueRange).stream();
+                if (getConfiguration().getMaxResults() > 0) {
+                    values = values.limit(getConfiguration().getMaxResults());
+                }
+                values.map(value -> createExchange(currentRange, valueIndex.incrementAndGet(),
+                        valueRange.getRange(), valueRange.getMajorDimension(), value))
+                        .forEach(answer::add);
+            }
+        } else {
+            valueRanges.stream()
+                    .peek(valueRange -> {
+                        if (getConfiguration().getMaxResults() > 0) {
+                            valueRange.setValues(valuesOf(valueRange)
+                                    .stream()
+                                    .limit(getConfiguration().getMaxResults())
+                                    .collect(Collectors.toList()));
+                        }
+                    })
+                    .map(valueRange -> createExchange(rangeIndex.incrementAndGet(), valueRange))
+                    .forEach(answer::add);
+        }
+
+        return answer;
+    }
+
+    /**
+     * The values of a range, never null: the sheets API omits the field for a range that holds no value at all.
+     */
+    private static List<List<Object>> valuesOf(ValueRange valueRange) {
+        return valueRange.getValues() != null ? valueRange.getValues() : List.of();
     }
 
     @Override

--- a/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/GoogleSheetsStreamConsumerRangeIndexTest.java
+++ b/components/camel-google/camel-google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/GoogleSheetsStreamConsumerRangeIndexTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.sheets.stream;
+
+import java.util.List;
+import java.util.Queue;
+
+import com.google.api.services.sheets.v4.model.ValueRange;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Verifies the exchanges the stream consumer builds out of a batch-get response: one per value when the results are
+ * split, one per range otherwise, and the range index counting the ranges of the response.
+ */
+class GoogleSheetsStreamConsumerRangeIndexTest {
+
+    private DefaultCamelContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    private GoogleSheetsStreamConsumer consumer(String query) throws Exception {
+        if (context != null) {
+            context.stop();
+        }
+        context = new DefaultCamelContext();
+        // the endpoint is deliberately not started, so no google client is built
+        GoogleSheetsStreamComponent component
+                = context.getComponent("google-sheets-stream", GoogleSheetsStreamComponent.class);
+        GoogleSheetsStreamEndpoint endpoint = (GoogleSheetsStreamEndpoint) component.createEndpoint(
+                "google-sheets-stream://sheet1?clientId=id&clientSecret=secret&range=A1:B2,C1:D2" + query);
+        return new GoogleSheetsStreamConsumer(endpoint, exchange -> {
+        });
+    }
+
+    private static ValueRange range(String name, List<List<Object>> values) {
+        return new ValueRange().setRange(name).setMajorDimension("ROWS").setValues(values);
+    }
+
+    private static List<Object> rangeIndexes(Queue<Exchange> exchanges) {
+        return exchanges.stream()
+                .map(e -> e.getIn().getHeader(GoogleSheetsStreamConstants.RANGE_INDEX))
+                .toList();
+    }
+
+    @Test
+    void splitResultsNumbersEveryRange() throws Exception {
+        Queue<Exchange> exchanges = consumer("&splitResults=true").createExchanges(List.of(
+                range("A1:B2", List.of(List.of("a1", "b1"), List.of("a2", "b2"))),
+                range("C1:D2", List.of(List.of("c1", "d1")))));
+
+        // one exchange per value, and the range index identifies which range the value came from
+        assertThat(rangeIndexes(exchanges)).containsExactly(1, 1, 2);
+        assertThat(exchanges.stream().map(e -> e.getIn().getHeader(GoogleSheetsStreamConstants.VALUE_INDEX)).toList())
+                .containsExactly(1, 2, 1);
+    }
+
+    @Test
+    void withoutSplitResultsEveryRangeIsOneExchange() throws Exception {
+        Queue<Exchange> exchanges = consumer("").createExchanges(List.of(
+                range("A1:B2", List.of(List.of("a1", "b1"))),
+                range("C1:D2", List.of(List.of("c1", "d1")))));
+
+        assertThat(rangeIndexes(exchanges)).containsExactly(1, 2);
+    }
+
+    @Test
+    void aRangeWithoutValuesIsNotAFailure() throws Exception {
+        // the sheets API omits the values field for a range that holds nothing
+        GoogleSheetsStreamConsumer consumer = consumer("&splitResults=true");
+        ValueRange empty = new ValueRange().setRange("A1:B2").setMajorDimension("ROWS");
+
+        assertThatCode(() -> consumer.createExchanges(List.of(empty))).doesNotThrowAnyException();
+        assertThat(consumer.createExchanges(List.of(empty))).isEmpty();
+    }
+
+    @Test
+    void aRangeWithoutValuesIsNotAFailureWhenResultsAreNotSplit() throws Exception {
+        GoogleSheetsStreamConsumer consumer = consumer("&maxResults=1");
+        ValueRange empty = new ValueRange().setRange("A1:B2").setMajorDimension("ROWS");
+
+        assertThatCode(() -> consumer.createExchanges(List.of(empty))).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Two defects in `GoogleSheetsStreamConsumer`, both covered by a new test.

**1. `splitResults` reported range index 1 for every value.** The counter was allocated *inside* the
loop over the ranges:

```java
for (ValueRange valueRange : response.getValueRanges()) {
    AtomicInteger rangeIndex = new AtomicInteger(1);
    ...
    rangeIndex.incrementAndGet();   // dead: a fresh counter next iteration
}
```

So a consumer configured with `range=A1:B2,C1:D2&splitResults=true` sent every exchange with
`CamelGoogleSheetsRangeIndex=1`, and there was no way to tell which range a value came from. The
counter now spans the whole response, which is what the non-split branch already did.

**2. A range without values threw.** `valueRange.getValues()` was dereferenced directly in both
branches, but the Sheets API omits the `values` field for a range that holds nothing, so polling a
spreadsheet with an empty range failed with a `NullPointerException` on every cycle.

Two smaller things while in there: the exchange building moved into `createExchanges(List<ValueRange>)`
so it can be tested without a Google client (the API client needs a real transport), and the branch
that reads a whole spreadsheet — used when no `range` is configured — now calls `forceConsumerAsReady()`
as well, so the consumer health check reports ready on that path too.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)