### PR TITLE
CAMEL-24466: Fix flaky KafkaConsumerHealthCheckIT.testReadinessWhenDown

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaConsumerHealthCheckIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaConsumerHealthCheckIT.java
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnabledOnOs(value = { OS.LINUX, OS.MAC, OS.FREEBSD, OS.OPENBSD, OS.WINDOWS },
              architectures = { "amd64", "aarch64", "s390x" },
              disabledReason = "This test does not run reliably on ppc64le")
-public class KafkaConsumerHealthCheckIT extends KafkaHealthCheckTestSupport {
+class KafkaConsumerHealthCheckIT extends KafkaHealthCheckTestSupport {
     public static final String TOPIC = "test-health";
     public static final String SKIPPED_HEADER_KEY = "CamelSkippedHeader";
     public static final String PROPAGATED_CUSTOM_HEADER = "PropagatedCustomHeader";
@@ -167,15 +167,19 @@ public class KafkaConsumerHealthCheckIT extends KafkaHealthCheckTestSupport {
 
     @Order(5)
     @Test
+    @Timeout(60)
     @DisplayName("Tests that readiness reports down when it's actually down")
-    public void testReadinessWhenDown() {
+    void testReadinessWhenDown() {
         CamelContext context = contextExtension.getContext();
         // and shutdown Kafka which will make readiness report as DOWN
         service.shutdown();
         serviceShutdown = true;
 
-        // health-check readiness should be DOWN
-        await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
+        // Detecting a downed broker relies on the Kafka client's hasReadyNodes(), which only flips
+        // after connection-failure detection bounded by request.timeout.ms (default 30s). The await
+        // window must therefore exceed 30s (and the method-level @Timeout must exceed the await) to
+        // avoid a flaky ConditionTimeout under CI load. See CAMEL-24466.
+        await().atMost(45, TimeUnit.SECONDS).untilAsserted(() -> {
             Collection<HealthCheck.Result> res2 = HealthCheckHelper.invokeReadiness(context);
             Assertions.assertTrue(res2.size() > 0);
             Optional<HealthCheck.Result> down

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaConsumerHealthCheckIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaConsumerHealthCheckIT.java
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnabledOnOs(value = { OS.LINUX, OS.MAC, OS.FREEBSD, OS.OPENBSD, OS.WINDOWS },
              architectures = { "amd64", "aarch64", "s390x" },
              disabledReason = "This test does not run reliably on ppc64le")
-class KafkaConsumerHealthCheckIT extends KafkaHealthCheckTestSupport {
+public class KafkaConsumerHealthCheckIT extends KafkaHealthCheckTestSupport {
     public static final String TOPIC = "test-health";
     public static final String SKIPPED_HEADER_KEY = "CamelSkippedHeader";
     public static final String PROPAGATED_CUSTOM_HEADER = "PropagatedCustomHeader";


### PR DESCRIPTION
## Issue

[CAMEL-24466](https://issues.apache.org/jira/browse/CAMEL-24466)

`KafkaConsumerHealthCheckIT.testReadinessWhenDown` fails intermittently in CI with `ConditionTimeout` — the readiness health check does not report `DOWN` within the 20s Awaitility window after the broker is shut down. In the reported run it failed all 3 attempts (initial + 2 `rerunFailingTestsCount` reruns), so it was not masked as flaky.

## Root cause

Readiness down-detection is driven by `KafkaFetchRecords.isReady()`, which (while `connected` stays `true`) relies on the Kafka client's `ConsumerNetworkClient.hasReadyNodes(now)`. When a *live* broker is killed without a prompt TCP reset (typical for a container stop under CI load), the client only marks the node not-ready once the in-flight request times out — bounded by the consumer's `request.timeout.ms`, which defaults to **30s** (`KafkaConfiguration.consumerRequestTimeoutMs = 30000`).

The test's **20s** await window is shorter than that 30s bound, so detection sometimes has not completed when Awaitility gives up → flaky `ConditionTimeout`.

This is corroborated by the sibling tests that are *not* flaky (`KafkaConsumerBadPortHealthCheckIT`, `KafkaConsumerUnresolvableHealthCheckIT`): they connect to a bad/unresolvable endpoint, so a connection *never becomes ready* and `hasReadyNodes()` returns `false` almost immediately — 20s is ample there. Only `testReadinessWhenDown` establishes a READY connection first and then kills the broker, exposing the ~30s detection delay.

## Fix

- Widen the Awaitility window from **20s → 45s** so it comfortably exceeds the 30s `request.timeout.ms` detection bound.
- Add a method-level **`@Timeout(60)`** (overriding the class-level `@Timeout(30)`, which would otherwise kill the method first).

Both are *upper bounds*, not sleeps: Awaitility returns as soon as the condition is met, and JUnit only fails past the ceiling, so passing runs are **not** slowed. Eliminating the fail-then-rerun cycle tends to *reduce* total CI time for this class.

Also dropped the unnecessary `public` modifiers on the touched class/method per JUnit 5 conventions.

## Testing

- `mvn -DskipTests install` on `camel-kafka` passes (test sources compile; `formatter:format` / `impsort:sort` produce no changes).
- Change is confined to a single test method (annotation + await ceiling + explanatory comment); no production code and no generated artifacts are affected (`generate-postcompile` reported everything up to date).

---
_Claude Code on behalf of davsclaus_
