### PR TITLE
CAMEL-24421: remove the spring-redis upgrade note from camel-4.22.x

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1766,26 +1766,3 @@ they say:
   `CamelGoogleVertexAIStreamOutputMode` header.
 * `jsonMode=true` sets the response MIME type of the request to `application/json`, so the model is
   asked to answer with JSON. The default `false` leaves the request untouched.
-
-=== camel-spring-redis - the default serializer applies a deserialization filter
-
-The default serializer, `JdkSerializationRedisSerializer`, now installs a JEP-290
-`java.io.ObjectInputFilter` while reading Redis payloads, resolved through
-`DeserializationFilterHelper`. Previously no filter was applied at all. This affects both the
-consumer, which deserializes the payload of every message published to the subscribed channels,
-and the producer read commands, which deserialize the values stored in Redis.
-
-When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
-otherwise the shared Camel default allow-list is applied (it permits standard Java and Apache Camel
-types, denies `java.net.**`, and enforces JEP-290 graph-shape limits). Routes that exchange classes
-outside that allow-list must widen it through the new `deserializationFilter` endpoint option, for
-example:
-
-[source,java]
-----
-from("spring-redis://localhost:6379?command=SUBSCRIBE&channels=myChannel"
-     + "&deserializationFilter=com.example.model.**;java.**;!*")
-----
-
-Setting the `serializer` option to a custom `RedisSerializer` bypasses the filter entirely, since
-Camel then no longer controls how the payload is read.


### PR DESCRIPTION
Doc-only cleanup after #25588.

The `camel-4x-upgrade-guide-4_XX.adoc` files for every release line live on `main`, which holds the canonical history across all releases. A backport should not carry an upgrade-guide edit, so this note does not belong on this branch — I added it here by mistake.

It was also appended to the end of the file, which placed it under `Upgrading Camel 4.21 to 4.22` rather than `Upgrading from 4.22.0 to 4.22.1`.

The note is added to main's `camel-4x-upgrade-guide-4_22.adoc`, in the correct section, by #25734.

Docs only — 23 lines removed, no code.

---
_Claude Code on behalf of oscerd_