### PR TITLE
CAMEL-24416: camel-core - align the XmlConverter SAX factory with the DOM factory on external resources

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/converter/jaxp/SaxParserFactoryHardeningTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/converter/jaxp/SaxParserFactoryHardeningTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.converter.jaxp;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The SAX factory and the DOM factory in {@link XmlConverter} are both reachable from a converted message body, so they
+ * must not disagree about external-resource resolution. The DOM factory has always blocked it; the SAX factory only
+ * blocked general entities.
+ * <p/>
+ * These assertions are on the factory configuration rather than on parse behaviour deliberately: whether a given JDK
+ * would have fetched the resource anyway varies by version, and the point is that Camel states the intent itself.
+ */
+class SaxParserFactoryHardeningTest {
+
+    private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+    private static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+    @Test
+    void saxFactoryBlocksExternalResourceResolution() throws Exception {
+        SAXParserFactory factory = new XmlConverter().createSAXParserFactory();
+
+        assertThat(factory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING)).isTrue();
+        assertThat(factory.getFeature(EXTERNAL_GENERAL_ENTITIES)).isFalse();
+        assertThat(factory.getFeature(EXTERNAL_PARAMETER_ENTITIES)).isFalse();
+        assertThat(factory.getFeature(LOAD_EXTERNAL_DTD)).isFalse();
+    }
+
+    @Test
+    void saxFactoryAgreesWithTheDomFactoryOnSharedFeatures() throws Exception {
+        SAXParserFactory sax = new XmlConverter().createSAXParserFactory();
+        var dom = new XmlConverter().createDocumentBuilderFactory();
+
+        assertThat(sax.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING))
+                .isEqualTo(dom.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+        assertThat(sax.getFeature(EXTERNAL_GENERAL_ENTITIES))
+                .isEqualTo(dom.getFeature(EXTERNAL_GENERAL_ENTITIES));
+    }
+}

--- a/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
+++ b/core/camel-xml-jaxp/src/main/java/org/apache/camel/converter/jaxp/XmlConverter.java
@@ -1205,6 +1205,18 @@ public class XmlConverter {
             LOG.warn("SAXParser doesn't support the feature {} with value {}, due to {}.",
                     "http://xml.org/sax/features/external-general-entities", false, e.getMessage());
         }
+        try {
+            sfactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        } catch (Exception e) {
+            LOG.warn("SAXParser doesn't support the feature {} with value {}, due to {}.",
+                    "http://xml.org/sax/features/external-parameter-entities", false, e.getMessage());
+        }
+        try {
+            sfactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (Exception e) {
+            LOG.warn("SAXParser doesn't support the feature {} with value {}, due to {}.",
+                    "http://apache.org/xml/features/nonvalidating/load-external-dtd", false, e.getMessage());
+        }
         sfactory.setNamespaceAware(true);
         return sfactory;
     }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -202,6 +202,25 @@ Routes that relied on steps after these processors running for unauthenticated r
 restructured. The authenticated paths are unchanged: a successfully authenticated request continues
 through the rest of the route exactly as before, and `OAuthLogoutProcessor` is unchanged.
 
+=== camel-core - XmlConverter SAX parser factory
+
+`XmlConverter.createSAXParserFactory()` now also disables external parameter entities and external
+DTD loading:
+
+* `http://xml.org/sax/features/external-parameter-entities` = `false`
+* `http://apache.org/xml/features/nonvalidating/load-external-dtd` = `false`
+
+It previously set only `FEATURE_SECURE_PROCESSING` and `external-general-entities=false`, while
+`createDocumentBuilderFactory()` in the same class already blocked external resource resolution more
+thoroughly. Both factories are reachable from a converted message body — `toSAXSource` is a
+registered converter, and the SAXSource route is tried first for bodies reaching camel-xslt — so the
+two should not disagree.
+
+Documents carrying an internal DTD subset still parse: `disallow-doctype-decl` is deliberately not
+set here, because that would reject input that parses today. Routes that genuinely need to resolve
+an external DTD or parameter entity through this converter must supply their own
+`SAXParserFactory`.
+
 === camel-netty-http
 
 The security-constraint lookup now strips the endpoint context-path from the request target


### PR DESCRIPTION
Fixes [CAMEL-24416](https://issues.apache.org/jira/browse/CAMEL-24416).

## Problem

`XmlConverter` holds two factory builders whose hardening has drifted apart.

| | `createDocumentBuilderFactory()` | `createSAXParserFactory()` |
|---|---|---|
| `FEATURE_SECURE_PROCESSING` | ✅ | ✅ |
| `external-general-entities=false` | ✅ | ✅ |
| `disallow-doctype-decl=true` | ✅ | ✖ |
| `external-parameter-entities=false` | — | ✖ |
| `load-external-dtd=false` | — | ✖ |
| Xerces security manager | ✅ | ✖ |
| `setupFeatures()` (system-property tuning) | ✅ | ✖ |

Both are reachable from a converted message body — `toSAXSource` is a registered converter and the SAXSource route is tried first for bodies reaching camel-xslt — so the two should not disagree about external resource resolution.

## Change

Adds the two features that close the difference:

```
http://xml.org/sax/features/external-parameter-entities   = false
http://apache.org/xml/features/nonvalidating/load-external-dtd = false
```

## What I deliberately did *not* do, and why

- **`disallow-doctype-decl` is not set here.** The DOM factory sets it, and adding it would make the two identical — but it would reject documents carrying an internal DTD subset that parse today. That is a separate, breaking decision and belongs in its own change with an upgrade-guide entry.
- **`setupFeatures()` is not reused.** It looks like the obvious route to parity, but it is `DocumentBuilderFactory`-typed and driven by the `DOCUMENT_BUILDER_FACTORY_FEATURE` system-property namespace. Applying it to a SAX factory would be wrong, not merely inconvenient.
- **The Xerces security-manager attribute is DOM-only** for the same reason — `SAXParserFactory` has no `setAttribute` equivalent. Worth a follow-up if wanted.

## Tests

`SaxParserFactoryHardeningTest` asserts the **factory configuration** rather than parse behaviour, on purpose: whether a given JDK would have resolved the external resource anyway varies by version, so configuration is what Camel can state and keep. Verified it catches the regression — with the change reverted, `saxFactoryBlocksExternalResourceResolution` fails with *"Expecting value to be false but was true"*.

```
mvn test -Dtest=SaxParserFactoryHardeningTest   # 2 passed
mvn clean install -DskipTests                   # full reactor, BUILD SUCCESS
```

## Backport

The two added features do not reject anything that parses today, so this is **backport-safe to camel-4.22.x / 4.18.x / 4.14.x**. Continues the parser-consistency work in CAMEL-24299.

---
_Claude Code on behalf of 