### PR TITLE
[backport camel-4.18.x] CAMEL-24419: camel-mail - filter the mail session property namespace on MimeMultipart unmarshal

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormat.java
@@ -50,10 +50,10 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.attachment.Attachment;
 import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.attachment.DefaultAttachment;
+import org.apache.camel.component.mail.MailHeaderFilterStrategy;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.annotations.Dataformat;
 import org.apache.camel.support.DefaultDataFormat;
-import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.support.ExchangeHelper;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.util.IOHelper;
@@ -74,7 +74,7 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
     private String includeHeaders;
     private Pattern includeHeadersPattern;
     private boolean binaryContent;
-    private final HeaderFilterStrategy headerFilterStrategy = createInboundHeaderFilterStrategy();
+    private final HeaderFilterStrategy headerFilterStrategy = new MailHeaderFilterStrategy();
 
     public String getMultipartSubType() {
         return multipartSubType;
@@ -122,15 +122,6 @@ public class MimeMultipartDataFormat extends DefaultDataFormat {
 
     public void setBinaryContent(boolean binaryContent) {
         this.binaryContent = binaryContent;
-    }
-
-    private static HeaderFilterStrategy createInboundHeaderFilterStrategy() {
-        DefaultHeaderFilterStrategy strategy = new DefaultHeaderFilterStrategy();
-        // camel-4.18 DefaultHeaderFilterStrategy does not enable the Camel* in-filter by default (that
-        // default was introduced on a later branch), so configure it explicitly to filter the Camel*
-        // namespace on the inbound path, matching the mail consumer's HeaderFilterStrategy.
-        strategy.setInFilterStartsWith(DefaultHeaderFilterStrategy.CAMEL_FILTER_STARTS_WITH);
-        return strategy;
     }
 
     @Override

--- a/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
+++ b/components/camel-mail/src/test/java/org/apache/camel/dataformat/mime/multipart/MimeMultipartDataFormatTest.java
@@ -40,6 +40,7 @@ import org.apache.camel.util.IOHelper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -425,6 +426,27 @@ public class MimeMultipartDataFormatTest extends CamelTestSupport {
         assertNull(out.getMessage().getHeader("CamelFoo"));
         assertNull(out.getMessage().getHeader("camelBar"));
         assertNull(out.getMessage().getHeader("CAMELBaz"));
+    }
+
+    @Test
+    void unmarshalInlineHeadersFiltersMailSessionPropertyHeaders() {
+        // MailHeaderFilterStrategy adds the mail.smtp. / mail.smtps. prefixes to the inbound filter
+        // (CAMEL-23522) so an external mail message cannot inject JavaMail session properties. The
+        // headersInline unmarshal path has to filter the same namespace as the mail consumer does.
+        String mime = "mail.smtp.host: blocked\r\n"
+                      + "mail.smtps.auth: blocked\r\n"
+                      + "MAIL.SMTP.PORT: blocked\r\n"
+                      + "X-Normal: keep-me\r\n"
+                      + "Content-Type: text/plain\r\n"
+                      + "\r\n"
+                      + "Body text";
+        in.setBody(mime);
+        Exchange out = template.send("direct:unmarshalonlyinlineheaders", exchange);
+        assertThat(out.getMessage()).isNotNull();
+        assertThat(out.getMessage().getHeader("X-Normal")).isEqualTo("keep-me");
+        assertThat(out.getMessage().getHeader("mail.smtp.host")).isNull();
+        assertThat(out.getMessage().getHeader("mail.smtps.auth")).isNull();
+        assertThat(out.getMessage().getHeader("MAIL.SMTP.PORT")).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Backport of #25568

Cherry-pick of #25568 onto `camel-4.18.x`.

**Original PR:** #25568
**Original author:** @oscerd

Resolution notes: the 4.23 upgrade-guide entry is dropped (guides for all lines live on `main`). On 4.18.x the field was `createInboundHeaderFilterStrategy()`, that branch's variant of the CAMEL-23891 fix. `MailHeaderFilterStrategy` there already filters `CAMEL_FILTER_STARTS_WITH` **plus** `mail.smtp.`/`mail.smtps.`, a strict superset, so the swap does not weaken the Camel* filtering; the now-unused factory method is removed.

Verified: cherry-pick applied with the conflicts resolved as above, and the branch builds on `camel-4.18.x`.

_Claude Code on behalf of oscerd_