### PR TITLE
CAMEL-24421: remove the spring-redis upgrade note from camel-4.18.x

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -1642,24 +1642,3 @@ that resolve outside the configured directory are rejected.
 
 If `downloadFileName` is configured with an expression (i.e. it contains `$`), the local
 path is built by that expression as before and is not subject to this check.
-
-=== camel-spring-redis - the default serializer applies a deserialization filter
-
-The default serializer, `JdkSerializationRedisSerializer`, now installs a
-`java.io.ObjectInputFilter` while reading Redis payloads. Previously no filter was applied at all.
-This affects both the consumer, which deserializes the payload of every message published to the
-subscribed channels, and the producer read commands, which deserialize the values stored in Redis.
-
-When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
-otherwise a conservative default allow-list is applied (it permits standard Java and Apache Camel
-types and denies `java.net.**`). Routes that exchange classes outside that allow-list must widen it
-through the new `deserializationFilter` endpoint option, for example:
-
-[source,java]
-----
-from("spring-redis://localhost:6379?command=SUBSCRIBE&channels=myChannel"
-     + "&deserializationFilter=com.example.model.**;java.**;!*")
-----
-
-Setting the `serializer` option to a custom `RedisSerializer` bypasses the filter entirely, since
-Camel then no longer controls how the payload is read.


### PR DESCRIPTION
Doc-only cleanup after #25589.

The `camel-4x-upgrade-guide-4_XX.adoc` files for every release line live on `main`, which holds the canonical history across all releases. A backport should not carry an upgrade-guide edit, so this note does not belong on this branch — I added it here by mistake.

It was also appended to the end of the file, which placed it under `Upgrading Camel 4.17 to 4.18` rather than `Upgrading from 4.18.4 to 4.18.5`.

The note is added to main's `camel-4x-upgrade-guide-4_18.adoc`, in the correct section, by #25734.

Docs only — 21 lines removed, no code.

---
_Claude Code on behalf of oscerd_