### PR TITLE
[backport camel-4.18.x] CAMEL-24487: remote-file consumers - contain remote operations within the configured directory

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileConsumer.java
@@ -620,6 +620,13 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
             return false;
         }
 
+        // the resolved path must stay within the starting directory, as the name it was built from is
+        // reported by the remote server and is not necessarily a single path segment
+        if (endpoint.isJailStartingDirectory() && !isWithinStartingDirectory(absoluteFilePath)) {
+            LOG.warn("Skipping file as it resolves outside the starting directory: {}", absoluteFilePath);
+            return false;
+        }
+
         // directory is always valid
         if (isDirectory) {
             return true;
@@ -667,6 +674,22 @@ public abstract class GenericFileConsumer<T> extends ScheduledBatchPollingConsum
             }
         }
         return answer;
+    }
+
+    /**
+     * Strategy to determine whether the resolved path of a listed file stays within the configured starting directory.
+     * <p/>
+     * Consumers that build the path from a name supplied by a remote server must override this, as such a name is not
+     * guaranteed to be a single path segment and can otherwise navigate outside the directory being polled. The check
+     * is only consulted when {@link GenericFileEndpoint#isJailStartingDirectory()} is enabled.
+     *
+     * @param  absoluteFilePath the resolved absolute path of the listed file
+     * @return                  {@code true} if the path stays within the starting directory
+     */
+    protected boolean isWithinStartingDirectory(String absoluteFilePath) {
+        // names obtained from a local directory listing are always single path segments, so there is no
+        // boundary to enforce here
+        return true;
     }
 
     /**

--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
@@ -58,8 +58,28 @@ public final class GenericFileHelper {
      * @param  compactTarget the compacted target path (see {@link FileUtil#compactPath(String)})
      * @param  compactDir    the compacted directory the target must stay within
      * @return               {@code true} if the target is the directory itself or a path inside it
+     * @see                  #isWithinDirectory(String, String, char)
      */
     public static boolean isWithinDirectory(String compactTarget, String compactDir) {
+        return isWithinDirectory(compactTarget, compactDir, File.separatorChar);
+    }
+
+    /**
+     * Determines whether a compacted target path is contained within a compacted directory path, using the given path
+     * separator. Remote file paths always use {@code /} regardless of the platform Camel runs on, so remote callers
+     * must pass {@code '/'} rather than relying on {@link File#separatorChar}.
+     *
+     * @param  compactTarget the compacted target path (see {@link FileUtil#compactPath(String, char)})
+     * @param  compactDir    the compacted directory the target must stay within
+     * @param  separator     the path separator both paths are expressed with
+     * @return               {@code true} if the target is the directory itself or a path inside it
+     */
+    public static boolean isWithinDirectory(String compactTarget, String compactDir, char separator) {
+        // a target that still resolves upwards after compaction escapes any root, even when no boundary is
+        // configured, so it is never contained
+        if (compactTarget.equals("..") || compactTarget.startsWith(".." + separator)) {
+            return false;
+        }
         if (compactDir.isEmpty()) {
             // no directory boundary configured
             return true;
@@ -67,10 +87,10 @@ public final class GenericFileHelper {
         // drop a trailing separator (if any) so the boundary comparison is exact, regardless of whether the
         // directory path was supplied with or without one
         String dir = compactDir;
-        if (dir.charAt(dir.length() - 1) == File.separatorChar) {
+        if (dir.charAt(dir.length() - 1) == separator) {
             dir = dir.substring(0, dir.length() - 1);
         }
-        return compactTarget.equals(dir) || compactTarget.startsWith(dir + File.separator);
+        return compactTarget.equals(dir) || compactTarget.startsWith(dir + separator);
     }
 
     public static String asExclusiveReadLockKey(GenericFile file, String key) {

--- a/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
+++ b/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
@@ -71,4 +71,31 @@ public class GenericFileHelperTest {
         // an empty directory imposes no boundary
         assertTrue(GenericFileHelper.isWithinDirectory("anything.txt", ""));
     }
+
+    @Test
+    public void isWithinDirectoryUsesTheGivenSeparator() {
+        // remote paths always use '/', regardless of the platform Camel runs on
+        assertTrue(GenericFileHelper.isWithinDirectory("poll/file.txt", "poll", '/'));
+        assertTrue(GenericFileHelper.isWithinDirectory("poll/sub/file.txt", "poll", '/'));
+        assertTrue(GenericFileHelper.isWithinDirectory("poll", "poll", '/'));
+        assertTrue(GenericFileHelper.isWithinDirectory("/poll/file.txt", "/poll", '/'));
+
+        // a trailing separator on the directory is tolerated
+        assertTrue(GenericFileHelper.isWithinDirectory("poll/file.txt", "poll/", '/'));
+
+        // a sibling whose name merely extends the directory name is NOT contained
+        assertFalse(GenericFileHelper.isWithinDirectory("pollute/file.txt", "poll", '/'));
+    }
+
+    @Test
+    public void isWithinDirectoryRejectsPathsResolvingOutsideTheDirectory() {
+        // the compacted result of a listing name that navigates above the polled directory
+        assertFalse(GenericFileHelper.isWithinDirectory("../secret.txt", "poll", '/'));
+        assertFalse(GenericFileHelper.isWithinDirectory("../../etc/shadow", "poll", '/'));
+        assertFalse(GenericFileHelper.isWithinDirectory("/secret.txt", "/poll", '/'));
+
+        // a target that still resolves upwards escapes even when no directory boundary is configured
+        assertFalse(GenericFileHelper.isWithinDirectory("..", "", '/'));
+        assertFalse(GenericFileHelper.isWithinDirectory("../secret.txt", "", '/'));
+    }
 }

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConsumer.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/RemoteFileConsumer.java
@@ -24,9 +24,11 @@ import org.apache.camel.Ordered;
 import org.apache.camel.Processor;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileConsumer;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileProcessStrategy;
 import org.apache.camel.support.SynchronizationAdapter;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,11 @@ import org.slf4j.LoggerFactory;
 public abstract class RemoteFileConsumer<T> extends GenericFileConsumer<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(RemoteFileConsumer.class);
+
+    /**
+     * Remote paths always use {@code /}, regardless of the platform Camel runs on.
+     */
+    private static final char REMOTE_PATH_SEPARATOR = '/';
 
     protected transient boolean loggedIn;
     protected transient boolean loggedInWarning;
@@ -58,6 +65,22 @@ public abstract class RemoteFileConsumer<T> extends GenericFileConsumer<T> {
 
     protected RemoteFileOperations<T> getOperations() {
         return (RemoteFileOperations<T>) operations;
+    }
+
+    /**
+     * The file name comes from the directory listing returned by the remote server and is not guaranteed to be a single
+     * path segment, so the path resolved from it is compacted and checked to still be inside the directory being polled
+     * before the file is accepted for retrieval, deletion or renaming.
+     */
+    @Override
+    protected boolean isWithinStartingDirectory(String absoluteFilePath) {
+        if (absoluteFilePath == null) {
+            return false;
+        }
+        String directory = getEndpoint().getConfiguration().getDirectory();
+        String compactDir = directory != null ? FileUtil.compactPath(directory, REMOTE_PATH_SEPARATOR) : "";
+        return GenericFileHelper.isWithinDirectory(
+                FileUtil.compactPath(absoluteFilePath, REMOTE_PATH_SEPARATOR), compactDir, REMOTE_PATH_SEPARATOR);
     }
 
     @Override

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/RemoteFileConsumerStartingDirectoryJailTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/RemoteFileConsumerStartingDirectoryJailTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote;
+
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The file name used to build the path of a polled file comes from the directory listing returned by the remote server,
+ * so it is not guaranteed to be a single path segment. Verifies the resolved path is kept inside the directory being
+ * polled before it is used as the operand for retrieving, deleting or renaming.
+ */
+class RemoteFileConsumerStartingDirectoryJailTest extends CamelTestSupport {
+
+    private RemoteFileConsumer<?> consumer(String uri) throws Exception {
+        RemoteFileEndpoint<?> endpoint = context.getEndpoint(uri, RemoteFileEndpoint.class);
+        return (RemoteFileConsumer<?>) endpoint.createConsumer(exchange -> {
+        });
+    }
+
+    @Test
+    void shouldAcceptPathsWithinTheStartingDirectory() throws Exception {
+        RemoteFileConsumer<?> consumer = consumer("ftp://hostname/poll");
+
+        assertTrue(consumer.isWithinStartingDirectory("poll/file.txt"));
+        assertTrue(consumer.isWithinStartingDirectory("poll/sub/file.txt"));
+        // a ../ that still resolves back inside the polled directory is legitimate
+        assertTrue(consumer.isWithinStartingDirectory("poll/sub/../file.txt"));
+    }
+
+    @Test
+    void shouldRejectPathsEscapingTheStartingDirectory() throws Exception {
+        RemoteFileConsumer<?> consumer = consumer("ftp://hostname/poll");
+
+        assertFalse(consumer.isWithinStartingDirectory("poll/a/../../../secret.txt"));
+        assertFalse(consumer.isWithinStartingDirectory("poll/../secret.txt"));
+        assertFalse(consumer.isWithinStartingDirectory("poll/../../etc/shadow"));
+        // a sibling directory whose name merely extends the polled directory name is not contained
+        assertFalse(consumer.isWithinStartingDirectory("poll/../pollute/secret.txt"));
+        assertFalse(consumer.isWithinStartingDirectory(null));
+    }
+
+    @Test
+    void shouldRejectPathsEscapingTheStartingDirectoryOverSftp() throws Exception {
+        RemoteFileConsumer<?> consumer = consumer("sftp://hostname/poll");
+
+        assertTrue(consumer.isWithinStartingDirectory("poll/file.txt"));
+        assertFalse(consumer.isWithinStartingDirectory("poll/a/../../../secret.txt"));
+        assertFalse(consumer.isWithinStartingDirectory("poll/../secret.txt"));
+    }
+
+    @Test
+    void shouldRejectUpwardsPathsWhenPollingTheSessionRoot() throws Exception {
+        RemoteFileConsumer<?> consumer = consumer("ftp://hostname");
+
+        assertTrue(consumer.isWithinStartingDirectory("file.txt"));
+        // no directory is configured, but navigating above the session root still escapes
+        assertFalse(consumer.isWithinStartingDirectory("../secret.txt"));
+    }
+}

--- a/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java
+++ b/components/camel-smb/src/main/java/org/apache/camel/component/smb/SmbConsumer.java
@@ -32,6 +32,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileConsumer;
 import org.apache.camel.component.file.GenericFileEndpoint;
+import org.apache.camel.component.file.GenericFileHelper;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileOperations;
 import org.apache.camel.component.file.GenericFileProcessStrategy;
@@ -46,6 +47,11 @@ import org.slf4j.LoggerFactory;
 public class SmbConsumer extends GenericFileConsumer<FileIdBothDirectoryInformation> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SmbConsumer.class);
+
+    /**
+     * Remote paths always use {@code /}, regardless of the platform Camel runs on.
+     */
+    private static final char REMOTE_PATH_SEPARATOR = '/';
 
     private final SmbEndpoint endpoint;
     private final SmbConfiguration configuration;
@@ -69,6 +75,21 @@ public class SmbConsumer extends GenericFileConsumer<FileIdBothDirectoryInformat
     @SuppressWarnings("unchecked")
     public GenericFileEndpoint<FileIdBothDirectoryInformation> getEndpoint() {
         return (GenericFileEndpoint<FileIdBothDirectoryInformation>) super.getEndpoint();
+    }
+
+    /**
+     * The file name comes from the directory listing returned by the remote share and is not guaranteed to be a single
+     * path segment, so the path resolved from it is compacted and checked to still be inside the directory being polled
+     * before the file is accepted for retrieval, deletion or renaming.
+     */
+    @Override
+    protected boolean isWithinStartingDirectory(String absoluteFilePath) {
+        if (absoluteFilePath == null) {
+            return false;
+        }
+        return GenericFileHelper.isWithinDirectory(
+                FileUtil.compactPath(absoluteFilePath, REMOTE_PATH_SEPARATOR),
+                FileUtil.compactPath(endpointPath, REMOTE_PATH_SEPARATOR), REMOTE_PATH_SEPARATOR);
     }
 
     @Override


### PR DESCRIPTION
Backport of #25730 (CAMEL-24487) to `camel-4.18.x`.

The remote-file consumers build the absolute remote path by concatenating the configured directory with the file name reported in the server directory listing, and then use that result as the operand for the subsequent retrieve, delete and rename operations. No lexical normalization or containment check was applied between the listing and those operations, so a listing entry that is not a single path segment could resolve outside the configured directory.

Adds a separator-aware `GenericFileHelper.isWithinDirectory` overload (remote paths always use `/` regardless of platform) and a `GenericFileConsumer.isWithinStartingDirectory` strategy consulted from `isValidFile` when `jailStartingDirectory` is enabled. The base implementation is a no-op for local directory listings; `RemoteFileConsumer` and `SmbConsumer` override it. A file resolving outside the polled directory is skipped with a warning.

Two divergences from main, both handled: `camel-ftp-common` does not exist on this branch, so `RemoteFileConsumer` lives in `camel-ftp` (all four of FtpConsumer, SftpConsumer, MinaSftpConsumer and FilesConsumer still extend it, so coverage is unchanged); and this branch is on JUnit 5, so the new test's `CamelTestSupport` import was rewritten from `junit6` to `junit5`.

**No upgrade-guide edit here** — the version-specific guides for all release lines are maintained on `main`. The matching note is added there in a separate doc-sync PR.

**Testing:** `camel-ftp` suite 60 tests / 0 failures; `core/camel-core` file tests 395 / 0 failures; the new `RemoteFileConsumerStartingDirectoryJailTest` (4 tests) green; camel-file, camel-ftp and camel-smb all build.

---

_Claude Code on behalf of oscerd_
