### PR TITLE
CAMEL-24469: Fix camel-jbang plugin versionCheck rejecting same SNAPSHOT release

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/common/PluginHelper.java
@@ -477,12 +477,17 @@ public final class PluginHelper {
     }
 
     static void versionCheck(CamelJBangMain main, String version, String firstVersion, String command) {
-        // compare versions without SNAPSHOT
+        // compare versions without SNAPSHOT (on both sides) so a SNAPSHOT build is not
+        // rejected against a plugin whose firstVersion is the same SNAPSHOT release
         String source = version;
-        if (source.endsWith("-SNAPSHOT")) {
+        if (source != null && source.endsWith("-SNAPSHOT")) {
             source = source.replace("-SNAPSHOT", "");
         }
-        boolean accept = VersionHelper.isGE(source, firstVersion);
+        String first = firstVersion;
+        if (first != null && first.endsWith("-SNAPSHOT")) {
+            first = first.replace("-SNAPSHOT", "");
+        }
+        boolean accept = VersionHelper.isGE(source, first);
         if (!accept) {
             main.getOut().println("Cannot load plugin camel-jbang-plugin-" + command + " with version: " + version
                                   + " because plugin has first version: " + firstVersion + ". Exit");

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/common/PluginHelperTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/common/PluginHelperTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -262,6 +263,26 @@ public class PluginHelperTest {
         assertFalse(after.quitCalled, "cache fast path resolved the plugin without invoking the resolver");
         assertEquals(FakePluginJar.PLUGIN_CLASS, plugins.get("fake").getClass().getName(),
                 "plugin loaded from the cached jar, not via FACTORY_FINDER");
+    }
+
+    @Test
+    void testVersionCheckAcceptsSameSnapshotVersion() {
+        // CAMEL-24469: a SNAPSHOT build must not be rejected against a plugin whose firstVersion
+        // is the same SNAPSHOT release. Rejection calls quit() which, on the real main, is System.exit
+        // and crashes the surefire fork. This regressed on patch releases such as 4.22.1-SNAPSHOT.
+        QuitCapture main = new QuitCapture();
+        assertThatCode(() -> PluginHelper.versionCheck(main, "4.22.1-SNAPSHOT", "4.22.1-SNAPSHOT", "fake"))
+                .doesNotThrowAnyException();
+        assertFalse(main.quitCalled, "same SNAPSHOT version must be accepted, not quit");
+    }
+
+    @Test
+    void testVersionCheckRejectsOlderVersion() {
+        // A plugin requiring a newer firstVersion than the current build must be rejected (quit).
+        QuitCapture main = new QuitCapture();
+        assertThrows(RuntimeException.class,
+                () -> PluginHelper.versionCheck(main, "4.22.1-SNAPSHOT", "4.23.0", "fake"));
+        assertTrue(main.quitCalled, "older build than plugin firstVersion must be rejected");
     }
 
     private void writeConfig(JsonObject pluginEntry) throws Exception {


### PR DESCRIPTION
Fixes [CAMEL-24469](https://issues.apache.org/jira/browse/CAMEL-24469) on `main`. Companion to the branch-specific fix in #25678 (`camel-4.22.x`).

## Why also on main

`main` carries the **identical buggy code**. It does not currently crash there only because main's version is a `.0` SNAPSHOT (`4.23.0-SNAPSHOT`), for which the broken string comparison happens to sort correctly. The latent bug resurfaces the moment main moves to a `.1` SNAPSHOT or the next `camel-4.23.x` maintenance branch is cut. Landing the fix on main keeps it the canonical source and prevents the regression from reappearing on future branch cuts.

## Root cause

`PluginHelper.versionCheck` stripped `-SNAPSHOT` from the current `version` but **not** from the plugin `firstVersion`, then compared with the string-based `VersionHelper.compare`:

```
compare("4.22.1", "4.22.1-SNAPSHOT")
  -> "042201" vs "04221-SNAPSHOT"
  -> position 4: '0' (48) < '1' (49) -> negative -> isGE == false
```

A plugin whose `firstVersion` equals the current SNAPSHOT was rejected, invoking `main.quit(1)` — `System.exit` on the real `CamelJBangMain`, which crashes the surefire fork running `PluginHelperTest`.

## Fix

Strip `-SNAPSHOT` from `firstVersion` as well before comparing. Added regression tests (`testVersionCheckAcceptsSameSnapshotVersion`, `testVersionCheckRejectsOlderVersion`).

## Verification

`PluginHelperTest` — 11 tests pass on JDK 21.

---
_Fix prepared by Claude Code on behalf of davsclaus_