### PR TITLE
CAMEL-24421: add the spring-redis deserialization-filter notes to the 4.22 and 4.18 upgrade guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -30,6 +30,27 @@ resolves back inside the polled directory remains accepted. Two configurations c
 server that reports names navigating above the polled directory, and a `fileName` expression (used when
 `useList=false`) that navigates above it. Set `jailStartingDirectory=false` if such a path is intended.
 
+=== camel-spring-redis - the default serializer applies a deserialization filter
+
+The default serializer, `JdkSerializationRedisSerializer`, now installs a
+`java.io.ObjectInputFilter` while reading Redis payloads. Previously no filter was applied at all.
+This affects both the consumer, which deserializes the payload of every message published to the
+subscribed channels, and the producer read commands, which deserialize the values stored in Redis.
+
+When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
+otherwise a conservative default allow-list is applied (it permits standard Java and Apache Camel
+types and denies `java.net.**`). Routes that exchange classes outside that allow-list must widen it
+through the new `deserializationFilter` endpoint option, for example:
+
+[source,java]
+----
+from("spring-redis://localhost:6379?command=SUBSCRIBE&channels=myChannel"
+     + "&deserializationFilter=com.example.model.**;java.**;!*")
+----
+
+Setting the `serializer` option to a custom `RedisSerializer` bypasses the filter entirely, since
+Camel then no longer controls how the payload is read.
+
 == Upgrading from 4.18.3 to 4.18.4
 
 === camel-core - Multicast EIP honors UseOriginalAggregationStrategy

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -30,6 +30,29 @@ resolves back inside the polled directory remains accepted. Two configurations c
 server that reports names navigating above the polled directory, and a `fileName` expression (used when
 `useList=false`) that navigates above it. Set `jailStartingDirectory=false` if such a path is intended.
 
+=== camel-spring-redis - the default serializer applies a deserialization filter
+
+The default serializer, `JdkSerializationRedisSerializer`, now installs a JEP-290
+`java.io.ObjectInputFilter` while reading Redis payloads, resolved through
+`DeserializationFilterHelper`. Previously no filter was applied at all. This affects both the
+consumer, which deserializes the payload of every message published to the subscribed channels,
+and the producer read commands, which deserialize the values stored in Redis.
+
+When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
+otherwise the shared Camel default allow-list is applied (it permits standard Java and Apache Camel
+types, denies `java.net.**`, and enforces JEP-290 graph-shape limits). Routes that exchange classes
+outside that allow-list must widen it through the new `deserializationFilter` endpoint option, for
+example:
+
+[source,java]
+----
+from("spring-redis://localhost:6379?command=SUBSCRIBE&channels=myChannel"
+     + "&deserializationFilter=com.example.model.**;java.**;!*")
+----
+
+Setting the `serializer` option to a custom `RedisSerializer` bypasses the filter entirely, since
+Camel then no longer controls how the payload is read.
+
 == Upgrading Camel 4.21 to 4.22
 
 === camel-reactive-executor-tomcat


### PR DESCRIPTION
Doc-only follow-up to #25587 / #25588 / #25589.

The upgrade guides for every release line live on `main`, which holds the canonical history across all releases. The deserialization filter shipped on three lines — 4.23.0, 4.22.1 and 4.18.5 — but only the 4.23 note landed here; the 4.22 and 4.18 notes went in on the maintenance branches, where they are not part of that history.

This adds both, into the `Upgrading from 4.22.0 to 4.22.1` and `Upgrading from 4.18.4 to 4.18.5` sections that already exist here:

| Guide | Note |
|---|---|
| `camel-4x-upgrade-guide-4_22.adoc` | names the JEP-290 graph-shape limits `DeserializationFilterHelper` enforces on that line |
| `camel-4x-upgrade-guide-4_18.adoc` | omits them — on 4.18.x the filter is the local constant without the limits |

The misplaced copies are removed from the maintenance branches by #25780 (4.22.x) and #25781 (4.18.x).

Docs only — no code, no generated files.

---
_Claude Code on behalf of oscerd_