### PR TITLE
CAMEL-24360: docs - note that the CAMEL-23588 undertow filter was not applied before the fix

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_14.adoc
@@ -1251,6 +1251,18 @@ query parameters can supply a custom `headerFilterStrategy` to restore the previ
 
 === camel-undertow - potential breaking change
 
+[NOTE]
+====
+The behaviour described in this section did not take effect in 4.14.8 on
+endpoint-configured routes. `UndertowEndpoint` defaulted its
+`headerFilterStrategy` to the base `HttpHeaderFilterStrategy` and pushed that
+into the `UndertowHttpBinding` it creates lazily, discarding the
+`UndertowHeaderFilterStrategy` this section describes. The filtering takes
+effect from 4.14.9 onwards; see the
+`camel-undertow - UndertowHeaderFilterStrategy is now the endpoint default`
+entry below.
+====
+
 `UndertowHeaderFilterStrategy` now also filters the legacy `websocket.*`
 Exchange-header prefix (in addition to the `Camel*` / `camel*` /
 `org.apache.camel.*` prefixes it already filtered). This applies to both the

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -1581,6 +1581,18 @@ to restore the previous behaviour.
 
 === camel-undertow - potential breaking change
 
+[NOTE]
+====
+The behaviour described in this section did not take effect in 4.18.3 on
+endpoint-configured routes. `UndertowEndpoint` defaulted its
+`headerFilterStrategy` to the base `HttpHeaderFilterStrategy` and pushed that
+into the `UndertowHttpBinding` it creates lazily, discarding the
+`UndertowHeaderFilterStrategy` this section describes. The filtering takes
+effect from 4.18.4 onwards; see the
+`camel-undertow - UndertowHeaderFilterStrategy is now the endpoint default`
+entry below.
+====
+
 `UndertowHeaderFilterStrategy` now also filters the legacy `websocket.*`
 Exchange-header prefix (in addition to the `Camel*` / `camel*` /
 `org.apache.camel.*` prefixes it already filtered). This applies to both the

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_21.adoc
@@ -1473,6 +1473,18 @@ A worked example is in `ShiroOverJmsTest` in the `camel-itest` module.
 
 === camel-undertow - potential breaking change
 
+[NOTE]
+====
+The behaviour described in this section did not take effect in 4.21.0 on
+endpoint-configured routes. `UndertowEndpoint` defaulted its
+`headerFilterStrategy` to the base `HttpHeaderFilterStrategy` and pushed that
+into the `UndertowHttpBinding` it creates lazily, discarding the
+`UndertowHeaderFilterStrategy` this section describes. The filtering takes
+effect from 4.22.0 onwards; see the
+`camel-undertow - UndertowHeaderFilterStrategy is now the endpoint default`
+entry in the 4.21 to 4.22 upgrade guide.
+====
+
 `UndertowHeaderFilterStrategy` now also filters the legacy `websocket.*`
 Exchange-header prefix (in addition to the `Camel*` / `camel*` /
 `org.apache.camel.*` prefixes it already filtered). This applies to both the


### PR DESCRIPTION
## Description

The 4.14, 4.18 and 4.21 upgrade guides each describe CAMEL-23588 as making `UndertowHeaderFilterStrategy` filter the legacy `websocket.*` Exchange-header prefix at the undertow transport boundary, and present that behaviour as shipped in 4.14.8, 4.18.3 and 4.21.0 respectively.

It was not. `UndertowEndpoint` defaulted its `headerFilterStrategy` to the base `HttpHeaderFilterStrategy` and pushed that into the `UndertowHttpBinding` it creates lazily, overwriting the `UndertowHeaderFilterStrategy` the binding installs in its own constructor. On endpoint-configured routes the undertow-specific filtering never executed. CAMEL-24360 (#25367) fixed the wiring in 4.14.9 / 4.18.4 / 4.22.0.

## Why this matters

| Guide | Currently claims | Actually took effect |
|---|---|---|
| `4_14` | active in 4.14.8 | 4.14.9 |
| `4_18` | active in 4.18.3 | 4.18.4 |
| `4_21` | active in 4.21.0 | 4.22.0 |

The 4.14, 4.18 and 4.22 guides already carry the `camel-undertow - UndertowHeaderFilterStrategy is now the endpoint default` entry from the CAMEL-24360 doc-sync, so a careful reader there could piece it together. **The 4.21 guide had no correction at all** — someone running 4.21.0 and reading that guide would believe `websocket.*` was being filtered at the undertow boundary when it never was.

## Changes

A `[NOTE]` admonition at the top of each of the three sections, naming the mechanism and pointing at the entry that fixes it (in-file for 4.14 / 4.18, forward to the 4.22 guide for 4.21). All three referenced anchors were verified to resolve.

Documentation only, no behaviour change.

## Testing

Full reactor build from root (`mvn clean install -DskipTests`) green, no regenerated-artifact drift.

---
_Claude Code on behalf of oscerd_