### PR TITLE
chore: fix state-store adoc duplicate include and incomplete operation list

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/state-store-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/state-store-component.adoc
@@ -32,7 +32,7 @@ Use State Store when:
 * You need a *simple key-value API* and want to switch backends without changing route logic.
 * You are *migrating from MuleSoft* and want an Object Store equivalent.
 * You want *backend portability* — develop with in-memory, deploy with Redis or Infinispan.
-* Your use case is limited to *put, get, delete, contains, keys* operations.
+* Your use case is limited to *put, putIfAbsent, get, delete, contains, keys, size, clear* operations.
 
 [width="100%",cols="1,2,1",options="header"]
 |===
@@ -53,7 +53,6 @@ Where `storeName` is a logical name for the store. Endpoints with the same `stor
 share the same backend instance within the same `CamelContext`.
 
 // component-configure options: START
-include::partial$component-configure-options.adoc[]
 // component-configure options: END
 
 // component options: START

--- a/components/camel-state-store/camel-state-store/src/main/docs/state-store-component.adoc
+++ b/components/camel-state-store/camel-state-store/src/main/docs/state-store-component.adoc
@@ -53,10 +53,10 @@ Where `storeName` is a logical name for the store. Endpoints with the same `stor
 share the same backend instance within the same `CamelContext`.
 
 // component-configure options: START
-include::partial$component-configure-options.adoc[]
 // component-configure options: END
 
 // component options: START
+include::partial$component-configure-options.adoc[]
 include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END

--- a/components/camel-state-store/camel-state-store/src/main/docs/state-store-component.adoc
+++ b/components/camel-state-store/camel-state-store/src/main/docs/state-store-component.adoc
@@ -32,7 +32,7 @@ Use State Store when:
 * You need a *simple key-value API* and want to switch backends without changing route logic.
 * You are *migrating from MuleSoft* and want an Object Store equivalent.
 * You want *backend portability* — develop with in-memory, deploy with Redis or Infinispan.
-* Your use case is limited to *put, get, delete, contains, keys* operations.
+* Your use case is limited to *put, putIfAbsent, get, delete, contains, keys, size, clear* operations.
 
 [width="100%",cols="1,2,1",options="header"]
 |===
@@ -57,7 +57,6 @@ include::partial$component-configure-options.adoc[]
 // component-configure options: END
 
 // component options: START
-include::partial$component-configure-options.adoc[]
 include::partial$component-endpoint-options.adoc[]
 include::partial$component-endpoint-headers.adoc[]
 // component options: END


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

Two minor documentation fixes for the `camel-state-store` component merged in PR #22158 (CAMEL-23239):

1. **Fix duplicate include** — `component-configure-options.adoc` was included in both the `component-configure options` section and the auto-generated `component options` section. Removed it from the manually-managed `component-configure options` section (keeping it in the `component options` section where the build plugin expects it), matching the standard component doc pattern.

2. **Complete operation list** — the "When to use" section listed only `put, get, delete, contains, keys` but the component also supports `putIfAbsent`, `size`, and `clear`. Updated to list all 8 operations.

## Test plan

- [x] Documentation-only change — no code impact
- [x] Build passes with no uncommitted generated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>