### PR TITLE
chore: fix camel-milvus docs tabs rendering and 4.23 upgrade guide xref

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/milvus-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/milvus-component.adoc
@@ -177,6 +177,7 @@ As an example, you could think about these routes:
 [tabs]
 ====
 Java::
++
 [source,java]
 ----
     protected RoutesBuilder createRouteBuilder() {

--- a/components/camel-ai/camel-milvus/src/main/docs/milvus-component.adoc
+++ b/components/camel-ai/camel-milvus/src/main/docs/milvus-component.adoc
@@ -177,6 +177,7 @@ As an example, you could think about these routes:
 [tabs]
 ====
 Java::
++
 [source,java]
 ----
     protected RoutesBuilder createRouteBuilder() {

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -53,7 +53,7 @@ LangChain4j components also expose request model names on new exchange headers
 (`CamelLangChain4j*RequestModel`). The response model header (`CamelLangChain4j*ResponseModel`) is set when
 the underlying client exposes it (for example langchain4j-chat); the agent and embeddings producers omit it when
 unavailable. See
-xref:components:others:ai-observability.adoc[AI Observability] for metric names and span attributes.
+xref:next@components:others:ai-observability.adoc[AI Observability] for metric names and span attributes.
 
 === camel-archetypes
 


### PR DESCRIPTION
# Description

Two small, unrelated documentation fixes bundled on this branch:

- `chore(docs): fix tabs block rendering in camel-milvus docs` — corrects tabs-block markup in `milvus-component.adoc` (also tracked separately in #25493), plus regenerated the `camel-catalog` generated mirror of that doc (CI's "Fail if there are uncommitted changes" check caught the missed regeneration).
- `chore: fix unresolved xref to ai-observability.adoc in 4.23 upgrade guide` — the `ai-observability.adoc` page was added on `main` in the same dev cycle and only exists in the `next` version of the `components` Antora component. The unversioned user-manual falls back to the latest released `components` version, which doesn't have the page yet, so the unqualified xref failed to resolve. Qualified it with `next@`, matching the existing convention already used in `references.adoc` and `index.adoc`.

_Claude Code on behalf of ammachado_

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.