### PR TITLE
Fix KafkaConsumerHealthCheckIT

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaHealthCheckTestSupport.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/health/KafkaHealthCheckTestSupport.java
@@ -48,7 +48,7 @@ abstract class KafkaHealthCheckTestSupport implements ConfigurableRoute, Configu
     protected static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerUnresolvableHealthCheckIT.class);
     @Order(1)
     @RegisterExtension
-    protected static KafkaService service = KafkaServiceFactory.createSingletonService();
+    protected static KafkaService service = KafkaServiceFactory.createService();
 
     @Order(2)
     @RegisterExtension


### PR DESCRIPTION
regression introduced by usage of singleton service https://github.com/apache/camel/commit/bb6882f9f2f041015227f874fb4b51910d09ee9c

the test is doing a shutdown of the service, it doesn't sound safe to do it on a singletonservice used by other tests and anyways it seems thtait wasn't implemented correctly for this singletonservice so revert back to a "normal" service

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

