### PR TITLE
CAMEL-24521: camel-google-pubsub - document the authentication that actually works

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/google-pubsub-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/google-pubsub-component.adoc
@@ -178,40 +178,27 @@ By default, this component acquires credentials using `GoogleCredentials.getAppl
 This behavior can be disabled by setting _authenticate_ option to `false`, in which case requests to Google API will be made without authentication details. This is only desirable when developing against an emulator.
 This behavior can be altered by supplying a path to a service account key file.
 
-==== Workload Identity Federation (WIF)
+==== Workload Identity on GKE and other Google-managed environments
 
-All Google components support https://cloud.google.com/iam/docs/workload-identity-federation[Workload Identity Federation], which enables workloads running outside of Google Cloud (e.g., on AWS, Azure, GitHub Actions) or on GKE to authenticate without service account key files.
+Because the default is Application Default Credentials, a workload that already carries a Google
+identity needs no credential configuration at all: leave `serviceAccountKey` unset and ADC resolves
+the identity attached to the workload. On GKE with
+https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity[Workload Identity] that is
+the GCP service account bound to the pod's Kubernetes service account; the same applies on Compute
+Engine and Cloud Run.
 
-**On GKE with Workload Identity:** No configuration is needed. Application Default Credentials (ADC) automatically detects the GKE environment and uses the Kubernetes service account's associated GCP identity.
-
-**With an explicit WIF configuration file:** Set `useWorkloadIdentityFederation=true` and provide the path to the WIF JSON config file via `workloadIdentityConfig`. This is the typical setup for GitHub Actions, AWS, and Azure workloads.
-
-._Java-only: programmatic endpoint configuration for Workload Identity Federation_
 [source,java]
 ----
-// GKE with Workload Identity - ADC handles it automatically
+// on GKE with Workload Identity, Compute Engine or Cloud Run: nothing to configure
 from("google-pubsub:my-project:my-subscription")
     .to("direct:process");
-
-// GitHub Actions / AWS / Azure with WIF config file
-GooglePubsubEndpoint endpoint = context.getEndpoint("google-pubsub:my-project:my-subscription", GooglePubsubEndpoint.class);
-endpoint.setUseWorkloadIdentityFederation(true);
-endpoint.setWorkloadIdentityConfig("/path/to/wif-config.json");
 ----
 
-**With Service Account Impersonation:** Set `impersonatedServiceAccount` to a target service account email. The external credentials obtained via WIF will impersonate that service account, inheriting its permissions.
-
-._Java-only: programmatic endpoint configuration with service account impersonation_
-[source,java]
-----
-// WIF with service account impersonation
-GooglePubsubEndpoint endpoint = context.getEndpoint("google-pubsub:my-project:my-subscription", GooglePubsubEndpoint.class);
-endpoint.setUseWorkloadIdentityFederation(true);
-endpoint.setWorkloadIdentityConfig("/path/to/wif-config.json");
-endpoint.setImpersonatedServiceAccount("my-sa@my-project.iam.gserviceaccount.com");
-----
-
-NOTE: Workload Identity Federation support is available in all Google components (PubSub, Storage, BigQuery, Firestore, Sheets, Calendar, Drive, Mail, Functions, Secret Manager, Vision, Vertex AI, Speech-to-Text, Text-to-Speech) through the common `GoogleCommonConfiguration` interface.
+NOTE: Configuring
+https://cloud.google.com/iam/docs/workload-identity-federation[Workload Identity Federation] for an
+external identity provider (an explicit WIF credential configuration file for AWS, Azure or GitHub
+Actions), or service account impersonation, is not exposed as an endpoint option by the Google
+components.
 
 
 === Manual Acknowledgement

--- a/components/camel-google/camel-google-pubsub/src/main/docs/google-pubsub-component.adoc
+++ b/components/camel-google/camel-google-pubsub/src/main/docs/google-pubsub-component.adoc
@@ -178,40 +178,27 @@ By default, this component acquires credentials using `GoogleCredentials.getAppl
 This behavior can be disabled by setting _authenticate_ option to `false`, in which case requests to Google API will be made without authentication details. This is only desirable when developing against an emulator.
 This behavior can be altered by supplying a path to a service account key file.
 
-==== Workload Identity Federation (WIF)
+==== Workload Identity on GKE and other Google-managed environments
 
-All Google components support https://cloud.google.com/iam/docs/workload-identity-federation[Workload Identity Federation], which enables workloads running outside of Google Cloud (e.g., on AWS, Azure, GitHub Actions) or on GKE to authenticate without service account key files.
+Because the default is Application Default Credentials, a workload that already carries a Google
+identity needs no credential configuration at all: leave `serviceAccountKey` unset and ADC resolves
+the identity attached to the workload. On GKE with
+https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity[Workload Identity] that is
+the GCP service account bound to the pod's Kubernetes service account; the same applies on Compute
+Engine and Cloud Run.
 
-**On GKE with Workload Identity:** No configuration is needed. Application Default Credentials (ADC) automatically detects the GKE environment and uses the Kubernetes service account's associated GCP identity.
-
-**With an explicit WIF configuration file:** Set `useWorkloadIdentityFederation=true` and provide the path to the WIF JSON config file via `workloadIdentityConfig`. This is the typical setup for GitHub Actions, AWS, and Azure workloads.
-
-._Java-only: programmatic endpoint configuration for Workload Identity Federation_
 [source,java]
 ----
-// GKE with Workload Identity - ADC handles it automatically
+// on GKE with Workload Identity, Compute Engine or Cloud Run: nothing to configure
 from("google-pubsub:my-project:my-subscription")
     .to("direct:process");
-
-// GitHub Actions / AWS / Azure with WIF config file
-GooglePubsubEndpoint endpoint = context.getEndpoint("google-pubsub:my-project:my-subscription", GooglePubsubEndpoint.class);
-endpoint.setUseWorkloadIdentityFederation(true);
-endpoint.setWorkloadIdentityConfig("/path/to/wif-config.json");
 ----
 
-**With Service Account Impersonation:** Set `impersonatedServiceAccount` to a target service account email. The external credentials obtained via WIF will impersonate that service account, inheriting its permissions.
-
-._Java-only: programmatic endpoint configuration with service account impersonation_
-[source,java]
-----
-// WIF with service account impersonation
-GooglePubsubEndpoint endpoint = context.getEndpoint("google-pubsub:my-project:my-subscription", GooglePubsubEndpoint.class);
-endpoint.setUseWorkloadIdentityFederation(true);
-endpoint.setWorkloadIdentityConfig("/path/to/wif-config.json");
-endpoint.setImpersonatedServiceAccount("my-sa@my-project.iam.gserviceaccount.com");
-----
-
-NOTE: Workload Identity Federation support is available in all Google components (PubSub, Storage, BigQuery, Firestore, Sheets, Calendar, Drive, Mail, Functions, Secret Manager, Vision, Vertex AI, Speech-to-Text, Text-to-Speech) through the common `GoogleCommonConfiguration` interface.
+NOTE: Configuring
+https://cloud.google.com/iam/docs/workload-identity-federation[Workload Identity Federation] for an
+external identity provider (an explicit WIF credential configuration file for AWS, Azure or GitHub
+Actions), or service account impersonation, is not exposed as an endpoint option by the Google
+components.
 
 
 === Manual Acknowledgement


### PR DESCRIPTION
The `google-pubsub` docs advertise Workload Identity Federation for every Google component and show
code that does not compile:

```java
GooglePubsubEndpoint endpoint = context.getEndpoint("google-pubsub:my-project:my-subscription", GooglePubsubEndpoint.class);
endpoint.setUseWorkloadIdentityFederation(true);
endpoint.setWorkloadIdentityConfig("/path/to/wif-config.json");
endpoint.setImpersonatedServiceAccount("my-sa@my-project.iam.gserviceaccount.com");
```

Those setters do not exist. `useWorkloadIdentityFederation`, `workloadIdentityConfig` and
`impersonatedServiceAccount` are default methods on `GoogleCommonConfiguration` returning
`false`/`null`; no component overrides them, none declares a matching `@UriParam`, and no catalog
entry lists them. `GooglePubsubEndpoint` implements the interface directly and adds nothing. So
`config.isUseWorkloadIdentityFederation()` is always false and the WIF branch of
`GoogleCredentialsHelper.getCredentials` is never entered — which makes the explicit-config and
impersonation paths unreachable, not just undocumented.

The section's **GKE claim is correct**, but for a different reason than it gives: the plain
Application Default Credentials fallback (`GoogleCredentials.getApplicationDefault()`) resolves the
identity attached to the workload by itself, without involving the WIF code at all. That is what the
rewritten section documents — GKE Workload Identity, Compute Engine and Cloud Run all need no
credential configuration — plus a note that configuring an external identity provider or service
account impersonation is not exposed as an endpoint option.

Docs only, no production code touched. The catalog mirror is regenerated in the same commit.

The other half of CAMEL-24521 — actually wiring the three options up — is the feature asked for in
CAMEL-17368 (functions) and CAMEL-17369 (storage), which I have linked and commented on. This PR
makes the documentation honest in the meantime.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)