### PR TITLE
[backport camel-4.22.x] chore: fix NATS JetStream IT tests sharing a stream/durable name

### DIFF
--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerAckPolicyNoneIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerAckPolicyNoneIT.java
@@ -40,12 +40,12 @@ public class NatsJetstreamConsumerAckPolicyNoneIT extends NatsITSupport {
     @Test
     public void testConsumer() throws Exception {
         mockResultEndpoint.expectedBodiesReceived("Hello World 3");
-        mockResultEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2");
+        mockResultEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2-ackpolicynone");
         mockResultEndpoint.expectedHeaderReceived("counter", 3);
         mockResultEndpoint.expectedHeaderReceived(NatsConstants.NATS_DELIVERY_COUNTER, 1);
 
         mockInputEndpoint.expectedBodiesReceived("Hello World 1", "Hello World 2", "Hello World 3");
-        mockInputEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2");
+        mockInputEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2-ackpolicynone");
         mockInputEndpoint.message(0).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(1);
         mockInputEndpoint.message(1).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(1);
         mockInputEndpoint.message(2).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(1);
@@ -65,7 +65,7 @@ public class NatsJetstreamConsumerAckPolicyNoneIT extends NatsITSupport {
             @Override
             public void configure() {
                 String uri
-                        = "nats:mytopic2?jetstreamEnabled=true&jetstreamName=mystream2&jetstreamAsync=false&durableName=camel2&pullSubscription=false&ackPolicy=none";
+                        = "nats:mytopic2-ackpolicynone?jetstreamEnabled=true&jetstreamName=mystream2-ackpolicynone&jetstreamAsync=false&durableName=camel2-ackpolicynone&pullSubscription=false&ackPolicy=none";
 
                 from("direct:send")
                         // when running full test suite then send can fail due to nats server setup/teardown

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerMaxDeliverIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerMaxDeliverIT.java
@@ -42,7 +42,7 @@ public class NatsJetstreamConsumerMaxDeliverIT extends NatsITSupport {
         mockResultEndpoint.expectedMessageCount(0);
 
         mockInputEndpoint.expectedMessageCount(3);
-        mockInputEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2");
+        mockInputEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2-maxdeliver");
         mockInputEndpoint.message(0).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(1);
         mockInputEndpoint.message(1).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(2);
         mockInputEndpoint.message(2).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(3);
@@ -60,7 +60,7 @@ public class NatsJetstreamConsumerMaxDeliverIT extends NatsITSupport {
             @Override
             public void configure() {
                 String uri
-                        = "nats:mytopic2?jetstreamEnabled=true&jetstreamName=mystream2&jetstreamAsync=false&durableName=camel2&pullSubscription=false&nackWait=10&maxDeliver=3";
+                        = "nats:mytopic2-maxdeliver?jetstreamEnabled=true&jetstreamName=mystream2-maxdeliver&jetstreamAsync=false&durableName=camel2-maxdeliver&pullSubscription=false&nackWait=10&maxDeliver=3";
 
                 from("direct:send")
                         // when running full test suite then send can fail due to nats server setup/teardown

--- a/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerRedeliveryIT.java
+++ b/components/camel-nats/src/test/java/org/apache/camel/component/nats/jetstream/NatsJetstreamConsumerRedeliveryIT.java
@@ -40,12 +40,12 @@ public class NatsJetstreamConsumerRedeliveryIT extends NatsITSupport {
     @Test
     public void testConsumer() throws Exception {
         mockResultEndpoint.expectedBodiesReceived("Hello World");
-        mockResultEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2");
+        mockResultEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2-redelivery");
         mockResultEndpoint.expectedHeaderReceived("counter", 3);
         mockResultEndpoint.expectedHeaderReceived(NatsConstants.NATS_DELIVERY_COUNTER, 3);
 
         mockInputEndpoint.expectedMessageCount(3);
-        mockInputEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2");
+        mockInputEndpoint.expectedHeaderReceived(NatsConstants.NATS_SUBJECT, "mytopic2-redelivery");
         mockInputEndpoint.message(0).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(1);
         mockInputEndpoint.message(1).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(2);
         mockInputEndpoint.message(2).header(NatsConstants.NATS_DELIVERY_COUNTER).isEqualTo(3);
@@ -63,7 +63,7 @@ public class NatsJetstreamConsumerRedeliveryIT extends NatsITSupport {
             @Override
             public void configure() {
                 String uri
-                        = "nats:mytopic2?jetstreamEnabled=true&jetstreamName=mystream2&jetstreamAsync=false&durableName=camel2&pullSubscription=false&nackWait=10";
+                        = "nats:mytopic2-redelivery?jetstreamEnabled=true&jetstreamName=mystream2-redelivery&jetstreamAsync=false&durableName=camel2-redelivery&pullSubscription=false&nackWait=10";
 
                 from("direct:send")
                         // when running full test suite then send can fail due to nats server setup/teardown


### PR DESCRIPTION
## Backport of #25630

Cherry-pick of #25630 onto `camel-4.22.x`.

**Original PR:** #25630 - chore: fix NATS JetStream IT tests sharing a stream/durable name
**Original author:** @davsclaus
**Target branch:** `camel-4.22.x`

Verified this branch has the same collision as `main` had before the fix: `NatsJetstreamConsumerAckPolicyNoneIT`, `NatsJetstreamConsumerMaxDeliverIT`, and `NatsJetstreamConsumerRedeliveryIT` share the same JetStream stream name (`mystream2`), subject (`mytopic2`), and durable consumer name (`camel2`), with no `@DisabledIfSystemProperty` guard on this branch to mask it.

### Original description

- `NatsJetstreamConsumerAckPolicyNoneIT`, `NatsJetstreamConsumerMaxDeliverIT`, and `NatsJetstreamConsumerRedeliveryIT` all used the identical JetStream stream name (`mystream2`), subject (`mytopic2`), and durable consumer name (`camel2`).
- `NatsITSupport` doesn't tear down streams/consumers between IT classes, and `NatsConsumer.setupJetStreamConsumer()` never reconciles an already-existing durable consumer's config with a new subscribe request. Whichever of these three tests ran first bound its own `ackPolicy`/`maxDeliver` config to the shared durable consumer server-side; the next test(s) in the suite then silently bound to that stale, mismatched consumer and received zero messages.
- Fix: give each test its own unique stream/subject/durable name (`-ackpolicynone`, `-maxdeliver`, `-redelivery` suffixes), matching the convention already used correctly by the other JetStream IT tests in this package. Test-only change, no production code touched.

---

_Claude Code on behalf of davsclaus_