### PR TITLE
chore: document camel-publish.sh in the release guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/release-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/release-guide.adoc
@@ -447,6 +447,36 @@ approved local ZIP.
   git branch -D release/VERSION
   git push origin --delete release/VERSION
 
+[[ReleaseGuide-PublishingCamelCli]]
+== Publishing camel-cli packages
+
+Once the `camel-launcher` binary artifacts (`camel-launcher-<version>-bin.tar.gz` / `.zip`) have
+been built and staged, `camel-publish.sh` drives the JReleaser-based publish to the camel-cli
+package destinations. It is a single resumable orchestrator, not something invoked destination by
+destination.
+
+  cd ${CAMEL_ROOT_DIR}/dsl/camel-jbang/camel-launcher/src/jreleaser/bin
+  ./camel-publish.sh <Camel version> --channel stable|lts [--lts-line X.Y]
+
+* `--channel lts` requires `--lts-line X.Y` (e.g. `--lts-line 4.18`) and targets a versioned
+Homebrew formula (`apache-camel@X.Y`); `--channel stable` targets the unversioned formula
+(`apache-camel`).
+* Required environment: `GITHUB_TOKEN`, `SDKMAN_CONSUMER_KEY`, `SDKMAN_CONSUMER_SECRET`,
+`CHOCO_API_KEY`.
+* The `homebrew-core` and `winget-pkgs` destinations push to your own fork, not upstream. Fork
+both repositories first (`gh repo fork homebrew/homebrew-core --clone=false` and
+`gh repo fork microsoft/winget-pkgs --clone=false`) and make sure the `FORK_REMOTE`/
+`CAMEL_PUB_FORK_REMOTE` git remote used by the script is configured before running it.
+
+The script publishes to destinations in this order: JReleaser package → Homebrew tap → Camel
+website → WinGet → Scoop → SDKMAN → Chocolatey. `--channel lts` skips Scoop and SDKMAN (no
+versioned Scoop manifest, and SDKMAN only tracks the latest stable release).
+
+Progress is recorded in `target/jreleaser/publish-state.json`; re-running the same command after a
+partial failure resumes from the first incomplete destination instead of repeating completed ones.
+The script never merges the PRs it opens against `homebrew-core` or `winget-pkgs` — merge timing
+for those is up to each project's own maintainers.
+
 [[Publish-xsd-schemas]]
 == Publish xsd schemas
 


### PR DESCRIPTION
# Description

`camel-publish.sh` (`dsl/camel-jbang/camel-launcher/src/jreleaser/bin/camel-publish.sh`) is the
resumable orchestrator that publishes camel-cli release artifacts to JReleaser, Homebrew,
the Camel website, WinGet, Scoop, SDKMAN and Chocolatey, but none of these destinations were
documented in `release-guide.adoc`. This adds a "Publishing camel-cli packages" section covering
usage, required environment variables, the fork prerequisites for the Homebrew/WinGet
destinations, the publish order, and the resumable state-file behavior.

Docs-only change, no code touched.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking

- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

Trivial documentation fix, no JIRA issue filed per the template's own note on trivial changes.

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

Docs-only `.adoc` change; not applicable (no generated code to regenerate).

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code on behalf of ammachado_