### PR TITLE
CAMEL-24468: camel-ibm-secrets-manager - fix multiple defects in IBMSecretsManagerPropertiesFunction (env-var credentials, version pinning, missing KV field)

### DIFF
--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/IBMSecretsManagerPropertiesFunction.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/IBMSecretsManagerPropertiesFunction.java
@@ -214,14 +214,8 @@ public class IBMSecretsManagerPropertiesFunction extends ServiceSupport implemen
                     Response<SecretVersion> secVersion = client.getSecretVersion(getSecretVersionOptions).execute();
                     data = secVersion.getResult().getData();
                 }
-                if (ObjectHelper.isNotEmpty(data)) {
-                    data = response.getResult().getData();
-                }
-                if (ObjectHelper.isNotEmpty(subkey)) {
-                    returnValue = String.valueOf(data.get(subkey));
-                } else {
-                    returnValue = null;
-                }
+                Object subValue = data.get(subkey);
+                returnValue = subValue != null ? String.valueOf(subValue) : null;
                 if (ObjectHelper.isEmpty(returnValue)) {
                     returnValue = defaultValue;
                 }

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/IBMSecretsManagerPropertiesFunction.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/IBMSecretsManagerPropertiesFunction.java
@@ -100,6 +100,8 @@ public class IBMSecretsManagerPropertiesFunction extends ServiceSupport implemen
                 token = ibmVaultConfiguration.getToken();
                 serviceUrl = ibmVaultConfiguration.getServiceUrl();
             }
+        }
+        if (ObjectHelper.isNotEmpty(token) && ObjectHelper.isNotEmpty(serviceUrl)) {
             IamAuthenticator iamAuthenticator = new IamAuthenticator.Builder()
                     .apikey(token)
                     .build();


### PR DESCRIPTION
# CAMEL-24468: fix multiple defects in `IBMSecretsManagerPropertiesFunction`

This fixes three defects in the IBM Secrets Manager properties function (`ibm:` property placeholders), all caused by the class having been copied from another vault integration without adapting the logic.

## 1. Environment-variable credentials were always rejected (the main bug)

`doStart()` inverted the credential-resolution logic:

```java
if (isEmpty(token) && isEmpty(serviceUrl)) {
    // ... build the SecretsManager client (with the *empty* values)
} else {
    throw new RuntimeCamelException("... requires setting IBM Credentials and service url ...");
}
```

Setting the documented `CAMEL_VAULT_IBM_TOKEN` / `CAMEL_VAULT_IBM_SERVICE_URL` environment variables (or the `camel.vault.ibm.*` properties) made both values **non-empty**, so the `else` branch threw at startup with the exact message claiming those values were required. The function could therefore never be configured through the documented mechanism.

It now follows the standard pattern used by the other vault properties functions: read the environment variables, fall back to the vault configuration when they are absent, build the client when both token and service URL are present, and only throw when they are still missing.

## 2. Secret version pinning was ignored for KV secrets

`getSecretFromSource()` fetched the requested version's data and then immediately overwrote it with the current version's data:

```java
data = secVersion.getResult().getData();
if (isNotEmpty(data)) {
    data = response.getResult().getData(); // overwrites the versioned data
}
```

so `ibm:group:secret#field@version` silently returned the **current** field value. The overwrite block is removed (the `ARBITRARY`/payload branch was already correct).

## 3. A missing KV field returned the literal string `"null"`

`String.valueOf(data.get(subkey))` yields the string `"null"` when the field is absent, which is non-empty and therefore bypassed the `isEmpty()`-based default-value fallback — so `ibm:group:secret#missing:defaultValue` returned `"null"` instead of `defaultValue`. The lookup is now null-guarded so the provided default value is used.

## Testing

The module ships only integration tests (they require live IBM Secrets Manager credentials); there is no mocking dependency for the SDK client and the credential path is `System.getenv`-based, so these correctness fixes are not unit-testable in isolation without adding new test dependencies. Verified with a module build (`BUILD SUCCESS`, no generated-file drift).

---
_Claude Code on behalf of oscerd_
