### PR TITLE
CAMEL-24468 + CAMEL-24470: camel-ibm-secrets-manager credential/version-pin fixes (backport to camel-4.18.x)

### DIFF
--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/IBMSecretsManagerPropertiesFunction.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/IBMSecretsManagerPropertiesFunction.java
@@ -100,6 +100,8 @@ public class IBMSecretsManagerPropertiesFunction extends ServiceSupport implemen
                 token = ibmVaultConfiguration.getToken();
                 serviceUrl = ibmVaultConfiguration.getServiceUrl();
             }
+        }
+        if (ObjectHelper.isNotEmpty(token) && ObjectHelper.isNotEmpty(serviceUrl)) {
             IamAuthenticator iamAuthenticator = new IamAuthenticator.Builder()
                     .apikey(token)
                     .build();
@@ -212,14 +214,8 @@ public class IBMSecretsManagerPropertiesFunction extends ServiceSupport implemen
                     Response<SecretVersion> secVersion = client.getSecretVersion(getSecretVersionOptions).execute();
                     data = secVersion.getResult().getData();
                 }
-                if (ObjectHelper.isNotEmpty(data)) {
-                    data = response.getResult().getData();
-                }
-                if (ObjectHelper.isNotEmpty(subkey)) {
-                    returnValue = String.valueOf(data.get(subkey));
-                } else {
-                    returnValue = null;
-                }
+                Object subValue = data.get(subkey);
+                returnValue = subValue != null ? String.valueOf(subValue) : null;
                 if (ObjectHelper.isEmpty(returnValue)) {
                     returnValue = defaultValue;
                 }

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/vault/IBMEventStreamReloadTriggerTask.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/vault/IBMEventStreamReloadTriggerTask.java
@@ -119,15 +119,16 @@ public class IBMEventStreamReloadTriggerTask extends ServiceSupport implements C
                 groupId = ibmVaultConfiguration.getEventStreamGroupId();
                 topic = ibmVaultConfiguration.getEventStreamTopic();
                 if (ObjectHelper.isEmpty(username)) {
-                    if (ObjectHelper.isNotEmpty(ibmVaultConfiguration.getEventStreamUsername())) {
-                        username = ibmVaultConfiguration.getEventStreamUsername();
-                    } else {
-                        username = "token";
-                    }
+                    username = ibmVaultConfiguration.getEventStreamUsername();
                 }
                 password = ibmVaultConfiguration.getEventStreamPassword();
             }
-        } else {
+        }
+        if (ObjectHelper.isEmpty(username)) {
+            username = "token";
+        }
+        if (ObjectHelper.isEmpty(bootstrapServers) || ObjectHelper.isEmpty(groupId) || ObjectHelper.isEmpty(topic)
+                || ObjectHelper.isEmpty(password)) {
             throw new RuntimeCamelException(
                     "Using the IBM Secrets Refresh Task requires setting IBM Event Stream bootstrap servers, topic, groupId, username and password as application properties or environment variables");
         }


### PR DESCRIPTION
Backport of the camel-ibm-secrets-manager credential-handling fixes to `camel-4.18.x`.

Cherry-picks two fixes already merged to `main`:
- **CAMEL-24468** (#25640) — `IBMSecretsManagerPropertiesFunction`: fix the inverted environment-variable credential check, secret version pinning, and the missing-KV-field default.
- **CAMEL-24470** (#25648) — `IBMEventStreamReloadTriggerTask`: honor Event Stream credentials supplied via environment variables.

Both are method-body-only changes (no metadata/generated files, no tests changed); clean cherry-picks, module build green.

---
_Claude Code on behalf of oscerd_
