### PR TITLE
[backport camel-4.22.x] CAMEL-24347: camel-google-firestore - listCollections honours the configured documentId

### DIFF
--- a/components/camel-google/camel-google-firestore/pom.xml
+++ b/components/camel-google/camel-google-firestore/pom.xml
@@ -71,5 +71,10 @@
             <artifactId>camel-test-junit6</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-google/camel-google-firestore/src/main/java/org/apache/camel/component/google/firestore/GoogleFirestoreProducer.java
+++ b/components/camel-google/camel-google-firestore/src/main/java/org/apache/camel/component/google/firestore/GoogleFirestoreProducer.java
@@ -243,16 +243,24 @@ public class GoogleFirestoreProducer extends DefaultProducer {
         List<Map<String, Object>> results = new ArrayList<>();
 
         for (QueryDocumentSnapshot document : querySnapshot.getDocuments()) {
-            Map<String, Object> docData = document.getData();
-            docData.put("_id", document.getId());
-            docData.put("_path", document.getReference().getPath());
-            results.add(docData);
+            results.add(withDocumentMetadata(document));
         }
 
         LOG.debug("Query returned {} documents from collection: {}", results.size(), collectionName);
 
         Message message = getMessageForResponse(exchange);
         message.setBody(results);
+    }
+
+    /**
+     * The document data plus its id and path. The snapshot data is copied first: the returned map is handed to the
+     * route, and the id/path entries must not be written into the object the SDK gave us.
+     */
+    private static Map<String, Object> withDocumentMetadata(QueryDocumentSnapshot document) {
+        Map<String, Object> docData = new HashMap<>(document.getData());
+        docData.put("_id", document.getId());
+        docData.put("_path", document.getReference().getPath());
+        return docData;
     }
 
     private Query applyWhereClause(Query query, String field, String operator, Object value) {
@@ -291,10 +299,7 @@ public class GoogleFirestoreProducer extends DefaultProducer {
         List<Map<String, Object>> results = new ArrayList<>();
 
         for (QueryDocumentSnapshot document : querySnapshot.getDocuments()) {
-            Map<String, Object> docData = document.getData();
-            docData.put("_id", document.getId());
-            docData.put("_path", document.getReference().getPath());
-            results.add(docData);
+            results.add(withDocumentMetadata(document));
         }
 
         LOG.debug("Listed {} documents from collection: {}", results.size(), collectionName);
@@ -304,7 +309,7 @@ public class GoogleFirestoreProducer extends DefaultProducer {
     }
 
     private void listCollections(Firestore firestore, Exchange exchange) throws Exception {
-        String documentId = exchange.getIn().getHeader(GoogleFirestoreConstants.DOCUMENT_ID, String.class);
+        String documentId = determineListedDocumentId(exchange);
         List<String> collectionIds = new ArrayList<>();
 
         Iterable<CollectionReference> collections;
@@ -382,6 +387,19 @@ public class GoogleFirestoreProducer extends DefaultProducer {
             throw new IllegalArgumentException("Collection name must be specified.");
         }
         return collectionName;
+    }
+
+    /**
+     * The document id for listCollections, where it is optional: without one the root collections are listed. Unlike
+     * {@link #determineDocumentId(Exchange)} this does not fail when none is set, but it does fall back to the
+     * configured id the same way.
+     */
+    String determineListedDocumentId(Exchange exchange) {
+        String documentId = exchange.getIn().getHeader(GoogleFirestoreConstants.DOCUMENT_ID, String.class);
+        if (ObjectHelper.isEmpty(documentId)) {
+            documentId = getConfiguration().getDocumentId();
+        }
+        return documentId;
     }
 
     private String determineDocumentId(Exchange exchange) {

--- a/components/camel-google/camel-google-firestore/src/test/java/org/apache/camel/component/google/firestore/GoogleFirestoreProducerDocumentIdTest.java
+++ b/components/camel-google/camel-google-firestore/src/test/java/org/apache/camel/component/google/firestore/GoogleFirestoreProducerDocumentIdTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.firestore;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the operations resolve the document id the same way: the header first, then the endpoint option.
+ */
+class GoogleFirestoreProducerDocumentIdTest {
+
+    private DefaultCamelContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    private GoogleFirestoreProducer producer(String query) throws Exception {
+        if (context != null) {
+            context.stop();
+        }
+        context = new DefaultCamelContext();
+        // the endpoint is deliberately not started, so no firestore client is built
+        GoogleFirestoreComponent component = context.getComponent("google-firestore", GoogleFirestoreComponent.class);
+        GoogleFirestoreEndpoint endpoint
+                = (GoogleFirestoreEndpoint) component.createEndpoint("google-firestore://users" + query);
+        return new GoogleFirestoreProducer(endpoint);
+    }
+
+    @Test
+    void theConfiguredDocumentIdIsUsedWhenNoHeaderIsSet() throws Exception {
+        GoogleFirestoreProducer producer = producer("?documentId=configured");
+
+        assertThat(producer.determineListedDocumentId(new DefaultExchange(context))).isEqualTo("configured");
+    }
+
+    @Test
+    void theHeaderWinsOverTheConfiguredDocumentId() throws Exception {
+        GoogleFirestoreProducer producer = producer("?documentId=configured");
+
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setHeader(GoogleFirestoreConstants.DOCUMENT_ID, "from-header");
+
+        assertThat(producer.determineListedDocumentId(exchange)).isEqualTo("from-header");
+    }
+
+    @Test
+    void withoutAnyDocumentIdTheRootCollectionsAreListed() throws Exception {
+        // listCollections is the one operation where the document id is optional: no id means the root
+        GoogleFirestoreProducer producer = producer("");
+
+        assertThat(producer.determineListedDocumentId(new DefaultExchange(context))).isNull();
+    }
+}


### PR DESCRIPTION
Backport of #25430 (merged on `main`). This branch was missing it: the fix landed after the 4.22.0 cut,
so it is currently 4.23.0-only.

`listCollections` was the only document operation reading the document id straight from the header, so
`google-firestore:users?documentId=alice&operation=listCollections` silently listed the root
collections instead of the sub-collections of `users/alice`. It now falls back to the configured id
like every other operation, while still treating a missing id as "list the root collections".

Also in the commit: `queryCollection` and `listDocuments` no longer write their `_id`/`_path` entries
into the map returned by `QueryDocumentSnapshot.getData()` — they copy it first. Body content is
unchanged.

As on main, this does **not** touch the unbounded queue of the realtime consumer: bounding it needs a
decision on the overflow policy (drop the change or block the Firestore callback thread), which is
tracked on the JIRA issue.

Cherry-picked with no adaptation. Module tests (8) and the full reactor build are green here, with a
clean working tree afterwards.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)