### PR TITLE
CAMEL-24419: camel-mail - filter the mail session property namespace on MimeMultipart unmarshal

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
@@ -50,10 +50,10 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.attachment.Attachment;
 import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.attachment.DefaultAttachment;
+import org.apache.camel.component.mail.MailHeaderFilterStrategy;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.apache.camel.support.DefaultDataFormat;
-import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.IOHelper;
@@ -74,7 +74,7 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
     private String includeHeaders;
     private Pattern includeHeadersPattern;
     private boolean binaryContent;
-    private final HeaderFilterStrategy headerFilterStrategy = new DefaultHeaderFilterStrategy();
+    private final HeaderFilterStrategy headerFilterStrategy = new MailHeaderFilterStrategy();
 
     public String getMultipartSubType() {
         return multipartSubType;

--- a/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
@@ -40,6 +40,7 @@ import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -425,6 +426,27 @@ public class MimeMultipartDataFormatTest extends CamelTestSupport {
         assertNull(out.getMessage().getHeader("CamelFoo"));
         assertNull(out.getMessage().getHeader("camelBar"));
         assertNull(out.getMessage().getHeader("CAMELBaz"));
+    }
+
+    @Test
+    void unmarshalInlineHeadersFiltersMailSessionPropertyHeaders() {
+        // MailHeaderFilterStrategy adds the mail.smtp. / mail.smtps. prefixes to the inbound filter
+        // (CAMEL-23522) so an external mail message cannot inject JavaMail session properties. The
+        // headersInline unmarshal path has to filter the same namespace as the mail consumer does.
+        String mime = "mail.smtp.host: blocked\r\n"
+                      + "mail.smtps.auth: blocked\r\n"
+                      + "MAIL.SMTP.PORT: blocked\r\n"
+                      + "X-Normal: keep-me\r\n"
+                      + "Content-Type: text/plain\r\n"
+                      + "\r\n"
+                      + "Body text";
+        in.setBody(mime);
+        Exchange out = template.send("direct:unmarshalonlyinlineheaders", exchange);
+        assertThat(out.getMessage()).isNotNull();
+        assertThat(out.getMessage().getHeader("X-Normal")).isEqualTo("keep-me");
+        assertThat(out.getMessage().getHeader("mail.smtp.host")).isNull();
+        assertThat(out.getMessage().getHeader("mail.smtps.auth")).isNull();
+        assertThat(out.getMessage().getHeader("MAIL.SMTP.PORT")).isNull();
     }
 
     @Test

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -81,6 +81,18 @@ Applications that aggregate classes outside the default whitelist through the re
 without supplying their own `hazelcastInstance` must now provide a `Config` with a
 `JavaSerializationFilterConfig` covering their class names.
 
+=== camel-mail
+
+`MimeMultipartDataFormat` now uses `MailHeaderFilterStrategy` instead of a plain
+`DefaultHeaderFilterStrategy` when `headersInline` unmarshal copies the remaining MIME headers onto
+the Camel message. That strategy filters the `mail.smtp.` and `mail.smtps.` prefixes on the inbound
+path in addition to `Camel*`/`camel*`, so the data format now filters the same namespace the mail
+consumer has filtered since 4.14.9/4.18.4/4.22.0.
+
+Routes that relied on `mail.smtp.*` or `mail.smtps.*` headers arriving on the exchange from an
+unmarshalled MIME message must set those values explicitly on the route instead. Ordinary
+application headers are unaffected.
+
 === camel-netty - object codecs apply a deserialization filter by default
 
 The `ObjectDecoder` and `DatagramPacketObjectDecoder` codecs (used when a route configures Netty


### PR DESCRIPTION
Fixes [CAMEL-24419](https://issues.apache.org/jira/browse/CAMEL-24419).

## Problem

CAMEL-23522 extended `MailHeaderFilterStrategy` so the **inbound** path also filters the `mail.smtp.` and `mail.smtps.` prefixes, not just `Camel*`/`camel*`:

```java
String[] inFilter = Arrays.copyOf(CAMEL_FILTER_STARTS_WITH, CAMEL_FILTER_STARTS_WITH.length + 2);
inFilter[CAMEL_FILTER_STARTS_WITH.length] = "mail.smtp.";
inFilter[CAMEL_FILTER_STARTS_WITH.length + 1] = "mail.smtps.";
setInFilterStartsWith(inFilter);
```

`MimeMultipartDataFormat` — which CAMEL-23891 gave a header filter for the `Camel*` namespace — still held a plain `DefaultHeaderFilterStrategy`, which only knows `Camel*`/`camel*`. So the namespace CAMEL-23522 deliberately filters on the consumer path was **not** filtered by the `headersInline` unmarshal path. Two entry points into the same component disagreed about the filtered namespace.

## Change

One-line swap to `MailHeaderFilterStrategy`. I checked two things first to keep the blast radius honest:

1. `MailHeaderFilterStrategy.initialize()` only calls `setInFilterStartsWith(...)` — it never touches the out filter, which keeps `DefaultHeaderFilterStrategy`'s field default. **Marshal behaviour is unchanged.**
2. The strategy is referenced at exactly **one** site in the data format: `copyNonStandardHeaders()` → `applyFilterToExternalHeaders()`, which is the inbound direction.

So the change does precisely one thing: unmarshal now filters the same namespace as the consumer.

## Testing

New test sits next to the existing CAMEL-23891 `unmarshalInlineHeadersFiltersCamelInternalHeaders`. Verified it catches the regression: it **fails against the pre-fix code** and passes after.

```
mvn test -Dtest='MimeMultipartDataFormatTest#unmarshalInlineHeadersFiltersMailSessionPropertyHeaders'
mvn clean install -DskipTests    # full reactor, BUILD SUCCESS
```

## Backport

Intended for **camel-4.22.x, camel-4.18.x and camel-4.14.x**, matching the CAMEL-23891 backports. The upgrade-guide entry stays on `main` per the project's guide policy.

---
_Claude Code on behalf of 