### PR TITLE
CAMEL-24420: camel-hazelcast - apply the default serialization filter to Camel-built client configurations

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultComponent.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultComponent.java
@@ -217,6 +217,7 @@ public abstract class HazelcastDefaultComponent extends DefaultComponent {
                 // Disable the version check
                 config.getProperties().setProperty("hazelcast.version.check.enabled", "false");
                 config.getProperties().setProperty("hazelcast.phone.home.enabled", "false");
+                HazelcastSerializationFilterHelper.applyDefault(config);
 
                 hzInstance = HazelcastClient.newHazelcastClient(config);
             } else if (config != null) {

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelper.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelper.java
@@ -16,18 +16,19 @@
  */
 package org.apache.camel.component.hazelcast;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.SerializationConfig;
 
 /**
- * Applies a default {@link JavaSerializationFilterConfig} to Hazelcast {@link Config} instances built by Camel when the
- * user has not configured one. The default whitelists {@code java.}, {@code javax.} and {@code org.apache.camel.} class
- * name prefixes and blacklists {@code java.net.}.
+ * Applies a default {@link JavaSerializationFilterConfig} to Hazelcast {@link Config} and {@link ClientConfig}
+ * instances built by Camel when the user has not configured one. The default whitelists {@code java.}, {@code javax.}
+ * and {@code org.apache.camel.} class name prefixes and blacklists {@code java.net.}.
  * <p>
- * If the supplied {@link Config} already declares a {@link JavaSerializationFilterConfig} (e.g. provided by the user
- * via a reference or XML/YAML configuration), it is left untouched.
+ * If the supplied configuration already declares a {@link JavaSerializationFilterConfig} (e.g. provided by the user via
+ * a reference or XML/YAML configuration), it is left untouched.
  */
 public final class HazelcastSerializationFilterHelper {
 
@@ -46,7 +47,22 @@ public final class HazelcastSerializationFilterHelper {
         if (config == null) {
             return;
         }
-        SerializationConfig serializationConfig = config.getSerializationConfig();
+        applyDefaultFilter(config.getSerializationConfig());
+    }
+
+    /**
+     * Applies the default {@link JavaSerializationFilterConfig} on the {@link SerializationConfig} of the given
+     * {@link ClientConfig} when one is not already set. Has no effect when {@code config} is {@code null} or the user
+     * has already configured a {@link JavaSerializationFilterConfig}.
+     */
+    public static void applyDefault(ClientConfig config) {
+        if (config == null) {
+            return;
+        }
+        applyDefaultFilter(config.getSerializationConfig());
+    }
+
+    private static void applyDefaultFilter(SerializationConfig serializationConfig) {
         if (serializationConfig == null) {
             return;
         }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelperTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelperTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.camel.component.hazelcast;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -67,7 +69,35 @@ class HazelcastSerializationFilterHelperTest {
     }
 
     @Test
+    void appliesDefaultToClientConfigWhenNoneConfigured() {
+        ClientConfig config = new ClientConfig();
+        assertThat(config.getSerializationConfig().getJavaSerializationFilterConfig()).isNull();
+
+        HazelcastSerializationFilterHelper.applyDefault(config);
+
+        JavaSerializationFilterConfig filter = config.getSerializationConfig().getJavaSerializationFilterConfig();
+        assertThat(filter).isNotNull();
+        assertThat(filter.getWhitelist().getPrefixes()).contains("java.", "javax.", "org.apache.camel.");
+        assertThat(filter.getBlacklist().getPrefixes()).contains("java.net.");
+    }
+
+    @Test
+    void respectsExistingUserConfigurationOnClientConfig() {
+        ClientConfig config = new ClientConfig();
+        JavaSerializationFilterConfig userFilter = new JavaSerializationFilterConfig();
+        userFilter.setWhitelist(new ClassFilter().addPrefixes("com.example."));
+        config.getSerializationConfig().setJavaSerializationFilterConfig(userFilter);
+
+        HazelcastSerializationFilterHelper.applyDefault(config);
+
+        assertThat(config.getSerializationConfig().getJavaSerializationFilterConfig()).isSameAs(userFilter);
+        assertThat(userFilter.getWhitelist().getPrefixes()).containsExactly("com.example.");
+    }
+
+    @Test
     void handlesNullConfigGracefully() {
-        assertDoesNotThrow(() -> HazelcastSerializationFilterHelper.applyDefault(null));
+        assertThatCode(() -> HazelcastSerializationFilterHelper.applyDefault((Config) null)).doesNotThrowAnyException();
+        assertThatCode(() -> HazelcastSerializationFilterHelper.applyDefault((ClientConfig) null))
+                .doesNotThrowAnyException();
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -81,6 +81,10 @@ Applications that aggregate classes outside the default whitelist through the re
 without supplying their own `hazelcastInstance` must now provide a `Config` with a
 `JavaSerializationFilterConfig` covering their class names.
 
+The same default is now also applied to the `ClientConfig` that Camel builds for `hazelcastMode=client`
+endpoints, when neither a referenced `ClientConfig` nor `hazelcastConfigUri` is supplied. Client mode
+previously behaved differently from node mode for an otherwise identical endpoint configuration.
+
 === camel-mail
 
 `MimeMultipartDataFormat` now uses `MailHeaderFilterStrategy` instead of a plain


### PR DESCRIPTION
## What

CAMEL-23414 added `HazelcastSerializationFilterHelper.applyDefault(Config)` and applied it to the
Hazelcast configurations Camel builds itself, i.e. when the user supplies neither a `Config` nor a
`HazelcastInstance`. CAMEL-24413 then covered `ReplicatedHazelcastAggregationRepository#doStart()`,
which had been missed because it overrides `doStart()` without calling `super.doStart()`.

One Camel-built configuration path was still not covered.

`HazelcastDefaultComponent#getOrCreateHzClientInstance()` builds `new XmlClientConfigBuilder().build()`
when `hazelcastMode=client` and neither a referenced `ClientConfig` nor `hazelcastConfigUri` is supplied,
and created the client without a default `JavaSerializationFilterConfig`. The node-mode counterpart
`getOrCreateHzInstance()` has applied one since CAMEL-23414, so the two modes behaved differently for an
otherwise identical endpoint configuration.

## Changes

- Added an `applyDefault(ClientConfig)` overload to `HazelcastSerializationFilterHelper`. Both public
  overloads now share a private `applyDefaultFilter(SerializationConfig)`; `ClientConfig` exposes the
  same `SerializationConfig` as `Config`, so no logic is duplicated.
- Called it on the Camel-built branch of `getOrCreateHzClientInstance()`, mirroring
  `getOrCreateHzInstance()`.
- Extended `HazelcastSerializationFilterHelperTest` with the two `ClientConfig` cases (default applied,
  user configuration respected). The existing `handlesNullConfigGracefully` test now casts its argument,
  because the new overload makes an untyped `null` ambiguous.
- Extended the existing `camel-hazelcast` section of the 4.23 upgrade guide rather than adding a second
  one, so the anchor stays unique.

A user-supplied `ClientConfig` or a pre-built `HazelcastInstance` is left untouched, as established by
CAMEL-23414.

## Testing

`mvn test` in `components/camel-hazelcast`: **224/224 pass**, including the 5 helper tests and the 2
repository bootstrap tests. `mvn formatter:format impsort:sort` produces no further changes.

## Backports

Branches for `camel-4.22.x`, `camel-4.18.x` and `camel-4.14.x` are prepared and tested locally; each
stacks this change on top of the CAMEL-24413 backport, since the two edit the same upgrade-guide section.
They will be opened once this PR is merged.

JIRA: https://issues.apache.org/jira/browse/CAMEL-24420

---
_Claude Code on behalf of oscerd_