### PR TITLE
chore(deps): Bump OpenTelemetry from 1.64.0 to 1.65.0

### DIFF
--- a/components/camel-opentelemetry-metrics/pom.xml
+++ b/components/camel-opentelemetry-metrics/pom.xml
@@ -40,6 +40,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry-alpha-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/components/camel-opentelemetry2/pom.xml
+++ b/components/camel-opentelemetry2/pom.xml
@@ -46,6 +46,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry-alpha-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -411,8 +411,8 @@
         <opensearch-java-client-version>3.9.0</opensearch-java-client-version>
         <opensearch-testcontainers-version>2.1.3</opensearch-testcontainers-version>
         <openstack4j-version>3.12</openstack4j-version>
-        <opentelemetry-version>1.64.0</opentelemetry-version>
-        <opentelemetry-alpha-version>1.64.0-alpha</opentelemetry-alpha-version>
+        <opentelemetry-version>1.65.0</opentelemetry-version>
+        <opentelemetry-alpha-version>1.65.0-alpha</opentelemetry-alpha-version>
         <opentelemetry-proto-version>1.10.0-alpha</opentelemetry-proto-version>
         <opentelemetry-log4j2-version>2.30.0-alpha</opentelemetry-log4j2-version>
         <opentelemetry-incubator-version>1.43.0-alpha</opentelemetry-incubator-version>

--- a/test-infra/camel-test-infra-jaeger/pom.xml
+++ b/test-infra/camel-test-infra-jaeger/pom.xml
@@ -44,6 +44,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry-alpha-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary

- Bump `opentelemetry-version` from 1.64.0 to 1.65.0 and `opentelemetry-alpha-version` from 1.64.0-alpha to 1.65.0-alpha
- Add `opentelemetry-bom-alpha` import to `camel-opentelemetry-metrics`, `camel-opentelemetry2`, and `camel-test-infra-jaeger`

**Root cause of #25434 failure:** `opentelemetry-sdk-metrics:1.65.0` now contains compiled references to `BoundDoubleHistogram` and `BoundLongUpDownCounter` from `opentelemetry-api-incubator`. The stable `opentelemetry-bom` does not manage the incubator artifact, so the transitive incubator version (1.64.0-alpha via the instrumentation library) lacked those classes, causing `NoClassDefFoundError` at test time. Adding the `opentelemetry-bom-alpha` import aligns the incubator to 1.65.0-alpha where these classes exist. `camel-opentelemetry` already had this alpha BOM import.

Supersedes #25434.

## Test plan

- [x] `mvn verify` passes on `camel-opentelemetry-metrics`
- [x] `mvn verify` passes on `camel-opentelemetry2`
- [x] `mvn verify` passes on `camel-opentelemetry` (already had alpha BOM)
- [ ] CI build passes

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>