### PR TITLE
[backport camel-4.18.x] CAMEL-24411: camel-oauth - stop the route when the processors do not authenticate the request

### DIFF
--- a/components/camel-oauth/src/main/java/org/apache/camel/oauth/AbstractOAuthProcessor.java
+++ b/components/camel-oauth/src/main/java/org/apache/camel/oauth/AbstractOAuthProcessor.java
@@ -64,6 +64,33 @@ public abstract class AbstractOAuthProcessor implements Processor {
         });
     }
 
+    /**
+     * Rejects the current request and stops the route, so that no subsequent step runs for a request this processor did
+     * not authenticate. Absence of credentials must be rejected at least as strongly as invalid credentials.
+     *
+     * @param exchange   the exchange to reject and stop
+     * @param statusCode the HTTP status code to reply with
+     * @param body       the response body
+     */
+    protected void reject(Exchange exchange, int statusCode, String body) {
+        var msg = exchange.getMessage();
+        msg.setHeader(Exchange.HTTP_RESPONSE_CODE, statusCode);
+        msg.setBody(body);
+        exchange.setRouteStop(true);
+    }
+
+    /**
+     * Rejects the current request as unauthenticated with a {@code 401} and a {@code WWW-Authenticate: Bearer}
+     * challenge, as required by RFC 6750, and stops the route.
+     *
+     * @param exchange the exchange to reject and stop
+     * @param body     the response body
+     */
+    protected void rejectUnauthorized(Exchange exchange, String body) {
+        exchange.getMessage().setHeader("WWW-Authenticate", "Bearer");
+        reject(exchange, 401, body);
+    }
+
     protected void sendRedirect(Message msg, String redirectUrl) {
         log.debug("Redirect to: {}", redirectUrl);
         msg.setHeader(Exchange.HTTP_RESPONSE_CODE, 302);

--- a/components/camel-oauth/src/main/java/org/apache/camel/oauth/OAuthBearerTokenProcessor.java
+++ b/components/camel-oauth/src/main/java/org/apache/camel/oauth/OAuthBearerTokenProcessor.java
@@ -36,16 +36,14 @@ public class OAuthBearerTokenProcessor extends AbstractOAuthProcessor {
         var authHeader = msg.getHeader("Authorization", String.class);
         if (authHeader == null) {
             log.error("No Authorization header in request");
-            msg.setHeader("CamelHttpResponseCode", 400);
-            msg.setBody("Authorization header");
+            rejectUnauthorized(exchange, "Authorization header");
             return;
         }
 
         var toks = authHeader.split(" ");
         if (toks.length != 2 || !"Bearer".equals(toks[0])) {
-            log.error("Invalid Authorization header: {}", authHeader);
-            msg.setHeader("CamelHttpResponseCode", 400);
-            msg.setBody("Invalid Authorization header");
+            log.error("Invalid Authorization header");
+            rejectUnauthorized(exchange, "Invalid Authorization header");
             return;
         }
 

--- a/components/camel-oauth/src/main/java/org/apache/camel/oauth/OAuthCodeFlowCallback.java
+++ b/components/camel-oauth/src/main/java/org/apache/camel/oauth/OAuthCodeFlowCallback.java
@@ -39,8 +39,7 @@ public class OAuthCodeFlowCallback extends AbstractOAuthProcessor {
         var authCode = msg.getHeader("code", String.class);
         if (authCode == null) {
             log.error("Authorization code is missing in the request");
-            msg.setHeader("CamelHttpResponseCode", 400);
-            msg.setBody("Authorization code missing");
+            reject(exchange, 400, "Authorization code missing");
             return;
         }
 

--- a/components/camel-oauth/src/main/java/org/apache/camel/oauth/OAuthCodeFlowProcessor.java
+++ b/components/camel-oauth/src/main/java/org/apache/camel/oauth/OAuthCodeFlowProcessor.java
@@ -70,6 +70,9 @@ public class OAuthCodeFlowProcessor extends AbstractOAuthProcessor {
         var authRequestUrl = oauth.buildCodeFlowAuthRequestUrl(params);
 
         sendRedirect(msg, authRequestUrl);
+
+        // The caller is not authenticated: the redirect is the whole response, so the protected route must not run
+        exchange.setRouteStop(true);
     }
 
     private String getPostLoginUrl(Message msg) {

--- a/components/camel-oauth/src/test/java/org/apache/camel/oauth/OAuthProcessorFailClosedTest.java
+++ b/components/camel-oauth/src/test/java/org/apache/camel/oauth/OAuthProcessorFailClosedTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.oauth;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A request the processors do not authenticate must stop the route, so that no subsequent step runs for it. These are
+ * the paths that return before any identity provider is contacted, so they can be exercised without one.
+ */
+class OAuthProcessorFailClosedTest {
+
+    @Test
+    void missingAuthorizationHeaderStopsTheRoute() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(context);
+
+            new OAuthBearerTokenProcessor().process(exchange);
+
+            assertEquals(401, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+            assertEquals("Bearer", exchange.getMessage().getHeader("WWW-Authenticate"));
+            assertTrue(exchange.isRouteStop());
+        }
+    }
+
+    @Test
+    void nonBearerAuthorizationHeaderStopsTheRoute() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(context);
+            exchange.getMessage().setHeader("Authorization", "Basic c2NvdHQ6c2VjcmV0");
+
+            new OAuthBearerTokenProcessor().process(exchange);
+
+            assertEquals(401, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+            assertEquals("Bearer", exchange.getMessage().getHeader("WWW-Authenticate"));
+            assertTrue(exchange.isRouteStop());
+        }
+    }
+
+    @Test
+    void missingAuthorizationCodeStopsTheRoute() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(context);
+
+            new OAuthCodeFlowCallback().process(exchange);
+
+            assertEquals(400, exchange.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE));
+            assertTrue(exchange.isRouteStop());
+        }
+    }
+}


### PR DESCRIPTION
Backport of #25567 (`a3a98e4c959f`) to `camel-4.18.x`. Fixes [CAMEL-24411](https://issues.apache.org/jira/browse/CAMEL-24411) on this release line.

## What it fixes

The camel-oauth processors returned normally from `process()` on the paths where they do **not** authenticate the caller, so the rest of the route still ran — and overwrote the response the processor had just prepared. Three denial points were affected: a missing or unparseable `Authorization` header, the code-flow redirect to the IdP, and a callback without the `code` parameter. There was no `setRouteStop`, `CamelAuthorizationException` or `RoutePolicy` anywhere in camel-oauth `src/main`.

Now all three reject and stop the route; the bearer path answers `401` with a `WWW-Authenticate: Bearer` challenge (RFC 6750) instead of `400`. `sendRedirect()` and `OAuthLogoutProcessor` are unchanged, so the shipped logout flow that relies on the step after the redirect still works. Authenticated requests are unaffected.

## Deliberate differences from the main commit

1. **No upgrade-guide entry.** It stays on `main`; a doc-sync entry for this release line will be added to the matching `camel-4x-upgrade-guide` file there, per the project's guide policy.
2. **JUnit assertions instead of AssertJ.** `camel-oauth` has no `assertj-core` on this branch (nor on any maintenance branch — it was added to the pom on main). Rather than introduce a test dependency in a patch release, `OAuthProcessorFailClosedTest` uses JUnit assertions here and `pom.xml` is untouched.

## Verification on this branch

```
mvn -pl components/camel-oauth -am install -DskipTests   # OK
mvn test -Dtest=OAuthProcessorFailClosedTest             # 3 passed
```

Diff is 5 files, camel-oauth only — no generated-file drift.

---
_Claude Code on behalf of 