### PR TITLE
CAMEL-24518: camel-ibm-watson-language - validate that at least one analysis feature is enabled

### DIFF
--- a/components/camel-ibm/camel-ibm-watson-language/src/main/java/org/apache/camel/component/ibm/watson/language/WatsonLanguageProducer.java
+++ b/components/camel-ibm/camel-ibm-watson-language/src/main/java/org/apache/camel/component/ibm/watson/language/WatsonLanguageProducer.java
@@ -193,6 +193,12 @@ public class WatsonLanguageProducer extends DefaultProducer {
             builder.categories(new CategoriesOptions.Builder().build());
         }
 
+        if (!(analyzeSentiment || analyzeEmotion || analyzeEntities || analyzeKeywords || analyzeConcepts
+                || analyzeCategories)) {
+            throw new IllegalArgumentException(
+                    "At least one analysis feature (sentiment, emotion, entities, keywords, concepts, categories) must be enabled");
+        }
+
         return builder.build();
     }
 


### PR DESCRIPTION
# CAMEL-24518: validate at least one analysis feature is enabled

`WatsonLanguageProducer.buildFeatures()` builds a `Features` object from six boolean analysis flags (sentiment, emotion, entities, keywords, concepts, categories). If all six are disabled, an empty `Features` is passed to the NLU `analyze` call, which the Watson service rejects with an opaque HTTP 400. The common path is protected by three default-`true` flags, but a user who explicitly disables them hits the 400 instead of a clear error.

## Fix

Validate that at least one analysis feature is enabled before calling the service, throwing a clear `IllegalArgumentException` otherwise.

## Testing

Method-body change; verified with a module build (`BUILD SUCCESS`, no generated-file drift).

---
_Claude Code on behalf of oscerd_
