### PR TITLE
[backport camel-4.14.x] CAMEL-24348: camel-google-bigquery - report unusable bodies and missing jobs properly

### DIFF
--- a/components/camel-google/camel-google-bigquery/pom.xml
+++ b/components/camel-google/camel-google-bigquery/pom.xml
@@ -63,5 +63,10 @@
             <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/GoogleBigQueryProducer.java
+++ b/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/GoogleBigQueryProducer.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.support.DefaultProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
@@ -129,13 +130,16 @@ public class GoogleBigQueryProducer extends DefaultProducer {
         for (Exchange ex : exchanges) {
             Object entryObject = ex.getIn().getBody();
             if (entryObject instanceof List) {
+                // the insert id header identifies one row, so it is not applied to the rows of a list: BigQuery
+                // would treat them as duplicates of each other and keep only one. Use useAsInsertId for those
                 for (Map<String, Object> entry : (List<Map<String, Object>>) entryObject) {
                     apiRequestRows.add(createRowRequest(null, entry));
                 }
             } else if (entryObject instanceof Map) {
                 apiRequestRows.add(createRowRequest(ex, (Map<String, Object>) entryObject));
             } else {
-                ex.setException(new IllegalArgumentException("Cannot handle body type " + entryObject.getClass()));
+                ex.setException(new IllegalArgumentException(
+                        "Cannot handle body type " + (entryObject == null ? "null" : entryObject.getClass().getName())));
             }
         }
 
@@ -160,7 +164,7 @@ public class GoogleBigQueryProducer extends DefaultProducer {
         InsertAllResponse apiResponse = bigquery.insertAll(insertAllRequest);
 
         if (apiResponse.getInsertErrors() != null && !apiResponse.getInsertErrors().isEmpty()) {
-            throw new Exception("InsertAll into " + tableId + " failed: " + apiResponse.getInsertErrors());
+            throw new RuntimeCamelException("InsertAll into " + tableId + " failed: " + apiResponse.getInsertErrors());
         }
 
         if (LOG.isTraceEnabled()) {

--- a/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLProducer.java
+++ b/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/GoogleBigQuerySQLProducer.java
@@ -39,6 +39,7 @@ import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.component.google.bigquery.GoogleBigQueryConstants;
 import org.apache.camel.support.DefaultProducer;
@@ -130,6 +131,10 @@ public class GoogleBigQuerySQLProducer extends DefaultProducer {
             }
 
             Job job = bigquery.create(JobInfo.of(queryJobId, queryJobConfiguration)).waitFor();
+            if (job == null) {
+                // waitFor returns null when the job does not exist any more, for example when it expired
+                throw new RuntimeCamelException("BigQuery job " + queryJobId + " is no longer available");
+            }
             JobStatistics.QueryStatistics statistics = job.getStatistics();
             TableResult result;
             if (pageToken != null) {
@@ -150,9 +155,9 @@ public class GoogleBigQuerySQLProducer extends DefaultProducer {
             //in other cases (SELECT), process results
             return result;
         } catch (JobException e) {
-            throw new Exception("Query " + translatedQuery + " failed: " + e.getErrors(), e);
+            throw new RuntimeCamelException("Query " + translatedQuery + " failed: " + e.getErrors(), e);
         } catch (BigQueryException e) {
-            throw new Exception("Query " + translatedQuery + " failed: " + e.getError(), e);
+            throw new RuntimeCamelException("Query " + translatedQuery + " failed: " + e.getError(), e);
         }
     }
 

--- a/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/GoogleBigQueryProducerBodyTypeTest.java
+++ b/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/GoogleBigQueryProducerBodyTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.bigquery.unit;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies what the producer reports for a body it cannot turn into rows.
+ */
+class GoogleBigQueryProducerBodyTypeTest extends BaseBigQueryTest {
+
+    @Test
+    void aBodyThatIsNotAMapOrAListIsReported() throws Exception {
+        Exchange exchange = createExchangeWithBody("not a row");
+        producer.process(exchange);
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot handle body type java.lang.String");
+    }
+
+    @Test
+    void aMissingBodyIsReportedInsteadOfFailingWithANullPointer() throws Exception {
+        Exchange exchange = createExchangeWithBody(null);
+        producer.process(exchange);
+
+        assertThat(exchange.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot handle body type null");
+    }
+}


### PR DESCRIPTION
Backport of #25448 (merged on `main`).

A message with no body failed with a `NullPointerException` while building the "Cannot handle body type" error, an unknown job id was dereferenced unchecked, and the producers threw raw `java.lang.Exception`.

The producer part cherry-picked cleanly. `GoogleBigQuerySQLProducer` is a different implementation on this branch (it creates and waits for the job inline instead of the `executeJob`/`getTableResult` split), so the same two guards were applied by hand there: a null result from `waitFor()` is reported instead of dereferenced, and the two `throw new Exception` become `RuntimeCamelException`. Module tests and the full reactor build are green on this branch.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)