### PR TITLE
CAMEL-21622: Add camel.route.id attribute to camel-telemetry spans

### DIFF
--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/TagConstants.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/TagConstants.java
@@ -21,6 +21,7 @@ public class TagConstants {
     public static final String ERROR = "error";
     public static final String COMPONENT = "component";
     public static final String EXCHANGE_ID = "exchangeId";
+    public static final String ROUTE_ID = "camel.route.id";
 
     public static final String OP = "op";
 

--- a/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractSpanDecorator.java
+++ b/components/camel-telemetry/src/main/java/org/apache/camel/telemetry/decorators/AbstractSpanDecorator.java
@@ -114,6 +114,11 @@ public abstract class AbstractSpanDecorator implements SpanDecorator {
         span.setTag(TagConstants.URL_SCHEME, scheme);
         span.setTag(TagConstants.EXCHANGE_ID, exchange.getExchangeId());
 
+        final String routeId;
+        if (exchange != null && (routeId = exchange.getFromRouteId()) != null) {
+            span.setTag(TagConstants.ROUTE_ID, routeId);
+        }
+
         // Including the endpoint URI provides access to any options that may
         // have been provided, for subsequent analysis
         String uri = endpoint.toString(); // toString will sanitize

--- a/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AbstractSpanDecoratorTest.java
+++ b/components/camel-telemetry/src/test/java/org/apache/camel/telemetry/decorators/AbstractSpanDecoratorTest.java
@@ -60,6 +60,7 @@ public class AbstractSpanDecoratorTest {
 
         Mockito.when(endpoint.getEndpointUri()).thenReturn(TEST_URI);
         Mockito.when(endpoint.toString()).thenReturn(TEST_URI);
+        Mockito.when(exchange.getFromRouteId()).thenReturn("myRouteId");
 
         SpanDecorator decorator = new AbstractSpanDecorator() {
             @Override
@@ -81,6 +82,7 @@ public class AbstractSpanDecoratorTest {
         assertEquals("test", span.tags().get(TagConstants.URL_SCHEME));
         assertEquals("uri", span.tags().get(TagConstants.URL_PATH));
         assertEquals("query=hello", span.tags().get(TagConstants.URL_QUERY));
+        assertEquals("myRouteId", span.tags().get(TagConstants.ROUTE_ID));
     }
 
     @Test


### PR DESCRIPTION
The opentelemetry2 component uses camel-telemetry (not camel-tracing) as its base framework. The original CAMEL-21622 fix only added camel.route.id to camel-tracing, so spans produced by the otel2 component are missing this attribute.

Port the same logic: read Exchange.getFromRouteId() in AbstractSpanDecorator.beforeTracingEvent() and set it as a span tag.

# Description

Cherry pick from https://github.com/apache/camel/commit/e2ff44fc50f10a15fc9415dd096c4eddc55fa996

# Target

- [X ] I checked that the commit is targeting the correct branch (Camel 4 uses the `camel-4.18.x` branch)

