### PR TITLE
CAMEL-24470: camel-ibm-secrets-manager - honor Event Stream credentials from environment variables in the reload trigger task

### DIFF
--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/vault/IBMEventStreamReloadTriggerTask.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/vault/IBMEventStreamReloadTriggerTask.java
@@ -119,15 +119,16 @@ public class IBMEventStreamReloadTriggerTask extends ServiceSupport implements C
                 groupId = ibmVaultConfiguration.getEventStreamGroupId();
                 topic = ibmVaultConfiguration.getEventStreamTopic();
                 if (ObjectHelper.isEmpty(username)) {
-                    if (ObjectHelper.isNotEmpty(ibmVaultConfiguration.getEventStreamUsername())) {
-                        username = ibmVaultConfiguration.getEventStreamUsername();
-                    } else {
-                        username = "token";
-                    }
+                    username = ibmVaultConfiguration.getEventStreamUsername();
                 }
                 password = ibmVaultConfiguration.getEventStreamPassword();
             }
-        } else {
+        }
+        if (ObjectHelper.isEmpty(username)) {
+            username = "token";
+        }
+        if (ObjectHelper.isEmpty(bootstrapServers) || ObjectHelper.isEmpty(groupId) || ObjectHelper.isEmpty(topic)
+                || ObjectHelper.isEmpty(password)) {
             throw new RuntimeCamelException(
                     "Using the IBM Secrets Refresh Task requires setting IBM Event Stream bootstrap servers, topic, groupId, username and password as application properties or environment variables");
         }


### PR DESCRIPTION
# CAMEL-24470: honor Event Stream credentials from environment variables

`IBMEventStreamReloadTriggerTask` (the `ibm-secret-refresh` periodic task that watches an IBM Event Streams / Kafka topic for secret-rotation events) inverted its credential-resolution logic in `doStart()`:

```java
if (isEmpty(bootstrapServers) && isEmpty(groupId) && isEmpty(topic) && isEmpty(password)) {
    // read the values from the vault configuration
} else {
    throw new RuntimeCamelException(
        "... requires setting IBM Event Stream bootstrap servers, topic, groupId, username and password ...");
}
```

After reading the documented `CAMEL_VAULT_IBM_EVENTSTREAM_*` environment variables, non-empty values took the `else` branch and threw at startup with the exact message claiming those variables were required. The task could therefore only be configured through the vault configuration object; the environment-variable path always failed.

## Fix

Same shape as the `IBMSecretsManagerPropertiesFunction` fix in CAMEL-24468: resolve the credentials from the environment variables when present, fall back to the vault configuration when they are absent, keep defaulting the username to `token` (the IBM Event Streams SASL user) when not supplied, and only throw when a required value (bootstrap servers, group id, topic, password) is still missing after both sources have been consulted.

## Testing

The module ships only integration tests (they require live IBM credentials) and the credential path is `System.getenv`-based, so this is not unit-testable without new test dependencies. Verified with a module build (`BUILD SUCCESS`, no generated-file drift).

---
_Claude Code on behalf of oscerd_
