### PR TITLE
chore(docs): fix tabs block rendering in camel-milvus docs

### DIFF
--- a/components/camel-ai/camel-milvus/src/main/docs/milvus-component.adoc
+++ b/components/camel-ai/camel-milvus/src/main/docs/milvus-component.adoc
@@ -177,6 +177,7 @@ As an example, you could think about these routes:
 [tabs]
 ====
 Java::
++
 [source,java]
 ----
     protected RoutesBuilder createRouteBuilder() {


### PR DESCRIPTION
## Description

The last `[tabs]` block in the `camel-milvus` component documentation (the "Relation with Langchain4j-Embeddings component" section) was missing the AsciiDoc list continuation marker (`+`) after the `Java::` tab label.

Without the `+`, the following `[source,java]` block is not attached to the tab item, so Asciidoctor renders the code sample outside the tab instead of inside it.

The other three `[tabs]` blocks on the same page already had the marker, so this also makes the page internally consistent.

## Changes

- `components/camel-ai/camel-milvus/src/main/docs/milvus-component.adoc`: add the missing `+` continuation marker.

Documentation-only change: no code, no tests, no upgrade-guide entry needed.

---

_Claude Code on behalf of ammachado_