### PR TITLE
fix(camel-kafka): fail-closed readiness with group.protocol=consumer

### DIFF
--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -570,7 +570,7 @@ public class KafkaFetchRecords implements Runnable {
             return false;
         }
 
-        boolean ready = true;
+        boolean ready = false;
         try {
             if (consumer instanceof org.apache.kafka.clients.consumer.KafkaConsumer) {
                 // need to use reflection to access the network client which has API to check if the client has ready
@@ -585,12 +585,17 @@ public class KafkaFetchRecords implements Runnable {
                             "Health-Check calling org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.hasReadyNode");
                     ready = nc.hasReadyNodes(System.currentTimeMillis());
                 }
+            } else {
+                // fail-closed: unknown consumer type (e.g. AsyncKafkaConsumer with group.protocol=consumer) -> not ready
+                // alternative would be to reflectively check AsyncKafkaConsumer.applicationEventHandler
+                ready = false;
             }
         } catch (Exception e) {
-            // ignore
+            // fail-closed on reflection failure
             LOG.debug("Cannot check hasReadyNodes on KafkaConsumer client (ConsumerNetworkClient) due to: "
                       + e.getMessage() + ". This exception is ignored.",
                     e);
+            ready = false;
         }
         return ready;
     }

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaFetchRecords.java
@@ -79,6 +79,10 @@ public class KafkaFetchRecords implements Runnable {
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaFetchRecords.class);
+    // class name checked via getName() rather than instanceof so a future Kafka client release that
+    // renames/removes this internal class fails this branch at runtime instead of failing compilation
+    private static final String ASYNC_KAFKA_CONSUMER_CLASS_NAME
+            = "org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer";
 
     // There are a few of volatile fields here because they are usually read from other threads,
     // like from the health check thread. They are usually only read on those contexts.
@@ -585,9 +589,33 @@ public class KafkaFetchRecords implements Runnable {
                             "Health-Check calling org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.hasReadyNode");
                     ready = nc.hasReadyNodes(System.currentTimeMillis());
                 }
+            } else if (consumer.getClass().getName().equals(ASYNC_KAFKA_CONSUMER_CLASS_NAME)) {
+                // group.protocol=consumer uses the new AsyncKafkaConsumer, which has no ConsumerNetworkClient.
+                // Walk the equivalent internal chain to reach the real KafkaClient and ask it directly.
+                Object appEventHandler
+                        = ReflectionHelper.getField(consumer.getClass().getDeclaredField("applicationEventHandler"),
+                                consumer);
+                Object networkThread = appEventHandler == null
+                        ? null
+                        : ReflectionHelper.getField(appEventHandler.getClass().getDeclaredField("networkThread"),
+                                appEventHandler);
+                Object networkClientDelegate = networkThread == null
+                        ? null
+                        : ReflectionHelper.getField(networkThread.getClass().getDeclaredField("networkClientDelegate"),
+                                networkThread);
+                Object client = networkClientDelegate == null
+                        ? null
+                        : ReflectionHelper.getField(networkClientDelegate.getClass().getDeclaredField("client"),
+                                networkClientDelegate);
+                if (client instanceof org.apache.kafka.clients.KafkaClient) {
+                    LOG.trace(
+                            "Health-Check calling org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.client.hasReadyNode");
+                    ready = ((org.apache.kafka.clients.KafkaClient) client).hasReadyNodes(System.currentTimeMillis());
+                }
+                // else: consumer background thread has not finished initializing networkClientDelegate yet
+                // (it is set once, non-volatile, on the consumer's background thread) -> not yet ready
             } else {
-                // fail-closed: unknown consumer type (e.g. AsyncKafkaConsumer with group.protocol=consumer) -> not ready
-                // alternative would be to reflectively check AsyncKafkaConsumer.applicationEventHandler
+                // fail-closed: unrecognized consumer type -> not ready
                 ready = false;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #37475

Bug: _preparse_jinja_flags adds every jinja_variable_flags entry as an argparse flag without checking against known pipeline options. A jinja variable named runner, project, temp_location, etc. captures the pipeline flag and converts it into jinja_variables, removing it from pipeline_args.

Fix: Guard the loop by checking flag_name against PipelineOptions.get_all_options(). If the name collides (dash normalized to underscore), skip adding it to the jinja parser and require the variable via --jinja_variables JSON instead.

Verification: RED->GREEN verified with mocked PipelineOptions. Before fix, --jinja_variable_flags=runner --runner=DirectRunner produces --jinja_variables={"runner": "DirectRunner"} and loses the pipeline flag. After fix, runner stays in pipeline_args and only non-colliding vars are promoted. Dash variant temp-location also guarded. Existing behavior for non-colliding vars unchanged.
