### PR TITLE
CAMEL-24403: camel-mail: handle MessageRemovedException in processCommit to avoid null cause in error log

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
@@ -28,6 +28,7 @@ import jakarta.mail.Flags;
 import jakarta.mail.Folder;
 import jakarta.mail.FolderNotFoundException;
 import jakarta.mail.Message;
+import jakarta.mail.MessageRemovedException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Store;
@@ -526,6 +527,11 @@ public class MailConsumer extends ScheduledBatchPollingConsumer {
                 }
             }
 
+        } catch (MessageRemovedException e) {
+            MessagingException wrapped = new MessagingException(
+                    "Message already removed/expunged on server (no flag update possible)", e);
+            getExceptionHandler().handleException(
+                    "Error occurred during committing mail message: " + mail, exchange, wrapped);
         } catch (MessagingException e) {
             getExceptionHandler().handleException("Error occurred during committing mail message: " + mail, exchange, e);
         }

--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java
@@ -529,7 +529,7 @@ public class MailConsumer extends ScheduledBatchPollingConsumer {
 
         } catch (MessageRemovedException e) {
             MessagingException wrapped = new MessagingException(
-                    "Message already removed/expunged on server (no flag update possible)", e);
+                    "Message already removed/expunged on server (message state could not be updated)", e);
             getExceptionHandler().handleException(
                     "Error occurred during committing mail message: " + mail, exchange, wrapped);
         } catch (MessagingException e) {

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.mail;
+
+import java.lang.reflect.Field;
+
+import jakarta.mail.Flags;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessageRemovedException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.Processor;
+import org.apache.camel.component.mail.Mailbox.Protocol;
+import org.apache.camel.spi.ExceptionHandler;
+import org.apache.camel.spi.ExchangeFactory;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that processCommit() wraps MessageRemovedException (message already expunged on the IMAP server) with a
+ * non-null cause message so that the error log never shows "Caused by: [... - null]".
+ */
+public class MailConsumerCommitExpungedMessageTest {
+
+    @Test
+    public void testCommitWithExpungedMessageProducesNonNullCause() throws Exception {
+        // --- infrastructure mocks ---
+        JavaMailSender sender = mock(JavaMailSender.class);
+        Processor processor = mock(Processor.class);
+        CamelContext camelContext = mock(CamelContext.class);
+        ExtendedCamelContext ecc = mock(ExtendedCamelContext.class);
+        ExchangeFactory ef = mock(ExchangeFactory.class);
+        Session session = Session.getInstance(Mailbox.getSessionProperties(Protocol.imap));
+
+        when(sender.getSession()).thenReturn(session);
+        when(camelContext.getCamelContextExtension()).thenReturn(ecc);
+        when(ecc.getExchangeFactory()).thenReturn(ef);
+        when(ef.newExchangeFactory(any())).thenReturn(ef);
+
+        // --- endpoint/configuration ---
+        MailEndpoint endpoint = new MailEndpoint();
+        endpoint.setCamelContext(camelContext);
+        MailConfiguration config = new MailConfiguration();
+        config.configureProtocol(Protocol.imap.name());
+        config.setPort(Mailbox.getPort(Protocol.imap));
+        config.setFolderName("INBOX");
+        config.setDelete(false);
+        endpoint.setConfiguration(config);
+
+        // --- message mock: setFlag throws MessageRemovedException (no message text — simulates the null cause) ---
+        Message mail = mock(Message.class);
+        doThrow(new MessageRemovedException()).when(mail).setFlag(any(Flags.Flag.class), any(boolean.class));
+
+        // --- folder mock: open and isOpen so processCommit doesn't bail early ---
+        Folder folder = mock(Folder.class);
+        when(folder.isOpen()).thenReturn(true);
+
+        // --- exchange mock ---
+        Exchange exchange = mock(Exchange.class);
+        org.apache.camel.Message camelMsg = mock(org.apache.camel.Message.class);
+        when(exchange.getIn()).thenReturn(camelMsg);
+        when(camelMsg.getHeader(MailConstants.MAIL_COPY_TO, config.getCopyTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_MOVE_TO, config.getMoveTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_DELETE, config.isDelete(), boolean.class)).thenReturn(false);
+        // removeProperty returns null uid — fine because protocol is imap (not pop3)
+        when(exchange.removeProperty(MailConsumer.MAIL_MESSAGE_UID)).thenReturn(null);
+
+        // --- capture exception handler calls ---
+        ExceptionHandler exceptionHandler = mock(ExceptionHandler.class);
+
+        // --- build consumer and inject mocks via reflection ---
+        MailConsumer consumer = new MailConsumer(endpoint, processor, sender);
+        consumer.setExceptionHandler(exceptionHandler);
+
+        Field folderField = MailConsumer.class.getDeclaredField("folder");
+        folderField.setAccessible(true);
+        folderField.set(consumer, folder);
+
+        // --- exercise ---
+        consumer.processCommit(mail, exchange);
+
+        // --- verify exception handler was called with a MessagingException whose message is non-null ---
+        ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(exceptionHandler).handleException(msgCaptor.capture(), any(Exchange.class), causeCaptor.capture());
+
+        Throwable caught = causeCaptor.getValue();
+        assertInstanceOf(MessagingException.class, caught,
+                "Expected MessagingException wrapping MessageRemovedException");
+        assertNotNull(caught.getMessage(),
+                "Cause message must not be null — was: " + caught.getMessage());
+        assertEquals("Message already removed/expunged on server (no flag update possible)", caught.getMessage());
+
+        assertInstanceOf(MessageRemovedException.class, caught.getCause(),
+                "Root cause must be the original MessageRemovedException");
+    }
+
+    @Test
+    public void testCommitWithOtherMessagingExceptionPassedThroughAsIs() throws Exception {
+        // --- infrastructure mocks ---
+        JavaMailSender sender = mock(JavaMailSender.class);
+        Processor processor = mock(Processor.class);
+        CamelContext camelContext = mock(CamelContext.class);
+        ExtendedCamelContext ecc = mock(ExtendedCamelContext.class);
+        ExchangeFactory ef = mock(ExchangeFactory.class);
+        Session session = Session.getInstance(Mailbox.getSessionProperties(Protocol.imap));
+
+        when(sender.getSession()).thenReturn(session);
+        when(camelContext.getCamelContextExtension()).thenReturn(ecc);
+        when(ecc.getExchangeFactory()).thenReturn(ef);
+        when(ef.newExchangeFactory(any())).thenReturn(ef);
+
+        MailEndpoint endpoint = new MailEndpoint();
+        endpoint.setCamelContext(camelContext);
+        MailConfiguration config = new MailConfiguration();
+        config.configureProtocol(Protocol.imap.name());
+        config.setPort(Mailbox.getPort(Protocol.imap));
+        config.setFolderName("INBOX");
+        config.setDelete(false);
+        endpoint.setConfiguration(config);
+
+        MessagingException originalException = new MessagingException("Some other server error");
+
+        Message mail = mock(Message.class);
+        doThrow(originalException).when(mail).setFlag(any(Flags.Flag.class), any(boolean.class));
+
+        Folder folder = mock(Folder.class);
+        when(folder.isOpen()).thenReturn(true);
+
+        Exchange exchange = mock(Exchange.class);
+        org.apache.camel.Message camelMsg = mock(org.apache.camel.Message.class);
+        when(exchange.getIn()).thenReturn(camelMsg);
+        when(camelMsg.getHeader(MailConstants.MAIL_COPY_TO, config.getCopyTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_MOVE_TO, config.getMoveTo(), String.class)).thenReturn(null);
+        when(camelMsg.getHeader(MailConstants.MAIL_DELETE, config.isDelete(), boolean.class)).thenReturn(false);
+        when(exchange.removeProperty(MailConsumer.MAIL_MESSAGE_UID)).thenReturn(null);
+
+        ExceptionHandler exceptionHandler = mock(ExceptionHandler.class);
+
+        MailConsumer consumer = new MailConsumer(endpoint, processor, sender);
+        consumer.setExceptionHandler(exceptionHandler);
+
+        Field folderField = MailConsumer.class.getDeclaredField("folder");
+        folderField.setAccessible(true);
+        folderField.set(consumer, folder);
+
+        consumer.processCommit(mail, exchange);
+
+        ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(exceptionHandler).handleException(anyString(), any(Exchange.class), causeCaptor.capture());
+
+        // non-MessageRemovedException must be passed through unchanged (no wrapping)
+        assertInstanceOf(MessagingException.class, causeCaptor.getValue());
+        assertEquals("Some other server error", causeCaptor.getValue().getMessage());
+    }
+}

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
@@ -104,7 +104,7 @@ class MailConsumerCommitExpungedMessageTest {
         Throwable caught = causeCaptor.getValue();
         assertThat(caught)
                 .isInstanceOf(MessagingException.class)
-                .hasMessage("Message already removed/expunged on server (no flag update possible)")
+                .hasMessage("Message already removed/expunged on server (message state could not be updated)")
                 .hasCauseInstanceOf(MessageRemovedException.class);
     }
 

--- a/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java
@@ -35,9 +35,7 @@ import org.apache.camel.spi.ExchangeFactory;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -49,11 +47,10 @@ import static org.mockito.Mockito.when;
  * Verifies that processCommit() wraps MessageRemovedException (message already expunged on the IMAP server) with a
  * non-null cause message so that the error log never shows "Caused by: [... - null]".
  */
-public class MailConsumerCommitExpungedMessageTest {
+class MailConsumerCommitExpungedMessageTest {
 
     @Test
-    public void testCommitWithExpungedMessageProducesNonNullCause() throws Exception {
-        // --- infrastructure mocks ---
+    void testCommitWithExpungedMessageProducesNonNullCause() throws Exception {
         JavaMailSender sender = mock(JavaMailSender.class);
         Processor processor = mock(Processor.class);
         CamelContext camelContext = mock(CamelContext.class);
@@ -66,7 +63,6 @@ public class MailConsumerCommitExpungedMessageTest {
         when(ecc.getExchangeFactory()).thenReturn(ef);
         when(ef.newExchangeFactory(any())).thenReturn(ef);
 
-        // --- endpoint/configuration ---
         MailEndpoint endpoint = new MailEndpoint();
         endpoint.setCamelContext(camelContext);
         MailConfiguration config = new MailConfiguration();
@@ -76,28 +72,22 @@ public class MailConsumerCommitExpungedMessageTest {
         config.setDelete(false);
         endpoint.setConfiguration(config);
 
-        // --- message mock: setFlag throws MessageRemovedException (no message text — simulates the null cause) ---
         Message mail = mock(Message.class);
         doThrow(new MessageRemovedException()).when(mail).setFlag(any(Flags.Flag.class), any(boolean.class));
 
-        // --- folder mock: open and isOpen so processCommit doesn't bail early ---
         Folder folder = mock(Folder.class);
         when(folder.isOpen()).thenReturn(true);
 
-        // --- exchange mock ---
         Exchange exchange = mock(Exchange.class);
         org.apache.camel.Message camelMsg = mock(org.apache.camel.Message.class);
         when(exchange.getIn()).thenReturn(camelMsg);
         when(camelMsg.getHeader(MailConstants.MAIL_COPY_TO, config.getCopyTo(), String.class)).thenReturn(null);
         when(camelMsg.getHeader(MailConstants.MAIL_MOVE_TO, config.getMoveTo(), String.class)).thenReturn(null);
         when(camelMsg.getHeader(MailConstants.MAIL_DELETE, config.isDelete(), boolean.class)).thenReturn(false);
-        // removeProperty returns null uid — fine because protocol is imap (not pop3)
         when(exchange.removeProperty(MailConsumer.MAIL_MESSAGE_UID)).thenReturn(null);
 
-        // --- capture exception handler calls ---
         ExceptionHandler exceptionHandler = mock(ExceptionHandler.class);
 
-        // --- build consumer and inject mocks via reflection ---
         MailConsumer consumer = new MailConsumer(endpoint, processor, sender);
         consumer.setExceptionHandler(exceptionHandler);
 
@@ -105,28 +95,21 @@ public class MailConsumerCommitExpungedMessageTest {
         folderField.setAccessible(true);
         folderField.set(consumer, folder);
 
-        // --- exercise ---
         consumer.processCommit(mail, exchange);
 
-        // --- verify exception handler was called with a MessagingException whose message is non-null ---
         ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
         verify(exceptionHandler).handleException(msgCaptor.capture(), any(Exchange.class), causeCaptor.capture());
 
         Throwable caught = causeCaptor.getValue();
-        assertInstanceOf(MessagingException.class, caught,
-                "Expected MessagingException wrapping MessageRemovedException");
-        assertNotNull(caught.getMessage(),
-                "Cause message must not be null — was: " + caught.getMessage());
-        assertEquals("Message already removed/expunged on server (no flag update possible)", caught.getMessage());
-
-        assertInstanceOf(MessageRemovedException.class, caught.getCause(),
-                "Root cause must be the original MessageRemovedException");
+        assertThat(caught)
+                .isInstanceOf(MessagingException.class)
+                .hasMessage("Message already removed/expunged on server (no flag update possible)")
+                .hasCauseInstanceOf(MessageRemovedException.class);
     }
 
     @Test
-    public void testCommitWithOtherMessagingExceptionPassedThroughAsIs() throws Exception {
-        // --- infrastructure mocks ---
+    void testCommitWithOtherMessagingExceptionPassedThroughAsIs() throws Exception {
         JavaMailSender sender = mock(JavaMailSender.class);
         Processor processor = mock(Processor.class);
         CamelContext camelContext = mock(CamelContext.class);
@@ -178,8 +161,8 @@ public class MailConsumerCommitExpungedMessageTest {
         ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
         verify(exceptionHandler).handleException(anyString(), any(Exchange.class), causeCaptor.capture());
 
-        // non-MessageRemovedException must be passed through unchanged (no wrapping)
-        assertInstanceOf(MessagingException.class, causeCaptor.getValue());
-        assertEquals("Some other server error", causeCaptor.getValue().getMessage());
+        assertThat(causeCaptor.getValue())
+                .isInstanceOf(MessagingException.class)
+                .hasMessage("Some other server error");
     }
 }


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24403](https://issues.apache.org/jira/browse/CAMEL-24403).

When an IMAP message is expunged between fetch time and the on-completion commit callback, `IMAPMessage.setFlag()` throws `MessageRemovedException` whose `getMessage()` returns `null`, producing a confusing log entry:

```
Caused by: [javax.mail.MessageRemovedException - null]
```

## Root Cause

`MessageRemovedException` extends `MessagingException` but is constructed without a message string so `getMessage()` returns `null`. The existing `catch (MessagingException e)` block in `processCommit()` passed it directly to the exception handler, which included the null in the formatted output.

## Fix

Catch `MessageRemovedException` before the generic `MessagingException` handler in `processCommit()` and wrap it with an explicit description:

```java
} catch (MessageRemovedException e) {
    MessagingException wrapped = new MessagingException(
            "Message already removed/expunged on server (no flag update possible)", e);
    getExceptionHandler().handleException(
            "Error occurred during committing mail message: " + mail, exchange, wrapped);
} catch (MessagingException e) {
    getExceptionHandler().handleException(
            "Error occurred during committing mail message: " + mail, exchange, e);
}
```

Expected log output after fix:

```
Caused by: [javax.mail.MessagingException - Message already removed/expunged on server (no flag update possible)]
```

## Stack Trace (from CAMEL-24403)

```
javax.mail.MessageRemovedException
  at com.sun.mail.imap.IMAPMessage.checkExpunged(IMAPMessage.java:280)
  at com.sun.mail.imap.IMAPMessage.setFlags(IMAPMessage.java:1110)
  at javax.mail.Message.setFlag(Message.java:596)
  at org.apache.camel.component.mail.MailConsumer.processCommit(MailConsumer.java:506)
  at org.apache.camel.component.mail.MailConsumer$1.onComplete(MailConsumer.java:237)
  at org.apache.camel.support.UnitOfWorkHelper.doneSynchronization(UnitOfWorkHelper.java:104)
  at org.apache.camel.support.UnitOfWorkHelper.doneSynchronizations(UnitOfWorkHelper.java:89)
  at org.apache.camel.impl.engine.DefaultUnitOfWork.done(DefaultUnitOfWork.java:238)
  at org.apache.camel.support.UnitOfWorkHelper.doneUow(UnitOfWorkHelper.java:61)
  at org.apache.camel.impl.engine.CamelInternalProcessor$UnitOfWorkProcessorAdvice.after(CamelInternalProcessor.java:770)
  at org.apache.camel.impl.engine.CamelInternalProcessor$AsyncAfterTask.done(CamelInternalProcessor.java:263)
  at org.apache.camel.AsyncCallback.run(AsyncCallback.java:44)
  at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:193)
  at org.apache.camel.processor.Pipeline.process(Pipeline.java:185)
  at org.apache.camel.impl.engine.CamelInternalProcessor.process(CamelInternalProcessor.java:398)
  at org.apache.camel.component.mail.MailConsumer.processExchange(MailConsumer.java:449)
  at org.apache.camel.component.mail.MailConsumer.processBatch(MailConsumer.java:258)
  at org.apache.camel.component.mail.MailConsumer.poll(MailConsumer.java:165)
  at org.apache.camel.support.ScheduledPollConsumer.doRun(ScheduledPollConsumer.java:202)
  at org.apache.camel.support.ScheduledPollConsumer.run(ScheduledPollConsumer.java:116)
  at org.apache.camel.pollconsumer.quartz.QuartzScheduledPollConsumerJob.execute(QuartzScheduledPollConsumerJob.java:61)
  at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
  at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

## Changes

- `components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConsumer.java` — add `jakarta.mail.MessageRemovedException` import; split catch block
- `components/camel-mail/src/test/java/org/apache/camel/component/mail/MailConsumerCommitExpungedMessageTest.java` (new) — 2 unit tests:
  - `testCommitWithExpungedMessageProducesNonNullCause` — verifies `MessageRemovedException` is wrapped with a non-null message and root cause preserved
  - `testCommitWithOtherMessagingExceptionPassedThroughAsIs` — verifies other `MessagingException` types pass through unchanged

## Test Results

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0  (JDK 21, Maven 3.9)
```

## AI Attribution

This contribution was developed with AI assistance using [Claude Code](https://github.com/anthropics/claude-code).

```
Co-authored-by: Claude <claude@anthropic.com>
```