### PR TITLE
CAMEL-24388: Guard against duplicate plugin subcommand registration (backport 4.22.x)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
@@ -170,8 +170,9 @@ public final class PluginHelper {
         // Maven resolution for plugins unrelated to the current command.
         Map<String, Plugin> plugins = getActivePlugins(main, repos, target);
         for (Map.Entry<String, Plugin> plugin : plugins.entrySet()) {
-            // Skip if this plugin was already loaded from embedded plugins
-            if (foundEmbeddedPlugins && commandLine.getSubcommands().containsKey(plugin.getKey())) {
+            // Skip if this plugin command is already registered (e.g. loaded from embedded plugins,
+            // or stale JSON config listing a plugin that is now built-in)
+            if (commandLine.getSubcommands().containsKey(plugin.getKey())) {
                 continue;
             }
 
@@ -754,6 +755,11 @@ public final class PluginHelper {
                     if (!version.isBlank() && !firstVersion.isBlank()) {
                         PluginHelper.versionCheck(main, version, firstVersion, command);
                     }
+                }
+
+                // Skip if this plugin command is already registered
+                if (command != null && commandLine.getSubcommands().containsKey(command)) {
+                    return true;
                 }
 
                 plugin.customize(commandLine, main);


### PR DESCRIPTION
## Summary

_Claude Code on behalf of @davsclaus_

Backport of #25487 to `camel-4.22.x`.

Guard against duplicate plugin subcommand registration in `PluginHelper` to prevent `DuplicateNameException` when upgrading the Camel CLI with stale `~/.camel-jbang-plugins.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>