### PR TITLE
CAMEL-24413: camel-hazelcast - apply the default serialization filter in ReplicatedHazelcastAggregationRepository

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/ReplicatedHazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/ReplicatedHazelcastAggregationRepository.java
@@ -31,6 +31,7 @@ import com.hazelcast.transaction.TransactionalMap;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.component.hazelcast.HazelcastSerializationFilterHelper;
 import org.apache.camel.spi.OptimisticLockingAggregationRepository;
 import org.apache.camel.spi.RecoverableAggregationRepository;
 import org.apache.camel.support.DefaultExchangeHolder;
@@ -342,6 +343,7 @@ public class ReplicatedHazelcastAggregationRepository extends HazelcastAggregati
             useLocalHzInstance = true;
             Config cfg = new XmlConfigBuilder().build();
             cfg.setProperty("hazelcast.version.check.enabled", "false");
+            HazelcastSerializationFilterHelper.applyDefault(cfg);
             hazelcastInstance = Hazelcast.newHazelcastInstance(cfg);
         } else {
             ObjectHelper.notNull(hazelcastInstance, "hazelcastInstance");

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositorySerializationFilterTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositorySerializationFilterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.hazelcast;
+
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Both aggregation repositories bootstrap their own Hazelcast instance when none is injected.
+ * {@link ReplicatedHazelcastAggregationRepository} overrides {@code doStart()} without calling {@code super.doStart()},
+ * so the two bootstrap paths have to be asserted separately to keep them from drifting apart again.
+ */
+class HazelcastAggregationRepositorySerializationFilterTest {
+
+    @Test
+    void locallyInitializedInstanceCarriesTheDefaultFilter() throws Exception {
+        assertDefaultFilterApplied(new HazelcastAggregationRepository("hzFilterRepoMap"));
+    }
+
+    @Test
+    void replicatedLocallyInitializedInstanceCarriesTheDefaultFilter() throws Exception {
+        assertDefaultFilterApplied(new ReplicatedHazelcastAggregationRepository("hzFilterReplicatedRepoMap"));
+    }
+
+    private static void assertDefaultFilterApplied(HazelcastAggregationRepository repo) throws Exception {
+        repo.doStart();
+        try {
+            JavaSerializationFilterConfig filter = repo.getHazelcastInstance()
+                    .getConfig().getSerializationConfig().getJavaSerializationFilterConfig();
+
+            assertThat(filter).isNotNull();
+            assertThat(filter.getWhitelist().getPrefixes()).contains("java.", "javax.", "org.apache.camel.");
+            assertThat(filter.getBlacklist().getPrefixes()).contains("java.net.");
+        } finally {
+            repo.doStop();
+        }
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -64,3 +64,19 @@ an `AGENTS.md` file with guidance for AI coding assistants, pointing at the Apac
 
 The `camel-archetype-api-component` archetype also generates its readme again: the file was declared
 in the wrong file set and was therefore silently skipped.
+
+=== camel-hazelcast
+
+`ReplicatedHazelcastAggregationRepository` now applies the same default
+`JavaSerializationFilterConfig` that the other repositories and the component endpoints have applied
+since 4.14.8/4.18.3/4.21.0, when it bootstraps its own `HazelcastInstance` (that is, when no
+`hazelcastInstance` is supplied). It overrides `doStart()` without calling `super.doStart()` and was
+therefore left out of that change.
+
+The default whitelists the class name prefixes `java.`, `javax.`, `org.apache.camel.` and blacklists
+`java.net.`, and a user-supplied `JavaSerializationFilterConfig` is still respected and never
+overwritten.
+
+Applications that aggregate classes outside the default whitelist through the replicated repository
+without supplying their own `hazelcastInstance` must now provide a `Config` with a
+`JavaSerializationFilterConfig` covering their class names.


### PR DESCRIPTION
Fixes [CAMEL-24413](https://issues.apache.org/jira/browse/CAMEL-24413).

## Problem

CAMEL-23414 introduced `HazelcastSerializationFilterHelper.applyDefault(Config)` and called it from every place where camel-hazelcast bootstraps its own managed Hazelcast instance:

- `HazelcastAggregationRepository.doStart()`
- `HazelcastIdempotentRepository`
- `HazelcastDefaultComponent`
- `HazelcastUtil`

`ReplicatedHazelcastAggregationRepository.doStart()` builds its `Config` the same way but was missed. It overrides `doStart()` **without calling `super.doStart()`**, so the parent's call never runs — a route using the replicated repository without injecting its own `hazelcastInstance` gets different defaults from every sibling bootstrap site.

## Change

- Add the missing `HazelcastSerializationFilterHelper.applyDefault(cfg)` call so all five bootstrap sites behave identically.
- Add `HazelcastAggregationRepositorySerializationFilterTest`, which asserts **both** bootstrap paths (plain and replicated) end up with the default `JavaSerializationFilterConfig`, so the two cannot drift apart again. Verified it actually catches the regression: with the fix reverted, `replicatedLocallyInitializedInstanceCarriesTheDefaultFilter` fails on a null filter config; with the fix, both pass.
- Add a 4.23 upgrade-guide entry. Worth noting the CAMEL-23414 entries in the 4.14/4.18/4.21 guides enumerate `HazelcastAggregationRepository` and `HazelcastIdempotentRepository` as covered but never mentioned the replicated repository — the guide documented behaviour it did not have.

A user-supplied `JavaSerializationFilterConfig` is still respected and never overwritten (unchanged helper behaviour).

## Backport

Intended for **camel-4.22.x, camel-4.18.x and camel-4.14.x**, matching CAMEL-23414's own backports. The upgrade-guide entry stays on `main` per the project's guide policy.

## Testing

```
mvn test -Dtest=HazelcastAggregationRepositorySerializationFilterTest   # 2 passed
mvn clean install -DskipTests                                          # full reactor, BUILD SUCCESS
```

---
_Claude Code on behalf of 