### PR TITLE
[backport camel-4.22.x] CAMEL-24413/CAMEL-24420: camel-hazelcast - apply the default serialization filter to the remaining Camel-built configurations

### DIFF
--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultComponent.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastDefaultComponent.java
@@ -217,6 +217,7 @@ public abstract class HazelcastDefaultComponent extends DefaultComponent {
                 // Disable the version check
                 config.getProperties().setProperty("hazelcast.version.check.enabled", "false");
                 config.getProperties().setProperty("hazelcast.phone.home.enabled", "false");
+                HazelcastSerializationFilterHelper.applyDefault(config);
 
                 hzInstance = HazelcastClient.newHazelcastClient(config);
             } else if (config != null) {

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelper.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelper.java
@@ -16,18 +16,19 @@
  */
 package org.apache.camel.component.hazelcast;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.SerializationConfig;
 
 /**
- * Applies a default {@link JavaSerializationFilterConfig} to Hazelcast {@link Config} instances built by Camel when the
- * user has not configured one. The default whitelists {@code java.}, {@code javax.} and {@code org.apache.camel.} class
- * name prefixes and blacklists {@code java.net.}.
+ * Applies a default {@link JavaSerializationFilterConfig} to Hazelcast {@link Config} and {@link ClientConfig}
+ * instances built by Camel when the user has not configured one. The default whitelists {@code java.}, {@code javax.}
+ * and {@code org.apache.camel.} class name prefixes and blacklists {@code java.net.}.
  * <p>
- * If the supplied {@link Config} already declares a {@link JavaSerializationFilterConfig} (e.g. provided by the user
- * via a reference or XML/YAML configuration), it is left untouched.
+ * If the supplied configuration already declares a {@link JavaSerializationFilterConfig} (e.g. provided by the user via
+ * a reference or XML/YAML configuration), it is left untouched.
  */
 public final class HazelcastSerializationFilterHelper {
 
@@ -46,7 +47,22 @@ public final class HazelcastSerializationFilterHelper {
         if (config == null) {
             return;
         }
-        SerializationConfig serializationConfig = config.getSerializationConfig();
+        applyDefaultFilter(config.getSerializationConfig());
+    }
+
+    /**
+     * Applies the default {@link JavaSerializationFilterConfig} on the {@link SerializationConfig} of the given
+     * {@link ClientConfig} when one is not already set. Has no effect when {@code config} is {@code null} or the user
+     * has already configured a {@link JavaSerializationFilterConfig}.
+     */
+    public static void applyDefault(ClientConfig config) {
+        if (config == null) {
+            return;
+        }
+        applyDefaultFilter(config.getSerializationConfig());
+    }
+
+    private static void applyDefaultFilter(SerializationConfig serializationConfig) {
         if (serializationConfig == null) {
             return;
         }

--- a/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/ReplicatedHazelcastAggregationRepository.java
+++ b/components/camel-hazelcast/src/main/java/org/apache/camel/processor/aggregate/hazelcast/ReplicatedHazelcastAggregationRepository.java
@@ -31,6 +31,7 @@ import com.hazelcast.transaction.TransactionalMap;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.component.hazelcast.HazelcastSerializationFilterHelper;
 import org.apache.camel.spi.OptimisticLockingAggregationRepository;
 import org.apache.camel.spi.RecoverableAggregationRepository;
 import org.apache.camel.support.DefaultExchangeHolder;
@@ -342,6 +343,7 @@ public class ReplicatedHazelcastAggregationRepository extends HazelcastAggregati
             useLocalHzInstance = true;
             Config cfg = new XmlConfigBuilder().build();
             cfg.setProperty("hazelcast.version.check.enabled", "false");
+            HazelcastSerializationFilterHelper.applyDefault(cfg);
             hazelcastInstance = Hazelcast.newHazelcastInstance(cfg);
         } else {
             ObjectHelper.notNull(hazelcastInstance, "hazelcastInstance");

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelperTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/component/hazelcast/HazelcastSerializationFilterHelperTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.camel.component.hazelcast;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -67,7 +69,35 @@ class HazelcastSerializationFilterHelperTest {
     }
 
     @Test
+    void appliesDefaultToClientConfigWhenNoneConfigured() {
+        ClientConfig config = new ClientConfig();
+        assertThat(config.getSerializationConfig().getJavaSerializationFilterConfig()).isNull();
+
+        HazelcastSerializationFilterHelper.applyDefault(config);
+
+        JavaSerializationFilterConfig filter = config.getSerializationConfig().getJavaSerializationFilterConfig();
+        assertThat(filter).isNotNull();
+        assertThat(filter.getWhitelist().getPrefixes()).contains("java.", "javax.", "org.apache.camel.");
+        assertThat(filter.getBlacklist().getPrefixes()).contains("java.net.");
+    }
+
+    @Test
+    void respectsExistingUserConfigurationOnClientConfig() {
+        ClientConfig config = new ClientConfig();
+        JavaSerializationFilterConfig userFilter = new JavaSerializationFilterConfig();
+        userFilter.setWhitelist(new ClassFilter().addPrefixes("com.example."));
+        config.getSerializationConfig().setJavaSerializationFilterConfig(userFilter);
+
+        HazelcastSerializationFilterHelper.applyDefault(config);
+
+        assertThat(config.getSerializationConfig().getJavaSerializationFilterConfig()).isSameAs(userFilter);
+        assertThat(userFilter.getWhitelist().getPrefixes()).containsExactly("com.example.");
+    }
+
+    @Test
     void handlesNullConfigGracefully() {
-        assertDoesNotThrow(() -> HazelcastSerializationFilterHelper.applyDefault(null));
+        assertThatCode(() -> HazelcastSerializationFilterHelper.applyDefault((Config) null)).doesNotThrowAnyException();
+        assertThatCode(() -> HazelcastSerializationFilterHelper.applyDefault((ClientConfig) null))
+                .doesNotThrowAnyException();
     }
 }

--- a/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositorySerializationFilterTest.java
+++ b/components/camel-hazelcast/src/test/java/org/apache/camel/processor/aggregate/hazelcast/HazelcastAggregationRepositorySerializationFilterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.hazelcast;
+
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Both aggregation repositories bootstrap their own Hazelcast instance when none is injected.
+ * {@link ReplicatedHazelcastAggregationRepository} overrides {@code doStart()} without calling {@code super.doStart()},
+ * so the two bootstrap paths have to be asserted separately to keep them from drifting apart again.
+ */
+class HazelcastAggregationRepositorySerializationFilterTest {
+
+    @Test
+    void locallyInitializedInstanceCarriesTheDefaultFilter() throws Exception {
+        assertDefaultFilterApplied(new HazelcastAggregationRepository("hzFilterRepoMap"));
+    }
+
+    @Test
+    void replicatedLocallyInitializedInstanceCarriesTheDefaultFilter() throws Exception {
+        assertDefaultFilterApplied(new ReplicatedHazelcastAggregationRepository("hzFilterReplicatedRepoMap"));
+    }
+
+    private static void assertDefaultFilterApplied(HazelcastAggregationRepository repo) throws Exception {
+        repo.doStart();
+        try {
+            JavaSerializationFilterConfig filter = repo.getHazelcastInstance()
+                    .getConfig().getSerializationConfig().getJavaSerializationFilterConfig();
+
+            assertThat(filter).isNotNull();
+            assertThat(filter.getWhitelist().getPrefixes()).contains("java.", "javax.", "org.apache.camel.");
+            assertThat(filter.getBlacklist().getPrefixes()).contains("java.net.");
+        } finally {
+            repo.doStop();
+        }
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -11,6 +11,24 @@ Note that manual migration is still required.
 See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 ====
 
+== Upgrading from 4.22.0 to 4.22.1
+
+=== camel-hazelcast - ReplicatedHazelcastAggregationRepository now applies the default serialization filter
+
+`ReplicatedHazelcastAggregationRepository` now applies the same default
+`JavaSerializationFilterConfig` that the other repositories and the component endpoints have applied
+since 4.14.8/4.18.3/4.21.0, when it bootstraps its own `HazelcastInstance` (that is, when no
+`hazelcastInstance` is supplied). It overrides `doStart()` without calling `super.doStart()` and was
+therefore left out of that change.
+
+The default whitelists the class name prefixes `java.`, `javax.`, `org.apache.camel.` and blacklists
+`java.net.`, and a user-supplied `JavaSerializationFilterConfig` is still respected and never
+overwritten.
+
+Applications that aggregate classes outside the default whitelist through the replicated repository
+without supplying their own `hazelcastInstance` must now provide a `Config` with a
+`JavaSerializationFilterConfig` covering their class names.
+
 == Upgrading Camel 4.21 to 4.22
 
 === camel-reactive-executor-tomcat

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -29,6 +29,10 @@ Applications that aggregate classes outside the default whitelist through the re
 without supplying their own `hazelcastInstance` must now provide a `Config` with a
 `JavaSerializationFilterConfig` covering their class names.
 
+The same default is now also applied to the `ClientConfig` that Camel builds for `hazelcastMode=client`
+endpoints, when neither a referenced `ClientConfig` nor `hazelcastConfigUri` is supplied. Client mode
+previously behaved differently from node mode for an otherwise identical endpoint configuration.
+
 == Upgrading Camel 4.21 to 4.22
 
 === camel-reactive-executor-tomcat


### PR DESCRIPTION
Backport of CAMEL-24413 (#25566) and CAMEL-24420 (#25595) to `camel-4.22.x`.

Both fixes complete the work started in CAMEL-23414, which applied a default
`JavaSerializationFilterConfig` to the Hazelcast configurations Camel builds itself — that is, when the
user supplies neither a `Config`/`ClientConfig` nor a `HazelcastInstance`. Two Camel-built paths were
missed at the time and are still unfiltered on this branch.

## CAMEL-24413 — ReplicatedHazelcastAggregationRepository

The class extends `HazelcastAggregationRepository` but overrides `doStart()` without calling
`super.doStart()`, so it kept its own copy of the bootstrap block and never picked up the CAMEL-23414
change. `HazelcastSerializationFilterHelper.applyDefault(cfg)` is now applied before
`Hazelcast.newHazelcastInstance(cfg)`, matching the parent class.

The added test asserts **both** repository bootstrap paths, so they cannot drift apart again.

## CAMEL-24420 — Camel-built client configurations

`HazelcastDefaultComponent#getOrCreateHzClientInstance()` builds `new XmlClientConfigBuilder().build()`
for `hazelcastMode=client` when neither a referenced `ClientConfig` nor `hazelcastConfigUri` is supplied,
and applied no filter. The node-mode counterpart has applied one since CAMEL-23414, so the two modes
behaved differently for an otherwise identical endpoint configuration.

An `applyDefault(ClientConfig)` overload was added, sharing the existing logic through a private
`applyDefaultFilter(SerializationConfig)`.

A user-supplied `Config`/`ClientConfig` or a pre-built `HazelcastInstance` is left untouched throughout,
as established by CAMEL-23414.

## Differences from the main-branch commits

- The upgrade-guide entries live in `camel-4x-upgrade-guide-4_22.adoc` under a new `4.22.0 to 4.22.1` section instead of the 4.23 guide.

The two commits are stacked in one PR on purpose: they edit the same upgrade-guide section, so separate
branches would conflict on merge.

## Testing

`mvn test` in `components/camel-hazelcast` on this branch: the 5 `HazelcastSerializationFilterHelperTest`
cases and the 2 `HazelcastAggregationRepositorySerializationFilterTest` cases all pass.

JIRA: https://issues.apache.org/jira/browse/CAMEL-24413 and
https://issues.apache.org/jira/browse/CAMEL-24420

---
_Claude Code on behalf of oscerd_