### PR TITLE
camel-ibm MED fixes backport to camel-4.18.x (CAMEL-24488, 24490, 24491, 24493)

### DIFF
--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSConsumer.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSConsumer.java
@@ -158,15 +158,23 @@ public class IBMCOSConsumer extends ScheduledBatchPollingConsumer {
             }
 
             if (getEndpoint().getInProgressRepository() != null
-                    && getEndpoint().getInProgressRepository().contains(s3ObjectSummary.getKey())) {
+                    && !getEndpoint().getInProgressRepository().add(s3ObjectSummary.getKey())) {
                 LOG.trace("Object {} is already in progress", s3ObjectSummary.getKey());
                 continue;
             }
 
-            S3Object s3Object = getCosClient().getObject(
-                    new GetObjectRequest(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey()));
-            Exchange exchange = createExchange(s3Object, s3ObjectSummary.getKey());
-            exchanges.add(exchange);
+            try {
+                S3Object s3Object = getCosClient().getObject(
+                        new GetObjectRequest(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey()));
+                Exchange exchange = createExchange(s3Object, s3ObjectSummary.getKey());
+                exchanges.add(exchange);
+            } catch (Exception e) {
+                // Fetching the object or creating the exchange failed after we claimed the in-progress key;
+                // release it so the object is not left permanently unconsumable, and skip it for this poll.
+                LOG.warn("Error fetching object {} from bucket {}: {}. Skipping it for this poll.",
+                        s3ObjectSummary.getKey(), s3ObjectSummary.getBucketName(), e.getMessage());
+                removeInProgress(s3ObjectSummary.getKey());
+            }
         }
 
         return exchanges;
@@ -244,11 +252,20 @@ public class IBMCOSConsumer extends ScheduledBatchPollingConsumer {
             }
         } catch (Exception e) {
             LOG.warn("Error during post processing of object {} from bucket {}: {}", key, bucketName, e.getMessage());
+        } finally {
+            removeInProgress(key);
         }
     }
 
     protected void processRollback(String key) {
         LOG.trace("Processing failed for object with key {}", key);
+        removeInProgress(key);
+    }
+
+    private void removeInProgress(String key) {
+        if (getEndpoint().getInProgressRepository() != null) {
+            getEndpoint().getInProgressRepository().remove(key);
+        }
     }
 
     private void copyObject(String bucketName, String key) {

--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSEndpoint.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSEndpoint.java
@@ -115,6 +115,9 @@ public class IBMCOSEndpoint extends ScheduledPollEndpoint implements EndpointSer
     protected void doStart() throws Exception {
         super.doStart();
 
+        // Start the in-progress repository up front so consumer deduplication works even when doStart returns early
+        ServiceHelper.startService(inProgressRepository);
+
         cosClient = configuration.getCosClient() != null
                 ? configuration.getCosClient() : createCosClient();
 
@@ -146,8 +149,6 @@ public class IBMCOSEndpoint extends ScheduledPollEndpoint implements EndpointSer
             cosClient.createBucket(bucketName);
             LOG.trace("Bucket created");
         }
-
-        ServiceHelper.startService(inProgressRepository);
     }
 
     @Override

--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSProducer.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.ibm.cos;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +34,14 @@ import com.ibm.cloud.objectstorage.services.s3.model.ObjectMetadata;
 import com.ibm.cloud.objectstorage.services.s3.model.PutObjectRequest;
 import com.ibm.cloud.objectstorage.services.s3.model.PutObjectResult;
 import com.ibm.cloud.objectstorage.services.s3.model.S3Object;
+import com.ibm.cloud.objectstorage.services.s3.transfer.TransferManager;
+import com.ibm.cloud.objectstorage.services.s3.transfer.TransferManagerBuilder;
+import com.ibm.cloud.objectstorage.services.s3.transfer.model.UploadResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.WrappedFile;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.FileUtil;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,12 +159,52 @@ public class IBMCOSProducer extends DefaultProducer {
 
         PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, inputStream, metadata);
 
+        String storageClass = getConfiguration().getStorageClass();
+        if (ObjectHelper.isNotEmpty(storageClass)) {
+            putObjectRequest.withStorageClass(storageClass);
+        }
+
         LOG.trace("Putting object [{}] into bucket [{}]...", key, bucketName);
-        PutObjectResult putObjectResult = cosClient.putObject(putObjectRequest);
+
+        String eTag;
+        String versionId;
+        if (getConfiguration().isMultiPartUpload()) {
+            // Upload via the TransferManager so large payloads are sent as a multipart upload with the configured part size
+            TransferManager transferManager = TransferManagerBuilder.standard()
+                    .withS3Client(cosClient)
+                    .withMinimumUploadPartSize(getConfiguration().getPartSize())
+                    .withMultipartUploadThreshold(getConfiguration().getPartSize())
+                    .build();
+            try {
+                UploadResult uploadResult = transferManager.upload(putObjectRequest).waitForUploadResult();
+                eTag = uploadResult.getETag();
+                versionId = uploadResult.getVersionId();
+            } finally {
+                // shut down the TransferManager's own thread pool but keep the shared COS client open
+                transferManager.shutdownNow(false);
+            }
+        } else {
+            PutObjectResult putObjectResult = cosClient.putObject(putObjectRequest);
+            eTag = putObjectResult.getETag();
+            versionId = putObjectResult.getVersionId();
+        }
 
         Message message = getMessageForResponse(exchange);
-        message.setHeader(IBMCOSConstants.E_TAG, putObjectResult.getETag());
-        message.setHeader(IBMCOSConstants.VERSION_ID, putObjectResult.getVersionId());
+        message.setHeader(IBMCOSConstants.E_TAG, eTag);
+        message.setHeader(IBMCOSConstants.VERSION_ID, versionId);
+
+        if (getConfiguration().isDeleteAfterWrite()) {
+            File filePayload = null;
+            if (body instanceof File file) {
+                filePayload = file;
+            } else if (body instanceof WrappedFile<?> wrapped && wrapped.getFile() instanceof File file) {
+                filePayload = file;
+            }
+            if (filePayload != null) {
+                LOG.trace("Deleting file payload [{}] after write", filePayload);
+                FileUtil.deleteFile(filePayload);
+            }
+        }
     }
 
     private void getObject(AmazonS3 cosClient, Exchange exchange) {

--- a/components/camel-ibm/camel-ibm-watson-speech-to-text/src/main/java/org/apache/camel/component/ibm/watson/stt/WatsonSpeechToTextProducer.java
+++ b/components/camel-ibm/camel-ibm-watson-speech-to-text/src/main/java/org/apache/camel/component/ibm/watson/stt/WatsonSpeechToTextProducer.java
@@ -34,6 +34,7 @@ import com.ibm.watson.speech_to_text.v1.model.SpeechRecognitionResults;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.IOHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,15 +100,18 @@ public class WatsonSpeechToTextProducer extends DefaultProducer {
         // Get audio input from header or body
         File audioFile = exchange.getIn().getHeader(WatsonSpeechToTextConstants.AUDIO_FILE, File.class);
         InputStream audioStream = null;
+        boolean ownStream = false;
 
         if (audioFile != null) {
             audioStream = new FileInputStream(audioFile);
+            ownStream = true;
         } else {
             audioStream = exchange.getIn().getBody(InputStream.class);
             if (audioStream == null) {
                 File bodyFile = exchange.getIn().getBody(File.class);
                 if (bodyFile != null) {
                     audioStream = new FileInputStream(bodyFile);
+                    ownStream = true;
                 }
             }
         }
@@ -129,32 +133,38 @@ public class WatsonSpeechToTextProducer extends DefaultProducer {
 
         LOG.trace("Recognizing audio with STT: model={}, contentType={}", model, contentType);
 
-        RecognizeOptions options = new RecognizeOptions.Builder()
-                .audio(audioStream)
-                .model(model)
-                .contentType(contentType)
-                .timestamps(timestamps)
-                .wordConfidence(wordConfidence)
-                .speakerLabels(speakerLabels)
-                .build();
+        try {
+            RecognizeOptions options = new RecognizeOptions.Builder()
+                    .audio(audioStream)
+                    .model(model)
+                    .contentType(contentType)
+                    .timestamps(timestamps)
+                    .wordConfidence(wordConfidence)
+                    .speakerLabels(speakerLabels)
+                    .build();
 
-        SpeechRecognitionResults results = stt.recognize(options).execute().getResult();
+            SpeechRecognitionResults results = stt.recognize(options).execute().getResult();
 
-        // Extract transcript text
-        StringBuilder transcript = new StringBuilder();
-        if (results.getResults() != null && !results.getResults().isEmpty()) {
-            for (SpeechRecognitionResult result : results.getResults()) {
-                if (result.getAlternatives() != null && !result.getAlternatives().isEmpty()) {
-                    transcript.append(result.getAlternatives().get(0).getTranscript());
+            // Extract transcript text
+            StringBuilder transcript = new StringBuilder();
+            if (results.getResults() != null && !results.getResults().isEmpty()) {
+                for (SpeechRecognitionResult result : results.getResults()) {
+                    if (result.getAlternatives() != null && !result.getAlternatives().isEmpty()) {
+                        transcript.append(result.getAlternatives().get(0).getTranscript());
+                    }
                 }
             }
-        }
 
-        Message message = getMessageForResponse(exchange);
-        message.setBody(results);
-        message.setHeader(WatsonSpeechToTextConstants.TRANSCRIPT, transcript.toString());
-        message.setHeader(WatsonSpeechToTextConstants.MODEL, model);
-        message.setHeader(WatsonSpeechToTextConstants.CONTENT_TYPE, contentType);
+            Message message = getMessageForResponse(exchange);
+            message.setBody(results);
+            message.setHeader(WatsonSpeechToTextConstants.TRANSCRIPT, transcript.toString());
+            message.setHeader(WatsonSpeechToTextConstants.MODEL, model);
+            message.setHeader(WatsonSpeechToTextConstants.CONTENT_TYPE, contentType);
+        } finally {
+            if (ownStream) {
+                IOHelper.close(audioStream);
+            }
+        }
     }
 
     private void listModels(Exchange exchange) {

--- a/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/service/WatsonxAiServiceFactory.java
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/src/main/java/org/apache/camel/component/ibm/watsonx/ai/service/WatsonxAiServiceFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.component.ibm.watsonx.ai.service;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 import com.ibm.watsonx.ai.chat.ChatService;
@@ -51,6 +52,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -66,6 +68,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -81,6 +84,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -96,6 +100,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -111,6 +116,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -126,6 +132,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         // DetectionService doesn't have modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -150,6 +157,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         // TextExtractionService doesn't have modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -171,6 +179,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         // TextClassificationService doesn't have modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -186,6 +195,7 @@ public final class WatsonxAiServiceFactory {
         applyIfNotNull(config.getSpaceId(), builder::spaceId);
         applyIfNotNull(config.getModelId(), builder::modelId);
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -198,6 +208,7 @@ public final class WatsonxAiServiceFactory {
 
         // FoundationModelService doesn't have projectId, spaceId, modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -211,6 +222,7 @@ public final class WatsonxAiServiceFactory {
 
         // DeploymentService doesn't have projectId, spaceId, modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 
@@ -231,6 +243,7 @@ public final class WatsonxAiServiceFactory {
 
         // ToolService doesn't have projectId, spaceId, modelId
         applyIfNotNull(config.getVerifySsl(), builder::verifySsl);
+        applyIfNotNull(config.getTimeout(), t -> builder.timeout(Duration.ofMillis(t)));
         applyIfTrue(config.getLogRequests(), () -> builder.logRequests(true));
         applyIfTrue(config.getLogResponses(), () -> builder.logResponses(true));
 


### PR DESCRIPTION
Backport of the camel-ibm MED fixes to `camel-4.18.x`.

Cherry-picks four fixes already merged to `main`:
- **CAMEL-24488** (#25737) — camel-ibm-watson-speech-to-text: close the audio `FileInputStream` opened by the producer.
- **CAMEL-24490** (#25739) — camel-ibm-watsonx-ai: apply the configured `timeout` to the watsonx.ai service clients.
- **CAMEL-24491** (#25740) — camel-ibm-cos: make the consumer in-progress deduplication effective.
- **CAMEL-24493** (#25750) — camel-ibm-cos: honor the `multiPartUpload`/`partSize`/`storageClass`/`deleteAfterWrite` producer options.

All are method-body-only changes (no metadata/generated files); clean cherry-picks.

---
_Claude Code on behalf of oscerd_
