### PR TITLE
Hapi-fhir ppc64le integration tests activation

### DIFF
--- a/components/camel-fhir/pom.xml
+++ b/components/camel-fhir/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <!-- FHIR container is not available on these platforms -->
-        <skipITs.ppc64le>true</skipITs.ppc64le>
         <skipITs.s390x>true</skipITs.s390x>
     </properties>
 

--- a/test-infra/camel-test-infra-fhir/src/main/resources/org/apache/camel/test/infra/fhir/services/container.properties
+++ b/test-infra/camel-test-infra-fhir/src/main/resources/org/apache/camel/test/infra/fhir/services/container.properties
@@ -15,4 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 fhir.container=mirror.gcr.io/hapiproject/hapi:v8.10.0-3
-fhir.container=icr.io/ppc64le-oss/hapi-fhir-ppc64le:8.10.0
+fhir.container.ppc64le=icr.io/ppc64le-oss/hapi-fhir-ppc64le:8.10.0

--- a/test-infra/camel-test-infra-fhir/src/main/resources/org/apache/camel/test/infra/fhir/services/container.properties
+++ b/test-infra/camel-test-infra-fhir/src/main/resources/org/apache/camel/test/infra/fhir/services/container.properties
@@ -15,3 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 fhir.container=mirror.gcr.io/hapiproject/hapi:v8.10.0-3
+fhir.container=icr.io/ppc64le-oss/hapi-fhir-ppc64le:8.10.0


### PR DESCRIPTION
# Description
This pull request is to provide ppc64le support to camel-fhir component.
Tested all changes on a PowerPC machine. Log is attached below.
[camel_fhir_power_logs.txt](https://github.com/user-attachments/files/31193072/camel_fhir_power_logs.txt)

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

