### PR TITLE
CAMEL-24296: document the setObjectInputFilter IllegalStateException gotcha in the upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -78,6 +78,12 @@ allow-list must pass an explicit filter pattern to the new
 `CamelObjectInputStream(InputStream, CamelContext, String)` constructor (or configure
 `jdk.serialFilter`) to permit them.
 
+Because the two-argument `CamelObjectInputStream(InputStream, CamelContext)` constructor now always
+installs a filter, calling `setObjectInputFilter()` on the resulting stream throws
+`IllegalStateException` ("filter can not be set more than once") on JDK 17+. Downstream code that
+previously constructed the stream and then set a filter separately should pass the pattern to the
+new `CamelObjectInputStream(InputStream, CamelContext, String)` constructor instead.
+
 ==== Attachments preserved when a producer creates a fresh OUT message
 
 Since Camel 4.10.1, message attachments were silently lost when a producer (such as `camel-http`)


### PR DESCRIPTION
Follow-up to #25378 (CAMEL-24296).

During the merge of #25378 this upgrade-guide note — requested by @gnodet in review — was left behind by GitHub's fork-head sync lag: the PR was merged at the previous commit before the doc commit synced to the PR head. This lands it on `main`.

It documents that the two-argument `CamelObjectInputStream(InputStream, CamelContext)` constructor now always installs a filter, so a subsequent `setObjectInputFilter()` call throws `IllegalStateException` ("filter can not be set more than once") on JDK 17+, and recommends the three-argument constructor as the migration path.

Docs-only.

_Claude Code on behalf of oscerd_
