### PR TITLE
chore: Remove test-visibility convention (public tests are fine)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,57 +251,6 @@ await().atMost(10, TimeUnit.SECONDS).until(() -> mock.getReceivedCounter() >= 2)
 - Use `untilAsserted` or `until` with a clear predicate — do not replace a sleep with a
   busy-wait loop.
 
-### Test Visibility: Drop `public` From Test Classes and Methods
-
-JUnit 5 does **not** require test classes or test methods to be `public` — package-private
-(the default, no modifier) is sufficient and preferred. Removing the unnecessary `public`
-qualifier reduces visual noise and follows modern JUnit 5 conventions.
-
-**Examples:**
-
-```java
-// Preferred — package-private (no modifier):
-class MyComponentTest extends CamelTestSupport {
-    @Test
-    void testSendMessage() { ... }
-
-    @Override
-    protected RoutesBuilder createRouteBuilder() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() {   // stays public — overrides RouteBuilder.configure()
-                from("direct:start").to("mock:result");
-            }
-        };
-    }
-}
-
-// Avoid — unnecessary public:
-public class MyComponentTest extends CamelTestSupport {
-    @Test
-    public void testSendMessage() { ... }
-}
-```
-
-**Rules:**
-
-- New test classes and test methods MUST NOT use the `public` modifier.
-- When modifying an existing test file, remove the `public` modifier from the class declaration
-  and from any test methods you touch. Do NOT sweep the entire file — only change what you are
-  already modifying.
-- `@BeforeAll`, `@AfterAll`, `@BeforeEach` and `@AfterEach` methods follow the same rule: drop
-  `public` when adding or modifying them.
-- **Exception — methods that override or implement a supertype method keep the supertype's
-  visibility.** Java forbids reducing visibility on an override (JLS 8.4.8.3), so
-  `public void configure()` in a `RouteBuilder`, and any override of a public method from
-  `CamelTestSupport` or an implemented interface, MUST stay `public`.
-- **Exception — base and support classes stay `public`** when they are extended from another
-  package or module (a package-private class cannot be), and anything under
-  `components/camel-test/**` or `test-infra/**` stays `public` because those are released
-  artifacts consumed by downstream projects and by users' own tests.
-- Do NOT create a standalone PR solely to remove `public` from test files in bulk — apply the
-  convention incrementally as part of other work.
-
 ### Issue Investigation (Before Implementation)
 
 Before implementing a fix for a JIRA issue, **thoroughly investigate** the issue's validity and context.


### PR DESCRIPTION
## Motivation

Remove the **"Test Visibility: Drop \`public\` From Test Classes and Methods"** section from `AGENTS.md` (`CLAUDE.md` is a symlink to it).

Camel test classes have been `public` for **~20 years**, and essentially every existing test class in the codebase is `public`. AIs — and humans — overwhelmingly learn by copying nearby tests, so this rule actively fights the corpus it lives in: it instructs contributors to write package-private tests while thousands of surrounding examples are `public`. The result is pointless style drift in every touched file, for zero functional benefit.

The rule had also accreted a thicket of exceptions and *still* didn't cover everything:

- supertype overrides must stay `public` (JLS 8.4.8.3),
- base/support classes must stay `public`,
- anything under `components/camel-test/**` and `test-infra/**` must stay `public`,
- **and, not previously documented:** tests driven by the test-infra `CamelContextExtension` (`@RouteFixture` / `@ContextFixture`) must stay `public`, because the extension invokes the fixture methods **reflectively** — and on **Java 25** `Method.invoke` on a package-private receiver class throws `IllegalAccessException`.

That last gap recently broke CI: a change that faithfully followed the rule (dropping `public` from a Kafka health-check IT) made every test in the class fail at fixture setup on Java 25 with *"illegal access to method: createRouteBuilder"*.

A convention that needs this many carve-outs, contradicts 20 years of existing code, drives AI-generated drift, and still causes build failures is not worth keeping. `public` tests are perfectly fine.

## Change

- Delete the entire "Test Visibility" section (51 lines) from `AGENTS.md`.

No code changes; documentation/guidance only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Opus 4.8 on behalf of @davsclaus_