### PR TITLE
CAMEL-24388: Guard against duplicate plugin subcommand registration

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
@@ -170,8 +170,9 @@ public final class PluginHelper {
         // Maven resolution for plugins unrelated to the current command.
         Map<String, Plugin> plugins = getActivePlugins(main, repos, target);
         for (Map.Entry<String, Plugin> plugin : plugins.entrySet()) {
-            // Skip if this plugin was already loaded from embedded plugins
-            if (foundEmbeddedPlugins && commandLine.getSubcommands().containsKey(plugin.getKey())) {
+            // Skip if this plugin command is already registered (e.g. loaded from embedded plugins,
+            // or stale JSON config listing a plugin that is now built-in)
+            if (commandLine.getSubcommands().containsKey(plugin.getKey())) {
                 continue;
             }
 
@@ -754,6 +755,11 @@ public final class PluginHelper {
                     if (!version.isBlank() && !firstVersion.isBlank()) {
                         PluginHelper.versionCheck(main, version, firstVersion, command);
                     }
+                }
+
+                // Skip if this plugin command is already registered
+                if (command != null && commandLine.getSubcommands().containsKey(command)) {
+                    return true;
                 }
 
                 plugin.customize(commandLine, main);


### PR DESCRIPTION
## Summary

_Claude Code on behalf of @${OPERATOR}_

When upgrading the Camel CLI, the old `~/.camel-jbang-plugins.json` file may still list plugins that are now bundled as embedded plugins. This causes picocli to throw a `DuplicateNameException` because the same subcommand name gets registered twice.

This fix makes `PluginHelper` guard against duplicate registrations in both plugin loading paths:
- **JSON config path**: the existing `containsKey` guard was conditional on `foundEmbeddedPlugins` — now it fires unconditionally so stale JSON entries are always skipped
- **Embedded plugin path**: added a `containsKey` guard before `plugin.customize()` in `loadPluginFromService()`

Both guards protect all plugins generically.

## Test plan

- [x] Verified the module compiles cleanly
- [ ] Manual test: install Camel CLI 4.22, add a stale `tui` entry to `~/.camel-jbang-plugins.json`, run `camel --version` — should work without `DuplicateNameException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>