### PR TITLE
CAMEL-24370: move the netty deserialization-filter upgrade note to the 4.23 guide

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/netty-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/netty-component.adoc
@@ -624,7 +624,7 @@ from("netty:udp://0.0.0.0:5155?sync=true&decoders=#decoder")
 
 [NOTE]
 ====
-Since Camel 4.22, `ObjectDecoder` and `DatagramPacketObjectDecoder` always install a JEP-290
+Since Camel 4.23, `ObjectDecoder` and `DatagramPacketObjectDecoder` always install a JEP-290
 `java.io.ObjectInputFilter` while decoding, as a defense-in-depth measure against unsafe Java deserialization. When no
 explicit pattern is passed, the JVM-wide `jdk.serialFilter` is honoured if set, otherwise the shared Camel default
 allow-list is applied (it permits standard Java and Apache Camel types, denies `java.net.**`, and enforces JEP-290

--- a/components/camel-netty/src/main/docs/netty-component.adoc
+++ b/components/camel-netty/src/main/docs/netty-component.adoc
@@ -624,7 +624,7 @@ from("netty:udp://0.0.0.0:5155?sync=true&decoders=#decoder")
 
 [NOTE]
 ====
-Since Camel 4.22, `ObjectDecoder` and `DatagramPacketObjectDecoder` always install a JEP-290
+Since Camel 4.23, `ObjectDecoder` and `DatagramPacketObjectDecoder` always install a JEP-290
 `java.io.ObjectInputFilter` while decoding, as a defense-in-depth measure against unsafe Java deserialization. When no
 explicit pattern is passed, the JVM-wide `jdk.serialFilter` is honoured if set, otherwise the shared Camel default
 allow-list is applied (it permits standard Java and Apache Camel types, denies `java.net.**`, and enforces JEP-290

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -104,21 +104,6 @@ IN message to the new OUT message, restoring the pre-4.10.1 behavior where attac
 across the exchange. If you added a workaround (for example, stashing and restoring attachments
 in exchange properties around a producer call), it can be removed.
 
-=== camel-netty - object codecs apply a deserialization filter by default
-
-The `ObjectDecoder` and `DatagramPacketObjectDecoder` codecs (used when a route configures Netty
-object serialization through the `encoders` / `decoders` options) now always install a JEP-290
-`java.io.ObjectInputFilter` while decoding, resolved through `DeserializationFilterHelper`.
-Previously a decoder built without an explicit filter pattern applied no filter at all and only
-logged a warning.
-
-When no explicit pattern is passed, the JVM-wide `jdk.serialFilter` is honoured if set, otherwise
-the shared Camel default allow-list is applied (it permits standard Java and Apache Camel types,
-denies `java.net.**`, and enforces JEP-290 graph-shape limits). Routes that deserialize classes
-outside that allow-list must pass an explicit filter pattern to the two-argument
-`ObjectDecoder(ClassResolver, String)` / `DatagramPacketObjectDecoder(ClassResolver, String)`
-constructor (or configure `jdk.serialFilter`) to permit them.
-
 === camel-jbang
 
 The Camel JBang CLI (Camel CLI) and TUI have been promoted from _Preview_ to _Stable_ support level.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -80,3 +80,18 @@ overwritten.
 Applications that aggregate classes outside the default whitelist through the replicated repository
 without supplying their own `hazelcastInstance` must now provide a `Config` with a
 `JavaSerializationFilterConfig` covering their class names.
+
+=== camel-netty - object codecs apply a deserialization filter by default
+
+The `ObjectDecoder` and `DatagramPacketObjectDecoder` codecs (used when a route configures Netty
+object serialization through the `encoders` / `decoders` options) now always install a JEP-290
+`java.io.ObjectInputFilter` while decoding, resolved through `DeserializationFilterHelper`.
+Previously a decoder built without an explicit filter pattern applied no filter at all and only
+logged a warning.
+
+When no explicit pattern is passed, the JVM-wide `jdk.serialFilter` is honoured if set, otherwise
+the shared Camel default allow-list is applied (it permits standard Java and Apache Camel types,
+denies `java.net.**`, and enforces JEP-290 graph-shape limits). Routes that deserialize classes
+outside that allow-list must pass an explicit filter pattern to the two-argument
+`ObjectDecoder(ClassResolver, String)` / `DatagramPacketObjectDecoder(ClassResolver, String)`
+constructor (or configure `jdk.serialFilter`) to permit them.


### PR DESCRIPTION
Follow-up doc correction to CAMEL-24370 (#25562).

CAMEL-24370 merged **after** main was bumped to `4.23.0-SNAPSHOT` (#25445), so it ships in 4.23.0, not 4.22.0. This moves its upgrade-guide entry from `camel-4x-upgrade-guide-4_22.adoc` to `camel-4x-upgrade-guide-4_23.adoc` — so users upgrading to 4.23 actually see the netty default-filter migration note — and corrects the "Since Camel 4.22" note in `netty-component.adoc` (and its generated catalog copy) to 4.23.

Docs-only.

_Claude Code on behalf of oscerd_
