### PR TITLE
chore(deps): Bump jolokia-version from 2.6.0 to 2.6.1

### DIFF
--- a/components/camel-platform-http-jolokia/src/main/java/org/apache/camel/component/platform/http/plugin/DefaultJolokiaPlatformHttpPlugin.java
+++ b/components/camel-platform-http-jolokia/src/main/java/org/apache/camel/component/platform/http/plugin/DefaultJolokiaPlatformHttpPlugin.java
@@ -40,6 +40,7 @@ import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.ReflectionHelper;
 import org.jolokia.core.api.LogHandler;
 import org.jolokia.server.core.config.ConfigKey;
+import org.jolokia.server.core.config.Configuration;
 import org.jolokia.server.core.config.StaticConfiguration;
 import org.jolokia.server.core.http.HttpRequestHandler;
 import org.jolokia.server.core.restrictor.AllowAllRestrictor;
@@ -62,13 +63,15 @@ public class DefaultJolokiaPlatformHttpPlugin extends ServiceSupport implements 
     private CamelContext camelContext;
     private final JolokiaServiceManager serviceManager;
     private final LogHandler jolokiaLogHandler;
+    private final Configuration config;
+    private final Restrictor restrictor;
     private HttpRequestHandler requestHandler;
     private Handler<RoutingContext> handler;
 
     public DefaultJolokiaPlatformHttpPlugin() {
-        var config = new StaticConfiguration(ConfigKey.AGENT_ID, NetworkUtil.getAgentId(hashCode(), "vertx"));
+        config = new StaticConfiguration(ConfigKey.AGENT_ID, NetworkUtil.getAgentId(hashCode(), "vertx"));
         jolokiaLogHandler = new JolokiaLogHandler(LOG);
-        var restrictor = createRestrictor(config.getConfig(ConfigKey.POLICY_LOCATION));
+        restrictor = createRestrictor(config.getConfig(ConfigKey.POLICY_LOCATION));
 
         serviceManager = JolokiaServiceManagerFactory.createJolokiaServiceManager(
                 config,
@@ -83,7 +86,8 @@ public class DefaultJolokiaPlatformHttpPlugin extends ServiceSupport implements 
     @Override
     public void doStart() {
         var jolokiaContext = serviceManager.start();
-        requestHandler = new HttpRequestHandler(jolokiaContext);
+        requestHandler
+                = new HttpRequestHandler(jolokiaContext, restrictor, config.getSecurityDetails().isAuthenticationEnabled());
         handler = createVertxHandler();
     }
 
@@ -175,8 +179,8 @@ public class DefaultJolokiaPlatformHttpPlugin extends ServiceSupport implements 
             Object json = null;
             int status = 200;
             try {
-                ObjectHelper.invokeMethodSafe("checkAccess", requestHandler, req.scheme(), req.remoteAddress().host(),
-                        req.remoteAddress().host(), getOriginOrReferer(req));
+                requestHandler.checkAccess(req.scheme(), req.remoteAddress().host(),
+                        new String[] { req.remoteAddress().host() }, getOriginOrReferer(req), null);
                 if (req.method() == HttpMethod.GET) {
                     Method m = ReflectionHelper.findMethod(requestHandler.getClass(), "handleGetRequest", String.class,
                             String.class, Map.class);

--- a/components/camel-platform-http-jolokia/src/test/java/org/apache/camel/component/platform/http/plugin/DefaultJolokiaPlatformHttpPluginTest.java
+++ b/components/camel-platform-http-jolokia/src/test/java/org/apache/camel/component/platform/http/plugin/DefaultJolokiaPlatformHttpPluginTest.java
@@ -29,6 +29,7 @@ import org.jolokia.server.core.http.HttpRequestHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -56,6 +57,17 @@ public class DefaultJolokiaPlatformHttpPluginTest extends ContextTestSupport {
 
         assertEquals("version", type);
         assertNotNull(agentVersion, "There should be an agent version");
+    }
+
+    @Test
+    void jolokiaPlatformHttpPluginCheckAccessTest() throws Exception {
+        PlatformHttpPluginRegistry registry = resolvePlatformHttpPluginRegistry();
+        DefaultJolokiaPlatformHttpPlugin plugin = registry
+                .resolvePluginById("jolokia", DefaultJolokiaPlatformHttpPlugin.class).orElseThrow();
+        HttpRequestHandler handler = plugin.getJolokiaRequestHandler();
+
+        assertDoesNotThrow(
+                () -> handler.checkAccess("http", "localhost", new String[] { "127.0.0.1" }, null, null));
     }
 
     private PlatformHttpPluginRegistry resolvePlatformHttpPluginRegistry() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -310,7 +310,7 @@
         <jline-version>4.3.1</jline-version>
         <libthrift-version>0.24.0</libthrift-version>
         <jodatime2-version>2.14.3</jodatime2-version>
-        <jolokia-version>2.6.0</jolokia-version>
+        <jolokia-version>2.6.1</jolokia-version>
         <jolt-version>0.1.8</jolt-version>
         <jool-version>0.9.15</jool-version>
         <!-- jooq 3.20 is Java 21+ only so we need to be 3.19.x -->


### PR DESCRIPTION
## Summary

Supersedes #25545 (blocked on a compile failure). This bumps `jolokia-version` from 2.6.0 to 2.6.1 and adapts `camel-platform-http-jolokia` to the Jolokia `HttpRequestHandler` API changes introduced in that release:

- The constructor now requires a `Restrictor` and an `authenticationEnabled` flag in addition to the `JolokiaContext`.
- `checkAccess()` now takes a `String[]` of addresses and an (optional) `FetchMetadata` parameter instead of a single address `String`.

`checkAccess()` is now called directly instead of through reflection, since none of its parameter types are affected by the JSON-shading concern that the reflective dispatch in this class exists for.

## Test plan

- [x] `mvn -DskipTests install` in `components/camel-platform-http-jolokia`
- [x] `mvn test` in `components/camel-platform-http-jolokia` (existing test + new regression test for `checkAccess`)

---

_Claude Code on behalf of davsclaus_