### PR TITLE
CAMEL-24489: camel-api: fix TypeConversionException printing 'from type: null' for anonymous/local classes

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java
+++ b/core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java
@@ -75,9 +75,21 @@ public class TypeConversionException extends RuntimeCamelException {
     public static String createMessage(@Nullable Object value, Class<?> type, Throwable cause) {
         Objects.requireNonNull(type, "type");
         Objects.requireNonNull(cause, "cause");
-        return "Error during type conversion from type: " + (value != null ? value.getClass().getCanonicalName() : null)
-               + " to the required type: " + type.getCanonicalName() + " with value " + value + " due to "
+        return "Error during type conversion from type: " + typeName(value != null ? value.getClass() : null)
+               + " to the required type: " + typeName(type) + " with value " + value + " due to "
                + cause.getClass().getName() + ": " + cause.getMessage();
+    }
+
+    /**
+     * Returns the class name, preferring canonical name but falling back to {@link Class#getName()} for anonymous or
+     * local classes whose canonical name is {@code null}.
+     */
+    private static String typeName(Class<?> clazz) {
+        if (clazz == null) {
+            return "null";
+        }
+        String name = clazz.getCanonicalName();
+        return name != null ? name : clazz.getName();
     }
 
 }

--- a/core/camel-core/src/test/java/org/apache/camel/TypeConversionExceptionMessageTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/TypeConversionExceptionMessageTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies {@link TypeConversionException#createMessage} handles anonymous and local classes whose
+ * {@link Class#getCanonicalName()} returns {@code null}.
+ *
+ * <p>
+ * Real-world trigger: SFTP stream body is an anonymous inner class ({@code ChannelSftp$2}); its canonical name is
+ * {@code null}, causing the error message to print {@code "from type: null"} instead of the actual class name.
+ */
+class TypeConversionExceptionMessageTest {
+
+    @Test
+    void createMessage_anonymousClassUsesGetName() {
+        // anonymous Runnable — getCanonicalName() returns null
+        Object anon = new Runnable() {
+            @Override
+            public void run() {
+            }
+        };
+        assertThat(anon.getClass().getCanonicalName()).isNull();
+
+        String msg = TypeConversionException.createMessage(anon, String.class, new RuntimeException("boom"));
+
+        assertThat(msg)
+                .doesNotContain("from type: null")
+                .contains("from type: ")
+                .contains("$"); // binary name contains $ for anonymous classes
+    }
+
+    @Test
+    void createMessage_namedClassUsesCanonicalName() {
+        String msg = TypeConversionException.createMessage("hello", Integer.class, new RuntimeException("oops"));
+
+        assertThat(msg)
+                .contains("from type: java.lang.String")
+                .contains("to the required type: java.lang.Integer")
+                .contains("due to java.lang.RuntimeException: oops");
+    }
+
+    @Test
+    void createMessage_nullValueShowsNull() {
+        String msg = TypeConversionException.createMessage(null, String.class, new RuntimeException("npe"));
+
+        assertThat(msg)
+                .contains("from type: null")
+                .contains("to the required type: java.lang.String");
+    }
+}


### PR DESCRIPTION
## JIRA

https://issues.apache.org/jira/browse/CAMEL-24489

## Problem

`TypeConversionException.createMessage()` uses `Class.getCanonicalName()` to include the source type in the error message. For anonymous and local classes (e.g. lambda expressions, anonymous inner classes like `ChannelSftp$2`), `getCanonicalName()` returns `null`, so the message prints:

```
Error during type conversion from type: null to the required type: org.apache.camel.StreamCache
with value com.jcraft.jsch.ChannelSftp$2@56b4885a due to java.io.IOException: error
```

The body is **not** null — the value is a JSch anonymous stream class. The `null` in the message is misleading and makes diagnosis harder.

## Stack trace

```
Caused by: org.apache.camel.TypeConversionException: Error during type conversion from type: null to the required type: org.apache.camel.StreamCache with value com.jcraft.jsch.ChannelSftp$2@56b4885a due to java.io.IOException: error
    at org.apache.camel.converter.stream.StreamCacheBulkConverterLoader.convertTo(StreamCacheBulkConverterLoader.java:60)
```

## Fix

Add a private `typeName(Class<?>)` helper that falls back to `getName()` when `getCanonicalName()` is null. Also apply the same helper to the `type` parameter (target type) for consistency.

**After fix:**
```
Error during type conversion from type: com.jcraft.jsch.ChannelSftp$2 to the required type: org.apache.camel.StreamCache
with value com.jcraft.jsch.ChannelSftp$2@56b4885a due to java.io.IOException: error
```

## Changes

- `core/camel-api/src/main/java/org/apache/camel/TypeConversionException.java` — fix + `typeName()` helper
- `core/camel-core/src/test/java/org/apache/camel/TypeConversionExceptionMessageTest.java` — 3 tests: anonymous class, named class, null value

## Test plan

- [x] `mvn test -pl core/camel-core -Dtest=TypeConversionExceptionMessageTest` — Tests run: 3, Failures: 0
- [x] `mvn formatter:format impsort:sort` — no changes needed

> AI-assisted contribution. Co-authored-by: Claude <claude@anthropic.com>