### PR TITLE
CAMEL-24205: Upgrade camel-as2 test dependency from as2-lib 5.1.8 to phase2-lib 6.2.1

### DIFF
--- a/components/camel-as2/camel-as2-api/pom.xml
+++ b/components/camel-as2/camel-as2-api/pom.xml
@@ -94,9 +94,9 @@
         </dependency>
         <!-- added for binary content transfer encoding test because Camel AS2 client doesn't support binary currently -->
         <dependency>
-            <groupId>com.helger.as2</groupId>
-            <artifactId>as2-lib</artifactId>
-            <version>${as2-lib-version}</version>
+            <groupId>com.helger.phase2</groupId>
+            <artifactId>phase2-lib</artifactId>
+            <version>${phase2-lib-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
+++ b/components/camel-as2/camel-as2-api/src/test/java/org/apache/camel/component/as2/api/AS2MessageTestBase.java
@@ -33,14 +33,14 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.helger.as2lib.client.AS2Client;
-import com.helger.as2lib.client.AS2ClientRequest;
-import com.helger.as2lib.client.AS2ClientResponse;
-import com.helger.as2lib.client.AS2ClientSettings;
-import com.helger.as2lib.crypto.ECompressionType;
-import com.helger.as2lib.crypto.ECryptoAlgorithmCrypt;
-import com.helger.as2lib.crypto.ECryptoAlgorithmSign;
 import com.helger.mail.cte.EContentTransferEncoding;
+import com.helger.phase2.client.AS2Client;
+import com.helger.phase2.client.AS2ClientRequest;
+import com.helger.phase2.client.AS2ClientResponse;
+import com.helger.phase2.client.AS2ClientSettings;
+import com.helger.phase2.crypto.ECompressionType;
+import com.helger.phase2.crypto.ECryptoAlgorithmCrypt;
+import com.helger.phase2.crypto.ECryptoAlgorithmSign;
 import com.helger.security.keystore.EKeyStoreType;
 import org.apache.camel.component.as2.api.entity.ApplicationEntity;
 import org.apache.hc.core5.http.protocol.HttpDateGenerator;
@@ -144,7 +144,7 @@ public class AS2MessageTestBase {
         signingKP = kpg.generateKeyPair();
         signingCert = Utils.makeCertificate(signingKP, signingDN, issueKP, issueDN);
 
-        // initialize as2-lib keystore file
+        // initialize phase2 keystore file
         KeyStore ks = KeyStore.getInstance(EKeyStoreType.PKCS12.getID());
         ks.load(null, "test".toCharArray());
         ks.setKeyEntry("openas2a_alias", issueKP.getPrivate(), "test".toCharArray(), new X509Certificate[] { issueCert });
@@ -160,8 +160,8 @@ public class AS2MessageTestBase {
     }
 
     protected void binaryContentTransferEncodingTest(boolean encrypt, boolean sign, boolean compress) throws IOException {
-        // test with as2-lib because Camel AS2 client doesn't support binary content transfer encoding at the moment
-        // inspired from https://github.com/phax/as2-lib/wiki/Submodule-as2%E2%80%90lib#as2-client
+        // test with phase2 because Camel AS2 client doesn't support binary content transfer encoding at the moment
+        // inspired from https://github.com/phax/phase2/wiki/Submodule-phase2%E2%80%90lib#as2-client
 
         // Start client configuration
         final AS2ClientSettings aSettings = new AS2ClientSettings();
@@ -178,7 +178,7 @@ public class AS2MessageTestBase {
         aSettings.setPartnershipName(aSettings.getSenderAS2ID() + "_" + aSettings.getReceiverAS2ID());
 
         // Build client request
-        final AS2ClientRequest aRequest = new AS2ClientRequest("AS2 test message from as2-lib");
+        final AS2ClientRequest aRequest = new AS2ClientRequest("AS2 test message from phase2");
         aRequest.setData(EDI_MESSAGE, StandardCharsets.US_ASCII);
         aRequest.setContentType(AS2MediaType.APPLICATION_EDIFACT);
 
@@ -206,8 +206,8 @@ public class AS2MessageTestBase {
     }
 
     protected void compressionSignatureOrderTest(boolean encrypt, boolean compressBeforeSign) throws IOException {
-        // test with as2-lib because Camel AS2 client doesn't support different orders at the moment
-        // inspired from https://github.com/phax/as2-lib/wiki/Submodule-as2%E2%80%90lib#as2-client
+        // test with phase2 because Camel AS2 client doesn't support different orders at the moment
+        // inspired from https://github.com/phax/phase2/wiki/Submodule-phase2%E2%80%90lib#as2-client
 
         // Start client configuration
         final AS2ClientSettings aSettings = new AS2ClientSettings();
@@ -224,7 +224,7 @@ public class AS2MessageTestBase {
         aSettings.setPartnershipName(aSettings.getSenderAS2ID() + "_" + aSettings.getReceiverAS2ID());
 
         // Build client request
-        final AS2ClientRequest aRequest = new AS2ClientRequest("AS2 test message from as2-lib");
+        final AS2ClientRequest aRequest = new AS2ClientRequest("AS2 test message from phase2");
         aRequest.setData(EDI_MESSAGE, StandardCharsets.US_ASCII);
         aRequest.setContentType(AS2MediaType.APPLICATION_EDIFACT);
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -69,7 +69,6 @@
         <apacheds-version>2.0.0.AM27</apacheds-version>
         <apache-drill-version>1.22.0</apache-drill-version>
         <arangodb-java-version>7.26.0</arangodb-java-version>
-        <as2-lib-version>5.1.8</as2-lib-version>
         <ascii-table-version>1.13.0</ascii-table-version>
         <asm-version>9.10.1</asm-version>
         <asn1bean-version>1.14.0</asn1bean-version>
@@ -426,6 +425,7 @@
         <pgjdbc-driver-version>42.7.13</pgjdbc-driver-version>
         <pgjdbc-ng-driver-version>0.8.9</pgjdbc-ng-driver-version>
         <pgvector-version>0.1.6</pgvector-version>
+        <phase2-lib-version>6.2.1</phase2-lib-version>
         <picocli-version>4.7.7</picocli-version>
         <pinecone-client-version>3.1.0</pinecone-client-version>
         <plc4x-version>0.13.1</plc4x-version>


### PR DESCRIPTION
# Description

The `as2-lib` library was [renamed to `phase2`](https://github.com/phax/phase2) in September 2025
  (v6.0.0) and the old `com.helger.as2:as2-lib` artifact will no longer receive updates.

  This PR migrates the test dependency to the new Maven coordinates and version:
  - `com.helger.as2:as2-lib:5.1.8` → `com.helger.phase2:phase2-lib:6.2.1`
  - Updated Java package imports (`com.helger.as2lib.*` → `com.helger.phase2.*`)
  - Updated stale comments and wiki URLs referencing the old library name

  The library is used only as a **test-scoped** dependency in `camel-as2-api` for
  interoperability testing (binary content transfer encoding and compression/signature
  ordering). No production code, public API, or user-facing behavior is affected.

  The class names and method signatures are unchanged between as2-lib 5.x and phase2 6.x —
  this is purely a coordinate and package rename. All 94 tests in camel-as2-api pass.


# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

