### PR TITLE
CAMEL-24383: camel-azure-key-vault - fix copy-pasted validation messages

### DIFF
--- a/components/camel-azure/camel-azure-key-vault/src/main/java/org/apache/camel/component/azure/key/vault/KeyVaultProducer.java
+++ b/components/camel-azure/camel-azure-key-vault/src/main/java/org/apache/camel/component/azure/key/vault/KeyVaultProducer.java
@@ -29,7 +29,8 @@ import org.apache.camel.util.ObjectHelper;
 
 public class KeyVaultProducer extends DefaultProducer {
 
-    public static final String MISSING_SECRET_NAME = "Secret Name must be specified for createSecret Operation";
+    public static final String MISSING_SECRET_NAME = "Secret Name must be specified";
+    public static final String MISSING_SECRET_PROPERTIES = "Secret Properties must be specified";
 
     public KeyVaultProducer(final Endpoint endpoint) {
         super(endpoint);
@@ -85,7 +86,7 @@ public class KeyVaultProducer extends DefaultProducer {
         final SecretProperties secretProperties
                 = exchange.getMessage().getHeader(KeyVaultConstants.SECRET_PROPERTIES, SecretProperties.class);
         if (ObjectHelper.isEmpty(secretProperties)) {
-            throw new IllegalArgumentException(MISSING_SECRET_NAME);
+            throw new IllegalArgumentException(MISSING_SECRET_PROPERTIES);
         }
         SecretProperties p = getEndpoint().getSecretClient()
                 .updateSecretProperties(secretProperties);


### PR DESCRIPTION
The key-vault producer reused one constant — `MISSING_SECRET_NAME = "Secret Name must be specified for createSecret Operation"` — in all five operations. So `getSecret`/`deleteSecret`/`purgeDeletedSecret` reported the wrong operation, and `updateSecretProperties` was doubly wrong: it validates the `CamelAzureKeyVaultSecretProperties` header (not a name) yet said "Secret Name … createSecret".

The shared message is now generic ("Secret Name must be specified") and `updateSecretProperties` throws a dedicated `MISSING_SECRET_PROPERTIES` message. This is a **diagnostic-message-only** change — validation behaviour and the thrown `IllegalArgumentException` type are unchanged, so no test change is needed (mirrors the camel-aws2 message cleanup in CAMEL-24249). Key-vault module builds green.

_Claude Code on behalf of oscerd_