### PR TITLE
ci: scope the local docs build to components 4.22.x so PR doc validation resolves xrefs

### DIFF
--- a/docs/source-watch.yml
+++ b/docs/source-watch.yml
@@ -23,8 +23,7 @@
           branch_includes: main
           start_path_includes: docs/components,components-starter
       components:
-# uncomment to work only on components
-#        - name: components
-#          version: next
+        - name: components
+          version: 4.22.x
 # uncomment to work only on the user manual
 #        - name: manual


### PR DESCRIPTION
## Problem

`PR doc validation` fails on **every** PR targeting `camel-4.22.x`, with 433 asciidoctor errors, all of the same shape:

```
ERROR (asciidoctor): target of xref not found: components::index.adoc
ERROR (asciidoctor): target of xref not found: components:languages:simple-language.adoc
ERROR (asciidoctor): target of xref not found: next@components:eips:ai-patterns.adoc
```

They land in files such as `core/camel-core-engine/src/main/docs/modules/eips/pages/*.adoc` — files the failing PRs never touch. Confirmed on two unrelated PRs:

- #25733 (camel-docling backport)
- #25588 (camel-spring-redis backport, which touches no core EIP docs at all)

A main-based run of the same job reports **0** asciidoctor errors, so this is branch-level, not PR content.

## Cause

The job runs camel-website's `antora-local-build.sh` in `quick` mode. Quick mode builds the local checkout and resolves everything else from the published `site-manifest.json`. Which components are taken from local sources is decided by the `components:` filter in `docs/source-watch.yml`.

On `main` that filter is active:

```yaml
      components:
        - name: components
          version: next
```

On this branch it was left commented out, so `components:` is an empty key. With no filter the local build isn't scoped, Antora tries to resolve the whole `components` namespace out of the local checkout, and every xref into it fails.

The `next@components:...` error is the same cause seen from the other side: with the filter empty there is no correctly-scoped components source at all.

## Fix

Uncomment the filter using this branch's own version:

```yaml
      components:
        - name: components
          version: 4.22.x
```

`4.22.x` matches what both `docs/components/antora.yml` and `core/camel-core-engine/src/main/docs/antora.yml` already declare on this branch. Components other than the local one then come from the site manifest, exactly as on `main`.

## Verification

This PR **is** the verification. I could not reproduce the Antora build locally (camel-website has no toolchain installed here, and installing it hits the same native-dependency problem that intermittently breaks this job), so the doc-validation job on this PR is the test: it should go from 433 errors to clean.

If it does not, the change should be dropped rather than iterated on blindly.

## Note

`camel-4.18.x` and `camel-4.4.x` carry the same commented-out filter, so the same failure is latent there. Nothing currently triggers doc validation on those branches; worth a follow-up if that changes.