### PR TITLE
[backport camel-4.22.x] CAMEL-24486: camel-core - Simple language init block custom function lookup fails in dev profile

### DIFF
--- a/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultSimpleFunctionRegistry.java
+++ b/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultSimpleFunctionRegistry.java
@@ -110,6 +110,10 @@ public class DefaultSimpleFunctionRegistry extends ServiceSupport implements Sim
                 removeFunction(name);
                 addFunction(sf);
                 exp = functions.get(name);
+            } else if (dev) {
+                // fallback to an already registered function (eg from a simple language init block)
+                // that is not backed by a SimpleFunction bean in the registry
+                exp = functions.get(name);
             }
         }
         return exp;

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SimpleInitBlockTest.groovy
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/test/groovy/org/apache/camel/dsl/yaml/SimpleInitBlockTest.groovy
@@ -57,4 +57,69 @@ class SimpleInitBlockTest extends YamlTestSupport {
         MockEndpoint.assertIsSatisfied(context)
     }
 
+    def "initBlockCompactCustomFunction"() {
+        setup:
+        loadRoutes '''
+                - route:
+                    from:
+                      uri: direct:map
+                      steps:
+                        - setBody:
+                            simple: |-
+                              $init{
+                                $foo ~:= ${uppercase()};
+                              }init$
+                              ${foo('hello')}
+                        - to:
+                            uri: mock:result
+                        '''
+        withMock('mock:result') {
+            expectedMessageCount(1)
+            message(0).body().isEqualTo("HELLO")
+        }
+
+        when:
+        context.start()
+
+        withTemplate {
+            to('direct:map').withBody('test').send()
+        }
+
+        then:
+        MockEndpoint.assertIsSatisfied(context)
+    }
+
+    def "initBlockCustomFunctionInDevProfile"() {
+        setup:
+        context.getCamelContextExtension().setProfile("dev")
+        loadRoutes '''
+                - route:
+                    from:
+                      uri: direct:map
+                      steps:
+                        - setBody:
+                            simple: |-
+                              $init{
+                                $foo ~:= ${uppercase()};
+                              }init$
+                              ${foo('hello')}
+                        - to:
+                            uri: mock:result
+                        '''
+        withMock('mock:result') {
+            expectedMessageCount(1)
+            message(0).body().isEqualTo("HELLO")
+        }
+
+        when:
+        context.start()
+
+        withTemplate {
+            to('direct:map').withBody('test').send()
+        }
+
+        then:
+        MockEndpoint.assertIsSatisfied(context)
+    }
+
 }


### PR DESCRIPTION
## Backport of #25729

Cherry-pick of #25729 onto `camel-4.22.x`.

**Original PR:** #25729 - CAMEL-24486: camel-core - Simple language init block custom function lookup fails in dev profile
**Original author:** @davsclaus
**Target branch:** `camel-4.22.x`

### Original description

- Fixes `DefaultSimpleFunctionRegistry.getFunction()` incorrectly failing to resolve Simple language custom functions defined via the init block (`$foo ~:= <expr>;`) whenever the `CamelContext` profile is `dev`.
- In dev profile, the lookup intentionally bypasses its own function cache to support hot-reloading `SimpleFunction` beans registered in the Camel registry — but init-block custom functions are plain `Expression`s stored directly in that cache, not registry beans, so they were never found and route creation failed with `No custom simple function with name: X`.
- Since `camel run` (camel-jbang) defaults to `--profile=dev`, this broke the init-block custom-function feature for essentially every JBang user, even though it worked fine outside dev profile (e.g. plain `mvn`/unit tests).
- Reported by a community member via Zulip. Root-caused and reproduced independently of YAML/JBang in a plain unit test by setting `context.getCamelContextExtension().setProfile("dev")`.

_Claude Code on behalf of davsclaus_