### PR TITLE
Fix unregistered and hijacked external links in documentation

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/snakeYaml-dataformat.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/snakeYaml-dataformat.adoc
@@ -15,7 +15,7 @@ Java objects to and from http://www.yaml.org/[YAML].
 For YAML to object marshalling, Camel provides integration with three
 popular YAML libraries:
 
-* The http://www.snakeyaml.org/[SnakeYAML] library
+* The https://bitbucket.org/snakeyaml/snakeyaml[SnakeYAML] library
 
 Every library requires adding the special camel component (see
 "Dependency..." paragraphs further down). By default Camel uses the

--- a/components/camel-snakeyaml/src/main/docs/snakeYaml-dataformat.adoc
+++ b/components/camel-snakeyaml/src/main/docs/snakeYaml-dataformat.adoc
@@ -15,7 +15,7 @@ Java objects to and from http://www.yaml.org/[YAML].
 For YAML to object marshalling, Camel provides integration with three
 popular YAML libraries:
 
-* The http://www.snakeyaml.org/[SnakeYAML] library
+* The https://bitbucket.org/snakeyaml/snakeyaml[SnakeYAML] library
 
 Every library requires adding the special camel component (see
 "Dependency..." paragraphs further down). By default Camel uses the

--- a/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/SnakeYAMLDataFormat.java
+++ b/components/camel-snakeyaml/src/main/java/org/apache/camel/component/snakeyaml/SnakeYAMLDataFormat.java
@@ -43,7 +43,7 @@ import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
 
 /**
- * Marshal and unmarshal Java objects to and from YAML using <a href="http://www.snakeyaml.org">SnakeYAML</a>
+ * Marshal and unmarshal Java objects to and from YAML using <a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a>
  */
 @Dataformat("snakeYaml")
 public final class SnakeYAMLDataFormat extends ServiceSupport implements DataFormat, DataFormatName, CamelContextAware {

--- a/docs/user-manual/modules/ROOT/pages/testing.adoc
+++ b/docs/user-manual/modules/ROOT/pages/testing.adoc
@@ -129,7 +129,7 @@ There are a number of third party testing libraries that Camel users have found 
 === Citrus test framework
 
 As an example of writing integration tests for Camel applications you can use the
-https://citfrusframework.org[Citrus] test framework.
+https://citrusframework.org[Citrus] test framework.
 Citrus is an Open Source Java testing framework with focus on integration testing and messaging.
 
 The framework provides a very good integration with Apache Camel.


### PR DESCRIPTION
### What

Fixes two external documentation links that point at domains not controlled by the projects they claim to reference:

1. **Citrus link typo** — `docs/user-manual/modules/ROOT/pages/testing.adoc` linked to `citfrusframework.org` instead of `citrusframework.org`. The misspelled domain is **unregistered** (verified via RDAP on 2026-08-25), so anyone could register it and serve arbitrary content to readers — and to AI agents that consume the generated `https://camel.apache.org/manual/testing.md` / llms.txt files — under the authority of the Camel documentation. Introduced in 67a4e6264704 (#18883); reported to security@apache.org by an external researcher and triaged as a documentation fix rather than a vulnerability.

2. **Hijacked snakeyaml.org** — the SnakeYAML docs and Javadoc linked to `www.snakeyaml.org`, but that domain lapsed and was **re-registered on 2025-01-01 by an unrelated third party** that now serves an SEO content site trading on the SnakeYAML name. The links now point to the project's real home at `https://bitbucket.org/snakeyaml/snakeyaml`. The catalog copy of the doc page (a verbatim sync of the source `.adoc`) was updated to match.

### Verification sweep

All ~400 external domains referenced across the documentation tree were checked for: look-alike misspellings (edit-distance comparison), unregistered domains (DNS + RDAP), nameservers pointing at domain-parking services, RDAP re-registration dates newer than the doc references, and "for sale" landing pages. No other compromised or claimable real-project domain was found. Notes for potential follow-ups (not security-relevant, so left out of this PR): `kaotoio.github.io/kaoto/` in `getting-started.adoc` is a dead GitHub Pages link (the KaotoIO org still exists, so it is not takeover-able), and `random-data-api.com` (used in JBang examples) no longer serves DNS but remains registered until 2027.

---
_This PR was created by Claude Code on behalf of ppkarwasz._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JZf5SuQcZsKEyX9MRWMbh