### PR TITLE
CAMEL-24379: Fix AS2 client ignoring custom HostnameVerifier

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ClientConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ClientConnection.java
@@ -42,6 +42,7 @@ import org.apache.hc.client5.http.io.ConnectionEndpoint;
 import org.apache.hc.client5.http.io.LeaseRequest;
 import org.apache.hc.client5.http.io.ManagedHttpClientConnection;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.*;
 import org.apache.hc.core5.http.config.Http1Config;
@@ -136,7 +137,7 @@ public class AS2ClientConnection {
             if (hostnameVerifier == null) {
                 tlsStrategy = new DefaultClientTlsStrategy(sslContext);
             } else {
-                tlsStrategy = new DefaultClientTlsStrategy(sslContext, hostnameVerifier);
+                tlsStrategy = new DefaultClientTlsStrategy(sslContext, HostnameVerificationPolicy.CLIENT, hostnameVerifier);
             }
             builder.setTlsSocketStrategy(tlsStrategy);
         }

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/MendelsonSslEndpointManualTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/MendelsonSslEndpointManualTest.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * committed with @Disabled annotation due to the test can bring dependency on 3rd party resource.
  */
 @Disabled("Run this test manually")
-public class MendelsonSslEndpointManualTest extends AbstractAS2ITSupport {
+class MendelsonSslEndpointManualTest extends AbstractAS2ITSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(MendelsonSslEndpointManualTest.class);
     private static HostnameVerifier hostnameVerifier;
@@ -51,7 +51,7 @@ public class MendelsonSslEndpointManualTest extends AbstractAS2ITSupport {
     private static final Properties props = new Properties();
 
     @BeforeAll
-    public static void setupTest() {
+    static void setupTest() {
         TestSupport.loadExternalPropertiesQuietly(props, MendelsonSslEndpointManualTest.class.getClassLoader(),
                 "test-server.properties");
 
@@ -66,7 +66,7 @@ public class MendelsonSslEndpointManualTest extends AbstractAS2ITSupport {
     }
 
     @Test
-    public void testCreateEndpointAndSendViaHTTPS() throws Exception {
+    void testCreateEndpointAndSendViaHTTPS() throws Exception {
         CamelContext camelContext = new DefaultCamelContext();
         camelContext.start();
 
@@ -89,7 +89,6 @@ public class MendelsonSslEndpointManualTest extends AbstractAS2ITSupport {
         endpointConfiguration.setAs2From(props.getProperty("as2.as2from"));
         endpointConfiguration.setFrom(props.getProperty("as2.from"));
         endpointConfiguration.setSubject(props.getProperty("as2.subject"));
-        endpointConfiguration.setSigningAlgorithm(AS2SignatureAlgorithm.MD2WITHRSA);
         endpointConfiguration.setEdiMessageTransferEncoding(props.getProperty("as2.transfer.encoding"));
         endpointConfiguration.setAttachedFileName(props.getProperty("as2.attached.filename"));
 
@@ -113,10 +112,17 @@ public class MendelsonSslEndpointManualTest extends AbstractAS2ITSupport {
                 = camelContext.createProducerTemplate().request(endpoint,
                         exchange -> exchange.getIn().setBody(props.getProperty("as2.edi.message")));
         Throwable cause = out.getException();
-        Assertions.assertNull(cause);
+        Assertions.assertNull(cause, () -> "AS2 send failed; root cause: " + getRootCause(cause));
         LOG.debug(
                 "Sending done. If you used Mendelson settings for connection, " +
                   "you can check your message in http://testas2.mendelson-e-c.com:8080/webas2/ " +
                   "Login guest, password guest");
+    }
+
+    private static Throwable getRootCause(Throwable t) {
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
     }
 }


### PR DESCRIPTION
# Description

When a custom `HostnameVerifier` (e.g. `NoopHostnameVerifier`) was configured on the AS2 endpoint, it was silently ignored. The `DefaultClientTlsStrategy` defaulted to `HostnameVerificationPolicy.BOTH`, which sets `endpointIdentificationAlgorithm="HTTPS"` on the `SSLParameters`. This causes the JDK trust manager to perform hostname verification during the TLS handshake, before the custom `HostnameVerifier` ever runs.

Fix: use `HostnameVerificationPolicy.CLIENT` when a custom `HostnameVerifier` is provided, so hostname verification is delegated entirely to it.

Also in `MendelsonSslEndpointManualTest`:
- Replace bare `assertNull` with a lazy message that surfaces the root cause exception, since AS2 wraps low-level exceptions in multiple layers
- Remove dead `setSigningAlgorithm(MD2WITHRSA)` call that was immediately overridden by the signingAlgorithm URI parameter on the endpoint
- Drop unnecessary public modifier from test class and methods

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.
