### PR TITLE
CAMEL-24408: Fix SEDA discardIfNoConsumers after consumer route removal (4.19.x backport)

### DIFF
--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
@@ -101,6 +101,9 @@ public final class QueueReference {
         return queue;
     }
 
+    /**
+     * Whether any of the endpoints sharing this queue reference still have active consumers.
+     */
     public boolean hasConsumers() {
         lock.lock();
         try {
@@ -116,6 +119,9 @@ public final class QueueReference {
         }
     }
 
+    /**
+     * Whether any of the endpoints sharing this queue reference still have active producers.
+     */
     public boolean hasProducers() {
         lock.lock();
         try {

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/QueueReference.java
@@ -115,4 +115,19 @@ public final class QueueReference {
             lock.unlock();
         }
     }
+
+    public boolean hasProducers() {
+        lock.lock();
+        try {
+            for (SedaEndpoint endpoint : endpoints) {
+                if (!endpoint.getProducers().isEmpty()) {
+                    return true;
+                }
+            }
+
+            return false;
+        } finally {
+            lock.unlock();
+        }
+    }
 }

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
@@ -327,9 +327,10 @@ public class SedaComponent extends DefaultComponent {
         String key = getQueueKey(endpoint.getEndpointUri());
         QueueReference ref = getQueues().get(key);
         if (ref != null && endpoint.getConsumers().isEmpty()) {
-            // only remove the endpoint when the consumers are removed
-            ref.removeReference(endpoint);
-            if (ref.getCount() <= 0) {
+            if (endpoint.getProducers().isEmpty()) {
+                ref.removeReference(endpoint);
+            }
+            if (ref.getCount() <= 0 && !ref.hasProducers()) {
                 // reference no longer needed so remove from queues
                 getQueues().remove(key);
             }

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaComponent.java
@@ -326,11 +326,10 @@ public class SedaComponent extends DefaultComponent {
         // we need to remove the endpoint from the reference counter
         String key = getQueueKey(endpoint.getEndpointUri());
         QueueReference ref = getQueues().get(key);
-        if (ref != null && endpoint.getConsumers().isEmpty()) {
-            if (endpoint.getProducers().isEmpty()) {
-                ref.removeReference(endpoint);
-            }
-            if (ref.getCount() <= 0 && !ref.hasProducers()) {
+        if (ref != null && endpoint.getConsumers().isEmpty() && endpoint.getProducers().isEmpty()) {
+            // only remove the endpoint when both consumers and producers are removed
+            ref.removeReference(endpoint);
+            if (ref.getCount() <= 0) {
                 // reference no longer needed so remove from queues
                 getQueues().remove(key);
             }

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -609,6 +609,9 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
 
     void onStopped(SedaProducer producer) {
         producers.remove(producer);
+        if (getConsumers().isEmpty() && getProducers().isEmpty() && getComponent() != null) {
+            getComponent().onShutdownEndpoint(this);
+        }
     }
 
     void onStarted(SedaConsumer consumer) throws Exception {
@@ -660,14 +663,11 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
 
     @Override
     public void stop() {
-        if (getConsumers().isEmpty()) {
-            super.stop();
-        } else {
-            LOG.debug("There is still active consumers.");
-        }
-
         if (getConsumers().isEmpty() && getProducers().isEmpty()) {
+            super.stop();
             ref = null;
+        } else {
+            LOG.debug("There is still active consumers or producers.");
         }
     }
 

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaEndpoint.java
@@ -666,7 +666,9 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
             LOG.debug("There is still active consumers.");
         }
 
-        ref = null;
+        if (getConsumers().isEmpty() && getProducers().isEmpty()) {
+            ref = null;
+        }
     }
 
     @Override
@@ -681,10 +683,10 @@ public class SedaEndpoint extends DefaultEndpoint implements AsyncEndpoint, Brow
             getComponent().onShutdownEndpoint(this);
         }
 
-        if (getConsumers().isEmpty()) {
+        if (getConsumers().isEmpty() && getProducers().isEmpty()) {
             super.shutdown();
         } else {
-            LOG.debug("There is still active consumers.");
+            LOG.debug("There is still active consumers or producers.");
         }
     }
 

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaProducer.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaProducer.java
@@ -196,6 +196,10 @@ public class SedaProducer extends DefaultAsyncProducer {
             queue = queueReference.getQueue();
         }
         if (queue == null) {
+            if (endpoint.isDiscardIfNoConsumers()) {
+                LOG.debug("Discard message as no queue available on endpoint: {}", endpoint);
+                return;
+            }
             throw new SedaConsumerNotAvailableException("No queue available on endpoint: " + endpoint, exchange);
         }
 

--- a/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaProducer.java
+++ b/components/camel-seda/src/main/java/org/apache/camel/component/seda/SedaProducer.java
@@ -196,10 +196,6 @@ public class SedaProducer extends DefaultAsyncProducer {
             queue = queueReference.getQueue();
         }
         if (queue == null) {
-            if (endpoint.isDiscardIfNoConsumers()) {
-                LOG.debug("Discard message as no queue available on endpoint: {}", endpoint);
-                return;
-            }
             throw new SedaConsumerNotAvailableException("No queue available on endpoint: " + endpoint, exchange);
         }
 

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaDiscardIfNoConsumerAfterRemovalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaDiscardIfNoConsumerAfterRemovalTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.seda;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SedaDiscardIfNoConsumerAfterRemovalTest extends ContextTestSupport {
+
+    @Test
+    void testDiscardAfterConsumerRouteRemoved() throws Exception {
+        SedaEndpoint bar = getMandatoryEndpoint("seda:bar?discardIfNoConsumers=true", SedaEndpoint.class);
+        assertThat(bar.getCurrentQueueSize()).isZero();
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedBodiesReceived("Hello World");
+
+        template.sendBody("direct:start", "Hello World");
+
+        mock.assertIsSatisfied();
+
+        context.getRouteController().stopRoute("consumer");
+        context.removeRoute("consumer");
+
+        mock.reset();
+        mock.expectedMessageCount(0);
+
+        template.sendBody("direct:start", "Should be discarded");
+
+        mock.assertIsSatisfied();
+        assertThat(bar.getCurrentQueueSize()).isZero();
+    }
+
+    @Test
+    void testQueueReferenceKeptWhenProducerStillActive() throws Exception {
+        SedaComponent seda = context.getComponent("seda", SedaComponent.class);
+        SedaEndpoint bar = getMandatoryEndpoint("seda:bar?discardIfNoConsumers=true", SedaEndpoint.class);
+        String key = seda.getQueueKey(bar.getEndpointUri());
+
+        template.sendBody("direct:start", "Hello World");
+        getMockEndpoint("mock:result").assertIsSatisfied();
+
+        context.getRouteController().stopRoute("consumer");
+        context.removeRoute("consumer");
+
+        assertThat(seda.getQueues().get(key)).isNotNull();
+        assertThat(seda.getQueues().get(key).getCount()).isGreaterThan(0);
+    }
+
+    @Test
+    void testFailIfNoConsumersAfterConsumerRouteRemoved() throws Exception {
+        context.getRouteController().stopRoute("producer");
+        context.removeRoute("producer");
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:fail").to("seda:fail?failIfNoConsumers=true");
+            }
+        });
+
+        context.getRouteController().stopRoute("failConsumer");
+        context.removeRoute("failConsumer");
+
+        assertThatThrownBy(() -> template.sendBody("direct:fail", "Should fail"))
+                .hasCauseInstanceOf(SedaConsumerNotAvailableException.class);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("producer").to("seda:bar?discardIfNoConsumers=true");
+                from("seda:bar?discardIfNoConsumers=true").routeId("consumer").to("mock:result");
+                from("seda:fail").routeId("failConsumer").to("mock:fail");
+            }
+        };
+    }
+}

--- a/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaDiscardIfNoConsumerAfterRemovalTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/component/seda/SedaDiscardIfNoConsumerAfterRemovalTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.seda;
 import org.apache.camel.ContextTestSupport;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.support.service.ServiceHelper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +29,9 @@ class SedaDiscardIfNoConsumerAfterRemovalTest extends ContextTestSupport {
 
     @Test
     void testDiscardAfterConsumerRouteRemoved() throws Exception {
+        SedaComponent seda = context.getComponent("seda", SedaComponent.class);
         SedaEndpoint bar = getMandatoryEndpoint("seda:bar?discardIfNoConsumers=true", SedaEndpoint.class);
+        String key = seda.getQueueKey(bar.getEndpointUri());
         assertThat(bar.getCurrentQueueSize()).isZero();
 
         MockEndpoint mock = getMockEndpoint("mock:result");
@@ -41,17 +44,68 @@ class SedaDiscardIfNoConsumerAfterRemovalTest extends ContextTestSupport {
         context.getRouteController().stopRoute("consumer");
         context.removeRoute("consumer");
 
-        mock.reset();
-        mock.expectedMessageCount(0);
+        assertThat(ServiceHelper.isStarted(bar)).isTrue();
+        assertThat(bar.getQueueReference()).isNotNull();
+        assertThat(seda.getQueues().get(key)).isNotNull();
+        assertThat(bar.getQueueReference().hasConsumers()).isFalse();
 
         template.sendBody("direct:start", "Should be discarded");
 
-        mock.assertIsSatisfied();
         assertThat(bar.getCurrentQueueSize()).isZero();
     }
 
     @Test
-    void testQueueReferenceKeptWhenProducerStillActive() throws Exception {
+    void testReAddConsumerAfterRemoval() throws Exception {
+        template.sendBody("direct:start", "Hello World");
+        getMockEndpoint("mock:result").assertIsSatisfied();
+
+        context.getRouteController().stopRoute("consumer");
+        context.removeRoute("consumer");
+
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("seda:bar?discardIfNoConsumers=true").routeId("consumer").to("mock:result");
+            }
+        });
+
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.reset();
+        mock.expectedBodiesReceived("After re-add");
+
+        template.sendBody("direct:start", "After re-add");
+
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    void testFailIfNoConsumersAfterConsumerRouteRemoved() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:fail").routeId("failProducer").to("seda:fail?failIfNoConsumers=true");
+                from("seda:fail?failIfNoConsumers=true").routeId("failConsumer").to("mock:fail");
+            }
+        });
+
+        SedaComponent seda = context.getComponent("seda", SedaComponent.class);
+        SedaEndpoint fail = getMandatoryEndpoint("seda:fail?failIfNoConsumers=true", SedaEndpoint.class);
+        String key = seda.getQueueKey(fail.getEndpointUri());
+
+        context.getRouteController().stopRoute("failConsumer");
+        context.removeRoute("failConsumer");
+
+        assertThat(fail.getQueueReference()).isNotNull();
+        assertThat(seda.getQueues().get(key)).isNotNull();
+
+        assertThatThrownBy(() -> template.sendBody("direct:fail", "Should fail"))
+                .cause()
+                .isInstanceOf(SedaConsumerNotAvailableException.class)
+                .hasMessageContaining("No consumers available");
+    }
+
+    @Test
+    void testQueueRemovedAfterProducerRouteRemoved() throws Exception {
         SedaComponent seda = context.getComponent("seda", SedaComponent.class);
         SedaEndpoint bar = getMandatoryEndpoint("seda:bar?discardIfNoConsumers=true", SedaEndpoint.class);
         String key = seda.getQueueKey(bar.getEndpointUri());
@@ -63,26 +117,11 @@ class SedaDiscardIfNoConsumerAfterRemovalTest extends ContextTestSupport {
         context.removeRoute("consumer");
 
         assertThat(seda.getQueues().get(key)).isNotNull();
-        assertThat(seda.getQueues().get(key).getCount()).isGreaterThan(0);
-    }
 
-    @Test
-    void testFailIfNoConsumersAfterConsumerRouteRemoved() throws Exception {
         context.getRouteController().stopRoute("producer");
         context.removeRoute("producer");
 
-        context.addRoutes(new RouteBuilder() {
-            @Override
-            public void configure() {
-                from("direct:fail").to("seda:fail?failIfNoConsumers=true");
-            }
-        });
-
-        context.getRouteController().stopRoute("failConsumer");
-        context.removeRoute("failConsumer");
-
-        assertThatThrownBy(() -> template.sendBody("direct:fail", "Should fail"))
-                .hasCauseInstanceOf(SedaConsumerNotAvailableException.class);
+        assertThat(seda.getQueues().get(key)).isNull();
     }
 
     @Override
@@ -92,7 +131,6 @@ class SedaDiscardIfNoConsumerAfterRemovalTest extends ContextTestSupport {
             public void configure() {
                 from("direct:start").routeId("producer").to("seda:bar?discardIfNoConsumers=true");
                 from("seda:bar?discardIfNoConsumers=true").routeId("consumer").to("mock:result");
-                from("seda:fail").routeId("failConsumer").to("mock:fail");
             }
         };
     }


### PR DESCRIPTION
## Summary

_AI-generated on behalf of atiaomar1978-hub._

Backport of #25558 for `camel-4.19.x`.

Fixes [CAMEL-24408](https://issues.apache.org/jira/browse/CAMEL-24408): when a SEDA producer and consumer share the same endpoint URI with `discardIfNoConsumers=true`, removing the consumer route must silently discard subsequent messages instead of throwing `SedaConsumerNotAvailableException`.

## Related

- Main PR: #25558