### PR TITLE
CAMEL-21313: Refactor camel-clickup tests for clarity and consistency

### DIFF
--- a/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpConfigurationTest.java
+++ b/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpConfigurationTest.java
@@ -24,37 +24,33 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.clickup.util.ClickUpTestSupport;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ClickUpConfigurationTest extends ClickUpTestSupport {
+class ClickUpConfigurationTest extends ClickUpTestSupport {
 
-    private final static Long WORKSPACE_ID = 12345L;
-    private final static String BASE_URL = "https://mock-api.clickup.com";
-    private final static String AUTHORIZATION_TOKEN = "mock-authorization-token";
-    private final static String WEBHOOK_SECRET = "mock-webhook-secret";
-    private final static Set<String> EVENTS = new HashSet<>(Arrays.asList("taskTimeTrackedUpdated"));
+    private static final String BASE_URL = "https://mock-api.clickup.com";
+    private static final Set<String> EVENTS = new HashSet<>(Arrays.asList("taskTimeTrackedUpdated"));
 
     @Test
-    public void testClickUpConfiguration() {
+    void testClickUpConfiguration() {
         ClickUpEndpoint endpoint = (ClickUpEndpoint) context().getEndpoints().stream()
                 .filter(e -> e instanceof ClickUpEndpoint).findAny().get();
         ClickUpConfiguration config = endpoint.getConfiguration();
 
-        assertEquals(WORKSPACE_ID, config.getWorkspaceId());
-        assertEquals(BASE_URL, config.getBaseUrl());
-        assertEquals(AUTHORIZATION_TOKEN, config.getAuthorizationToken());
-        assertEquals(WEBHOOK_SECRET, config.getWebhookSecret());
-        assertEquals(EVENTS, config.getEvents());
+        assertThat(config.getWorkspaceId()).isEqualTo(WORKSPACE_ID);
+        assertThat(config.getBaseUrl()).isEqualTo(BASE_URL);
+        assertThat(config.getAuthorizationToken()).isEqualTo(AUTHORIZATION_TOKEN);
+        assertThat(config.getWebhookSecret()).isEqualTo(WEBHOOK_SECRET);
+        assertThat(config.getEvents()).isEqualTo(EVENTS);
     }
 
     @Override
-    protected RouteBuilder createRouteBuilder() throws Exception {
+    protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
             @Override
             public void configure() {
-                from("webhook:clickup:" + WORKSPACE_ID + "?baseUrl=" + BASE_URL + "&authorizationToken=" + AUTHORIZATION_TOKEN
-                     + "&webhookSecret=" + WEBHOOK_SECRET + "&events=" + String.join(",", EVENTS)
-                     + "&webhookAutoRegister=false")
+                fromF("webhook:clickup:%s?baseUrl=%s&authorizationToken=%s&webhookSecret=%s&events=%s&webhookAutoRegister=false",
+                        WORKSPACE_ID, BASE_URL, AUTHORIZATION_TOKEN, WEBHOOK_SECRET, String.join(",", EVENTS))
                         .log("Received: ${body}");
             }
         };

--- a/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpWebhookCallTest.java
+++ b/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpWebhookCallTest.java
@@ -17,7 +17,10 @@
 package org.apache.camel.component.clickup;
 
 import java.io.InputStream;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.RoutesBuilder;
@@ -28,45 +31,35 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.webhook.WebhookConfiguration;
 import org.apache.camel.component.webhook.WebhookEndpoint;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class ClickUpWebhookCallTest extends ClickUpTestSupport {
+import static java.util.List.of;
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ClickUpWebhookCallTest.class);
+class ClickUpWebhookCallTest extends ClickUpTestSupport {
 
-    private final static Long WORKSPACE_ID = 12345L;
-    private final static String AUTHORIZATION_TOKEN = "mock-authorization-token";
-    private final static String WEBHOOK_SECRET = "mock-webhook-secret";
-    private final static Set<String> EVENTS = new HashSet<>(List.of("taskTimeTrackedUpdated"));
-
-    public static final String MESSAGES_EVENTS_TIME_TRACKING_CREATED_FILENAME = "messages/events/time-tracking-created.json";
-    public static final String MESSAGES_EVENTS_TIME_TRACKING_CREATED_SIGNATURE
+    private static final Set<String> EVENTS = new HashSet<>(of("taskTimeTrackedUpdated"));
+    private static final String TIME_TRACKING_CREATED_RESOURCE = "messages/events/time-tracking-created.json";
+    private static final String TIME_TRACKING_CREATED_SIGNATURE
             = "ac99f10017e28db6839941c184964890ec3262b1d6b1756d33ff53d972d5a361";
 
     @Test
-    public void testWebhookCall() throws Exception {
+    void testWebhookCall() throws Exception {
         WebhookConfiguration config
                 = ((WebhookEndpoint) context().getRoute("webhook").getConsumer().getEndpoint()).getConfiguration();
         String url = config.computeFullExternalUrl();
 
-        LOGGER.info("Webhook external url: {}", url);
+        MockEndpoint mock = getMockEndpoint("mock:endpoint");
+        mock.expectedMessageCount(1);
+        mock.expectedMessagesMatches(exchange -> exchange.getIn().getBody() instanceof TaskTimeTrackedUpdatedEvent);
 
-        try (InputStream content
-                = getClass().getClassLoader().getResourceAsStream(MESSAGES_EVENTS_TIME_TRACKING_CREATED_FILENAME)) {
-            LOGGER.info("message content: {}", content);
-
-            MockEndpoint mock = getMockEndpoint("mock:endpoint");
-            mock.expectedMessageCount(1);
-            mock.expectedMessagesMatches(exchange -> exchange.getIn().getBody() instanceof TaskTimeTrackedUpdatedEvent);
-
+        try (InputStream content = getClass().getClassLoader().getResourceAsStream(TIME_TRACKING_CREATED_RESOURCE)) {
             Map<String, Object> headers = new HashMap<>();
             headers.put(Exchange.HTTP_METHOD, "POST");
             headers.put(Exchange.CONTENT_TYPE, "application/json");
-            headers.put("x-signature", MESSAGES_EVENTS_TIME_TRACKING_CREATED_SIGNATURE);
+            headers.put("x-signature", TIME_TRACKING_CREATED_SIGNATURE);
             template().sendBodyAndHeaders("netty-http:" + url, content, headers);
-            mock.assertIsSatisfied();
         }
+
+        mock.assertIsSatisfied();
     }
 
     @Override
@@ -78,8 +71,8 @@ public class ClickUpWebhookCallTest extends ClickUpTestSupport {
                         .host("localhost")
                         .port(port.getPort());
 
-                from("webhook:clickup:" + WORKSPACE_ID + "?authorizationToken=" + AUTHORIZATION_TOKEN + "&webhookSecret="
-                     + WEBHOOK_SECRET + "&events=" + String.join(",", EVENTS) + "&webhookAutoRegister=false")
+                fromF("webhook:clickup:%s?authorizationToken=%s&webhookSecret=%s&events=%s&webhookAutoRegister=false",
+                        WORKSPACE_ID, AUTHORIZATION_TOKEN, WEBHOOK_SECRET, String.join(",", EVENTS))
                         .id("webhook")
                         .to("mock:endpoint");
             }

--- a/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpWebhookRegistrationAlreadyExistsTest.java
+++ b/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpWebhookRegistrationAlreadyExistsTest.java
@@ -18,16 +18,11 @@ package org.apache.camel.component.clickup;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.net.UnknownHostException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,98 +37,70 @@ import org.apache.camel.component.webhook.WebhookConfiguration;
 import org.apache.camel.component.webhook.WebhookEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.junit6.TestExecutionConfiguration;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ClickUpWebhookRegistrationAlreadyExistsTest extends ClickUpTestSupport {
+class ClickUpWebhookRegistrationAlreadyExistsTest extends ClickUpTestSupport {
 
-    private final static Long WORKSPACE_ID = 12345L;
-    private final static String AUTHORIZATION_TOKEN = "mock-authorization-token";
-    private final static String WEBHOOK_SECRET = "mock-webhook-secret";
-    private final static Set<String> EVENTS = new HashSet<>(List.of("taskTimeTrackedUpdated"));
-
+    private static final Set<String> EVENTS = new HashSet<>(List.of("taskTimeTrackedUpdated"));
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    public static final String WEBHOOK_ALREADY_EXISTS_JSON = "messages/webhook-already-exists.json";
-    public static final String WEBHOOKS = "messages/webhooks.json";
+    private static final String WEBHOOK_ALREADY_EXISTS_JSON = "messages/webhook-already-exists.json";
+    private static final String WEBHOOKS = "messages/webhooks.json";
 
     @Override
     public void configureTest(TestExecutionConfiguration testExecutionConfiguration) {
         super.configureTest(testExecutionConfiguration);
-
         testExecutionConfiguration.withUseRouteBuilder(false);
     }
 
     @Test
-    public void testAutomaticRegistrationWhenWebhookConfigurationAlreadyExists() throws Exception {
-        final ClickUpMockRoutes.MockProcessor<String> creationMockProcessor
+    void testAutomaticRegistrationWhenWebhookConfigurationAlreadyExists() throws Exception {
+        ClickUpMockRoutes.MockProcessor<String> creationMockProcessor
                 = getMockRoutes().getMock("POST", "team/" + WORKSPACE_ID + "/webhook");
         creationMockProcessor.clearRecordedMessages();
 
-        final ClickUpMockRoutes.MockProcessor<String> readMockProcessor
+        ClickUpMockRoutes.MockProcessor<String> readMockProcessor
                 = getMockRoutes().getMock("GET", "team/" + WORKSPACE_ID + "/webhook");
         readMockProcessor.clearRecordedMessages();
 
-        try (final DefaultCamelContext mockContext = new DefaultCamelContext()) {
+        try (DefaultCamelContext mockContext = new DefaultCamelContext()) {
             mockContext.addRoutes(getMockRoutes());
             mockContext.start();
 
-            /* Make sure the ClickUp mock API is up and running */
-            Awaitility.await()
-                    .atMost(5, TimeUnit.SECONDS)
-                    .until(() -> {
-                        HttpClient client = HttpClient.newBuilder().build();
-                        HttpRequest request = HttpRequest.newBuilder()
-                                .uri(URI.create("http://localhost:" + port + "/clickup-api-mock/health")).GET().build();
-
-                        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-                        return response.statusCode() == 200;
-                    });
-
-            context().addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    String apiMockBaseUrl = "http://localhost:" + port + "/clickup-api-mock";
-
-                    from("webhook:clickup:" + WORKSPACE_ID + "?authorizationToken=" + AUTHORIZATION_TOKEN + "&webhookSecret="
-                         + WEBHOOK_SECRET + "&events=" + String.join(",", EVENTS) + "&webhookAutoRegister=true&baseUrl="
-                         + apiMockBaseUrl)
-                            .id("webhook")
-                            .to("mock:endpoint");
-                }
-            });
+            waitForClickUpMockAPI();
+            addWebhookRoute();
 
             context().start();
 
-            {
-                final List<String> creationRecordedMessages = creationMockProcessor.awaitRecordedMessages(1, 5000);
-                assertEquals(1, creationRecordedMessages.size());
-                String webhookCreationMessage = creationRecordedMessages.get(0);
+            List<String> creationRecordedMessages = creationMockProcessor.awaitRecordedMessages(1, 5000);
+            assertThat(creationRecordedMessages).hasSize(1);
 
-                try {
-                    WebhookCreationCommand command = MAPPER.readValue(webhookCreationMessage, WebhookCreationCommand.class);
+            WebhookCreationCommand command = MAPPER.readValue(creationRecordedMessages.get(0), WebhookCreationCommand.class);
+            assertThat(command).isNotNull();
+            creationMockProcessor.clearRecordedMessages();
 
-                    assertInstanceOf(WebhookCreationCommand.class, command);
-                } catch (IOException e) {
-                    fail(e);
-                }
-
-                creationMockProcessor.clearRecordedMessages();
-            }
-
-            {
-                final List<String> readRecordedMessages = readMockProcessor.awaitRecordedMessages(1, 5000);
-                assertEquals(1, readRecordedMessages.size());
-                String webhookReadMessage = readRecordedMessages.get(0);
-
-                assertEquals("", webhookReadMessage);
-
-                readMockProcessor.clearRecordedMessages();
-            }
+            List<String> readRecordedMessages = readMockProcessor.awaitRecordedMessages(1, 5000);
+            assertThat(readRecordedMessages).hasSize(1);
+            assertThat(readRecordedMessages.get(0)).isEmpty();
+            readMockProcessor.clearRecordedMessages();
 
             context().stop();
         }
+    }
+
+    private void addWebhookRoute() throws Exception {
+        context().addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                String apiMockBaseUrl = "http://localhost:" + port + "/clickup-api-mock";
+
+                fromF("webhook:clickup:%s?authorizationToken=%s&webhookSecret=%s&events=%s&webhookAutoRegister=true&baseUrl=%s",
+                        WORKSPACE_ID, AUTHORIZATION_TOKEN, WEBHOOK_SECRET, String.join(",", EVENTS), apiMockBaseUrl)
+                        .id("webhook")
+                        .to("mock:endpoint");
+            }
+        });
     }
 
     @Override

--- a/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpWebhookRegistrationTest.java
+++ b/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/ClickUpWebhookRegistrationTest.java
@@ -18,14 +18,9 @@ package org.apache.camel.component.clickup;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.builder.RouteBuilder;
@@ -34,114 +29,79 @@ import org.apache.camel.component.clickup.util.ClickUpMockRoutes;
 import org.apache.camel.component.clickup.util.ClickUpTestSupport;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.test.junit6.TestExecutionConfiguration;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ClickUpWebhookRegistrationTest extends ClickUpTestSupport {
+class ClickUpWebhookRegistrationTest extends ClickUpTestSupport {
 
-    private final static Long WORKSPACE_ID = 12345L;
-    private final static String AUTHORIZATION_TOKEN = "mock-authorization-token";
-    private final static String WEBHOOK_SECRET = "mock-webhook-secret";
-    private final static Set<String> EVENTS = new HashSet<>(List.of("taskTimeTrackedUpdated"));
-
+    private static final Set<String> EVENTS = new HashSet<>(List.of("taskTimeTrackedUpdated"));
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    public static final String WEBHOOK_CREATED_JSON = "messages/webhook-created.json";
+    private static final String WEBHOOK_CREATED_JSON = "messages/webhook-created.json";
 
     @Override
     public void configureTest(TestExecutionConfiguration testExecutionConfiguration) {
         super.configureTest(testExecutionConfiguration);
-
         testExecutionConfiguration.withUseRouteBuilder(false);
     }
 
     @Test
-    public void testAutomaticRegistration() throws Exception {
-        final ClickUpMockRoutes.MockProcessor<String> mockProcessor
+    void testAutomaticRegistration() throws Exception {
+        ClickUpMockRoutes.MockProcessor<String> mockProcessor
                 = getMockRoutes().getMock("POST", "team/" + WORKSPACE_ID + "/webhook");
         mockProcessor.clearRecordedMessages();
 
-        try (final DefaultCamelContext mockContext = new DefaultCamelContext()) {
+        try (DefaultCamelContext mockContext = new DefaultCamelContext()) {
             mockContext.addRoutes(getMockRoutes());
             mockContext.start();
 
             waitForClickUpMockAPI();
-
-            setupContextRoutes();
+            addWebhookRoute();
 
             context().start();
 
-            final List<String> recordedMessages = mockProcessor.awaitRecordedMessages(1, 5000);
-            assertEquals(1, recordedMessages.size());
-            String recordedMessage = recordedMessages.get(0);
+            List<String> recordedMessages = mockProcessor.awaitRecordedMessages(1, 5000);
+            assertThat(recordedMessages).hasSize(1);
 
-            try {
-                WebhookCreationCommand command = MAPPER.readValue(recordedMessage, WebhookCreationCommand.class);
-
-                assertInstanceOf(WebhookCreationCommand.class, command);
-            } catch (IOException e) {
-                throw new AssertionError("Failed to parse recorded message", e);
-            }
+            WebhookCreationCommand command = MAPPER.readValue(recordedMessages.get(0), WebhookCreationCommand.class);
+            assertThat(command).isNotNull();
 
             mockProcessor.clearRecordedMessages();
-
             context().stop();
         }
     }
 
     @Test
-    public void testAutomaticUnregistration() throws Exception {
-        final ClickUpMockRoutes.MockProcessor<String> mockProcessor = getMockRoutes().getMock("DELETE", "webhook/");
+    void testAutomaticUnregistration() throws Exception {
+        ClickUpMockRoutes.MockProcessor<String> mockProcessor = getMockRoutes().getMock("DELETE", "webhook/");
         mockProcessor.clearRecordedMessages();
 
-        try (final DefaultCamelContext mockContext = new DefaultCamelContext()) {
+        try (DefaultCamelContext mockContext = new DefaultCamelContext()) {
             mockContext.addRoutes(getMockRoutes());
             mockContext.start();
 
             waitForClickUpMockAPI();
-
-            setupContextRoutes();
+            addWebhookRoute();
 
             context().start();
-
             context().stop();
 
-            {
-                final List<String> readRecordedMessages = mockProcessor.awaitRecordedMessages(1, 5000);
-                assertEquals(1, readRecordedMessages.size());
-                String webhookDeleteMessage = readRecordedMessages.get(0);
+            List<String> recordedMessages = mockProcessor.awaitRecordedMessages(1, 5000);
+            assertThat(recordedMessages).hasSize(1);
+            assertThat(recordedMessages.get(0)).isEmpty();
 
-                assertEquals("", webhookDeleteMessage);
-
-                mockProcessor.clearRecordedMessages();
-            }
+            mockProcessor.clearRecordedMessages();
         }
     }
 
-    private static void waitForClickUpMockAPI() {
-        /* Make sure the ClickUp mock API is up and running */
-        Awaitility.await()
-                .atMost(5, TimeUnit.SECONDS)
-                .until(() -> {
-                    HttpClient client = HttpClient.newBuilder().build();
-                    HttpRequest request = HttpRequest.newBuilder()
-                            .uri(URI.create("http://localhost:" + port + "/clickup-api-mock/health")).GET().build();
-
-                    final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-                    return response.statusCode() == 200;
-                });
-    }
-
-    private void setupContextRoutes() throws Exception {
+    private void addWebhookRoute() throws Exception {
         context().addRoutes(new RouteBuilder() {
             @Override
             public void configure() {
                 String apiMockBaseUrl = "http://localhost:" + port + "/clickup-api-mock";
 
-                from("webhook:clickup:" + WORKSPACE_ID + "?authorizationToken=" + AUTHORIZATION_TOKEN + "&webhookSecret="
-                     + WEBHOOK_SECRET + "&events=" + String.join(",", EVENTS) + "&webhookAutoRegister=true&baseUrl="
-                     + apiMockBaseUrl)
+                fromF("webhook:clickup:%s?authorizationToken=%s&webhookSecret=%s&events=%s&webhookAutoRegister=true&baseUrl=%s",
+                        WORKSPACE_ID, AUTHORIZATION_TOKEN, WEBHOOK_SECRET, String.join(",", EVENTS), apiMockBaseUrl)
                         .id("webhook")
                         .to("mock:endpoint");
             }

--- a/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/util/ClickUpTestSupport.java
+++ b/components/camel-clickup/src/test/java/org/apache/camel/component/clickup/util/ClickUpTestSupport.java
@@ -18,18 +18,28 @@ package org.apache.camel.component.clickup.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.clickup.ClickUpComponent;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * A support test class for ClickUp tests.
  */
 public class ClickUpTestSupport extends CamelTestSupport {
+
+    protected static final Long WORKSPACE_ID = 12345L;
+    protected static final String AUTHORIZATION_TOKEN = "mock-authorization-token";
+    protected static final String WEBHOOK_SECRET = "mock-webhook-secret";
 
     @RegisterExtension
     protected static AvailablePortFinder.Port port = AvailablePortFinder.find();
@@ -47,11 +57,25 @@ public class ClickUpTestSupport extends CamelTestSupport {
     public static <T> T getJSONResource(String fileName, Class<T> clazz) {
         ObjectMapper mapper = new ObjectMapper();
         try (InputStream stream = ClickUpTestSupport.class.getClassLoader().getResourceAsStream(fileName)) {
-            T value = mapper.readValue(stream, clazz);
-            return value;
+            return mapper.readValue(stream, clazz);
         } catch (IOException e) {
             throw new IllegalArgumentException("Unable to load file " + fileName, e);
         }
+    }
+
+    /**
+     * Waits until the ClickUp mock API health endpoint responds with HTTP 200.
+     */
+    protected void waitForClickUpMockAPI() {
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> {
+                    HttpClient client = HttpClient.newBuilder().build();
+                    HttpRequest request = HttpRequest.newBuilder()
+                            .uri(URI.create("http://localhost:" + port + "/clickup-api-mock/health")).GET().build();
+                    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                    return response.statusCode() == 200;
+                });
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Refactor `camel-clickup` tests to keep test methods focused on assertions and move setup/lifecycle concerns into helpers.
- Standardize route URI construction by replacing concatenated `from(...)` strings with `fromF(...)` in the affected tests.
- Improve consistency by removing anonymous assertion blocks, reusing shared test support utilities, and migrating touched assertions to AssertJ.

## Test plan
- [x] `./mvnw install -Dquickly -pl components/camel-clickup -am`
- [x] `cd components/camel-clickup && ../../mvnw test`
- [x] `cd components/camel-clickup && ../../mvnw formatter:format impsort:sort`

_AI-generated by Cursor on behalf of misrasuraj._

Made with [Cursor](https://cursor.com)