### PR TITLE
CAMEL-24382: camel-azure-cosmosdb - process change-feed batches synchronously so events are not lost on failure

### DIFF
--- a/components/camel-azure/camel-azure-cosmosdb/src/main/java/org/apache/camel/component/azure/cosmosdb/CosmosDbConsumer.java
+++ b/components/camel-azure/camel-azure-cosmosdb/src/main/java/org/apache/camel/component/azure/cosmosdb/CosmosDbConsumer.java
@@ -24,18 +24,18 @@ import com.azure.cosmos.implementation.apachecommons.lang.RandomStringUtils;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.component.azure.cosmosdb.client.CosmosAsyncClientWrapper;
 import org.apache.camel.component.azure.cosmosdb.operations.CosmosDbContainerOperations;
 import org.apache.camel.component.azure.cosmosdb.operations.CosmosDbOperationsBuilder;
 import org.apache.camel.spi.Synchronization;
 import org.apache.camel.support.DefaultConsumer;
-import org.apache.camel.support.EmptyAsyncCallback;
 import org.apache.camel.support.SynchronizationAdapter;
 import org.apache.camel.util.ObjectHelper;
 
 public class CosmosDbConsumer extends DefaultConsumer {
 
-    private Synchronization onCompletion;
+    private final Synchronization onCompletion = new ConsumerOnCompletion();
     private CosmosAsyncClientWrapper clientWrapper;
     private ChangeFeedProcessor changeFeedProcessor;
 
@@ -47,7 +47,6 @@ public class CosmosDbConsumer extends DefaultConsumer {
     protected void doInit() throws Exception {
         super.doInit();
         this.clientWrapper = new CosmosAsyncClientWrapper(getEndpoint().getCosmosAsyncClient());
-        this.onCompletion = new ConsumerOnCompletion();
         this.changeFeedProcessor = getContainerOperations().captureEventsWithChangeFeed(
                 getLeaseContainerOperations().getContainer(), getHostName(),
                 this::onEventListener, getConfiguration().getChangeFeedProcessorOptions());
@@ -83,12 +82,28 @@ public class CosmosDbConsumer extends DefaultConsumer {
     }
 
     private void onEventListener(final List<Map<String, ?>> recordList) {
-        final Exchange exchange = createAzureCosmosDbExchange(recordList);
+        processBatch(createAzureCosmosDbExchange(recordList));
+    }
 
+    // Visible for testing.
+    void processBatch(final Exchange exchange) {
         // add exchange callback
         exchange.getExchangeExtension().addOnCompletion(onCompletion);
-        // use default consumer callback
-        getAsyncProcessor().process(exchange, EmptyAsyncCallback.get());
+
+        // Process the batch synchronously: the Azure ChangeFeedProcessor advances (checkpoints) the lease as
+        // soon as this handler returns, so processing must complete before we return. On failure we rethrow,
+        // so the lease is not advanced and the batch is redelivered on the next feed poll (at-least-once)
+        // instead of being silently lost.
+        try {
+            getProcessor().process(exchange);
+        } catch (Exception e) {
+            exchange.setException(e);
+        }
+
+        final Exception cause = exchange.getException();
+        if (cause != null) {
+            throw new RuntimeCamelException("Error processing Azure CosmosDB change feed batch", cause);
+        }
     }
 
     private Exchange createAzureCosmosDbExchange(final List<Map<String, ?>> recordList) {

--- a/components/camel-azure/camel-azure-cosmosdb/src/test/java/org/apache/camel/component/azure/cosmosdb/CosmosDbConsumerTest.java
+++ b/components/camel-azure/camel-azure-cosmosdb/src/test/java/org/apache/camel/component/azure/cosmosdb/CosmosDbConsumerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.cosmosdb;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CosmosDbConsumerTest extends CamelTestSupport {
+
+    private CosmosDbConsumer newConsumer(Processor processor) throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("databaseEndpoint", "https://test.com:443");
+        params.put("accountKey", "myKey");
+        CosmosDbEndpoint endpoint = (CosmosDbEndpoint) context.getComponent("azure-cosmosdb", CosmosDbComponent.class)
+                .createEndpoint("azure-cosmosdb://mydb/myContainer", "mydb/myContainer", params);
+        return new CosmosDbConsumer(endpoint, processor);
+    }
+
+    private Exchange batchExchange() {
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(List.of(Map.of("id", "1")));
+        return exchange;
+    }
+
+    @Test
+    void failedBatchIsRethrownSoTheLeaseIsNotAdvanced() throws Exception {
+        // a failing route must not let the change feed advance the lease: the batch has to be rethrown so
+        // the Azure ChangeFeedProcessor redelivers it (at-least-once) instead of silently losing it
+        CosmosDbConsumer consumer = newConsumer(exchange -> {
+            throw new IllegalStateException("boom");
+        });
+
+        RuntimeCamelException thrown
+                = assertThrows(RuntimeCamelException.class, () -> consumer.processBatch(batchExchange()));
+        assertInstanceOf(IllegalStateException.class, thrown.getCause());
+    }
+
+    @Test
+    void successfulBatchReturnsNormally() throws Exception {
+        boolean[] processed = { false };
+        CosmosDbConsumer consumer = newConsumer(exchange -> processed[0] = true);
+
+        consumer.processBatch(batchExchange());
+
+        assertTrue(processed[0]);
+    }
+}


### PR DESCRIPTION
Backport of #25617 (CAMEL-24382) to `camel-4.18.x`.

## The bug

The `camel-azure-cosmosdb` change-feed consumer processed each batch with a fire-and-forget async
callback (`getAsyncProcessor().process(exchange, EmptyAsyncCallback.get())`). Azure's
`ChangeFeedProcessor` advances (checkpoints) the lease as soon as the event handler returns, so the
lease could move past a batch **before** processing finished — and if processing then failed, those
events were silently lost.

## The fix

Process each batch **synchronously** and rethrow on failure as a `RuntimeCamelException`, so the
handler only returns normally once the exchange has completed. On failure the lease is not advanced
and the batch is redelivered on the next feed poll (at-least-once) instead of being dropped.

## Backport notes

- Cherry-pick of the merged main commit (`4e94d720ec40`) with one adaptation: `camel-4.18.x` uses
  `camel-test-junit5`, so the new test's `CamelTestSupport` import was switched from
  `org.apache.camel.test.junit6` to `org.apache.camel.test.junit5`. The production fix is identical.
- Verified locally: full-reactor `install -DskipTests` is green and `CosmosDbConsumerTest` passes
  (2 tests), with no generated-file drift.

---

_Claude Code on behalf of @oscerd_
