### PR TITLE
Upgrade guide missing LTS tag for 4.22

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide.adoc
@@ -30,7 +30,7 @@ You can find the upgrade guide for each release in the following pages:
 - xref:camel-4x-upgrade-guide-4_19.adoc[Upgrade guide 4.18 -> 4.19]
 - xref:camel-4x-upgrade-guide-4_20.adoc[Upgrade guide 4.19 -> 4.20]
 - xref:camel-4x-upgrade-guide-4_21.adoc[Upgrade guide 4.20 -> 4.21]
-- xref:camel-4x-upgrade-guide-4_22.adoc[Upgrade guide 4.21 -> 4.22]
+- xref:camel-4x-upgrade-guide-4_22.adoc[Upgrade guide 4.21 -> 4.22 LTS]
 - xref:camel-4x-upgrade-guide-4_23.adoc[Upgrade guide 4.22 -> 4.23]
 
 [NOTE]


### PR DESCRIPTION
Fix missing LTS tag under [camel-4x-upgrade-guide](https://camel.apache.org/manual/camel-4x-upgrade-guide.html)