### PR TITLE
CAMEL-24349: camel-google-functions - name the header createFunction is missing

### DIFF
--- a/components/camel-google/camel-google-functions/pom.xml
+++ b/components/camel-google/camel-google-functions/pom.xml
@@ -89,5 +89,10 @@
             <artifactId>camel-test-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-google/camel-google-functions/src/main/java/org/apache/camel/component/google/functions/GoogleCloudFunctionsProducer.java
+++ b/components/camel-google/camel-google-functions/src/main/java/org/apache/camel/component/google/functions/GoogleCloudFunctionsProducer.java
@@ -41,6 +41,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.Message;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.ObjectHelper;
 
 /**
  * The GoogleCloudFunctions producer.
@@ -93,10 +94,12 @@ public class GoogleCloudFunctionsProducer extends DefaultProducer {
             ListFunctionsPagedResponse pagedListResponse = client.listFunctions(request);
             response = Lists.newArrayList(pagedListResponse.iterateAll());
         } else {
+            // no page size: iterateAll below follows the pages itself, and the service rejects an
+            // oversized one
             ListFunctionsRequest request = ListFunctionsRequest
                     .newBuilder().setParent(LocationName
                             .of(getConfiguration().getProject(), getConfiguration().getLocation()).toString())
-                    .setPageSize(Integer.MAX_VALUE).build();
+                    .build();
             ListFunctionsPagedResponse pagedListResponse = client.listFunctions(request);
             response = Lists.newArrayList(pagedListResponse.iterateAll());
         }
@@ -182,11 +185,9 @@ public class GoogleCloudFunctionsProducer extends DefaultProducer {
             final String project = getConfiguration().getProject();
             final String location = getConfiguration().getLocation();
             final String functionName = getConfiguration().getFunctionName();
-            final String entryPoint = exchange.getIn().getHeader(GoogleCloudFunctionsConstants.ENTRY_POINT,
-                    String.class);
-            final String runtime = exchange.getIn().getHeader(GoogleCloudFunctionsConstants.RUNTIME, String.class);
-            final String sourceArchiveUrl = exchange.getIn().getHeader(GoogleCloudFunctionsConstants.SOURCE_ARCHIVE_URL,
-                    String.class);
+            final String entryPoint = mandatoryHeader(exchange, GoogleCloudFunctionsConstants.ENTRY_POINT);
+            final String runtime = mandatoryHeader(exchange, GoogleCloudFunctionsConstants.RUNTIME);
+            final String sourceArchiveUrl = mandatoryHeader(exchange, GoogleCloudFunctionsConstants.SOURCE_ARCHIVE_URL);
             CloudFunction function = CloudFunction.newBuilder()
                     .setName(CloudFunctionName.of(project, location, functionName).toString()).setEntryPoint(entryPoint)
                     .setRuntime(runtime).setHttpsTrigger(HttpsTrigger.getDefaultInstance())
@@ -226,6 +227,18 @@ public class GoogleCloudFunctionsProducer extends DefaultProducer {
         }
         Message message = getMessageForResponse(exchange);
         message.setBody(response);
+    }
+
+    /**
+     * A header the request cannot be built without. The protobuf setters reject null, so without this the missing
+     * header surfaces as a bare NullPointerException instead of naming what is missing.
+     */
+    private static String mandatoryHeader(Exchange exchange, String header) {
+        String value = exchange.getIn().getHeader(header, String.class);
+        if (ObjectHelper.isEmpty(value)) {
+            throw new IllegalArgumentException("The " + header + " header must be set for this operation");
+        }
+        return value;
     }
 
     private GoogleCloudFunctionsOperations determineOperation(Exchange exchange) {

--- a/components/camel-google/camel-google-functions/src/test/java/org/apache/camel/component/google/functions/unit/GoogleCloudFunctionsCreateFunctionValidationTest.java
+++ b/components/camel-google/camel-google-functions/src/test/java/org/apache/camel/component/google/functions/unit/GoogleCloudFunctionsCreateFunctionValidationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.functions.unit;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.google.functions.GoogleCloudFunctionsConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that createFunction reports the header it is missing instead of failing inside protobuf.
+ */
+class GoogleCloudFunctionsCreateFunctionValidationTest extends GoogleCloudFunctionsBaseTest {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:createFunction")
+                        .to("google-functions://myCamelFunction?project=project123&location=location123"
+                            + "&operation=createFunction");
+            }
+        };
+    }
+
+    @Test
+    void aMissingEntryPointIsReported() {
+        Exchange exchange = template.request("direct:createFunction", e -> {
+        });
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The " + GoogleCloudFunctionsConstants.ENTRY_POINT + " header must be set for this operation");
+    }
+
+    @Test
+    void aMissingRuntimeIsReported() {
+        Exchange exchange = template.request("direct:createFunction",
+                e -> e.getIn().setHeader(GoogleCloudFunctionsConstants.ENTRY_POINT, "myEntryPoint"));
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The " + GoogleCloudFunctionsConstants.RUNTIME + " header must be set for this operation");
+    }
+
+    @Test
+    void aMissingSourceArchiveUrlIsReported() {
+        Exchange exchange = template.request("direct:createFunction", e -> {
+            e.getIn().setHeader(GoogleCloudFunctionsConstants.ENTRY_POINT, "myEntryPoint");
+            e.getIn().setHeader(GoogleCloudFunctionsConstants.RUNTIME, "java17");
+        });
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The " + GoogleCloudFunctionsConstants.SOURCE_ARCHIVE_URL
+                            + " header must be set for this operation");
+    }
+}


### PR DESCRIPTION
`createFunction` fed three headers straight into protobuf setters:

```java
final String entryPoint = exchange.getIn().getHeader(GoogleCloudFunctionsConstants.ENTRY_POINT, String.class);
final String runtime = exchange.getIn().getHeader(GoogleCloudFunctionsConstants.RUNTIME, String.class);
final String sourceArchiveUrl = exchange.getIn().getHeader(GoogleCloudFunctionsConstants.SOURCE_ARCHIVE_URL, String.class);
CloudFunction function = CloudFunction.newBuilder()
        .setName(...).setEntryPoint(entryPoint)
        .setRuntime(runtime)...
        .setSourceArchiveUrl(sourceArchiveUrl).build();
```

Protobuf setters reject `null`, so a request missing any of them failed with a bare
`NullPointerException` and no hint about which header the operation needs. Each is now validated and
reported by name.

`listFunctions` also built its request with `setPageSize(Integer.MAX_VALUE)` while collecting the
result through `iterateAll()`, which follows the pages itself. The oversized page size is dropped —
the request the service sees is the paging default and the returned list is unchanged.

Covered by a new test on the existing gRPC mock-service base.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)