### PR TITLE
CAMEL-24403: camel-mail: handle MessageRemovedException in processCommit to avoid null cause in error log

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
@@ -28,6 +28,7 @@ import jakarta.mail.Flags;
 import jakarta.mail.Folder;
 import jakarta.mail.FolderNotFoundException;
 import jakarta.mail.Message;
+import jakarta.mail.MessageRemovedException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Store;
@@ -526,6 +527,11 @@ public class MailConsumer extends ScheduledBatchPollingConsumer {
                 }
             }
 
+        } catch (MessageRemovedException e) {
+            MessagingException wrapped = new MessagingException(
+                    "Message already removed/expunged on server (no flag update possible)", e);
+            getExceptionHandler().handleException(
+                    "Error occurred during committing mail message: " + mail, exchange, wrapped);
         } catch (MessagingException e) {
             getExceptionHandler().handleException("Error occurred during committing mail message: " + mail, exchange, e);
         }

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mail;
+
+import java.lang.reflect.Field;
+
+import jakarta.mail.Flags;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessageRemovedException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.Processor;
+import org.apache.camel.component.mail.Mailbox.Protocol;
+import org.apache.camel.spi.ExceptionHandler;
+import org.apache.camel.spi.ExchangeFactory;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that processCommit() wraps MessageRemovedException (message already expunged on the IMAP server) with a
+ * non-null cause message so that the error log never shows "Caused by: [... - null]".
+ */
+public class MailConsumerCommitExpungedMessageTest {
+
+    @Test
+    public void testCommitWithExpungedMessageProducesNonNullCause() throws Exception {
+        // --- infrastructure mocks ---
+        JavaMailSender sender = mock(JavaMailSender.class);
+        Processor processor = mock(Processor.class);
+        CamelContext camelContext = mock(CamelContext.class);
+        ExtendedCamelContext ecc = mock(ExtendedCamelContext.class);
+        ExchangeFactory ef = mock(ExchangeFactory.class);
+        Session session = Session.getInstance(Mailbox.getSessionProperties(Protocol.imap));
+
+        when(sender.getSession()).thenReturn(session);
+        when(camelContext.getCamelContextExtension()).thenReturn(ecc);
+        when(ecc.getExchangeFactory()).thenReturn(ef);
+        when(ef.newExchangeFactory(any())).thenReturn(ef);
+
+        // --- endpoint/configuration ---
+        MailEndpoint endpoint = new MailEndpoint();
+        endpoint.setCamelContext(camelContext);
+        MailConfiguration config = new MailConfiguration();
+        config.configureProtocol(Protocol.imap.name());
+        config.setPort(Mailbox.getPort(Protocol.imap));
+        config.setFolderName("INBOX");
+        config.setDelete(false);
+        endpoint.setConfiguration(config);
+
+        // --- message mock: setFlag throws MessageRemovedException (no message text — simulates the null cause) ---
+        Message mail = mock(Message.class);
+        doThrow(new MessageRemovedException()).when(mail).setFlag(any(Flags.Flag.class), any(boolean.class));
+
+        // --- folder mock: open and isOpen so processCommit doesn't bail early ---
+        Folder folder = mock(Folder.class);
+        when(folder.isOpen()).thenReturn(true);
+
+        // --- exchange mock ---
+        Exchange exchange = mock(Exchange.class);
+        org.apache.camel.Message camelMsg = mock(org.apache.camel.Message.class);
+        when(exchange.getIn()).thenReturn(camelMsg);
+        when(camelMsg.getHeader(MailConstants.MAIL_COPY_TO, config.getCopyTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_MOVE_TO, config.getMoveTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_DELETE, config.isDelete(), boolean.class)).thenReturn(false);
+        // removeProperty returns null uid — fine because protocol is imap (not pop3)
+        when(exchange.removeProperty(MailConsumer.MAIL_MESSAGE_UID)).thenReturn(null);
+
+        // --- capture exception handler calls ---
+        ExceptionHandler exceptionHandler = mock(ExceptionHandler.class);
+
+        // --- build consumer and inject mocks via reflection ---
+        MailConsumer consumer = new MailConsumer(endpoint, processor, sender);
+        consumer.setExceptionHandler(exceptionHandler);
+
+        Field folderField = MailConsumer.class.getDeclaredField("folder");
+        folderField.setAccessible(true);
+        folderField.set(consumer, folder);
+
+        // --- exercise ---
+        consumer.processCommit(mail, exchange);
+
+        // --- verify exception handler was called with a MessagingException whose message is non-null ---
+        ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(exceptionHandler).handleException(msgCaptor.capture(), any(Exchange.class), causeCaptor.capture());
+
+        Throwable caught = causeCaptor.getValue();
+        assertInstanceOf(MessagingException.class, caught,
+                "Expected MessagingException wrapping MessageRemovedException");
+        assertNotNull(caught.getMessage(),
+                "Cause message must not be null — was: " + caught.getMessage());
+        assertEquals("Message already removed/expunged on server (no flag update possible)", caught.getMessage());
+
+        assertInstanceOf(MessageRemovedException.class, caught.getCause(),
+                "Root cause must be the original MessageRemovedException");
+    }
+
+    @Test
+    public void testCommitWithOtherMessagingExceptionPassedThroughAsIs() throws Exception {
+        // --- infrastructure mocks ---
+        JavaMailSender sender = mock(JavaMailSender.class);
+        Processor processor = mock(Processor.class);
+        CamelContext camelContext = mock(CamelContext.class);
+        ExtendedCamelContext ecc = mock(ExtendedCamelContext.class);
+        ExchangeFactory ef = mock(ExchangeFactory.class);
+        Session session = Session.getInstance(Mailbox.getSessionProperties(Protocol.imap));
+
+        when(sender.getSession()).thenReturn(session);
+        when(camelContext.getCamelContextExtension()).thenReturn(ecc);
+        when(ecc.getExchangeFactory()).thenReturn(ef);
+        when(ef.newExchangeFactory(any())).thenReturn(ef);
+
+        MailEndpoint endpoint = new MailEndpoint();
+        endpoint.setCamelContext(camelContext);
+        MailConfiguration config = new MailConfiguration();
+        config.configureProtocol(Protocol.imap.name());
+        config.setPort(Mailbox.getPort(Protocol.imap));
+        config.setFolderName("INBOX");
+        config.setDelete(false);
+        endpoint.setConfiguration(config);
+
+        MessagingException originalException = new MessagingException("Some other server error");
+
+        Message mail = mock(Message.class);
+        doThrow(originalException).when(mail).setFlag(any(Flags.Flag.class), any(boolean.class));
+
+        Folder folder = mock(Folder.class);
+        when(folder.isOpen()).thenReturn(true);
+
+        Exchange exchange = mock(Exchange.class);
+        org.apache.camel.Message camelMsg = mock(org.apache.camel.Message.class);
+        when(exchange.getIn()).thenReturn(camelMsg);
+        when(camelMsg.getHeader(MailConstants.MAIL_COPY_TO, config.getCopyTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_MOVE_TO, config.getMoveTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_DELETE, config.isDelete(), boolean.class)).thenReturn(false);
+        when(exchange.removeProperty(MailConsumer.MAIL_MESSAGE_UID)).thenReturn(null);
+
+        ExceptionHandler exceptionHandler = mock(ExceptionHandler.class);
+
+        MailConsumer consumer = new MailConsumer(endpoint, processor, sender);
+        consumer.setExceptionHandler(exceptionHandler);
+
+        Field folderField = MailConsumer.class.getDeclaredField("folder");
+        folderField.setAccessible(true);
+        folderField.set(consumer, folder);
+
+        consumer.processCommit(mail, exchange);
+
+        ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(exceptionHandler).handleException(anyString(), any(Exchange.class), causeCaptor.capture());
+
+        // non-MessageRemovedException must be passed through unchanged (no wrapping)
+        assertInstanceOf(MessagingException.class, causeCaptor.getValue());
+        assertEquals("Some other server error", causeCaptor.getValue().getMessage());
+    }
+}

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/RouteService.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/RouteService.java
@@ -143,13 +143,12 @@ public class RouteService extends ChildServiceSupport {
 
     /**
      * Extracts a non-null, non-empty error message from the exception or its cause chain.
-     * <p>
+     * <p/>
      * {@link Throwable#getLocalizedMessage()} can return {@code null} for exceptions such as
-     * {@link NullPointerException} that carry no message, which would cause
-     * {@link FailedToStartRouteException} to throw {@link NullPointerException} from its own constructor
-     * (via {@code Objects.requireNonNull}) instead of wrapping the original failure. This helper walks the
-     * cause chain to find the first meaningful message and falls back to the simple class name so the
-     * caller always receives a non-null string.
+     * {@link NullPointerException} that carry no message, which would cause {@link FailedToStartRouteException} to
+     * throw {@link NullPointerException} from its own constructor (via {@code Objects.requireNonNull}) instead of
+     * wrapping the original failure. This helper walks the cause chain to find the first meaningful message and falls
+     * back to the simple class name so the caller always receives a non-null string.
      */
     private static String extractUsefulMessage(Throwable e) {
         Throwable current = e;

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/RouteService.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/RouteService.java
@@ -127,7 +127,7 @@ public class RouteService extends ChildServiceSupport {
         try {
             doWarmUp();
         } catch (Exception e) {
-            throw new FailedToStartRouteException(getId(), getLocation(), e.getLocalizedMessage(), e);
+            throw new FailedToStartRouteException(getId(), getLocation(), extractUsefulMessage(e), e);
         }
     }
 
@@ -136,9 +136,31 @@ public class RouteService extends ChildServiceSupport {
             try {
                 doSetup();
             } catch (Exception e) {
-                throw new FailedToStartRouteException(getId(), getLocation(), e.getLocalizedMessage(), e);
+                throw new FailedToStartRouteException(getId(), getLocation(), extractUsefulMessage(e), e);
             }
         }
+    }
+
+    /**
+     * Extracts a non-null, non-empty error message from the exception or its cause chain.
+     * <p>
+     * {@link Throwable#getLocalizedMessage()} can return {@code null} for exceptions such as
+     * {@link NullPointerException} that carry no message, which would cause
+     * {@link FailedToStartRouteException} to throw {@link NullPointerException} from its own constructor
+     * (via {@code Objects.requireNonNull}) instead of wrapping the original failure. This helper walks the
+     * cause chain to find the first meaningful message and falls back to the simple class name so the
+     * caller always receives a non-null string.
+     */
+    private static String extractUsefulMessage(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            String msg = current.getLocalizedMessage();
+            if (msg != null && !msg.isBlank()) {
+                return msg;
+            }
+            current = current.getCause();
+        }
+        return e.getClass().getSimpleName();
     }
 
     public boolean isAutoStartup() {

--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/RouteService.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/RouteService.java
@@ -150,7 +150,7 @@ public class RouteService extends ChildServiceSupport {
      * wrapping the original failure. This helper walks the cause chain to find the first meaningful message and falls
      * back to the simple class name so the caller always receives a non-null string.
      */
-    private static String extractUsefulMessage(Throwable e) {
+    static String extractUsefulMessage(Throwable e) {
         Throwable current = e;
         while (current != null) {
             String msg = current.getLocalizedMessage();

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
@@ -37,54 +37,59 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Verifies that {@link RouteService#warmUp()} wraps startup failures in a {@link FailedToStartRouteException} whose
- * message is always meaningful — even when the root cause exception itself carries a {@code null} message (e.g. a bare
- * {@link NullPointerException}).
+ * Verifies that {@link RouteService#warmUp()} and {@link RouteService#setUp()} wrap startup failures in a
+ * {@link FailedToStartRouteException} whose message is always meaningful — even when the root cause exception carries a
+ * {@code null} message (e.g. a bare {@link NullPointerException}).
  *
  * <p>
  * Before the fix, {@code RouteService} passed {@code e.getLocalizedMessage()} directly to the
  * {@link FailedToStartRouteException} constructor, which calls {@code Objects.requireNonNull} on that argument. A
  * message-less exception therefore caused a secondary {@link NullPointerException} to be thrown from inside the
  * exception constructor rather than a proper {@link FailedToStartRouteException}.
+ *
+ * <p>
+ * The tests trigger the failure during endpoint initialisation (inside {@code doSetup()}), which is the code path
+ * covered by the {@code RouteService} fix.
  */
 class RouteServiceWarmUpNullMessageTest {
 
     /**
-     * When a route's consumer throws a {@link NullPointerException} with no message during warm-up, the resulting
-     * {@link FailedToStartRouteException} must still carry a non-null, non-empty message.
+     * When the endpoint throws a message-less {@link NullPointerException} during route setup, the result must be a
+     * {@link FailedToStartRouteException}, not a raw NPE.
      */
     @Test
-    void testWarmUpNullMessageExceptionProducesUsefulFailedToStartMessage() throws Exception {
+    void testSetUpNullMessageExceptionProducesFailedToStartRouteException() {
         CamelContext context = new DefaultCamelContext();
         context.addComponent("fail", new NullMessageFailComponent());
-        context.addRoutes(new RouteBuilder() {
-            @Override
-            public void configure() {
-                from("fail:trigger").routeId("test-route").to("direct:out");
-            }
-        });
 
-        assertThatThrownBy(context::start)
-                .isInstanceOf(FailedToStartRouteException.class);
+        assertThatThrownBy(() -> {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("fail:trigger").routeId("test-route").to("direct:out");
+                }
+            });
+            context.start();
+        }).isInstanceOf(FailedToStartRouteException.class);
     }
 
     /**
-     * The {@link FailedToStartRouteException} message must not be null, must contain the route id, and must not use the
-     * literal string "null" as the failure description.
+     * The {@link FailedToStartRouteException} message must contain the route id and must not use the literal string
+     * "null" as the failure description.
      */
     @Test
-    void testFailedToStartMessageIsNonNullAndMeaningful() throws Exception {
+    void testFailedToStartMessageIsNonNullAndMeaningful() {
         CamelContext context = new DefaultCamelContext();
         context.addComponent("fail", new NullMessageFailComponent());
-        context.addRoutes(new RouteBuilder() {
-            @Override
-            public void configure() {
-                from("fail:trigger").routeId("meaningful-route").to("direct:out");
-            }
-        });
 
         FailedToStartRouteException caught = null;
         try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("fail:trigger").routeId("meaningful-route").to("direct:out");
+                }
+            });
             context.start();
         } catch (FailedToStartRouteException e) {
             caught = e;
@@ -115,23 +120,23 @@ class RouteServiceWarmUpNullMessageTest {
     }
 
     /**
-     * Verifies that when the root exception has a null message but its cause has a real message, the cause's message is
-     * surfaced in the {@link FailedToStartRouteException}.
+     * When the endpoint throws a message-less outer exception wrapping an inner exception that has a message, the inner
+     * message must be surfaced in the {@link FailedToStartRouteException}.
      */
     @Test
-    void testWarmUpWalksCauseChainForMessage() throws Exception {
+    void testSetUpWalksCauseChainForMessage() {
         CamelContext context = new DefaultCamelContext();
         String expectedFragment = "real cause message from chain";
         context.addComponent("fail", new ChainedNullMessageFailComponent(expectedFragment));
-        context.addRoutes(new RouteBuilder() {
-            @Override
-            public void configure() {
-                from("fail:trigger").routeId("chain-route").to("direct:out");
-            }
-        });
 
         FailedToStartRouteException caught = null;
         try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("fail:trigger").routeId("chain-route").to("direct:out");
+                }
+            });
             context.start();
         } catch (FailedToStartRouteException e) {
             caught = e;
@@ -159,47 +164,52 @@ class RouteServiceWarmUpNullMessageTest {
 
     // ---- helpers ----
 
-    /** A component whose endpoint throws a message-less {@link NullPointerException} on start. */
+    /**
+     * A component whose endpoint throws a message-less {@link NullPointerException} during its own {@code doStart()} —
+     * which is invoked by {@code RouteService.doSetup()} via {@code ServiceHelper.initService(endpoint)}, exercising
+     * the {@code setUp()} fix.
+     */
     private static class NullMessageFailComponent extends DefaultComponent {
         @Override
         protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
-            return new FailOnStartEndpoint(uri, this);
+            return new NullMessageFailEndpoint(uri, this);
+        }
+    }
+
+    private static class NullMessageFailEndpoint extends DefaultEndpoint {
+        NullMessageFailEndpoint(String uri, NullMessageFailComponent component) {
+            super(uri, component);
         }
 
-        private static class FailOnStartEndpoint extends DefaultEndpoint {
-            FailOnStartEndpoint(String uri, NullMessageFailComponent component) {
-                super(uri, component);
-            }
+        @Override
+        protected void doStart() {
+            throw new NullPointerException();
+        }
 
-            @Override
-            public Consumer createConsumer(Processor processor) {
-                return new DefaultConsumer(this, processor) {
-                    @Override
-                    protected void doStart() {
-                        throw new NullPointerException();
-                    }
-                };
-            }
+        @Override
+        public Consumer createConsumer(Processor processor) {
+            return new DefaultConsumer(this, processor) {
+            };
+        }
 
-            @Override
-            public Producer createProducer() {
-                return new DefaultProducer(this) {
-                    @Override
-                    public void process(Exchange exchange) {
-                    }
-                };
-            }
+        @Override
+        public Producer createProducer() {
+            return new DefaultProducer(this) {
+                @Override
+                public void process(Exchange exchange) {
+                }
+            };
+        }
 
-            @Override
-            public boolean isSingleton() {
-                return true;
-            }
+        @Override
+        public boolean isSingleton() {
+            return true;
         }
     }
 
     /**
      * A component whose endpoint throws a message-less outer exception wrapping an inner exception that does have a
-     * message — used to test cause-chain walking.
+     * message — used to test cause-chain walking in {@code extractUsefulMessage}.
      */
     private static class ChainedNullMessageFailComponent extends DefaultComponent {
         private final String causeMessage;
@@ -210,40 +220,41 @@ class RouteServiceWarmUpNullMessageTest {
 
         @Override
         protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
-            return new FailOnStartEndpoint(uri, this, causeMessage);
+            return new ChainedNullMessageFailEndpoint(uri, this, causeMessage);
+        }
+    }
+
+    private static class ChainedNullMessageFailEndpoint extends DefaultEndpoint {
+        private final String causeMessage;
+
+        ChainedNullMessageFailEndpoint(String uri, ChainedNullMessageFailComponent component, String causeMessage) {
+            super(uri, component);
+            this.causeMessage = causeMessage;
         }
 
-        private static class FailOnStartEndpoint extends DefaultEndpoint {
-            private final String causeMessage;
+        @Override
+        protected void doStart() {
+            throw new RuntimeException(new IllegalStateException(causeMessage));
+        }
 
-            FailOnStartEndpoint(String uri, ChainedNullMessageFailComponent component, String causeMessage) {
-                super(uri, component);
-                this.causeMessage = causeMessage;
-            }
+        @Override
+        public Consumer createConsumer(Processor processor) {
+            return new DefaultConsumer(this, processor) {
+            };
+        }
 
-            @Override
-            public Consumer createConsumer(Processor processor) {
-                return new DefaultConsumer(this, processor) {
-                    @Override
-                    protected void doStart() {
-                        throw new RuntimeException(new IllegalStateException(causeMessage));
-                    }
-                };
-            }
+        @Override
+        public Producer createProducer() {
+            return new DefaultProducer(this) {
+                @Override
+                public void process(Exchange exchange) {
+                }
+            };
+        }
 
-            @Override
-            public Producer createProducer() {
-                return new DefaultProducer(this) {
-                    @Override
-                    public void process(Exchange exchange) {
-                    }
-                };
-            }
-
-            @Override
-            public boolean isSingleton() {
-                return true;
-            }
+        @Override
+        public boolean isSingleton() {
+            return true;
         }
     }
 }

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.engine;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.FailedToStartRouteException;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.direct.DirectComponent;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.support.DefaultEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link RouteService#warmUp()} wraps startup failures in a {@link FailedToStartRouteException}
+ * whose message is always meaningful — even when the root cause exception itself carries a {@code null} message
+ * (e.g. a bare {@link NullPointerException}).
+ *
+ * <p>Before the fix, {@code RouteService} passed {@code e.getLocalizedMessage()} directly to the
+ * {@link FailedToStartRouteException} constructor, which calls {@code Objects.requireNonNull} on that
+ * argument. A message-less exception therefore caused a secondary {@link NullPointerException} to be thrown
+ * from inside the exception constructor rather than a proper {@link FailedToStartRouteException}.
+ */
+public class RouteServiceWarmUpNullMessageTest {
+
+    /**
+     * When a route's consumer throws a {@link NullPointerException} with no message during warm-up, the
+     * resulting {@link FailedToStartRouteException} must still carry a non-null, non-empty message.
+     */
+    @Test
+    public void testWarmUpNullMessageExceptionProducesUsefulFailedToStartMessage() {
+        CamelContext context = new DefaultCamelContext();
+        // Register a component whose endpoint start throws a message-less NullPointerException
+        context.addComponent("fail", new NullMessageFailComponent());
+
+        assertThrows(FailedToStartRouteException.class, () -> {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("fail:trigger").routeId("test-route").to("direct:out");
+                }
+            });
+            context.start();
+        });
+    }
+
+    /**
+     * The {@link FailedToStartRouteException} message must not be null, must contain the route id, and must
+     * not use the literal string "null" as the failure description.
+     */
+    @Test
+    public void testFailedToStartMessageIsNonNullAndMeaningful() {
+        CamelContext context = new DefaultCamelContext();
+        context.addComponent("fail", new NullMessageFailComponent());
+
+        FailedToStartRouteException caught = null;
+        try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("fail:trigger").routeId("meaningful-route").to("direct:out");
+                }
+            });
+            context.start();
+        } catch (FailedToStartRouteException e) {
+            caught = e;
+        } catch (Exception e) {
+            Throwable t = e;
+            while (t != null) {
+                if (t instanceof FailedToStartRouteException) {
+                    caught = (FailedToStartRouteException) t;
+                    break;
+                }
+                t = t.getCause();
+            }
+        } finally {
+            try {
+                context.stop();
+            } catch (Exception ignored) {
+            }
+        }
+
+        assertNotNull(caught, "Expected FailedToStartRouteException");
+        String message = caught.getMessage();
+        assertNotNull(message, "FailedToStartRouteException message must not be null");
+        assertTrue(message.contains("meaningful-route"), "Message must contain the route id");
+        // The key regression guard: must NOT say "because: null"
+        assertFalse(message.contains("because: null"),
+                "Message must not contain 'because: null' — was: " + message);
+        // The fallback must surface something useful (class name at minimum)
+        assertTrue(message.length() > "Failed to start route: meaningful-route because: ".length(),
+                "Message must have a non-empty failure description — was: " + message);
+    }
+
+    /**
+     * Verifies that when the root exception has a null message but its cause has a real message,
+     * the cause's message is surfaced in the {@link FailedToStartRouteException}.
+     */
+    @Test
+    public void testWarmUpWalksCauseChainForMessage() {
+        CamelContext context = new DefaultCamelContext();
+        String expectedFragment = "real cause message from chain";
+        context.addComponent("fail", new ChainedNullMessageFailComponent(expectedFragment));
+
+        FailedToStartRouteException caught = null;
+        try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("fail:trigger").routeId("chain-route").to("direct:out");
+                }
+            });
+            context.start();
+        } catch (FailedToStartRouteException e) {
+            caught = e;
+        } catch (Exception e) {
+            Throwable t = e;
+            while (t != null) {
+                if (t instanceof FailedToStartRouteException) {
+                    caught = (FailedToStartRouteException) t;
+                    break;
+                }
+                t = t.getCause();
+            }
+        } finally {
+            try {
+                context.stop();
+            } catch (Exception ignored) {
+            }
+        }
+
+        assertNotNull(caught, "Expected FailedToStartRouteException");
+        assertTrue(caught.getMessage().contains(expectedFragment),
+                "Message should surface cause chain message — was: " + caught.getMessage());
+    }
+
+    // ---- helpers ----
+
+    /** A component whose endpoint throws a message-less {@link NullPointerException} on start. */
+    private static class NullMessageFailComponent extends DefaultComponent {
+        @Override
+        protected org.apache.camel.Endpoint createEndpoint(String uri, String remaining,
+                java.util.Map<String, Object> parameters) {
+            return new FailOnStartEndpoint(uri, this);
+        }
+
+        private static class FailOnStartEndpoint extends DefaultEndpoint {
+            FailOnStartEndpoint(String uri, NullMessageFailComponent component) {
+                super(uri, component);
+            }
+
+            @Override
+            public org.apache.camel.Consumer createConsumer(org.apache.camel.Processor processor) {
+                return new org.apache.camel.support.DefaultConsumer(this, processor) {
+                    @Override
+                    protected void doStart() {
+                        // Throw a NullPointerException with no message — the classic null-message case
+                        throw new NullPointerException();
+                    }
+                };
+            }
+
+            @Override
+            public org.apache.camel.Producer createProducer() {
+                return new org.apache.camel.support.DefaultProducer(this) {
+                    @Override
+                    public void process(org.apache.camel.Exchange exchange) {
+                    }
+                };
+            }
+
+            @Override
+            public boolean isSingleton() {
+                return true;
+            }
+        }
+    }
+
+    /**
+     * A component whose endpoint throws a message-less outer exception wrapping an inner exception that
+     * does have a message — used to test cause-chain walking.
+     */
+    private static class ChainedNullMessageFailComponent extends DefaultComponent {
+        private final String causeMessage;
+
+        ChainedNullMessageFailComponent(String causeMessage) {
+            this.causeMessage = causeMessage;
+        }
+
+        @Override
+        protected org.apache.camel.Endpoint createEndpoint(String uri, String remaining,
+                java.util.Map<String, Object> parameters) {
+            return new FailOnStartEndpoint(uri, this, causeMessage);
+        }
+
+        private static class FailOnStartEndpoint extends DefaultEndpoint {
+            private final String causeMessage;
+
+            FailOnStartEndpoint(String uri, ChainedNullMessageFailComponent component, String causeMessage) {
+                super(uri, component);
+                this.causeMessage = causeMessage;
+            }
+
+            @Override
+            public org.apache.camel.Consumer createConsumer(org.apache.camel.Processor processor) {
+                return new org.apache.camel.support.DefaultConsumer(this, processor) {
+                    @Override
+                    protected void doStart() {
+                        // Outer exception has no message; inner cause has the real message
+                        throw new RuntimeException(new IllegalStateException(causeMessage));
+                    }
+                };
+            }
+
+            @Override
+            public org.apache.camel.Producer createProducer() {
+                return new org.apache.camel.support.DefaultProducer(this) {
+                    @Override
+                    public void process(org.apache.camel.Exchange exchange) {
+                    }
+                };
+            }
+
+            @Override
+            public boolean isSingleton() {
+                return true;
+            }
+        }
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
@@ -33,7 +33,6 @@ import org.apache.camel.support.DefaultEndpoint;
 import org.apache.camel.support.DefaultProducer;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -62,15 +61,22 @@ class RouteServiceWarmUpNullMessageTest {
         CamelContext context = new DefaultCamelContext();
         context.addComponent("fail", new NullMessageFailComponent());
 
-        assertThatThrownBy(() -> {
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("fail:trigger").routeId("test-route").to("direct:out");
-                }
-            });
-            context.start();
-        }).isInstanceOf(FailedToStartRouteException.class);
+        try {
+            assertThatThrownBy(() -> {
+                context.addRoutes(new RouteBuilder() {
+                    @Override
+                    public void configure() {
+                        from("fail:trigger").routeId("test-route").to("direct:out");
+                    }
+                });
+                context.start();
+            }).isInstanceOf(FailedToStartRouteException.class);
+        } finally {
+            try {
+                context.stop();
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     /**
@@ -82,41 +88,24 @@ class RouteServiceWarmUpNullMessageTest {
         CamelContext context = new DefaultCamelContext();
         context.addComponent("fail", new NullMessageFailComponent());
 
-        FailedToStartRouteException caught = null;
         try {
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("fail:trigger").routeId("meaningful-route").to("direct:out");
-                }
-            });
-            context.start();
-        } catch (FailedToStartRouteException e) {
-            caught = e;
-        } catch (Exception e) {
-            Throwable t = e;
-            while (t != null) {
-                if (t instanceof FailedToStartRouteException ftsre) {
-                    caught = ftsre;
-                    break;
-                }
-                t = t.getCause();
-            }
+            assertThatThrownBy(() -> {
+                context.addRoutes(new RouteBuilder() {
+                    @Override
+                    public void configure() {
+                        from("fail:trigger").routeId("meaningful-route").to("direct:out");
+                    }
+                });
+                context.start();
+            }).isInstanceOf(FailedToStartRouteException.class)
+                    .hasMessageContaining("meaningful-route")
+                    .hasMessageNotContaining("because: null");
         } finally {
             try {
                 context.stop();
             } catch (Exception ignored) {
             }
         }
-
-        assertThat(caught).as("Expected FailedToStartRouteException").isNotNull();
-        assertThat(caught.getMessage())
-                .as("FailedToStartRouteException message must not be null")
-                .isNotNull()
-                .as("Message must contain the route id")
-                .contains("meaningful-route")
-                .as("Message must not contain 'because: null'")
-                .doesNotContain("because: null");
     }
 
     /**
@@ -129,37 +118,23 @@ class RouteServiceWarmUpNullMessageTest {
         String expectedFragment = "real cause message from chain";
         context.addComponent("fail", new ChainedNullMessageFailComponent(expectedFragment));
 
-        FailedToStartRouteException caught = null;
         try {
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("fail:trigger").routeId("chain-route").to("direct:out");
-                }
-            });
-            context.start();
-        } catch (FailedToStartRouteException e) {
-            caught = e;
-        } catch (Exception e) {
-            Throwable t = e;
-            while (t != null) {
-                if (t instanceof FailedToStartRouteException ftsre) {
-                    caught = ftsre;
-                    break;
-                }
-                t = t.getCause();
-            }
+            assertThatThrownBy(() -> {
+                context.addRoutes(new RouteBuilder() {
+                    @Override
+                    public void configure() {
+                        from("fail:trigger").routeId("chain-route").to("direct:out");
+                    }
+                });
+                context.start();
+            }).isInstanceOf(FailedToStartRouteException.class)
+                    .hasMessageContaining(expectedFragment);
         } finally {
             try {
                 context.stop();
             } catch (Exception ignored) {
             }
         }
-
-        assertThat(caught).as("Expected FailedToStartRouteException").isNotNull();
-        assertThat(caught.getMessage())
-                .as("Message should surface cause chain message")
-                .contains(expectedFragment);
     }
 
     // ---- helpers ----

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
@@ -234,7 +234,11 @@ class RouteServiceWarmUpNullMessageTest {
 
         @Override
         protected void doStart() {
-            throw new RuntimeException(new IllegalStateException(causeMessage));
+            // Outer NPE has no message; initCause sets the cause without supplying a message to
+            // the outer exception — forces extractUsefulMessage to walk the chain to find causeMessage.
+            NullPointerException outer = new NullPointerException();
+            outer.initCause(new IllegalStateException(causeMessage));
+            throw outer;
         }
 
         @Override

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/RouteServiceWarmUpNullMessageTest.java
@@ -16,78 +16,83 @@
  */
 package org.apache.camel.impl.engine;
 
+import java.util.Map;
+
 import org.apache.camel.CamelContext;
+import org.apache.camel.Consumer;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
 import org.apache.camel.FailedToStartRouteException;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.direct.DirectComponent;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.support.DefaultConsumer;
 import org.apache.camel.support.DefaultEndpoint;
+import org.apache.camel.support.DefaultProducer;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Verifies that {@link RouteService#warmUp()} wraps startup failures in a {@link FailedToStartRouteException}
- * whose message is always meaningful — even when the root cause exception itself carries a {@code null} message
- * (e.g. a bare {@link NullPointerException}).
+ * Verifies that {@link RouteService#warmUp()} wraps startup failures in a {@link FailedToStartRouteException} whose
+ * message is always meaningful — even when the root cause exception itself carries a {@code null} message (e.g. a bare
+ * {@link NullPointerException}).
  *
- * <p>Before the fix, {@code RouteService} passed {@code e.getLocalizedMessage()} directly to the
- * {@link FailedToStartRouteException} constructor, which calls {@code Objects.requireNonNull} on that
- * argument. A message-less exception therefore caused a secondary {@link NullPointerException} to be thrown
- * from inside the exception constructor rather than a proper {@link FailedToStartRouteException}.
+ * <p>
+ * Before the fix, {@code RouteService} passed {@code e.getLocalizedMessage()} directly to the
+ * {@link FailedToStartRouteException} constructor, which calls {@code Objects.requireNonNull} on that argument. A
+ * message-less exception therefore caused a secondary {@link NullPointerException} to be thrown from inside the
+ * exception constructor rather than a proper {@link FailedToStartRouteException}.
  */
-public class RouteServiceWarmUpNullMessageTest {
+class RouteServiceWarmUpNullMessageTest {
 
     /**
-     * When a route's consumer throws a {@link NullPointerException} with no message during warm-up, the
-     * resulting {@link FailedToStartRouteException} must still carry a non-null, non-empty message.
+     * When a route's consumer throws a {@link NullPointerException} with no message during warm-up, the resulting
+     * {@link FailedToStartRouteException} must still carry a non-null, non-empty message.
      */
     @Test
-    public void testWarmUpNullMessageExceptionProducesUsefulFailedToStartMessage() {
+    void testWarmUpNullMessageExceptionProducesUsefulFailedToStartMessage() throws Exception {
         CamelContext context = new DefaultCamelContext();
-        // Register a component whose endpoint start throws a message-less NullPointerException
         context.addComponent("fail", new NullMessageFailComponent());
-
-        assertThrows(FailedToStartRouteException.class, () -> {
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("fail:trigger").routeId("test-route").to("direct:out");
-                }
-            });
-            context.start();
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("fail:trigger").routeId("test-route").to("direct:out");
+            }
         });
+
+        assertThatThrownBy(context::start)
+                .isInstanceOf(FailedToStartRouteException.class);
     }
 
     /**
-     * The {@link FailedToStartRouteException} message must not be null, must contain the route id, and must
-     * not use the literal string "null" as the failure description.
+     * The {@link FailedToStartRouteException} message must not be null, must contain the route id, and must not use the
+     * literal string "null" as the failure description.
      */
     @Test
-    public void testFailedToStartMessageIsNonNullAndMeaningful() {
+    void testFailedToStartMessageIsNonNullAndMeaningful() throws Exception {
         CamelContext context = new DefaultCamelContext();
         context.addComponent("fail", new NullMessageFailComponent());
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("fail:trigger").routeId("meaningful-route").to("direct:out");
+            }
+        });
 
         FailedToStartRouteException caught = null;
         try {
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("fail:trigger").routeId("meaningful-route").to("direct:out");
-                }
-            });
             context.start();
         } catch (FailedToStartRouteException e) {
             caught = e;
         } catch (Exception e) {
             Throwable t = e;
             while (t != null) {
-                if (t instanceof FailedToStartRouteException) {
-                    caught = (FailedToStartRouteException) t;
+                if (t instanceof FailedToStartRouteException ftsre) {
+                    caught = ftsre;
                     break;
                 }
                 t = t.getCause();
@@ -99,44 +104,42 @@ public class RouteServiceWarmUpNullMessageTest {
             }
         }
 
-        assertNotNull(caught, "Expected FailedToStartRouteException");
-        String message = caught.getMessage();
-        assertNotNull(message, "FailedToStartRouteException message must not be null");
-        assertTrue(message.contains("meaningful-route"), "Message must contain the route id");
-        // The key regression guard: must NOT say "because: null"
-        assertFalse(message.contains("because: null"),
-                "Message must not contain 'because: null' — was: " + message);
-        // The fallback must surface something useful (class name at minimum)
-        assertTrue(message.length() > "Failed to start route: meaningful-route because: ".length(),
-                "Message must have a non-empty failure description — was: " + message);
+        assertThat(caught).as("Expected FailedToStartRouteException").isNotNull();
+        assertThat(caught.getMessage())
+                .as("FailedToStartRouteException message must not be null")
+                .isNotNull()
+                .as("Message must contain the route id")
+                .contains("meaningful-route")
+                .as("Message must not contain 'because: null'")
+                .doesNotContain("because: null");
     }
 
     /**
-     * Verifies that when the root exception has a null message but its cause has a real message,
-     * the cause's message is surfaced in the {@link FailedToStartRouteException}.
+     * Verifies that when the root exception has a null message but its cause has a real message, the cause's message is
+     * surfaced in the {@link FailedToStartRouteException}.
      */
     @Test
-    public void testWarmUpWalksCauseChainForMessage() {
+    void testWarmUpWalksCauseChainForMessage() throws Exception {
         CamelContext context = new DefaultCamelContext();
         String expectedFragment = "real cause message from chain";
         context.addComponent("fail", new ChainedNullMessageFailComponent(expectedFragment));
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("fail:trigger").routeId("chain-route").to("direct:out");
+            }
+        });
 
         FailedToStartRouteException caught = null;
         try {
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("fail:trigger").routeId("chain-route").to("direct:out");
-                }
-            });
             context.start();
         } catch (FailedToStartRouteException e) {
             caught = e;
         } catch (Exception e) {
             Throwable t = e;
             while (t != null) {
-                if (t instanceof FailedToStartRouteException) {
-                    caught = (FailedToStartRouteException) t;
+                if (t instanceof FailedToStartRouteException ftsre) {
+                    caught = ftsre;
                     break;
                 }
                 t = t.getCause();
@@ -148,9 +151,10 @@ public class RouteServiceWarmUpNullMessageTest {
             }
         }
 
-        assertNotNull(caught, "Expected FailedToStartRouteException");
-        assertTrue(caught.getMessage().contains(expectedFragment),
-                "Message should surface cause chain message — was: " + caught.getMessage());
+        assertThat(caught).as("Expected FailedToStartRouteException").isNotNull();
+        assertThat(caught.getMessage())
+                .as("Message should surface cause chain message")
+                .contains(expectedFragment);
     }
 
     // ---- helpers ----
@@ -158,8 +162,7 @@ public class RouteServiceWarmUpNullMessageTest {
     /** A component whose endpoint throws a message-less {@link NullPointerException} on start. */
     private static class NullMessageFailComponent extends DefaultComponent {
         @Override
-        protected org.apache.camel.Endpoint createEndpoint(String uri, String remaining,
-                java.util.Map<String, Object> parameters) {
+        protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
             return new FailOnStartEndpoint(uri, this);
         }
 
@@ -169,21 +172,20 @@ public class RouteServiceWarmUpNullMessageTest {
             }
 
             @Override
-            public org.apache.camel.Consumer createConsumer(org.apache.camel.Processor processor) {
-                return new org.apache.camel.support.DefaultConsumer(this, processor) {
+            public Consumer createConsumer(Processor processor) {
+                return new DefaultConsumer(this, processor) {
                     @Override
                     protected void doStart() {
-                        // Throw a NullPointerException with no message — the classic null-message case
                         throw new NullPointerException();
                     }
                 };
             }
 
             @Override
-            public org.apache.camel.Producer createProducer() {
-                return new org.apache.camel.support.DefaultProducer(this) {
+            public Producer createProducer() {
+                return new DefaultProducer(this) {
                     @Override
-                    public void process(org.apache.camel.Exchange exchange) {
+                    public void process(Exchange exchange) {
                     }
                 };
             }
@@ -196,8 +198,8 @@ public class RouteServiceWarmUpNullMessageTest {
     }
 
     /**
-     * A component whose endpoint throws a message-less outer exception wrapping an inner exception that
-     * does have a message — used to test cause-chain walking.
+     * A component whose endpoint throws a message-less outer exception wrapping an inner exception that does have a
+     * message — used to test cause-chain walking.
      */
     private static class ChainedNullMessageFailComponent extends DefaultComponent {
         private final String causeMessage;
@@ -207,8 +209,7 @@ public class RouteServiceWarmUpNullMessageTest {
         }
 
         @Override
-        protected org.apache.camel.Endpoint createEndpoint(String uri, String remaining,
-                java.util.Map<String, Object> parameters) {
+        protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
             return new FailOnStartEndpoint(uri, this, causeMessage);
         }
 
@@ -221,21 +222,20 @@ public class RouteServiceWarmUpNullMessageTest {
             }
 
             @Override
-            public org.apache.camel.Consumer createConsumer(org.apache.camel.Processor processor) {
-                return new org.apache.camel.support.DefaultConsumer(this, processor) {
+            public Consumer createConsumer(Processor processor) {
+                return new DefaultConsumer(this, processor) {
                     @Override
                     protected void doStart() {
-                        // Outer exception has no message; inner cause has the real message
                         throw new RuntimeException(new IllegalStateException(causeMessage));
                     }
                 };
             }
 
             @Override
-            public org.apache.camel.Producer createProducer() {
-                return new org.apache.camel.support.DefaultProducer(this) {
+            public Producer createProducer() {
+                return new DefaultProducer(this) {
                     @Override
-                    public void process(org.apache.camel.Exchange exchange) {
+                    public void process(Exchange exchange) {
                     }
                 };
             }


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24403](https://issues.apache.org/jira/browse/CAMEL-24403): When an IMAP message is expunged between fetch time and the on-completion commit callback, `IMAPMessage.setFlag()` throws `MessageRemovedException` whose `getMessage()` returns `null`. This produced a confusing log entry:

```
Error occurred during committing mail message: com.sun.mail.imap.IMAPMessage@542a494d. Exchange[...]. Caused by: [javax.mail.MessageRemovedException - null]
```

## JIRA

**[CAMEL-24403](https://issues.apache.org/jira/browse/CAMEL-24403)** — camel-mail: MessageRemovedException in processCommit causes null in error log

## Root Cause

`MessageRemovedException` extends `MessagingException` but is constructed without a message string, so `getMessage()` returns `null`. The existing `catch (MessagingException e)` block in `processCommit()` passed it directly to the exception handler, which included the null in the formatted output.

## Fix

Catch `MessageRemovedException` before the generic `MessagingException` handler in `processCommit()` and wrap it with an explicit description:

```java
} catch (MessageRemovedException e) {
    MessagingException wrapped = new MessagingException(
            "Message already removed/expunged on server (no flag update possible)", e);
    getExceptionHandler().handleException(
            "Error occurred during committing mail message: " + mail, exchange, wrapped);
} catch (MessagingException e) {
    getExceptionHandler().handleException(
            "Error occurred during committing mail message: " + mail, exchange, e);
}
```

Expected log output after fix:

```
Caused by: [javax.mail.MessagingException - Message already removed/expunged on server (no flag update possible)]
```

## Stack Trace (from CAMEL-24403)

```
javax.mail.MessageRemovedException
  at com.sun.mail.imap.IMAPMessage.checkExpunged(IMAPMessage.java:280)
  at com.sun.mail.imap.IMAPMessage.setFlags(IMAPMessage.java:1110)
  at javax.mail.Message.setFlag(Message.java:596)
  at org.apache.camel.component.mail.MailConsumer.processCommit(MailConsumer.java:506)
  at org.apache.camel.component.mail.MailConsumer$1.onComplete(MailConsumer.java:237)
  at org.apache.camel.support.UnitOfWorkHelper.doneSynchronization(UnitOfWorkHelper.java:104)
  at org.apache.camel.support.UnitOfWorkHelper.doneSynchronizations(UnitOfWorkHelper.java:89)
  at org.apache.camel.impl.engine.DefaultUnitOfWork.done(DefaultUnitOfWork.java:238)
  at org.apache.camel.support.UnitOfWorkHelper.doneUow(UnitOfWorkHelper.java:61)
  at org.apache.camel.impl.engine.CamelInternalProcessor$UnitOfWorkProcessorAdvice.after(CamelInternalProcessor.java:770)
  at org.apache.camel.impl.engine.CamelInternalProcessor$AsyncAfterTask.done(CamelInternalProcessor.java:263)
  at org.apache.camel.AsyncCallback.run(AsyncCallback.java:44)
  at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:193)
  at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:64)
  at org.apache.camel.processor.Pipeline.process(Pipeline.java:185)
  at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:398)
  at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:83)
  at org.apache.camel.support.AsyncProcessorSupport.process(AsyncProcessorSupport.java:41)
  at org.apache.camel.component.mail.MailConsumer.processExchange(MailConsumer.java:449)
  at org.apache.camel.component.mail.MailConsumer.processBatch(MailConsumer.java:258)
  at org.apache.camel.component.mail.MailConsumer.poll(MailConsumer.java:165)
  at org.apache.camel.support.ScheduledPollConsumer.doRun(ScheduledPollConsumer.java:202)
  at org.apache.camel.support.ScheduledPollConsumer.run(ScheduledPollConsumer.java:116)
  at org.apache.camel.pollconsumer.quartz.QuartzScheduledPollConsumerJob.execute(QuartzScheduledPollConsumerJob.java:61)
  at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
  at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

## Changes

- `MailConsumer.java` — add `jakarta.mail.MessageRemovedException` import; split catch block to handle expunged-message case explicitly
- `MailConsumerCommitExpungedMessageTest.java` (new) — 2 unit tests:
  - `testCommitWithExpungedMessageProducesNonNullCause` — verifies `MessageRemovedException` is wrapped with a non-null message and root cause is preserved
  - `testCommitWithOtherMessagingExceptionPassedThroughAsIs` — verifies other `MessagingException` types pass through unchanged

## Test Results

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0  (JDK 21, Maven 3.9)
```

## AI Attribution

This contribution was developed with AI assistance using [Claude Code](https://github.com/anthropics/claude-code).

```
Co-authored-by: Claude <claude@anthropic.com>
```