### PR TITLE
CAMEL-24483: camel-jbang export - explicit --dep version overrides auto-detected dependency

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -811,14 +811,29 @@ public abstract class ExportBaseCommand extends CamelCommand {
             answer.add("mvn:org.hibernate.orm:hibernate-core");
         }
 
-        // remove duplicate versions (keep first)
-        Map<String, String> versions = new HashMap<>();
+        // remove duplicate versions (keep first) but an explicit --dep version always wins over
+        // an auto-detected dependency for the same groupId:artifactId (e.g. a JDBC driver whose
+        // version is inferred from the camel-dependencies BOM)
+        Set<String> preferred = new HashSet<>();
+        for (String d : dependencies) {
+            String line = normalizeDependency(d);
+            MavenGav gav = MavenGav.parseGav(line);
+            if (gav.getVersion() != null && !gav.getVersion().isBlank()) {
+                preferred.add(line);
+            }
+        }
+        Map<String, String> kept = new HashMap<>();
         Set<String> toBeRemoved = new HashSet<>();
         for (String line : answer) {
             MavenGav gav = MavenGav.parseGav(line);
             String ga = gav.getGroupId() + ":" + gav.getArtifactId();
-            if (!versions.containsKey(ga)) {
-                versions.put(ga, gav.getVersion());
+            String existing = kept.get(ga);
+            if (existing == null) {
+                kept.put(ga, line);
+            } else if (preferred.contains(line) && !preferred.contains(existing)) {
+                // the user-supplied --dep version takes precedence over the auto-detected one
+                toBeRemoved.add(existing);
+                kept.put(ga, line);
             } else {
                 toBeRemoved.add(line);
             }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -1130,6 +1130,32 @@ class ExportTest {
         }
     }
 
+    @Test
+    void shouldOverrideAutoDetectedDriverVersion() throws Exception {
+        LOG.info("shouldOverrideAutoDetectedDriverVersion");
+        // the bean uses driverClassName org.postgresql.Driver which Camel auto-detects and adds
+        // org.postgresql:postgresql with the version from the camel-dependencies BOM. An explicit
+        // --dep for the same groupId:artifactId must override that auto-detected version.
+        Export command = new Export(new CamelJBangMain());
+        CommandLine.populateCommand(command,
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet",
+                "--runtime=camel-main",
+                "--dep=org.postgresql:postgresql:42.7.99",
+                "src/test/resources/k8s-secret-bean.yaml");
+        int exit = command.doCall();
+
+        assertThat(exit).isZero();
+        Model model = readMavenModel();
+
+        List<Dependency> pg = model.getDependencies().stream()
+                .filter(d -> "org.postgresql".equals(d.getGroupId()) && "postgresql".equals(d.getArtifactId()))
+                .toList();
+        assertThat(pg)
+                .as("Explicit --dep version must override the auto-detected postgresql driver version")
+                .singleElement()
+                .satisfies(d -> assertThat(d.getVersion()).isEqualTo("42.7.99"));
+    }
+
     @ParameterizedTest
     @MethodSource("runtimeProvider")
     public void shouldExportWithCustomRepos(RuntimeType rt) throws Exception {


### PR DESCRIPTION
# Description

Fixes [CAMEL-24483](https://issues.apache.org/jira/browse/CAMEL-24483).

When running `camel export` on a project that contains a bean Camel auto-detects a dependency for — e.g. a Postgres `BasicDataSource` whose `driverClassName` is `org.postgresql.Driver` — Camel adds `org.postgresql:postgresql` to the generated `pom.xml` using the version inferred from the `camel-dependencies` BOM. Passing `--dep=org.postgresql:postgresql:<version>` to override that version had **no effect**: the generated POM kept the auto-detected version and the user's explicit version was silently dropped.

## Root cause

In `ExportBaseCommand.resolveDependencies()` the dependencies are collected into a `TreeSet` and then de-duplicated by `groupId:artifactId` only, keeping the **first** entry in the set's sorted order (the version is ignored). Auto-detected dependencies are recorded with an `mvn:` prefix (written by `Run.RunDownloadListener.onDownloadDependency`), while a plain `--dep=group:artifact:version` is not — so the `mvn:`-prefixed auto-detected entry always sorts first and wins. There was no precedence for a user-supplied `--dep`. Adding the `mvn:` prefix manually (`--dep=mvn:...`) did not reliably help either, since dedup then fell back to lexicographic comparison of the version strings.

## Fix

During de-duplication, an explicit `--dep` entry that carries a version now takes precedence over an auto-detected dependency for the same `groupId:artifactId`. Behaviour is otherwise unchanged (keep-first for all non-user conflicts).

## Testing

Added `ExportTest#shouldOverrideAutoDetectedDriverVersion`, which exports a route with a Postgres `BasicDataSource` bean plus `--dep=org.postgresql:postgresql:42.7.99` and asserts the generated POM contains exactly that version. Verified the test fails without the fix (`expected: "42.7.99" but was: "42.7.13"`) and passes with it.

---
_Reported via the Camel community (Marat Gubaidullin). Fix authored by Claude Code on behalf of Claus Ibsen (@davsclaus)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)