### PR TITLE
CAMEL-24483: camel-jbang export - explicit --dep version overrides auto-detected dependency (4.22.x backport)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -811,14 +811,29 @@ public abstract class ExportBaseCommand extends CamelCommand {
             answer.add("mvn:org.hibernate.orm:hibernate-core");
         }
 
-        // remove duplicate versions (keep first)
-        Map<String, String> versions = new HashMap<>();
+        // remove duplicate versions (keep first) but an explicit --dep version always wins over
+        // an auto-detected dependency for the same groupId:artifactId (e.g. a JDBC driver whose
+        // version is inferred from the camel-dependencies BOM)
+        Set<String> preferred = new HashSet<>();
+        for (String d : dependencies) {
+            String line = normalizeDependency(d);
+            MavenGav gav = MavenGav.parseGav(line);
+            if (gav.getVersion() != null && !gav.getVersion().isBlank()) {
+                preferred.add(line);
+            }
+        }
+        Map<String, String> kept = new HashMap<>();
         Set<String> toBeRemoved = new HashSet<>();
         for (String line : answer) {
             MavenGav gav = MavenGav.parseGav(line);
             String ga = gav.getGroupId() + ":" + gav.getArtifactId();
-            if (!versions.containsKey(ga)) {
-                versions.put(ga, gav.getVersion());
+            String existing = kept.get(ga);
+            if (existing == null) {
+                kept.put(ga, line);
+            } else if (preferred.contains(line) && !preferred.contains(existing)) {
+                // the user-supplied --dep version takes precedence over the auto-detected one
+                toBeRemoved.add(existing);
+                kept.put(ga, line);
             } else {
                 toBeRemoved.add(line);
             }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -1130,6 +1130,32 @@ class ExportTest {
         }
     }
 
+    @Test
+    void shouldOverrideAutoDetectedDriverVersion() throws Exception {
+        LOG.info("shouldOverrideAutoDetectedDriverVersion");
+        // the bean uses driverClassName org.postgresql.Driver which Camel auto-detects and adds
+        // org.postgresql:postgresql with the version from the camel-dependencies BOM. An explicit
+        // --dep for the same groupId:artifactId must override that auto-detected version.
+        Export command = new Export(new CamelJBangMain());
+        CommandLine.populateCommand(command,
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet",
+                "--runtime=camel-main",
+                "--dep=org.postgresql:postgresql:42.7.99",
+                "src/test/resources/k8s-secret-bean.yaml");
+        int exit = command.doCall();
+
+        assertThat(exit).isZero();
+        Model model = readMavenModel();
+
+        List<Dependency> pg = model.getDependencies().stream()
+                .filter(d -> "org.postgresql".equals(d.getGroupId()) && "postgresql".equals(d.getArtifactId()))
+                .toList();
+        assertThat(pg)
+                .as("Explicit --dep version must override the auto-detected postgresql driver version")
+                .singleElement()
+                .satisfies(d -> assertThat(d.getVersion()).isEqualTo("42.7.99"));
+    }
+
     @ParameterizedTest
     @MethodSource("runtimeProvider")
     public void shouldExportWithCustomRepos(RuntimeType rt) throws Exception {


### PR DESCRIPTION
# Description

Backport of #25715 to `camel-4.22.x`. Fixes [CAMEL-24483](https://issues.apache.org/jira/browse/CAMEL-24483).

> ⚠️ **Do not merge before the main PR #25715 is merged.**

An explicit `--dep=group:artifact:version` passed to `camel export` was silently dropped when Camel auto-detected the same `groupId:artifactId` (e.g. a Postgres JDBC driver inferred from a `BasicDataSource` bean), because the export dedup in `ExportBaseCommand.resolveDependencies()` keyed only on `groupId:artifactId` and kept the first entry by `TreeSet` sort order, ignoring the version. This fix makes an explicit `--dep` version take precedence over the auto-detected one.

Clean cherry-pick of the `main` commit (`git cherry-pick -x`).

## Testing

`ExportTest#shouldOverrideAutoDetectedDriverVersion` verified passing on this branch.

---
_Reported via the Camel community (Marat Gubaidullin). Backport authored by Claude Code on behalf of Claus Ibsen (@davsclaus)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)