### PR TITLE
CAMEL-24490: camel-ibm-watsonx-ai - apply the configured timeout to the watsonx.ai service clients

### DIFF
--- a/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/service/WatsonxAiServiceFactory.java
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/service/WatsonxAiServiceFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.ibm.watsonx.ai.service;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 import com.ibm.watsonx.ai.chat.ChatService;
@@ -51,6 +52,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -66,6 +68,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -81,6 +84,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -96,6 +100,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -111,6 +116,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -126,6 +132,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         // DetectionService doesn't have modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -150,6 +157,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         // TextExtractionService doesn't have modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -171,6 +179,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         // TextClassificationService doesn't have modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -186,6 +195,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -198,6 +208,7 @@ public final class WatsonxAiServiceFactory {
 
         // FoundationModelService doesn't have projectId, spaceId, modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -211,6 +222,7 @@ public final class WatsonxAiServiceFactory {
 
         // DeploymentService doesn't have projectId, spaceId, modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -231,6 +243,7 @@ public final class WatsonxAiServiceFactory {
 
         // ToolService doesn't have projectId, spaceId, modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 


### PR DESCRIPTION
# CAMEL-24490: apply the configured timeout to the watsonx.ai service clients

`WatsonxAiConfiguration` declares a `timeout` `@UriParam` (_"Request timeout in milliseconds"_), but `WatsonxAiServiceFactory` never applied it. Each of the 12 `createXxxService()` methods set `baseUrl`/`apiKey`/`projectId`/`spaceId`/`modelId`/`verifySsl`/`logRequests`/`logResponses` on the SDK builder but omitted `timeout`, so the configured value was silently ignored and every watsonx.ai request used the SDK default timeout. Streaming operations (`ChatHandler`, `TextGenerationHandler`) that block on the returned `CompletableFuture` were likewise left effectively unbounded.

## Fix

The SDK builder base (`com.ibm.watsonx.ai` `WatsonxService.Builder`, verified in `watsonx-ai` 0.30.1) exposes `timeout(java.time.Duration)`. Apply the configured timeout to every service builder:

```java
applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
```

The SDK then governs how the timeout applies to both unary and streaming requests (via its HTTP client), so a configured timeout now bounds the previously-unbounded streaming `future.get()` as well.

## Testing

The module ships only integration tests (they require live watsonx.ai credentials); this is a client-configuration fix. Verified with a module build (`BUILD SUCCESS`, no generated-file drift — the `timeout` option already existed, so no catalog/metadata change).

---
_Claude Code on behalf of oscerd_
