### PR TITLE
[backport camel-4.18.x] Bump org.jsoup:jsoup from 1.22.1 to 1.23.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -343,7 +343,7 @@
         <json-smart-version>2.6.0</json-smart-version>
         <jsonata-version>0.9.9</jsonata-version>
         <json-unit-version>5.1.0</json-unit-version>
-        <jsoup-version>1.22.1</jsoup-version>
+        <jsoup-version>1.23.1</jsoup-version>
         <jt400-version>21.0.6</jt400-version>
         <jte-version>3.2.3</jte-version>
         <junit-toolbox-version>2.4</junit-toolbox-version>


### PR DESCRIPTION
Backport of #25256 onto `camel-4.18.x`.

The branch was on jsoup 1.22.1 (main was on 1.22.2), so the property goes 1.22.1 -> 1.23.1 here.

Verified with `mvn verify -pl components/camel-box/camel-box-component,components/camel-oaipmh` — the only two modules consuming `jsoup-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)