### PR TITLE
CAMEL-21577: Fix test-infra modules not using container.properties for Dockerfile base images

### DIFF
--- a/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliBuiltContainer.java
+++ b/test-infra/camel-test-infra-cli/src/main/java/org/apache/camel/test/infra/cli/services/CliBuiltContainer.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.camel.test.infra.cli.common.CliProperties;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
 import org.apache.camel.test.infra.common.TestUtils;
 import org.junit.platform.commons.util.StringUtils;
 import org.slf4j.Logger;
@@ -48,9 +49,6 @@ public class CliBuiltContainer extends GenericContainer<CliBuiltContainer> {
     private static final String KEEP_RUNNING_ARG = "KEEP_RUNNING";
     private static final String MOUNT_POINT = "/deployments/data";
     private static final String SSH_PASSWORD_ARG = "SSH_PASSWORD_ARG";
-    // NOTE: make sure to run integration tests locally when changing in order to
-    // validate potential breaking changes compatibility when building the container
-    private static final String FROM_IMAGE_NAME = "mirror.gcr.io/fedora:43";
     private static final String FROM_IMAGE_ARG = "FROMIMAGE";
     protected static final int DEV_CONSOLE_PORT = 8080;
     protected static final int SSH_PORT = 22;
@@ -87,7 +85,7 @@ public class CliBuiltContainer extends GenericContainer<CliBuiltContainer> {
                 .withFileFromClasspath("99-ssh-jbang.conf",
                         "org/apache/camel/test/infra/cli/services/99-ssh-jbang.conf")
                 .withBuildArg(FROM_IMAGE_ARG, TestUtils.prependHubImageNamePrefixIfNeeded(
-                        System.getProperty(CliProperties.FROM_IMAGE, FROM_IMAGE_NAME)))
+                        LocalPropertyResolver.getProperty(CliBuiltContainer.class, CliProperties.FROM_IMAGE)))
                 .withBuildArg(CAMEL_REF_ARG, params.getCamelRef())
                 .withBuildArg(KEEP_RUNNING_ARG, String.valueOf(params.getKeepContainerRunning()))
                 .withBuildArg(SSH_PASSWORD_ARG, params.getSshPassword())

--- a/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-ARG FROMIMAGE
+ARG FROMIMAGE=mirror.gcr.io/fedora:43
 
 FROM $FROMIMAGE
 

--- a/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/container.properties
+++ b/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/container.properties
@@ -1,0 +1,20 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+#
+# NOTE: make sure to run integration tests locally when changing in order to
+# validate potential breaking changes compatibility when building the container
+cli.service.from.image=mirror.gcr.io/fedora:43

--- a/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/common/HiveMQProperties.java
+++ b/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/common/HiveMQProperties.java
@@ -26,6 +26,7 @@ public final class HiveMQProperties {
     public static final String HIVEMQ_CONTAINER = "hivemq.container";
     public static final String HIVEMQ_RESOURCE_PATH = "hivemq.resource.path";
     public static final String HIVEMQ_SPARKPLUG_CONTAINER = "hivemq.sparkplug.container";
+    public static final String HIVEMQ_SPARKPLUG_FROM_IMAGE = "hivemq.sparkplug.from.image";
     public static final String HIVEMQ_SPARKPLUG_INSTANCE_SELECTOR = "hivemq-sparkplug";
 
     public static final String HIVEMQ_TEST_SERVICE_NAME = "hivemq";

--- a/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/LocalHiveMQSparkplugTCKInfraService.java
+++ b/test-infra/camel-test-infra-hivemq/src/main/java/org/apache/camel/test/infra/hivemq/services/LocalHiveMQSparkplugTCKInfraService.java
@@ -18,6 +18,7 @@ package org.apache.camel.test.infra.hivemq.services;
 
 import org.apache.camel.spi.annotations.InfraService;
 import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.TestUtils;
 import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
 import org.apache.camel.test.infra.hivemq.common.HiveMQProperties;
 import org.testcontainers.hivemq.HiveMQContainer;
@@ -40,8 +41,14 @@ public class LocalHiveMQSparkplugTCKInfraService extends AbstractLocalHiveMQServ
         String dockerfileResourcePath = LocalPropertyResolver.getProperty(LocalHiveMQSparkplugTCKInfraService.class,
                 HiveMQProperties.HIVEMQ_RESOURCE_PATH);
 
+        String fromImage = TestUtils.prependHubImageNamePrefixIfNeeded(
+                LocalPropertyResolver.getProperty(
+                        LocalHiveMQSparkplugTCKInfraService.class, HiveMQProperties.HIVEMQ_SPARKPLUG_FROM_IMAGE));
+
         ImageFromDockerfile newImage
-                = new ImageFromDockerfile(imageName, false).withFileFromClasspath(".", dockerfileResourcePath);
+                = new ImageFromDockerfile(imageName, false)
+                        .withFileFromClasspath(".", dockerfileResourcePath)
+                        .withBuildArg("FROMIMAGE", fromImage);
         String newImageName = newImage.get();
 
         class TestInfraHiveMQContainer extends HiveMQContainer {

--- a/test-infra/camel-test-infra-hivemq/src/main/resources/org/apache/camel/test/infra/hivemq/services/Dockerfile
+++ b/test-infra/camel-test-infra-hivemq/src/main/resources/org/apache/camel/test/infra/hivemq/services/Dockerfile
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-ARG HIVEMQ_VERSION=2024.6
+ARG FROMIMAGE=mirror.gcr.io/hivemq/hivemq-ce:2024.6
 
-FROM mirror.gcr.io/hivemq/hivemq-ce:$HIVEMQ_VERSION as hivemq-ce-sparkplug-tck
+FROM $FROMIMAGE as hivemq-ce-sparkplug-tck
 
 ARG SPARKPLUG_TCK_VERSION=3.0.0
 

--- a/test-infra/camel-test-infra-hivemq/src/main/resources/org/apache/camel/test/infra/hivemq/services/container.properties
+++ b/test-infra/camel-test-infra-hivemq/src/main/resources/org/apache/camel/test/infra/hivemq/services/container.properties
@@ -17,3 +17,4 @@
 hivemq.container=mirror.gcr.io/hivemq/hivemq-ce:2025.5
 hivemq.resource.path=org/apache/camel/test/infra/hivemq/services
 hivemq.sparkplug.container=localhost/hivemq-ce-sparkplug-tck:camel
+hivemq.sparkplug.from.image=mirror.gcr.io/hivemq/hivemq-ce:2024.6

--- a/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/common/SmbProperties.java
+++ b/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/common/SmbProperties.java
@@ -22,5 +22,6 @@ public class SmbProperties {
     public static final String SHARE_NAME = "smb.service.share";
     public static final String SMB_USERNAME = "smb.service.username";
     public static final String SMB_PASSWORD = "smb.service.password";
+    public static final String SMB_FROM_IMAGE = "smb.service.from.image";
 
 }

--- a/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbContainer.java
+++ b/test-infra/camel-test-infra-smb/src/main/java/org/apache/camel/test/infra/smb/services/SmbContainer.java
@@ -19,7 +19,10 @@ package org.apache.camel.test.infra.smb.services;
 
 import java.nio.file.Path;
 
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.common.TestUtils;
 import org.apache.camel.test.infra.common.services.ContainerEnvironmentUtil;
+import org.apache.camel.test.infra.smb.common.SmbProperties;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
@@ -31,6 +34,7 @@ public class SmbContainer extends GenericContainer<SmbContainer> {
     public static final String DEFAULT_USER = "camel";
     // NOTE: default value used for testing purposes only.
     public static final String DEFAULT_PASSWORD = "camelTester123"; // NOSONAR
+    private static final String FROM_IMAGE_ARG = "FROMIMAGE";
 
     public SmbContainer(boolean fixedPort) {
         super(new ImageFromDockerfile("localhost/samba:camel", false)
@@ -41,7 +45,10 @@ public class SmbContainer extends GenericContainer<SmbContainer> {
                 .withFileFromClasspath("smb.conf",
                         "org/apache/camel/test/infra/smb/services/smb.conf")
                 .withFileFromClasspath("start.sh",
-                        "org/apache/camel/test/infra/smb/services/start.sh"));
+                        "org/apache/camel/test/infra/smb/services/start.sh")
+                .withBuildArg(FROM_IMAGE_ARG,
+                        TestUtils.prependHubImageNamePrefixIfNeeded(
+                                LocalPropertyResolver.getProperty(SmbContainer.class, SmbProperties.SMB_FROM_IMAGE))));
 
         ContainerEnvironmentUtil.configurePort(this, fixedPort, SMB_PORT_DEFAULT);
 

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/Dockerfile
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/Dockerfile
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-FROM mirror.gcr.io/fedora:43 as samba
+ARG FROMIMAGE=mirror.gcr.io/fedora:43
+FROM $FROMIMAGE as samba
 LABEL maintainer="orpiske@apache.org"
 ENV SAMBA_ROOT /opt/camel/samba
 EXPOSE 139 445

--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/container.properties
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/container.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+smb.service.from.image=mirror.gcr.io/fedora:43
+


### PR DESCRIPTION
# Description

## Summary

Three test-infra modules that build containers from Dockerfiles (`camel-test-infra-smb`, `camel-test-infra-cli`, `camel-test-infra-hivemq`) had their base images hardcoded in Java constants or Dockerfile `ARG` defaults, bypassing `container.properties`. 
This meant the images could not be overridden via system properties or platform-specific keys, and environments using a private registry proxy (`hub.image.name.prefix`) could not redirect the pulls.

This PR externalizes the base image references into `container.properties` using a consistent pattern across all three modules:

  - **container.properties** — declares the base image (e.g., `smb.service.from.image=mirror.gcr.io/fedora:43`)
  - **Dockerfile** — uses `ARG FROMIMAGE=<default>` / `FROM $FROMIMAGE` (default preserved for standalone `docker build`)
  - **Java** — resolves the property via `LocalPropertyResolver`, wraps with `TestUtils.prependHubImageNamePrefixIfNeeded()`, and passes it via
  `.withBuildArg("FROMIMAGE", ...)`

### Per-module details

**camel-test-infra-smb** — New `container.properties` and `SmbProperties.SMB_FROM_IMAGE` constant. `SmbContainer` now resolves the base image from properties instead of hardcoding it.

**camel-test-infra-cli** — New `container.properties` (includes the existing "run integration tests locally" warning). `CliBuiltContainer` now uses `LocalPropertyResolver` instead of `System.getProperty` with a hardcoded fallback constant.

**camel-test-infra-hivemq** — The Sparkplug TCK Dockerfile hardcoded `ARG HIVEMQ_VERSION=2024.6` and the Java code never passed a build arg. Added `hivemq.sparkplug.from.image` to the existing `container.properties` and wired `withBuildArg` in `LocalHiveMQSparkplugTCKInfraService`. The standard HiveMQ service (`LocalHiveMQInfraService`) already used `container.properties` correctly and was not changed.

## Test plan

  - [x] Build all three modules: `mvn -DskipTests install` in each module directory
  - [x] Verify system property override works (e.g., `-Dsmb.service.from.image=...`)
  - [x] Run integration tests for camel-smb, camel-cli, and camel-mqtt (HiveMQ Sparkplug) components

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

