### PR TITLE
[backport camel-4.22.x] Fix contract-first REST DSL 404 when OpenAPI base path is root

### DIFF
--- a/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumer.java
+++ b/components/camel-platform-http-vertx/src/main/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumer.java
@@ -56,6 +56,7 @@ import org.apache.camel.component.platform.http.spi.PlatformHttpConsumer;
 import org.apache.camel.component.platform.http.spi.PlatformHttpSecurityHandler;
 import org.apache.camel.spi.HeaderFilterStrategy;
 import org.apache.camel.spi.RestRegistry;
+import org.apache.camel.spi.RestRegistry.RestService;
 import org.apache.camel.support.DefaultConsumer;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.util.FileUtil;
@@ -221,7 +222,7 @@ public class VertxPlatformHttpConsumer extends DefaultConsumer
             }
             if (r.isContractFirst() && target.equals(r.getBasePath())) {
                 matched = true;
-                String u = r.getBasePath() + r.getBaseUrl();
+                String u = buildNormalizedEndpoint(r);
                 u = configureEndpointPath(u); // in vertx-web we should replace path parameters from {xxx} to :xxx syntax
                 String v = r.getMethod();
                 String c = r.getConsumes();
@@ -258,7 +259,7 @@ public class VertxPlatformHttpConsumer extends DefaultConsumer
                 target = target.substring(0, target.length() - 1);
             }
             if (r.isSpecification() && target.equals(r.getBasePath())) {
-                String u = r.getBasePath() + r.getBaseUrl();
+                String u = buildNormalizedEndpoint(r);
                 String v = r.getMethod();
                 String p = r.getProduces();
 
@@ -281,6 +282,15 @@ public class VertxPlatformHttpConsumer extends DefaultConsumer
             }
         }
         return matched;
+    }
+
+    static String buildNormalizedEndpoint(RestService restService) {
+        String base = restService.getBasePath();
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        String u = base + restService.getBaseUrl();
+        return u;
     }
 
     private String configureEndpointPath(PlatformHttpEndpoint endpoint) {

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/RestOpenApiContractFirstRootBasePathTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/RestOpenApiContractFirstRootBasePathTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.vertx;
+
+import io.restassured.RestAssured;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.test.AvailablePortFinder;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static io.restassured.RestAssured.given;
+
+/**
+ * Reproduces the contract-first root basePath bug: when the REST configuration's context-path resolves to the root
+ * ("/"), {@code VertxPlatformHttpConsumer} used to register Vert.x routes with a doubled leading slash (e.g.
+ * "//pet/:petId"), so real requests to "/pet/1" never matched and the API 404'd.
+ */
+public class RestOpenApiContractFirstRootBasePathTest extends CamelTestSupport {
+
+    @RegisterExtension
+    AvailablePortFinder.Port port = AvailablePortFinder.find();
+
+    @Override
+    protected boolean useJmx() {
+        return true;
+    }
+
+    @Test
+    public void getPetByIdAtRootBasePath() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                restConfiguration().contextPath("/");
+
+                rest().openApi().specification("openapi-v3.json").missingOperation("ignore").routeId("petStoreRoot");
+
+                from("direct:getPetById")
+                        .setBody(constant("{\"id\":1,\"name\":\"doggie\"}"));
+            }
+        });
+
+        given()
+                .when()
+                .get("/pet/1")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void getInventoryAtRootBasePath() throws Exception {
+        context.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                restConfiguration().contextPath("/");
+
+                rest().openApi().specification("openapi-v3.json").missingOperation("ignore").routeId("petStoreRoot");
+
+                from("direct:getInventory")
+                        .setBody(constant("{\"available\":1}"));
+            }
+        });
+
+        given()
+                .when()
+                .get("/store/inventory")
+                .then()
+                .statusCode(200);
+    }
+
+    @Override
+    public CamelContext createCamelContext() throws Exception {
+        VertxPlatformHttpServerConfiguration conf = new VertxPlatformHttpServerConfiguration();
+        conf.setBindPort(port.getPort());
+
+        RestAssured.port = port.getPort();
+
+        CamelContext context = new DefaultCamelContext();
+        context.addService(new VertxPlatformHttpServer(conf));
+        return context;
+    }
+
+}

--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumerNormalizedEndpointTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxPlatformHttpConsumerNormalizedEndpointTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.vertx;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.spi.RestRegistry.RestService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit test for {@link VertxPlatformHttpConsumer#buildNormalizedEndpoint(RestService)}, in isolation from the
+ * OpenAPI/Vert.x wiring, covering the contract-first root basePath double-slash bug.
+ */
+public class VertxPlatformHttpConsumerNormalizedEndpointTest {
+
+    @Test
+    public void rootBasePathIsNotDoubled() {
+        assertEquals("/pet/{petId}", VertxPlatformHttpConsumer.buildNormalizedEndpoint(restService("/", "/pet/{petId}")));
+    }
+
+    @Test
+    public void nonRootBasePathIsUnchanged() {
+        assertEquals("/api/v3/pet", VertxPlatformHttpConsumer.buildNormalizedEndpoint(restService("/api/v3", "/pet")));
+    }
+
+    @Test
+    public void trailingSlashOnNonRootBasePathIsStripped() {
+        assertEquals("/api/v3/pet", VertxPlatformHttpConsumer.buildNormalizedEndpoint(restService("/api/v3/", "/pet")));
+    }
+
+    private static RestService restService(String basePath, String baseUrl) {
+        return new StubRestService(basePath, baseUrl);
+    }
+
+    private static final class StubRestService implements RestService {
+
+        private final String basePath;
+        private final String baseUrl;
+
+        StubRestService(String basePath, String baseUrl) {
+            this.basePath = basePath;
+            this.baseUrl = baseUrl;
+        }
+
+        @Override
+        public Consumer getConsumer() {
+            return null;
+        }
+
+        @Override
+        public boolean isSpecification() {
+            return false;
+        }
+
+        @Override
+        public boolean isContractFirst() {
+            return true;
+        }
+
+        @Override
+        public String getState() {
+            return null;
+        }
+
+        @Override
+        public String getRouteId() {
+            return null;
+        }
+
+        @Override
+        public String getOperationId() {
+            return null;
+        }
+
+        @Override
+        public String getUrl() {
+            return null;
+        }
+
+        @Override
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        @Override
+        public String getBasePath() {
+            return basePath;
+        }
+
+        @Override
+        public String getUriTemplate() {
+            return null;
+        }
+
+        @Override
+        public String getMethod() {
+            return null;
+        }
+
+        @Override
+        public String getConsumes() {
+            return null;
+        }
+
+        @Override
+        public String getProduces() {
+            return null;
+        }
+
+        @Override
+        public String getInType() {
+            return null;
+        }
+
+        @Override
+        public String getOutType() {
+            return null;
+        }
+
+        @Override
+        public String getDescription() {
+            return null;
+        }
+
+        @Override
+        public String getSpecificationUri() {
+            return null;
+        }
+
+        @Override
+        public long getHits() {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Backport of #25752

Cherry-pick of #25752 onto `camel-4.22.x`.

**Original PR:** #25752 - Fix contract-first REST DSL 404 when OpenAPI base path is root
**Original author:** @tools400
**Target branch:** `camel-4.22.x`

### Original description

RestOpenApiHelper.determineBasePath() always falls back to
DEFAULT_BASE_PATH ("/") when the OpenAPI servers[0].url has no path
segment, so the effective base path is never truly empty. In
VertxPlatformHttpConsumer.startRestServicesContractFirst(), the Vert.x
route path was built by plain concatenation of basePath + baseUrl
("/" + "/hello" -> "//hello"), which Vert.x normalizes away when
matching incoming requests, making every contract-first route
permanently unreachable whenever the contract's base path is root.

Normalize the join via a new buildNormalizedEndpoint() helper that
strips a trailing slash from the base path before concatenation, used
at both call sites (operation routes and the api-specification route).

Add regression tests covering a contract-first spec without a path
segment in servers[0].url.

Closes #25752