### PR TITLE
chore(camel-test-infra-docling): upgrade docling.container to v1.30.0

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/docling-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/docling-component.adoc
@@ -301,18 +301,11 @@ YAML::
 === OCR and page headers/footers
 
 Docling recognizes page headers and footers (page numbers, copyright lines, running titles, footnotes, and similar
-content) during OCR, but it classifies them as page _furniture_: they are assigned to docling's `FURNITURE` content
-layer rather than the document `BODY`. Docling's Markdown, text and HTML exports include only the `BODY` layer by
-default, so header and footer text is omitted from the converted output even though the OCR engine read it correctly.
+content) during OCR, classifying them as page _furniture_ in docling's `FURNITURE` content layer.
 
-When using `useDoclingServe=true`, the component cannot currently change this, because the docling-serve API does not
-expose an option to choose which content layers are included in the export — even though docling's Python library can
-include the `FURNITURE` layer. This is tracked upstream in
-https://github.com/docling-project/docling-serve/issues/271[docling-serve#271]. The docling CLI
-(`useDoclingServe=false`) has the same limitation.
-
-If you need header or footer content in the output, restructure the source document so the text is part of the body,
-or track the upstream issue for a future option to include the furniture layer.
+Since docling v1.30.0, page furniture (headers and footers) is included in the default body export (Markdown, text
+and HTML). Earlier versions excluded the `FURNITURE` layer, so header and footer text was omitted from the converted
+output even though the OCR engine read it correctly.
 
 === Using headers to control processing
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -744,7 +744,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-docling",
   "version" : "4.23.0-SNAPSHOT",
-  "serviceVersion" : "v1.29.0",
+  "serviceVersion" : "v1.30.0",
   "uiSupported" : false
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
+++ b/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
@@ -301,18 +301,11 @@ YAML::
 === OCR and page headers/footers
 
 Docling recognizes page headers and footers (page numbers, copyright lines, running titles, footnotes, and similar
-content) during OCR, but it classifies them as page _furniture_: they are assigned to docling's `FURNITURE` content
-layer rather than the document `BODY`. Docling's Markdown, text and HTML exports include only the `BODY` layer by
-default, so header and footer text is omitted from the converted output even though the OCR engine read it correctly.
+content) during OCR, classifying them as page _furniture_ in docling's `FURNITURE` content layer.
 
-When using `useDoclingServe=true`, the component cannot currently change this, because the docling-serve API does not
-expose an option to choose which content layers are included in the export — even though docling's Python library can
-include the `FURNITURE` layer. This is tracked upstream in
-https://github.com/docling-project/docling-serve/issues/271[docling-serve#271]. The docling CLI
-(`useDoclingServe=false`) has the same limitation.
-
-If you need header or footer content in the output, restructure the source document so the text is part of the body,
-or track the upstream issue for a future option to include the furniture layer.
+Since docling v1.30.0, page furniture (headers and footers) is included in the default body export (Markdown, text
+and HTML). Earlier versions excluded the `FURNITURE` layer, so header and footer text was omitted from the converted
+output even though the OCR engine read it correctly.
 
 === Using headers to control processing
 

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
@@ -179,15 +179,10 @@ class OcrExtractionIT extends CamelTestSupport {
         assertTrue(foundFirst && foundSecond,
                 "OCR should extract at least some of the expected text. Got: " + result);
 
-        // The footer is recognized by OCR, but docling classifies it as a page_footer, which lives in the
-        // FURNITURE content layer. docling's default body export (Markdown/text/HTML) excludes that layer, and
-        // docling-serve exposes no option to include it (upstream: https://github.com/docling-project/docling-serve/issues/271).
-        // The footer text is therefore absent from the result. See the "OCR and page headers/footers" note in
-        // docling-component.adoc. This assertion documents and pins that behavior; it will start failing if a
-        // future docling release includes page furniture in the body export, prompting us to revisit the limitation.
+        // Since docling v1.30.0, page furniture (headers/footers) is included in the default body export.
         boolean foundFooter = resultLower.contains("footer");
-        assertFalse(foundFooter,
-                "Footer text is page furniture and is excluded from the docling body export. Got: " + result);
+        assertTrue(foundFooter,
+                "Footer text (page furniture) should be included in the docling body export since v1.30.0. Got: " + result);
 
         LOG.info("OCR extraction with multiple text blocks result:\n{}", result);
         LOG.info("Successfully extracted text from image with multiple text blocks");

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -744,7 +744,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-docling",
   "version" : "4.23.0-SNAPSHOT",
-  "serviceVersion" : "v1.29.0",
+  "serviceVersion" : "v1.30.0",
   "uiSupported" : false
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-docling/src/main/resources/org/apache/camel/test/infra/docling/services/container.properties
+++ b/test-infra/camel-test-infra-docling/src/main/resources/org/apache/camel/test/infra/docling/services/container.properties
@@ -15,4 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 ## Docling container configuration for test-infra
-docling.container=quay.io/docling-project/docling-serve:v1.29.0
+docling.container=quay.io/docling-project/docling-serve:v1.30.0


### PR DESCRIPTION
## Summary

- Upgrade docling container from v1.29.0 to v1.30.0
- Update `OcrExtractionIT.testOcrWithMultipleTextBlocks` sentinel assertion: docling v1.30.0 now includes page furniture (headers/footers) in the default body export, so the test now asserts footer text **is** present (was previously asserting it was absent)
- Update documentation note in `docling-component.adoc` to reflect the new behavior

Supersedes #25417 which had merge conflicts. Addresses the behavioral change flagged by @gnodet's local IT results.

## Test plan

- [ ] CI build passes
- [ ] Integration tests with docling v1.30.0 pass (the OCR test assertion is updated to match new behavior)

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>