### PR TITLE
CAMEL-24410: Fix camel-jbang export redeliveryDelay Duration parsing

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -104,6 +104,22 @@ class ExportTest {
 
     @ParameterizedTest
     @MethodSource("runtimeProvider")
+    void shouldExportRouteConfigurationWithStringRedeliveryDelay(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportRouteConfigurationWithStringRedeliveryDelay {}", rt);
+        Export command = createCommand(rt,
+                new String[] { "src/test/resources/route-configuration-redelivery-delay.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        assertThat(exit).isZero();
+        Model model = readMavenModel();
+        assertThat(model.getGroupId()).isEqualTo("examples");
+        assertThat(model.getArtifactId()).isEqualTo("route");
+        assertThat(model.getVersion()).isEqualTo("1.0.0");
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
     public void shouldExportDifferentVersion(RuntimeType rt) throws Exception {
         LOG.info("shouldExportDifferentVersion {}", rt);
         // only test for main/spring-boot

--- a/dsl/camel-jbang/camel-jbang-core/src/test/resources/route-configuration-redelivery-delay.yaml
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/resources/route-configuration-redelivery-delay.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- routeConfiguration:
+    errorHandler:
+      id: errorHandlerf23c
+      deadLetterChannel:
+        id: deadLetterChannelda61
+        deadLetterUri: direct:defaultDLQ
+        redeliveryPolicy:
+          id: redeliveryPolicybe2a
+          maximumRedeliveries: 0
+          redeliveryDelay: "500"
+- route:
+    id: testRoute
+    from:
+      uri: direct:start
+      steps:
+        - to:
+            uri: mock:result

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/ExportTypeConverter.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/ExportTypeConverter.java
@@ -16,11 +16,14 @@
  */
 package org.apache.camel.main.download;
 
+import java.time.Duration;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.TypeConversionException;
 import org.apache.camel.converter.ObjectConverter;
 import org.apache.camel.support.TypeConverterSupport;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.TimeUtils;
 
 /**
  * During export then we can be more flexible and allow missing property placeholders to resolve to a hardcoded value,
@@ -47,6 +50,8 @@ public class ExportTypeConverter extends TypeConverterSupport {
             return (T) ObjectConverter.toByte(s);
         } else if (type == String.class) {
             return (T) s;
+        } else if (type == Duration.class) {
+            return (T) TimeUtils.toDuration(s);
         }
         return null;
     }

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/ExportTypeConverterTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/ExportTypeConverterTest.java
@@ -18,6 +18,8 @@ package org.apache.camel.main.download;
 
 import java.time.Duration;
 
+import org.apache.camel.NoTypeConversionAvailableException;
+import org.apache.camel.TypeConverterExists;
 import org.apache.camel.impl.engine.SimpleCamelContext;
 import org.apache.camel.spi.TypeConverterRegistry;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ExportTypeConverterTest {
 
@@ -34,8 +37,8 @@ class ExportTypeConverterTest {
     void setUp() throws Exception {
         context = new SimpleCamelContext();
         TypeConverterRegistry registry = context.getTypeConverterRegistry();
-        ExportTypeConverter exportConverter = new ExportTypeConverter();
-        registry.addTypeConverter(Duration.class, String.class, exportConverter);
+        registry.setTypeConverterExists(TypeConverterExists.Override);
+        registry.addTypeConverter(Duration.class, String.class, new ExportTypeConverter());
         context.start();
     }
 
@@ -47,17 +50,26 @@ class ExportTypeConverterTest {
     }
 
     @Test
-    void shouldConvertStringToDurationAsMilliseconds() {
-        Duration duration = context.getTypeConverter().convertTo(Duration.class, "500");
+    void shouldConvertStringToDurationWhenExportConverterOverridesDefault() throws Exception {
+        Duration duration = context.getTypeConverter().mandatoryConvertTo(Duration.class, "500");
 
         assertEquals(Duration.ofMillis(500), duration);
     }
 
     @Test
-    void shouldConvertDurationTextWithUnit() {
-        Duration duration = context.getTypeConverter().convertTo(Duration.class, "2s");
+    void shouldConvertDurationTextWithUnitWhenExportConverterOverridesDefault() throws Exception {
+        Duration duration = context.getTypeConverter().mandatoryConvertTo(Duration.class, "2s");
 
         assertEquals(Duration.ofSeconds(2), duration);
+    }
+
+    @Test
+    void shouldFailMandatoryConversionWithoutDurationSupport() {
+        TypeConverterRegistry registry = context.getTypeConverterRegistry();
+        registry.addTypeConverter(Duration.class, String.class, new ExportTypeConverterWithoutDuration());
+
+        assertThrows(NoTypeConversionAvailableException.class,
+                () -> context.getTypeConverter().mandatoryConvertTo(Duration.class, "500"));
     }
 
     @Test
@@ -67,5 +79,18 @@ class ExportTypeConverterTest {
         Duration duration = converter.convertTo(Duration.class, null, "500ms");
 
         assertEquals(Duration.ofMillis(500), duration);
+    }
+
+    /**
+     * Mimics ExportTypeConverter before Duration support was added.
+     */
+    private static final class ExportTypeConverterWithoutDuration extends ExportTypeConverter {
+        @Override
+        public <T> T convertTo(Class<T> type, org.apache.camel.Exchange exchange, Object value) {
+            if (type == Duration.class) {
+                return null;
+            }
+            return super.convertTo(type, exchange, value);
+        }
     }
 }

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/ExportTypeConverterTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/download/ExportTypeConverterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main.download;
+
+import java.time.Duration;
+
+import org.apache.camel.impl.engine.SimpleCamelContext;
+import org.apache.camel.spi.TypeConverterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExportTypeConverterTest {
+
+    private SimpleCamelContext context;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        context = new SimpleCamelContext();
+        TypeConverterRegistry registry = context.getTypeConverterRegistry();
+        ExportTypeConverter exportConverter = new ExportTypeConverter();
+        registry.addTypeConverter(Duration.class, String.class, exportConverter);
+        context.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    @Test
+    void shouldConvertStringToDurationAsMilliseconds() {
+        Duration duration = context.getTypeConverter().convertTo(Duration.class, "500");
+
+        assertEquals(Duration.ofMillis(500), duration);
+    }
+
+    @Test
+    void shouldConvertDurationTextWithUnit() {
+        Duration duration = context.getTypeConverter().convertTo(Duration.class, "2s");
+
+        assertEquals(Duration.ofSeconds(2), duration);
+    }
+
+    @Test
+    void shouldConvertViaExportTypeConverterDirectly() {
+        ExportTypeConverter converter = new ExportTypeConverter();
+
+        Duration duration = converter.convertTo(Duration.class, null, "500ms");
+
+        assertEquals(Duration.ofMillis(500), duration);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24410](https://issues.apache.org/jira/browse/CAMEL-24410): `camel export` fails when YAML routes use Duration-typed options (including quoted `redeliveryDelay` values like `"500"`), while `camel run` works.

## Root cause

During export, `KameletMain.setupExport()` registers `ExportTypeConverter` with `TypeConverterExists.Override` for `Duration.class` ← `String.class`. The converter handled numeric and boolean types but returned `null` for `Duration`, effectively replacing the default `DurationConverter` and causing:

```
NoTypeConversionAvailableException: No type converter available to convert from type: java.lang.String to the required type: java.time.Duration
```

Note: CAMEL-24375 already moved `ErrorHandlerReifier` redelivery parsing to `TimeUtils.toDuration` via `parseDuration`, but export still overrides the type converter registry for other Duration bindings during export.

## Fix

Add `Duration` handling to `ExportTypeConverter` using `TimeUtils.toDuration(s)`, matching Camel's standard duration parsing (milliseconds as plain numbers, or values like `500ms`, `2s`).

## Tests

- `ExportTypeConverterTest` — uses `TypeConverterExists.Override` (mirrors export), verifies `mandatoryConvertTo` works/fails appropriately
- `ExportTest.shouldExportRouteConfigurationWithStringRedeliveryDelay` — integration test using the JIRA reproduction YAML across main, Spring Boot, and Quarkus export runtimes

## Verification

```
./mvnw -pl dsl/camel-kamelet-main -Dtest=ExportTypeConverterTest test
./mvnw -pl dsl/camel-jbang/camel-jbang-core -am -Dtest=ExportTest#shouldExportRouteConfigurationWithStringRedeliveryDelay test
```

---
_AI-generated PR description on behalf of atiaomar1978-hub_