### PR TITLE
[backport camel-4.22.x] CAMEL-24375: parseDuration should handle plain millis value

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/converter/DurationConverter.java
+++ b/core/camel-base/src/main/java/org/apache/camel/converter/DurationConverter.java
@@ -45,11 +45,7 @@ public final class DurationConverter {
 
     @Converter(order = 3)
     public static Duration toDuration(String source) {
-        if (source.startsWith("P") || source.startsWith("-P") || source.startsWith("p") || source.startsWith("-p")) {
-            return Duration.parse(source);
-        } else {
-            return Duration.ofMillis(TimeUtils.toMilliSeconds(source));
-        }
+        return TimeUtils.toDuration(source);
     }
 
     @Converter(order = 4)

--- a/core/camel-core/src/test/java/org/apache/camel/support/CamelContextHelperParseDurationTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/support/CamelContextHelperParseDurationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.support;
+
+import java.time.Duration;
+
+import org.apache.camel.ContextTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CamelContextHelperParseDurationTest extends ContextTestSupport {
+
+    @Test
+    void testParseDurationMillis() {
+        Duration d = CamelContextHelper.parseDuration(context, "20000");
+        assertThat(d).isEqualTo(Duration.ofMillis(20000));
+    }
+
+    @Test
+    void testParseDurationHumanReadable() {
+        Duration d = CamelContextHelper.parseDuration(context, "20s");
+        assertThat(d).isEqualTo(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void testParseDurationHumanReadableMinutes() {
+        Duration d = CamelContextHelper.parseDuration(context, "1m30s");
+        assertThat(d).isEqualTo(Duration.ofSeconds(90));
+    }
+
+    @Test
+    void testParseDurationISO8601() {
+        Duration d = CamelContextHelper.parseDuration(context, "PT20S");
+        assertThat(d).isEqualTo(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void testParseDurationISO8601Lowercase() {
+        Duration d = CamelContextHelper.parseDuration(context, "pt20s");
+        assertThat(d).isEqualTo(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void testParseDurationNull() {
+        Duration d = CamelContextHelper.parseDuration(context, null);
+        assertThat(d).isNull();
+    }
+}

--- a/core/camel-support/src/main/java/org/apache/camel/support/CamelContextHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/CamelContextHelper.java
@@ -461,7 +461,15 @@ public final class CamelContextHelper {
      * @throws IllegalStateException is thrown if illegal argument or type conversion not possible
      */
     public static Duration parseDuration(CamelContext camelContext, String text) {
-        return parse(camelContext, Duration.class, text);
+        if (text == null) {
+            return null;
+        }
+        // ensure we support property placeholders
+        String s = camelContext.resolvePropertyPlaceholders(text);
+        if (s == null) {
+            return null;
+        }
+        return TimeUtils.toDuration(s);
     }
 
     /**

--- a/core/camel-util/src/main/java/org/apache/camel/util/TimeUtils.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/TimeUtils.java
@@ -173,7 +173,11 @@ public final class TimeUtils {
      * @param source duration which can be in text format such as 15s
      */
     public static Duration toDuration(String source) {
-        return Duration.ofMillis(toMilliSeconds(source));
+        if (source.startsWith("P") || source.startsWith("-P") || source.startsWith("p") || source.startsWith("-p")) {
+            return Duration.parse(source);
+        } else {
+            return Duration.ofMillis(toMilliSeconds(source));
+        }
     }
 
     /**

--- a/core/camel-util/src/test/java/org/apache/camel/util/TimeUtilsTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/TimeUtilsTest.java
@@ -73,6 +73,36 @@ public class TimeUtilsTest {
     }
 
     @Test
+    public void testToDurationMillis() {
+        assertEquals(Duration.ofMillis(20000), TimeUtils.toDuration("20000"));
+    }
+
+    @Test
+    public void testToDurationHumanReadable() {
+        assertEquals(Duration.ofSeconds(20), TimeUtils.toDuration("20s"));
+    }
+
+    @Test
+    public void testToDurationHumanReadableMinutes() {
+        assertEquals(Duration.ofSeconds(90), TimeUtils.toDuration("1m30s"));
+    }
+
+    @Test
+    public void testToDurationISO8601() {
+        assertEquals(Duration.ofSeconds(20), TimeUtils.toDuration("PT20S"));
+    }
+
+    @Test
+    public void testToDurationISO8601Lowercase() {
+        assertEquals(Duration.ofSeconds(20), TimeUtils.toDuration("pt20s"));
+    }
+
+    @Test
+    public void testToDurationISO8601Negative() {
+        assertEquals(Duration.ofSeconds(-30), TimeUtils.toDuration("-PT30S"));
+    }
+
+    @Test
     void testDurationMatchesExpectWithDate() throws InterruptedException {
         Date startTime = new Date();
 


### PR DESCRIPTION
## Backport of #25412

Cherry-pick of #25412 onto `camel-4.22.x`.

**Original PR:** #25412 - CAMEL-24375: parseDuration should handle plain millis value
**Original author:** @davsclaus
**Target branch:** `camel-4.22.x`

### Original description

Consolidate duration parsing into TimeUtils.toDuration() so both
CamelContextHelper.parseDuration() and DurationConverter.toDuration()
delegate to a single implementation that handles plain millis, human-
readable (20s, 1m30s), and ISO-8601 (PT20S) formats. This fixes
NoTypeConversionAvailableException when parsing duration values during
early route initialization before the type converter registry is loaded.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>