### PR TITLE
[backport camel-4.22.x] Pin org.apache.directory.api artifacts to 2.1.8 to remediate CVE-2026-35563

### DIFF
--- a/components/camel-ldap/pom.xml
+++ b/components/camel-ldap/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>apacheds-server-jndi</artifactId>
             <version>${apacheds-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
@@ -63,6 +69,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -70,11 +80,53 @@
             <artifactId>apacheds-core-integ</artifactId>
             <version>${apacheds-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
             <version>${mina-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-client-api</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-util</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-codec-standalone</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-sp</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-dsml-engine</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-trigger</artifactId>
+            <version>${directory-api-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-ldif/pom.xml
+++ b/components/camel-ldif/pom.xml
@@ -53,7 +53,47 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Pin org.apache.directory.api transitively brought in by apacheds-core-api
+             (dormant, no release with the fix) to remediate CVE-2026-35563 -->
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-client-api</artifactId>
+            <version>${directory-api-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-util</artifactId>
+            <version>${directory-api-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-codec-standalone</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-sp</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-dsml-engine</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-extras-trigger</artifactId>
+            <version>${directory-api-version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- test dependencies -->
@@ -71,6 +111,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>
@@ -79,6 +123,12 @@
             <artifactId>apacheds-core-integ</artifactId>
             <version>${apacheds-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.api</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.mina</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,6 +141,7 @@
         <debezium-mysql-connector-version>26.7.0</debezium-mysql-connector-version>
         <dhis2-version>3.0.2</dhis2-version>
         <digitalocean-api-client-version>2.17</digitalocean-api-client-version>
+        <directory-api-version>2.1.8</directory-api-version>
         <directory-watcher-version>0.19.1</directory-watcher-version>
         <disruptor-version>3.4.4</disruptor-version>
         <dnsjava-version>3.6.5</dnsjava-version>


### PR DESCRIPTION
## Backport of #25622

Cherry-pick of #25622 onto `camel-4.22.x` to remediate **CVE-2026-35563**.

**Original PR:** #25622 — Pin org.apache.directory.api artifacts to 2.1.8 to remediate CVE-2026-35563
**Original author:** @ivonaest
**Target branch:** `camel-4.22.x`

### Summary

`apacheds-core-api` transitively pulls `org.apache.directory.api` 2.1.5, affected by CVE-2026-35563. ApacheDS is dormant and will not release a fix, but Apache Directory API 2.1.8 remediates it. This excludes `org.apache.directory.api:*` from the `apacheds-*` dependencies (camel-ldif compile scope, camel-ldap test scope) and re-declares the required artifacts at a new central `directory-api-version=2.1.8` property, avoiding any 2.1.5/2.1.8 version skew.

Cherry-picked cleanly. Verified: `camel-ldif` and `camel-ldap` build on this branch and their dependency trees resolve all `org.apache.directory.api` artifacts at 2.1.8 (no 2.1.5 remaining).

_Backport prepared by Claude Code on behalf of @davsclaus_