### PR TITLE
chore(camel-test-infra-milvus): upgrade milvus.container to v2.6.22

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -7,7 +7,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-milvus",
   "version" : "4.23.0-SNAPSHOT",
-  "serviceVersion" : "v2.6.21",
+  "serviceVersion" : "v2.6.22",
   "uiSupported" : false
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -7,7 +7,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-milvus",
   "version" : "4.23.0-SNAPSHOT",
-  "serviceVersion" : "v2.6.21",
+  "serviceVersion" : "v2.6.22",
   "uiSupported" : false
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-milvus/src/main/resources/org/apache/camel/test/infra/milvus/services/container.properties
+++ b/test-infra/camel-test-infra-milvus/src/main/resources/org/apache/camel/test/infra/milvus/services/container.properties
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-milvus.container=mirror.gcr.io/milvusdb/milvus:v2.6.21
+milvus.container=mirror.gcr.io/milvusdb/milvus:v2.6.22
 milvus.container.ppc64le=icr.io/ppc64le-oss/milvus-ppc64le:v2.6.5
 milvus.container.version.freeze.major=true
 milvus.container.ppc64le.version.freeze.major=true


### PR DESCRIPTION
## Summary

- Upgrade milvus container from v2.6.21 to v2.6.22

Supersedes #25420 which had merge conflicts due to the version bump from 4.22.0-SNAPSHOT to 4.23.0-SNAPSHOT in the generated metadata.json files.

## Test plan

- [ ] CI build passes

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>