### PR TITLE
CAMEL-24491: camel-ibm-cos - make consumer in-progress deduplication effective

### DIFF
--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSConsumer.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSConsumer.java
@@ -165,10 +165,18 @@ public class IBMCOSConsumer extends ScheduledBatchPollingConsumer {
                 continue;
             }
 
-            S3Object s3Object = getCosClient().getObject(
-                    new GetObjectRequest(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey()));
-            Exchange exchange = createExchange(s3Object, s3ObjectSummary.getKey());
-            exchanges.add(exchange);
+            try {
+                S3Object s3Object = getCosClient().getObject(
+                        new GetObjectRequest(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey()));
+                Exchange exchange = createExchange(s3Object, s3ObjectSummary.getKey());
+                exchanges.add(exchange);
+            } catch (Exception e) {
+                // Fetching the object or creating the exchange failed after we claimed the in-progress key;
+                // release it so the object is not left permanently unconsumable, and skip it for this poll.
+                LOG.warn("Error fetching object {} from bucket {}: {}. Skipping it for this poll.",
+                        s3ObjectSummary.getKey(), s3ObjectSummary.getBucketName(), e.getMessage());
+                removeInProgress(s3ObjectSummary.getKey());
+            }
         }
 
         return exchanges;

--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSConsumer.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSConsumer.java
@@ -160,7 +160,7 @@ public class IBMCOSConsumer extends ScheduledBatchPollingConsumer {
             }
 
             if (getEndpoint().getInProgressRepository() != null
-                    && getEndpoint().getInProgressRepository().contains(s3ObjectSummary.getKey())) {
+                    && !getEndpoint().getInProgressRepository().add(s3ObjectSummary.getKey())) {
                 LOG.trace("Object {} is already in progress", s3ObjectSummary.getKey());
                 continue;
             }
@@ -246,11 +246,20 @@ public class IBMCOSConsumer extends ScheduledBatchPollingConsumer {
             }
         } catch (Exception e) {
             LOG.warn("Error during post processing of object {} from bucket {}: {}", key, bucketName, e.getMessage());
+        } finally {
+            removeInProgress(key);
         }
     }
 
     protected void processRollback(String key) {
         LOG.trace("Processing failed for object with key {}", key);
+        removeInProgress(key);
+    }
+
+    private void removeInProgress(String key) {
+        if (getEndpoint().getInProgressRepository() != null) {
+            getEndpoint().getInProgressRepository().remove(key);
+        }
     }
 
     private void copyObject(String bucketName, String key) {

--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSEndpoint.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSEndpoint.java
@@ -115,6 +115,9 @@ public class IBMCOSEndpoint extends ScheduledPollEndpoint implements EndpointSer
     protected void doStart() throws Exception {
         super.doStart();
 
+        // Start the in-progress repository up front so consumer deduplication works even when doStart returns early
+        ServiceHelper.startService(inProgressRepository);
+
         cosClient = configuration.getCosClient() != null
                 ? configuration.getCosClient() : createCosClient();
 
@@ -146,8 +149,6 @@ public class IBMCOSEndpoint extends ScheduledPollEndpoint implements EndpointSer
             cosClient.createBucket(bucketName);
             LOG.trace("Bucket created");
         }
-
-        ServiceHelper.startService(inProgressRepository);
     }
 
     @Override


### PR DESCRIPTION
# CAMEL-24491: make the IBM COS consumer's in-progress deduplication effective

The IBM COS consumer is meant to skip objects that are already being processed, via the endpoint's in-progress `IdempotentRepository`, but the deduplication never worked:

1. `createExchanges()` only **checked** the repository (`getInProgressRepository().contains(key)`) and never **added** the key, so `contains()` was always false.
2. The repository is a `MemoryIdempotentRepository` service, but `IBMCOSEndpoint.doStart()` only started it (`ServiceHelper.startService`) **after** two early returns — when a `fileName` is configured, or when the bucket already exists (the normal consuming case). So in practice it was never started.
3. `processCommit()` / `processRollback()` never removed the key.

Together these meant overlapping polls could re-deliver an object still being processed when `deleteAfterRead`/`moveAfterRead` were off.

## Fix

Mirror `camel-aws2-s3`'s `AWS2S3Consumer` (this module was copied from it):
- Use `getInProgressRepository().add(key)` as the atomic guard (skip the object when `add` returns `false`, i.e. it is already in progress).
- Remove the key in `processCommit` (in a `finally`) and `processRollback`, via a null-safe `removeInProgress` helper.
- Start the in-progress repository up front in `doStart()`, before any early return.

## Testing

The module ships only integration tests (they require live IBM COS credentials) and has no mocking dependency, so this lifecycle fix is not unit-testable without adding new test dependencies. It ports the behavior of the reviewed `camel-aws2-s3` consumer. Verified with a module build (`BUILD SUCCESS`, no generated-file drift).

---
_Claude Code on behalf of oscerd_
