### PR TITLE
CAMEL-24348: camel-google-bigquery - report unusable bodies and missing jobs properly

### DIFF
--- a/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/GoogleBigQueryProducer.java
+++ b/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/GoogleBigQueryProducer.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -129,13 +130,16 @@ public class GoogleBigQueryProducer extends DefaultProducer {
         for (Exchange ex : exchanges) {
             Object entryObject = ex.getIn().getBody();
             if (entryObject instanceof List) {
+                // the insert id header identifies one row, so it is not applied to the rows of a list: BigQuery
+                // would treat them as duplicates of each other and keep only one. Use useAsInsertId for those
                 for (Map<String, Object> entry : (List<Map<String, Object>>) entryObject) {
                     apiRequestRows.add(createRowRequest(null, entry));
                 }
             } else if (entryObject instanceof Map) {
                 apiRequestRows.add(createRowRequest(ex, (Map<String, Object>) entryObject));
             } else {
-                ex.setException(new IllegalArgumentException("Cannot handle body type " + entryObject.getClass()));
+                ex.setException(new IllegalArgumentException(
+                        "Cannot handle body type " + (entryObject == null ? "null" : entryObject.getClass().getName())));
             }
         }
 
@@ -160,7 +164,7 @@ public class GoogleBigQueryProducer extends DefaultProducer {
         InsertAllResponse apiResponse = bigquery.insertAll(insertAllRequest);
 
         if (apiResponse.getInsertErrors() != null && !apiResponse.getInsertErrors().isEmpty()) {
-            throw new Exception("InsertAll into " + tableId + " failed: " + apiResponse.getInsertErrors());
+            throw new RuntimeCamelException("InsertAll into " + tableId + " failed: " + apiResponse.getInsertErrors());
         }
 
         if (LOG.isTraceEnabled()) {

--- a/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLProducer.java
+++ b/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLProducer.java
@@ -37,6 +37,7 @@ import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.component.google.bigquery.GoogleBigQueryConstants;
 import org.apache.camel.support.DefaultProducer;
@@ -157,10 +158,18 @@ public class GoogleBigQuerySQLProducer extends DefaultProducer {
             var job = ObjectHelper.isNotEmpty(jobId)
                     ? bigquery.getJob(jobId)
                     : bigquery.create(getJobInfo(queryJobConfiguration));
+            if (job == null) {
+                throw new RuntimeCamelException("BigQuery job " + jobId + " does not exist");
+            }
 
-            return job.waitFor();
+            Job completed = job.waitFor();
+            if (completed == null) {
+                // waitFor returns null when the job does not exist any more, for example when it expired
+                throw new RuntimeCamelException("BigQuery job " + job.getJobId() + " is no longer available");
+            }
+            return completed;
         } catch (BigQueryException e) {
-            throw new Exception("Query " + translatedQuery + " failed: " + e.getError(), e);
+            throw new RuntimeCamelException("Query " + translatedQuery + " failed: " + e.getError(), e);
         }
     }
 
@@ -186,7 +195,7 @@ public class GoogleBigQuerySQLProducer extends DefaultProducer {
             QueryResultsOption[] queryResultsOptions = getQueryResultsOptions(pageSize, pageToken);
             return job.getQueryResults(queryResultsOptions);
         } catch (BigQueryException e) {
-            throw new Exception("Query " + translatedQuery + " failed: " + e.getError(), e);
+            throw new RuntimeCamelException("Query " + translatedQuery + " failed: " + e.getError(), e);
         }
     }
 

--- a/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/GoogleBigQueryProducerBodyTypeTest.java
+++ b/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/GoogleBigQueryProducerBodyTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.bigquery.unit;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies what the producer reports for a body it cannot turn into rows.
+ */
+class GoogleBigQueryProducerBodyTypeTest extends BaseBigQueryTest {
+
+    @Test
+    void aBodyThatIsNotAMapOrAListIsReported() throws Exception {
+        Exchange exchange = createExchangeWithBody("not a row");
+        producer.process(exchange);
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot handle body type java.lang.String");
+    }
+
+    @Test
+    void aMissingBodyIsReportedInsteadOfFailingWithANullPointer() throws Exception {
+        Exchange exchange = createExchangeWithBody(null);
+        producer.process(exchange);
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot handle body type null");
+    }
+}


### PR DESCRIPTION
Three NPE/exception-hygiene fixes.

**1. A message with no body failed with a `NullPointerException`.** The producer built its error out
of the body's class:

```java
ex.setException(new IllegalArgumentException("Cannot handle body type " + entryObject.getClass()));
```

so the branch meant to report an unusable body threw while reporting it. It now says
`Cannot handle body type null`.

**2. An unknown `CamelGoogleBigQueryJobId` gave a `NullPointerException`.** In the SQL producer both
`bigquery.getJob(jobId)` and `job.waitFor()` return `null` for a job that no longer exists (expired,
or never created), and neither was checked before use. Both now fail with a message naming the job.

**3. Three raw `throw new Exception(...)`** in `GoogleBigQueryProducer` and `GoogleBigQuerySQLProducer`
are now `RuntimeCamelException`, so routes get a Camel exception. `onException(Exception.class)`
still matches, since `RuntimeCamelException` is one.

**Withdrawn from the issue description:** the audit also claimed the `CamelGoogleBigQueryInsertId`
header is wrongly ignored for `List` bodies. Applying it there would be a **bug**: BigQuery uses the
insert id for best-effort deduplication, so giving every row of a list the same id makes it keep one
row and drop the rest. The existing behaviour is right — `useAsInsertId` (a field name, so one id per
row) is the option for list payloads. This PR only adds a comment recording that, and I commented on
the JIRA issue.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)