### PR TITLE
Revert "Enable SjmsConnectionRecoveryTest for s390x by adding s390x container image configuration for Artemis"

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
@@ -35,6 +35,7 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +54,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Uses a real Artemis broker over TCP (via Testcontainers) so that connection close truly kills sessions and consumers,
  * matching the behavior of Oracle AQ and other remote JMS providers.
  */
+@DisabledOnOs(architectures = { "s390x" },
+              disabledReason = "The container image cannot be started for this test. Maybe because it is using the ArtemisContainer instead fo the service.")
 public class SjmsConnectionRecoveryTest extends CamelTestSupport {
 
     private static final String SJMS_QUEUE_NAME = "sjms:queue:SjmsConnectionRecoveryTest";

--- a/test-infra/camel-test-infra-artemis/src/main/resources/org/apache/camel/test/infra/artemis/services/container.properties
+++ b/test-infra/camel-test-infra-artemis/src/main/resources/org/apache/camel/test/infra/artemis/services/container.properties
@@ -16,5 +16,4 @@
 ## ---------------------------------------------------------------------------
 artemis.container=quay.io/artemiscloud/activemq-artemis-broker:latest
 artemis.container.ppc64le=icr.io/ppc64le-oss/activemq-artemis-broker-ppc64le:2.0.2
-artemis.container.s390x=icr.io/s390x-oss/activemq-artemis-broker-s390x:2.0.2
 artemis.container.version.exclude=dev,latest


### PR DESCRIPTION
Reverts apache/camel#25266

missing access authorization accesss for the image:

```
org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=icr.io/s390x-oss/activemq-artemis-broker-s390x:2.0.2, imagePullPolicy=DefaultPullPolicy(), imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@328e0f54)
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1308)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:346)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:317)
	at org.apache.camel.component.sjms.SjmsConnectionRecoveryTest.startBroker(SjmsConnectionRecoveryTest.java:68)
Caused by: com.github.dockerjava.api.exception.UnauthorizedException: Status 401: {"message":"Head \"https://icr.io/v2/s390x-oss/activemq-artemis-broker-s390x/manifests/2.0.2\": unauthorized: {\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"Authorization required. See https://cloud.ibm.com/docs/Registry?topic=Registry-troubleshoot-auth-req\",\"detail\":\"Authorization required. See https://cloud.ibm.com/docs/Registry?topic=Registry-troubleshoot-auth-req\"}]}\n"}

	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:239)
	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.lambda$executeAndStream$1(DefaultInvocationBuilder.java:269)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```