### PR TITLE
chore(deps): Bump opentelemetry-proto to 1.11.0-alpha and protobuf to 4.35.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -413,7 +413,7 @@
         <openstack4j-version>3.12</openstack4j-version>
         <opentelemetry-version>1.65.0</opentelemetry-version>
         <opentelemetry-alpha-version>1.65.0-alpha</opentelemetry-alpha-version>
-        <opentelemetry-proto-version>1.10.0-alpha</opentelemetry-proto-version>
+        <opentelemetry-proto-version>1.11.0-alpha</opentelemetry-proto-version>
         <opentelemetry-log4j2-version>2.30.0-alpha</opentelemetry-log4j2-version>
         <opentelemetry-incubator-version>1.43.0-alpha</opentelemetry-incubator-version>
         <opentelemetry-semconv-version>1.30.1-alpha</opentelemetry-semconv-version>
@@ -437,7 +437,7 @@
         <pooled-jms-version>3.2.3</pooled-jms-version>
         <properties-maven-plugin-version>1.3.0</properties-maven-plugin-version>
         <proto-google-common-protos-version>2.74.0</proto-google-common-protos-version>
-        <protobuf-version>4.34.2</protobuf-version>
+        <protobuf-version>4.35.1</protobuf-version>
         <protobuf-maven-plugin-version>4.1.3</protobuf-maven-plugin-version>
         <prowide-version>SRU2025-10.3.10</prowide-version>
         <pubnub-version>13.4.1</pubnub-version>


### PR DESCRIPTION
## Summary

_Claude Code on behalf of davsclaus_

- Bump `opentelemetry-proto` from 1.10.0-alpha to 1.11.0-alpha
- Bump `protobuf` from 4.34.2 to 4.35.1

The new `opentelemetry-proto 1.11.0-alpha` was generated with protobuf 4.35.1 and requires a matching runtime version (protobuf rejects older runtimes at class initialization). Both bumps are needed together.

Supersedes #25192.

## Test plan

- [x] `camel-opentelemetry2` — all 37 tests pass (was 10 errors with proto bump alone)
- [x] `camel-protobuf` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>