### PR TITLE
CAMEL-24493: camel-ibm-cos - honor the multiPartUpload, partSize, storageClass and deleteAfterWrite producer options

### DIFF
--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSProducer.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.ibm.cos;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +34,14 @@ import com.ibm.cloud.objectstorage.services.s3.model.ObjectMetadata;
 import com.ibm.cloud.objectstorage.services.s3.model.PutObjectRequest;
 import com.ibm.cloud.objectstorage.services.s3.model.PutObjectResult;
 import com.ibm.cloud.objectstorage.services.s3.model.S3Object;
+import com.ibm.cloud.objectstorage.services.s3.transfer.TransferManager;
+import com.ibm.cloud.objectstorage.services.s3.transfer.TransferManagerBuilder;
+import com.ibm.cloud.objectstorage.services.s3.transfer.model.UploadResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.WrappedFile;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,12 +159,52 @@ public class IBMCOSProducer extends DefaultProducer {
 
         PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, inputStream, metadata);
 
+        String storageClass = getConfiguration().getStorageClass();
+        if (ObjectHelper.isNotEmpty(storageClass)) {
+            putObjectRequest.withStorageClass(storageClass);
+        }
+
         LOG.trace("Putting object [{}] into bucket [{}]...", key, bucketName);
-        PutObjectResult putObjectResult = cosClient.putObject(putObjectRequest);
+
+        String eTag;
+        String versionId;
+        if (getConfiguration().isMultiPartUpload()) {
+            // Upload via the TransferManager so large payloads are sent as a multipart upload with the configured part size
+            TransferManager transferManager = TransferManagerBuilder.standard()
+                    .withS3Client(cosClient)
+                    .withMinimumUploadPartSize(getConfiguration().getPartSize())
+                    .withMultipartUploadThreshold(getConfiguration().getPartSize())
+                    .build();
+            try {
+                UploadResult uploadResult = transferManager.upload(putObjectRequest).waitForUploadResult();
+                eTag = uploadResult.getETag();
+                versionId = uploadResult.getVersionId();
+            } finally {
+                // shut down the TransferManager's own thread pool but keep the shared COS client open
+                transferManager.shutdownNow(false);
+            }
+        } else {
+            PutObjectResult putObjectResult = cosClient.putObject(putObjectRequest);
+            eTag = putObjectResult.getETag();
+            versionId = putObjectResult.getVersionId();
+        }
 
         Message message = getMessageForResponse(exchange);
-        message.setHeader(IBMCOSConstants.E_TAG, putObjectResult.getETag());
-        message.setHeader(IBMCOSConstants.VERSION_ID, putObjectResult.getVersionId());
+        message.setHeader(IBMCOSConstants.E_TAG, eTag);
+        message.setHeader(IBMCOSConstants.VERSION_ID, versionId);
+
+        if (getConfiguration().isDeleteAfterWrite()) {
+            File filePayload = null;
+            if (body instanceof File file) {
+                filePayload = file;
+            } else if (body instanceof WrappedFile<?> wrapped && wrapped.getFile() instanceof File file) {
+                filePayload = file;
+            }
+            if (filePayload != null) {
+                LOG.trace("Deleting file payload [{}] after write", filePayload);
+                FileUtil.deleteFile(filePayload);
+            }
+        }
     }
 
     private void getObject(AmazonS3 cosClient, Exchange exchange) {


### PR DESCRIPTION
# CAMEL-24493: honor the IBM COS producer options

`IBMCOSProducer.putObject()` built a plain `PutObjectRequest` and never read the four producer options declared on `IBMCOSConfiguration` — even though the component docs advertise them (a multipart upload _"if multiPartUpload option is enabled"_, with a `?multiPartUpload=true&partSize=5242880` example). So `multiPartUpload` / `partSize` / `storageClass` / `deleteAfterWrite` were silently ignored.

## Fix

Mirroring `camel-aws2-s3`'s `AWS2S3Producer` (this module was copied from it):
- **storageClass** → applied to the `PutObjectRequest` via `withStorageClass`.
- **multiPartUpload / partSize** → when enabled, upload through the IBM COS SDK `TransferManager` with the minimum upload part size and multipart threshold set to `partSize`, so large payloads are sent as a multipart upload. The `TransferManager`'s thread pool is shut down afterwards (`shutdownNow(false)`), leaving the shared COS client open.
- **deleteAfterWrite** → after a successful upload, delete the local `File` payload (a `File` body, or a `WrappedFile` backed by a local `File`).

## Testing

The module ships only integration tests (they require live IBM COS credentials) and has no mocking dependency, so these options can't be unit-tested without new test deps. The implementation ports the reviewed `camel-aws2-s3` producer semantics and uses the SDK's own `TransferManager` for multipart. Verified with a module build (`BUILD SUCCESS`, no generated-file drift — the options already existed).

---
_Claude Code on behalf of oscerd_
