### PR TITLE
Pin org.apache.directory.api artifacts to 2.1.8 to remediate CVE-2026-35563

### DIFF
--- a/components/camel-ldap/pom.xml
+++ b/components/camel-ldap/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>apacheds-server-jndi</artifactId>
             <version>${apacheds-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
@@ -63,6 +69,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -70,11 +80,53 @@
             <artifactId>apacheds-core-integ</artifactId>
             <version>${apacheds-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
             <version>${mina-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-client-api</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-util</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-codec-standalone</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-sp</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-dsml-engine</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-trigger</artifactId>
+            <version>${directory-api-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-ldif/pom.xml
+++ b/components/camel-ldif/pom.xml
@@ -53,7 +53,47 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Pin org.apache.directory.api transitively brought in by apacheds-core-api
+             (dormant, no release with the fix) to remediate CVE-2026-35563 -->
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-client-api</artifactId>
+            <version>${directory-api-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-util</artifactId>
+            <version>${directory-api-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-codec-standalone</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-sp</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-dsml-engine</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-trigger</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- test dependencies -->
@@ -71,6 +111,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>
@@ -79,6 +123,12 @@
             <artifactId>apacheds-core-integ</artifactId>
             <version>${apacheds-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.mina</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -148,6 +148,7 @@
         <debezium-mysql-connector-version>26.7.0</debezium-mysql-connector-version>
         <dhis2-version>3.0.2</dhis2-version>
         <digitalocean-api-client-version>2.17</digitalocean-api-client-version>
+        <directory-api-version>2.1.8</directory-api-version>
         <directory-watcher-version>0.19.1</directory-watcher-version>
         <disruptor-version>3.4.4</disruptor-version>
         <dnsjava-version>3.6.5</dnsjava-version>


### PR DESCRIPTION
# Description

Added pin for `api-ldap-client-api` which is transitively brought from `apacheds-core-api`. ApacheDS is dormant project and it won't release new version on Github. Apache Directory API project has released 2.1.8 with fix for CVE-2026-35563.

This version bump remediates CVE-2026-35563 [NVD-CVE](https://nvd.nist.gov/vuln/detail/CVE-2026-35563).

The other 11 `org.apache.directory.api` artifacts that are used by `camel-ldif` and `camel-ldap` (`api-asn1-api`, `api-asn1-ber`, `api-i18n`, `api-ldap-codec-core`, `api-ldap-extras-aci`, `api-ldap-extras-codec`, `api-ldap-extras-codec-api`, `api-ldap-extras-util`, `api-ldap-model`, `api-ldap-schema-data`, `api-util`) are pinned to the same version to avoid running mix of 2.1.5 and 2.1.8 modules from the same library. This was done to reduce risk of runtime incompatibilities.

`org.apache.directory.api` comes transitively through `org.apache.directory.server` (ApacheDS), it is not a direct dependency of either component. `camel-ldif` uses these classes
in its main code (`LdifProducer`), `camel-ldap` pulls them for
tests.
Pins are declared in camel-ldif/pom.xml (compile scope) and camel-ldap/pom.xml (test scope) as these are the only two affected components.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

