### PR TITLE
[backport camel-4.18.x] CAMEL-24350: camel-google-pubsub - stop dropping list elements and null header values

### DIFF
--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -85,5 +85,10 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubProducer.java
+++ b/components/camel-google/camel-google-pubsub/src/main/java/org/apache/camel/component/google/pubsub/GooglePubsubProducer.java
@@ -70,15 +70,21 @@ public class GooglePubsubProducer extends DefaultProducer {
         }
 
         if (exchange.getIn().getBody() instanceof List) {
-            boolean groupedExchanges = false;
-            for (Object body : exchange.getIn().getBody(List.class)) {
-                if (body instanceof Exchange) {
-                    send((Exchange) body);
-                    groupedExchanges = true;
-                }
-            }
-            if (!groupedExchanges) {
+            List<?> bodies = exchange.getIn().getBody(List.class);
+            long exchanges = bodies.stream().filter(Exchange.class::isInstance).count();
+            if (exchanges == 0) {
+                // not an aggregated list: the list itself is the payload of a single message
                 send(exchange);
+            } else if (exchanges == bodies.size()) {
+                for (Object body : bodies) {
+                    send((Exchange) body);
+                }
+            } else {
+                // a list holding both exchanges and plain payloads used to publish only the exchanges and
+                // drop the rest without a word
+                throw new IllegalArgumentException(
+                        "The body is a list mixing " + exchanges + " exchange(s) with " + (bodies.size() - exchanges)
+                                                   + " other element(s). Send either an aggregated list of exchanges or a single payload.");
             }
         } else {
             send(exchange);
@@ -127,6 +133,13 @@ public class GooglePubsubProducer extends DefaultProducer {
             String value = exchange.getIn().getHeader(camelHeader, String.class);
             if (headerFilterStrategy != null
                     && headerFilterStrategy.applyFilterToCamelHeaders(camelHeader, value, exchange)) {
+                continue;
+            }
+            if (value == null) {
+                // a pubsub attribute cannot be null, and a header that does not convert to a string is not
+                // one the message can carry
+                logger.debug("Skipping header {} as it has no string value to send as a message attribute",
+                        camelHeader);
                 continue;
             }
             messageBuilder.putAttributes(camelHeader, value);

--- a/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/unit/PubsubProducerBodyAndAttributesTest.java
+++ b/components/camel-google/camel-google-pubsub/src/test/java/org/apache/camel/component/google/pubsub/unit/PubsubProducerBodyAndAttributesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.pubsub.unit;
+
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
+import org.apache.camel.component.google.pubsub.GooglePubsubProducer;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies what the producer does with a list body that is neither a list of aggregated exchanges nor a payload.
+ */
+class PubsubProducerBodyAndAttributesTest {
+
+    private final GooglePubsubEndpoint endpoint = mock();
+    private final DefaultCamelContext context = new DefaultCamelContext();
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    @Test
+    void aListMixingExchangesAndPayloadsIsRejected() {
+        GooglePubsubProducer producer = new GooglePubsubProducer(endpoint);
+
+        Exchange grouped = new DefaultExchange(context);
+        grouped.getIn().setBody("an aggregated exchange");
+
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(List.of(grouped, "a plain payload"));
+
+        // publishing only the exchange and dropping the payload without a word is worse than refusing the body
+        assertThatThrownBy(() -> producer.process(exchange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mixing 1 exchange(s) with 1 other element(s)");
+    }
+}


### PR DESCRIPTION
Backport of #25564 (merged on `main`, 4.23.0-only until now).

Two ways the pubsub producer lost or broke a send:

* **A list body mixing aggregated exchanges with plain payloads published only the exchanges** and
  threw the rest away without a word. The producer documents two shapes — a list of aggregated
  exchanges, or a single payload — and a mixed list is neither, so it is now refused with a message
  saying how many of each it found. **Both documented shapes are unchanged:** a list of only exchanges
  still publishes one message per exchange, and a list with no exchange in it is still published as one
  payload.
* **A header that does not convert to a String failed the whole send with a `NullPointerException`**,
  because `putAttributes` rejects null. Such headers are now skipped (a Pub/Sub attribute cannot be
  null anyway) and logged at debug; headers that do convert are unaffected and the
  `HeaderFilterStrategy` still decides which ones travel.

Cherry-picked with no adaptation — the commit carries its own `assertj-core` test dependency, and
Mockito was already on this module's test classpath. Module tests and the full reactor build are green
here, with a clean working tree afterwards.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)