### PR TITLE
CAMEL-24517: camel-ibm-cos - set the BucketExists header in the headBucket operation

### DIFF
--- a/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSProducer.java
+++ b/components/camel-ibm/camel-ibm-cos/src/main/java/org/apache/camel/component/ibm/cos/IBMCOSProducer.java
@@ -348,6 +348,7 @@ public class IBMCOSProducer extends DefaultProducer {
 
         Message message = getMessageForResponse(exchange);
         message.setBody(exists);
+        message.setHeader(IBMCOSConstants.BUCKET_EXISTS, exists);
     }
 
     private String determineBucketName(Exchange exchange) {


### PR DESCRIPTION
# CAMEL-24517: set the BucketExists header in headBucket

The `headBucket` producer operation computed whether the bucket exists and set it as the message body, but never set the declared `CamelIBMCOSBucketExists` (`IBMCOSConstants.BUCKET_EXISTS`) producer header, so a route reading that header got `null`. It now also sets the header from the computed value.

## Testing

Method-body change; verified with a module build (`BUILD SUCCESS`, no generated-file drift).

---
_Claude Code on behalf of oscerd_
