### PR TITLE
chore: camel-lumberjack - fix flaky LumberjackMultiThreadIT

### DIFF
--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
@@ -80,7 +80,11 @@ public class LumberjackMultiThreadIT extends CamelTestSupport {
         mock.expectedMessageCount(25 * CONCURRENCY_LEVEL);
         mock.allMessages().body().isInstanceOf(Map.class);
 
-        final boolean await = latch.await(5, TimeUnit.SECONDS);
+        // LumberjackUtil.sendMessages() waits up to 30 seconds internally for ACKs before a thread
+        // counts down the latch (that 30s bound was itself raised from Awaitility's 10s default in
+        // 5df5b4719ac1 to fix flakiness on loaded CI runners). This wait must exceed 30s with margin,
+        // or a thread that legitimately takes close to the internal max would trip this latch first.
+        final boolean await = latch.await(35, TimeUnit.SECONDS);
         assertTrue(await, "All threads should have sent their messages by now");
 
         // Then we should have the messages we're expecting

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
@@ -80,11 +80,10 @@ public class LumberjackMultiThreadIT extends CamelTestSupport {
         mock.expectedMessageCount(25 * CONCURRENCY_LEVEL);
         mock.allMessages().body().isInstanceOf(Map.class);
 
-        // LumberjackUtil.sendMessages() waits up to 30 seconds internally for ACKs before a thread
-        // counts down the latch (that 30s bound was itself raised from Awaitility's 10s default in
-        // 5df5b4719ac1 to fix flakiness on loaded CI runners). This wait must exceed 30s with margin,
-        // or a thread that legitimately takes close to the internal max would trip this latch first.
-        final boolean await = latch.await(35, TimeUnit.SECONDS);
+        // LumberjackUtil.sendMessages() waits up to 60 seconds internally for ACKs before a thread
+        // counts down the latch. This wait must exceed that bound with margin, or a thread that
+        // legitimately takes close to the internal max would trip this latch first.
+        final boolean await = latch.await(65, TimeUnit.SECONDS);
         assertTrue(await, "All threads should have sent their messages by now");
 
         // Then we should have the messages we're expecting

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackMultiThreadIT.java
@@ -80,10 +80,11 @@ public class LumberjackMultiThreadIT extends CamelTestSupport {
         mock.expectedMessageCount(25 * CONCURRENCY_LEVEL);
         mock.allMessages().body().isInstanceOf(Map.class);
 
-        // LumberjackUtil.sendMessages() waits up to 60 seconds internally for ACKs before a thread
-        // counts down the latch. This wait must exceed that bound with margin, or a thread that
-        // legitimately takes close to the internal max would trip this latch first.
-        final boolean await = latch.await(65, TimeUnit.SECONDS);
+        // LumberjackUtil.sendMessages() waits up to 30 seconds internally for ACKs before a thread
+        // counts down the latch (that 30s bound was itself raised from Awaitility's 10s default in
+        // 5df5b4719ac1 to fix flakiness on loaded CI runners). This wait must exceed 30s with margin,
+        // or a thread that legitimately takes close to the internal max would trip this latch first.
+        final boolean await = latch.await(35, TimeUnit.SECONDS);
         assertTrue(await, "All threads should have sent their messages by now");
 
         // Then we should have the messages we're expecting

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
@@ -54,7 +54,9 @@ final class LumberjackUtil {
     static List<Integer> sendMessages(
             int port, SSLContextParameters sslContextParameters, List<Integer> windows, boolean waitForResult)
             throws InterruptedException {
-        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup();
+        // A single thread is enough for one client connection; avoids oversubscribing CPU when
+        // multiple client threads each spin up their own group (default is 2x available processors).
+        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
         try {
             // This list will hold the acknowledgment response sequence numbers
             List<Integer> responses = new ArrayList<>();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
@@ -97,7 +97,12 @@ final class LumberjackUtil {
             // send 5 frame windows, without pausing
             windows.stream().forEach(window -> channel.writeAndFlush(readSample(String.format("io/window%s.bin", window))));
             if (waitForResult) {
-                Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> windows.size() == responses.size());
+                // This bound was previously 30s (raised from Awaitility's 10s default in 5df5b4719ac1
+                // to fix CI flakiness) but LumberjackComponentTest.shouldListenToMessages still
+                // occasionally timed out on loaded CI runners, so it is widened again here. Callers
+                // that also wait on a completion signal (e.g. LumberjackMultiThreadIT's latch) must
+                // wait at least this long, with margin.
+                Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> windows.size() == responses.size());
             }
 
             channel.close().sync();

--- a/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
+++ b/components/camel-lumberjack/src/test/java/org/apache/camel/component/lumberjack/LumberjackUtil.java
@@ -97,12 +97,7 @@ final class LumberjackUtil {
             // send 5 frame windows, without pausing
             windows.stream().forEach(window -> channel.writeAndFlush(readSample(String.format("io/window%s.bin", window))));
             if (waitForResult) {
-                // This bound was previously 30s (raised from Awaitility's 10s default in 5df5b4719ac1
-                // to fix CI flakiness) but LumberjackComponentTest.shouldListenToMessages still
-                // occasionally timed out on loaded CI runners, so it is widened again here. Callers
-                // that also wait on a completion signal (e.g. LumberjackMultiThreadIT's latch) must
-                // wait at least this long, with margin.
-                Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> windows.size() == responses.size());
+                Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> windows.size() == responses.size());
             }
 
             channel.close().sync();


### PR DESCRIPTION
## Description

`LumberjackMultiThreadIT.shouldListenToMessages` has been intermittently flaky in CI (observed on PR #25778, an unrelated PR that pulled `camel-lumberjack` into its build via a shared parent POM property change).

## Root cause

- `LumberjackUtil.sendMessages()` waits up to **30 seconds** internally for ACKs via Awaitility (that bound was itself raised from Awaitility's 10s default in `5df5b4719ac1` to fix an earlier CI flake).
- `shouldListenToMessages()` only waited **5 seconds** on a `CountDownLatch` for all client threads to finish. Under load, a thread could legitimately take longer than 5s to receive its ACKs, so the latch wait could time out before the client finished — causing an intermittent failure.

## Fix

- Widen the latch wait to 35s so it comfortably exceeds the internal 30s ACK-wait ceiling, with a comment explaining why (to discourage a future accidental shrink of either number).
- Reduce client-side thread oversubscription: each client thread created its own `NioEventLoopGroup` with the default thread count (`2x available processors`); with up to 4 concurrent client threads this could oversubscribe CPU on constrained CI runners and slow down ACK delivery. Changed to `NioEventLoopGroup(1)` since each client only manages a single channel — Netty pins a channel to one event-loop thread for its lifetime, so extra threads in that group would sit idle.

## Note on a separate, pre-existing flaky test

CI on this branch separately surfaced `LumberjackComponentTest.shouldListenToMessages` timing out on that same internal 30s Awaitility wait — this is a different, already pre-existing flaky test (confirmed via an unrelated PR comment from a committer noting it's "known flaky"), not something this branch's changes touch or introduce (verified with 10 clean local re-runs on this branch).

We initially widened `LumberjackUtil`'s 30s ceiling to 60s as a guess, but the raw CI log shows the failure is a **deterministic ~30.1s stall repeated identically on 3/3 attempts** while every neighboring test in the same JVM fork passed in its normal ~8s — that's the signature of a genuine stuck condition, not marginal slowness, so widening the timeout would likely just double the CI time wasted on the same failure. That speculative change was reverted; this PR is scoped to the `LumberjackMultiThreadIT` fix only. The `LumberjackComponentTest` stall needs real reproduction/diagnostics and is left for separate follow-up.

## Testing

Ran the full `camel-lumberjack` module test suite (`mvn -Pit verify`) locally — all 5 unit tests and the `LumberjackMultiThreadIT` integration test pass, with `shouldListenToMessages` completing in ~8.8s (well under the 35s bound).

---
_Claude Code on behalf of davsclaus_