### PR TITLE
CAMEL-23703: camel-launcher - fix brew audit --strict redundant version

### DIFF
--- a/dsl/camel-jbang/camel-launcher/src/jreleaser/bin/camel-validate.sh
+++ b/dsl/camel-jbang/camel-launcher/src/jreleaser/bin/camel-validate.sh
@@ -233,6 +233,18 @@ validate_homebrew() {
     # failure of the audit gate below caused by the tap copy itself, not by the formula.
     chmod 644 "$tap_dir/Formula/${fmla}.rb"
 
+    # The formula carries no dedicated `version` field (brew audit --strict rejects one that
+    # merely duplicates what it already scans from the url), so the expected post-install
+    # version is read from the url instead - captured now, before Step 2 below may rewrite that
+    # same url to a local file:// path for the offline install, which would otherwise wipe out
+    # the "<version>/<artifact>" path segment this parses.
+    local expected_version
+    expected_version=$(sed -n 's#.*/camel-launcher/\([^/]*\)/[^/]*"$#\1#p' "$tap_dir/Formula/${fmla}.rb" | head -n1)
+    if [ -z "$expected_version" ]; then
+        echo "WARN: could not read the version from tapped formula ${fmla}.rb's url, falling back to \$RESOLVED_VERSION ($RESOLVED_VERSION)"
+        expected_version="$RESOLVED_VERSION"
+    fi
+
     # Step 1: Homebrew style + audit, referenced by tap-qualified name (not a path).
     # `brew style --fix` only normalizes formatting; its output is informational.
     local style_output=""
@@ -323,21 +335,8 @@ validate_homebrew() {
 
     # Step 3: Verify camel version after installation. A successful `brew install` exit code
     # is not proof the executable actually works, so a missing/empty/mismatched result here
-    # is a real failure, not something to warn past.
-    #
-    # Expected version comes from the formula's own `version` line, not $RESOLVED_VERSION.
-    # JReleaser renders the formula version from the real POM version, which in test mode is
-    # the -SNAPSHOT that the offline file:// install above actually installs; that differs from
-    # $RESOLVED_VERSION (which strips -SNAPSHOT for local-archive lookups). Reading the expected
-    # value back out of the tapped formula keeps this assertion correct in both the test-mode
-    # case and a real release (where the formula version is $RESOLVED_VERSION anyway).
-    local expected_version
-    expected_version=$(sed -n 's/^[[:space:]]*version "\(.*\)"/\1/p' "$tap_dir/Formula/${fmla}.rb" | head -n1)
-    if [ -z "$expected_version" ]; then
-        echo "WARN: could not read 'version' from tapped formula ${fmla}.rb, falling back to \$RESOLVED_VERSION ($RESOLVED_VERSION)"
-        expected_version="$RESOLVED_VERSION"
-    fi
-
+    # is a real failure, not something to warn past. $expected_version was captured above,
+    # before Step 2 rewrote the formula's url to a local file:// path.
     local camv_output=""
     if ! command -v camel >/dev/null 2>&1; then
         echo "FAIL: camel executable not found on PATH after a successful homebrew install"

--- a/dsl/camel-jbang/camel-launcher/src/jreleaser/distributions/camel-cli/brew/formula.rb.tpl
+++ b/dsl/camel-jbang/camel-launcher/src/jreleaser/distributions/camel-cli/brew/formula.rb.tpl
@@ -24,7 +24,6 @@ class {{brewFormulaName}} < Formula
   desc "{{projectDescription}}"
   homepage "{{{projectLinkHomepage}}}"
   url "{{{distributionUrl}}}"{{#brewDownloadStrategy}}, :using => {{.}}{{/brewDownloadStrategy}}
-  version "{{projectVersion}}"
   sha256 "{{distributionChecksumSha256}}"
   license "{{projectLicense}}"
 {{#brewVersionedFormula}}


### PR DESCRIPTION
# Description

`formula.rb.tpl` (the Homebrew formula template rendered by JReleaser for `camel-launcher`) set both a `url` and an explicit `version` field. Homebrew's `brew audit --strict` flags an explicit `version` as redundant whenever it can already be inferred by scanning the `url` (which it can here, since the URL embeds the Maven coordinate version). Any real submission of the generated formula to `homebrew-core` would fail this audit gate.

Fix: drop the redundant `version` line from the template.

`camel-validate.sh`'s Homebrew validation step previously read the *expected* post-install version back out of that same `version` field (needed because in CI's test-mode staging the formula's real POM version, e.g. a `-SNAPSHOT`, differs from the release-manager-facing resolved version). Removing the field regressed that check, so it now reads the expected version out of the formula's `url` instead, captured before the test-mode step rewrites that `url` to a local `file://` path for the offline install.

Found and fixed while running `camel-package.sh prepare` + `camel-validate.sh all` for the already-released `camel-4.22.0` version to verify the launcher's JReleaser release procedure end-to-end.

Verified locally: re-ran `camel-package.sh prepare --channel stable` + `camel-validate.sh all` in the project's own `CAMEL_PACKAGE_TEST_MODE` (the same mechanism `.github/workflows/package-native-validation.yml` uses in CI) — `brew audit --strict` now reports no offenses, and the post-install version check passes.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

This change only touches a shell script and a Mustache template (no Java sources), so the Maven formatter/impsort step has nothing to reformat; the pre-push hook's `mvn formatter:format impsort:sort` ran clean with no changes. A full root build was not run given the change's scope.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code (Sonnet 5) on behalf of Adriano Machado (@ammachado)_