### PR TITLE
[backport camel-4.18.x] CAMEL-24412: camel-netty-http - evaluate the security constraint against the same normalized target as dispatch

### DIFF
--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerChannelHandler.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/handlers/HttpServerChannelHandler.java
@@ -215,15 +215,13 @@ public class HttpServerChannelHandler extends ServerChannelHandler {
     private String extractTarget(URI uri) {
         String target = uri.getPath();
 
-        // strip the starting endpoint path so the target is relative to the endpoint uri
+        // strip the starting endpoint path so the target is relative to the endpoint uri.
+        // the comparison must ignore case on the context-path, the same way consumer dispatch does
+        // (RestConsumerContextPathMatcher), so the security constraint is evaluated against the same
+        // normalized target the request is actually routed to
         String path = consumer.getConfiguration().getPath();
-        if (path != null && target.startsWith(path)) {
-            // need to match by lower case as we want to ignore case on context-path
-            path = path.toLowerCase(Locale.US);
-            String match = target.toLowerCase(Locale.US);
-            if (match.startsWith(path)) {
-                target = target.substring(path.length());
-            }
+        if (path != null && target.toLowerCase(Locale.US).startsWith(path.toLowerCase(Locale.US))) {
+            target = target.substring(path.length());
         }
         return target;
     }

--- a/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBasicAuthConstraintCaseInsensitiveTest.java
+++ b/components/camel-netty-http/src/test/java/org/apache/camel/component/netty/http/NettyHttpBasicAuthConstraintCaseInsensitiveTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.netty.http;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.test.junit5.TestSupport.assertIsInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Consumer dispatch matches the context-path case-insensitively, so the security constraint has to be evaluated against
+ * the same normalized target. Otherwise a request that differs from the configured context-path only by case reaches
+ * the route while skipping the constraint that guards it.
+ */
+public class NettyHttpBasicAuthConstraintCaseInsensitiveTest extends BaseNettyTestSupport {
+
+    @Override
+    public void doPreSetup() {
+        System.setProperty("java.security.auth.login.config", "src/test/resources/myjaas.config");
+    }
+
+    @Override
+    public void doPostTearDown() {
+        System.clearProperty("java.security.auth.login.config");
+    }
+
+    @BindToRegistry("mySecurityConfig")
+    public NettyHttpSecurityConfiguration loadSecConf() {
+        NettyHttpSecurityConfiguration security = new NettyHttpSecurityConfiguration();
+        security.setRealm("karaf");
+        SecurityAuthenticator auth = new JAASSecurityAuthenticator();
+        auth.setName("karaf");
+        security.setSecurityAuthenticator(auth);
+
+        // a specific inclusion, not a catch-all: only /admin/* below the endpoint path is restricted
+        SecurityConstraintMapping matcher = new SecurityConstraintMapping();
+        matcher.addInclusion("/admin/*");
+        security.setSecurityConstraint(matcher);
+
+        return security;
+    }
+
+    @Test
+    public void exactCaseContextPathIsChallenged() {
+        CamelExecutionException e = assertThrows(CamelExecutionException.class,
+                () -> template.requestBody("netty-http:http://localhost:{{port}}/foo/admin/x", "Hello", String.class));
+        NettyHttpOperationFailedException cause = assertIsInstanceOf(NettyHttpOperationFailedException.class, e.getCause());
+        assertEquals(401, cause.getStatusCode());
+    }
+
+    @Test
+    public void differentlyCasedContextPathIsChallengedToo() {
+        // dispatch reaches the route either way, so the constraint must apply either way
+        CamelExecutionException e = assertThrows(CamelExecutionException.class,
+                () -> template.requestBody("netty-http:http://localhost:{{port}}/Foo/admin/x", "Hello", String.class));
+        NettyHttpOperationFailedException cause = assertIsInstanceOf(NettyHttpOperationFailedException.class, e.getCause());
+        assertEquals(401, cause.getStatusCode());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("netty-http:http://0.0.0.0:{{port}}/foo?matchOnUriPrefix=true&securityConfiguration=#mySecurityConfig")
+                        .transform().constant("Bye World");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Backport of #25578

Cherry-pick of #25578 onto `camel-4.18.x`.

**Original PR:** #25578
**Original author:** @oscerd

Resolution: the 4.23 upgrade-guide entry is dropped, since the guides for every release line live on `main`.

Verified: cherry-pick applied with the conflicts resolved as above, and the branch builds on `camel-4.18.x`.

_Claude Code on behalf of oscerd_