### PR TITLE
CAMEL-24392: Fix BacklogTracerRouteAdvice draining WrappedFile streambody

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/CamelInternalProcessor.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/CamelInternalProcessor.java
@@ -200,6 +200,9 @@ public class CamelInternalProcessor extends DelegateAsyncProcessor implements In
     @Override
     public void addRouteLifecycleAdvice(CamelContext camelContext, Route route, NamedRoute node) {
         addAdvice(new CamelInternalProcessor.RouteLifecycleAdvice());
+        if (route.isStreamCaching()) {
+            addAdvice(new StreamCachingAdvice(camelContext.getStreamCachingStrategy()));
+        }
         if (camelContext.isBacklogTracingStandby() || route.isBacklogTracing()) {
             addAdvice(new BacklogTracerRouteAdvice(camelContext, node));
         }

--- a/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileStreamBodyWithBacklogTracerTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/file/GenericFileStreamBodyWithBacklogTracerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.InputStream;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.BacklogTracer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that a GenericFile with a non-resettable InputStream body is preserved when the backlog tracer is active.
+ */
+class GenericFileStreamBodyWithBacklogTracerTest extends ContextTestSupport {
+
+    @Test
+    void testGenericFileStreamBodyPreservedWithBacklogTracer() throws Exception {
+        assertThat(context.isBacklogTracingStandby()).as("BacklogTracingStandby").isTrue();
+        assertThat(context.isMessageHistory()).as("MessageHistory").isTrue();
+
+        BacklogTracer tracer = context.getCamelContextExtension().getContextPlugin(BacklogTracer.class);
+        assertThat(tracer).as("BacklogTracer").isNotNull();
+        assertThat(tracer.isStandby()).as("BacklogTracer standby").isTrue();
+
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+
+        GenericFile<Object> file = new GenericFile<>();
+        file.setFileName("test.txt");
+        file.setBody(nonResettableStream("Hello World Body"));
+        template.sendBody("direct:start", file);
+
+        assertMockEndpointsSatisfied();
+
+        String body = getMockEndpoint("mock:result").getReceivedExchanges().get(0)
+                .getMessage().getBody(String.class);
+        assertThat(body).isEqualTo("Hello World Body");
+    }
+
+    private static InputStream nonResettableStream(String content) {
+        return new FilterInputStream(new ByteArrayInputStream(content.getBytes())) {
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+
+            @Override
+            public synchronized void mark(int readlimit) {
+            }
+
+            @Override
+            public synchronized void reset() {
+                throw new UnsupportedOperationException("reset not supported");
+            }
+        };
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                context.setUseBreadcrumb(false);
+                context.setBacklogTracingStandby(true);
+                context.setMessageHistory(true);
+
+                from("direct:start").routeId("myRoute").streamCaching("true")
+                        .to("mock:result").id("result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
CAMEL-24392

# Description

BacklogTracerRouteAdvice runs at route level before StreamCachingAdvice (channel level), so tracing drained stream bodies (e.g. SFTP streamDownload) before they could be cached.
    
Cache the stream in BacklogTracerRouteAdvice.before() when stream caching is enabled on the route, ensuring the body is converted to a re-readable StreamCache before the tracer reads it.

Test added camel-core to confirm the fix and avoid any new regression.
Backport will be done on 4.22 and 4.18

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [X] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

