### PR TITLE
CAMEL-24488: camel-ibm-watson-speech-to-text - close the audio FileInputStream opened by the producer

### DIFF
--- a/components/camel-ibm/camel-ibm-watson-speech-to-text/src/main/java/org/apache/camel/component/ibm/watson/stt/WatsonSpeechToTextProducer.java
+++ b/components/camel-ibm/camel-ibm-watson-speech-to-text/src/main/java/org/apache/camel/component/ibm/watson/stt/WatsonSpeechToTextProducer.java
@@ -35,6 +35,7 @@ import com.ibm.watson.speech_to_text.v1.model.SpeechRecognitionResults;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.IOHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,15 +101,18 @@ public class WatsonSpeechToTextProducer extends DefaultProducer {
         // Get audio input from header or body
         File audioFile = exchange.getIn().getHeader(WatsonSpeechToTextConstants.AUDIO_FILE, File.class);
         InputStream audioStream = null;
+        boolean ownStream = false;
 
         if (audioFile != null) {
             audioStream = new FileInputStream(audioFile);
+            ownStream = true;
         } else {
             audioStream = exchange.getIn().getBody(InputStream.class);
             if (audioStream == null) {
                 File bodyFile = exchange.getIn().getBody(File.class);
                 if (bodyFile != null) {
                     audioStream = new FileInputStream(bodyFile);
+                    ownStream = true;
                 }
             }
         }
@@ -130,32 +134,38 @@ public class WatsonSpeechToTextProducer extends DefaultProducer {
 
         LOG.trace("Recognizing audio with STT: model={}, contentType={}", model, contentType);
 
-        RecognizeOptions options = new RecognizeOptions.Builder()
-                .audio(audioStream)
-                .model(model)
-                .contentType(contentType)
-                .timestamps(timestamps)
-                .wordConfidence(wordConfidence)
-                .speakerLabels(speakerLabels)
-                .build();
+        try {
+            RecognizeOptions options = new RecognizeOptions.Builder()
+                    .audio(audioStream)
+                    .model(model)
+                    .contentType(contentType)
+                    .timestamps(timestamps)
+                    .wordConfidence(wordConfidence)
+                    .speakerLabels(speakerLabels)
+                    .build();
 
-        SpeechRecognitionResults results = stt.recognize(options).execute().getResult();
+            SpeechRecognitionResults results = stt.recognize(options).execute().getResult();
 
-        // Extract transcript text
-        StringBuilder transcript = new StringBuilder();
-        if (results.getResults() != null && !results.getResults().isEmpty()) {
-            for (SpeechRecognitionResult result : results.getResults()) {
-                if (result.getAlternatives() != null && !result.getAlternatives().isEmpty()) {
-                    transcript.append(result.getAlternatives().get(0).getTranscript());
+            // Extract transcript text
+            StringBuilder transcript = new StringBuilder();
+            if (results.getResults() != null && !results.getResults().isEmpty()) {
+                for (SpeechRecognitionResult result : results.getResults()) {
+                    if (result.getAlternatives() != null && !result.getAlternatives().isEmpty()) {
+                        transcript.append(result.getAlternatives().get(0).getTranscript());
+                    }
                 }
             }
-        }
 
-        Message message = getMessageForResponse(exchange);
-        message.setBody(results);
-        message.setHeader(WatsonSpeechToTextConstants.TRANSCRIPT, transcript.toString());
-        message.setHeader(WatsonSpeechToTextConstants.MODEL, model);
-        message.setHeader(WatsonSpeechToTextConstants.CONTENT_TYPE, contentType);
+            Message message = getMessageForResponse(exchange);
+            message.setBody(results);
+            message.setHeader(WatsonSpeechToTextConstants.TRANSCRIPT, transcript.toString());
+            message.setHeader(WatsonSpeechToTextConstants.MODEL, model);
+            message.setHeader(WatsonSpeechToTextConstants.CONTENT_TYPE, contentType);
+        } finally {
+            if (ownStream) {
+                IOHelper.close(audioStream);
+            }
+        }
     }
 
     private void listModels(Exchange exchange) {


### PR DESCRIPTION
# CAMEL-24488: close the audio FileInputStream in the Watson STT producer

`WatsonSpeechToTextProducer.recognize()` opens a `FileInputStream` for the audio input — from the `CamelIbmWatsonSttAudioFile` header (a `File`) or from a `File` message body — but never closes it. There is no `try`/`finally` or try-with-resources around `stt.recognize(options).execute()`, so on every File-based invocation (and on any exception during recognition) the file descriptor is leaked.

## Fix

Track an `ownStream` flag, set to `true` only for the two producer-opened `FileInputStream` cases, and close the stream via `IOHelper.close` in a `finally` block around the recognition. When the audio is supplied as an exchange-body `InputStream`, the caller owns it, so it is deliberately left untouched.

## Testing

The module ships only integration tests (they require live Watson credentials); this is a resource-lifecycle fix around an SDK call that cannot be unit-tested without new mocking dependencies. Verified with a module build (`BUILD SUCCESS`, no generated-file drift).

---
_Claude Code on behalf of oscerd_
