### PR TITLE
CAMEL-24524: camel-util - Fix URISupport.normalizeUri fast path producing different output depending on original parameter order

### DIFF
--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -799,21 +799,71 @@ public final class URISupport {
     private static String buildReorderingParameters(String scheme, String path, String query) throws URISyntaxException {
         Map<String, Object> parameters = URISupport.parseQuery(query, false, false);
 
-        if (parameters.size() > 1) {
+        final String[] keys = parameters.keySet().toArray(new String[0]);
+        if (keys.length > 1) {
             // reorder parameters a..z
-            // always rebuild (and thereby re-encode) the query, even if the keys were already in
-            // order, as rebuilding is the only place where parameter values get URL-encoded; skipping
-            // it would make the encoded output depend on the incidental original parameter order
-            final String[] array = parameters.keySet().toArray(new String[0]);
-            Arrays.sort(array);
-
-            query = URISupport.createQueryString(array, parameters, true);
-        } else {
-            // 0 or 1 parameter: order is not ambiguous, but still rebuild so the value is
-            // consistently encoded the same way as the multi-parameter case above
-            query = URISupport.createQueryString(parameters);
+            Arrays.sort(keys);
         }
+        // always rebuild the query, even if the keys were already in order, so the output does not
+        // depend on the incidental original parameter order. Escape only the characters that are
+        // genuinely unsafe in a URI (as UnsafeUriCharactersEncoder does elsewhere in Camel) rather than
+        // the much more aggressive application/x-www-form-urlencoded encoding used by
+        // createQueryString()/URLEncoder, which would needlessly percent-encode characters that are
+        // legal unescaped in a URI query, such as ':' (eg host:port) or '/' (eg produces=application/json)
+        query = buildSafeQueryString(keys, parameters);
         return buildUri(scheme, path, query);
+    }
+
+    private static String buildSafeQueryString(String[] sortedKeys, Map<String, Object> parameters) {
+        if (parameters.isEmpty()) {
+            return EMPTY_QUERY_STRING;
+        }
+
+        StringBuilder sb = new StringBuilder(128);
+        boolean first = true;
+        for (String key : sortedKeys) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append('&');
+            }
+
+            Object value = parameters.get(key);
+            if (value instanceof List) {
+                List<String> list = (List<String>) value;
+                for (Iterator<String> it = list.iterator(); it.hasNext();) {
+                    appendSafeQueryStringParameter(key, it.next(), sb);
+                    if (it.hasNext()) {
+                        sb.append('&');
+                    }
+                }
+            } else {
+                String s = value != null ? value.toString() : null;
+                appendSafeQueryStringParameter(key, s, sb);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void appendSafeQueryStringParameter(String key, String value, StringBuilder sb) {
+        sb.append(key);
+        if (value == null) {
+            return;
+        }
+        sb.append('=');
+        String raw = URIScanner.resolveRaw(value);
+        if (raw != null) {
+            // do not encode RAW parameters unless it has %
+            // need to replace % with %25 to avoid losing "%" when decoding
+            sb.append(URIScanner.replacePercent(value));
+        } else {
+            // '&' and '=' are structurally significant in Camel's key=value&key=value query syntax
+            // and must stay escaped inside a value even though they are otherwise legal, unescaped
+            // characters in a URI query per RFC 3986 - UnsafeUriCharactersEncoder does not escape them
+            // as it is also used outside of this query-value context
+            String encoded = UnsafeUriCharactersEncoder.encode(value).replace("&", "%26").replace("=", "%3D");
+            sb.append(encoded);
+        }
     }
 
     private static String buildUri(String scheme, String path, String query) {

--- a/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
+++ b/core/camel-util/src/main/java/org/apache/camel/util/URISupport.java
@@ -797,36 +797,21 @@ public final class URISupport {
     }
 
     private static String buildReorderingParameters(String scheme, String path, String query) throws URISyntaxException {
-        Map<String, Object> parameters = null;
-        if (query.indexOf('&') != -1) {
-            // only parse if there are parameters
-            parameters = URISupport.parseQuery(query, false, false);
-        }
+        Map<String, Object> parameters = URISupport.parseQuery(query, false, false);
 
-        if (parameters != null && parameters.size() != 1) {
-            final Set<String> entries = parameters.keySet();
-
+        if (parameters.size() > 1) {
             // reorder parameters a..z
-            // optimize and only build new query if the keys was resorted
-            boolean sort = false;
-            String prev = null;
-            for (String key : entries) {
-                if (prev != null) {
-                    int comp = key.compareTo(prev);
-                    if (comp < 0) {
-                        sort = true;
-                        break;
-                    }
-                }
-                prev = key;
-            }
-            if (sort) {
-                final String[] array = entries.toArray(new String[0]);
-                Arrays.sort(array);
+            // always rebuild (and thereby re-encode) the query, even if the keys were already in
+            // order, as rebuilding is the only place where parameter values get URL-encoded; skipping
+            // it would make the encoded output depend on the incidental original parameter order
+            final String[] array = parameters.keySet().toArray(new String[0]);
+            Arrays.sort(array);
 
-                query = URISupport.createQueryString(array, parameters, true);
-            }
-
+            query = URISupport.createQueryString(array, parameters, true);
+        } else {
+            // 0 or 1 parameter: order is not ambiguous, but still rebuild so the value is
+            // consistently encoded the same way as the multi-parameter case above
+            query = URISupport.createQueryString(parameters);
         }
         return buildUri(scheme, path, query);
     }

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -262,6 +262,81 @@ public class URISupportTest {
     }
 
     @Test
+    public void testNormalizeEndpointUriOrderIndependentWithColonValue() throws Exception {
+        // CAMEL-24524: a value containing a colon (eg host:port) must normalize the same way
+        // regardless of whether the original parameter order already happened to be alphabetical
+        String out1 = URISupport.normalizeUri("kafka:mytopic?brokers=localhost:19092&groupId=mygroup");
+        String out2 = URISupport.normalizeUri("kafka:mytopic?groupId=mygroup&brokers=localhost:19092");
+
+        assertThat(out1).isEqualTo(out2);
+        assertThat(out1).isEqualTo("kafka://mytopic?brokers=localhost%3A19092&groupId=mygroup");
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentWithThreeParameters() throws Exception {
+        // all 6 permutations of 3 keys (one already alphabetical, some not) must normalize identically
+        String[] permutations = new String[] {
+                "kafka:mytopic?brokers=localhost:19092&groupId=mygroup&clientId=myclient",
+                "kafka:mytopic?brokers=localhost:19092&clientId=myclient&groupId=mygroup",
+                "kafka:mytopic?groupId=mygroup&brokers=localhost:19092&clientId=myclient",
+                "kafka:mytopic?groupId=mygroup&clientId=myclient&brokers=localhost:19092",
+                "kafka:mytopic?clientId=myclient&brokers=localhost:19092&groupId=mygroup",
+                "kafka:mytopic?clientId=myclient&groupId=mygroup&brokers=localhost:19092" };
+
+        String expected = "kafka://mytopic?brokers=localhost%3A19092&clientId=myclient&groupId=mygroup";
+        for (String uri : permutations) {
+            assertThat(URISupport.normalizeUri(uri)).as("normalizing: " + uri).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentSingleParameterWithColonValue() throws Exception {
+        // CAMEL-24524: the single-parameter shortcut must also encode the value consistently
+        String out = URISupport.normalizeUri("kafka:mytopic?brokers=localhost:19092");
+        assertThat(out).isEqualTo("kafka://mytopic?brokers=localhost%3A19092");
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentWithCommaValue() throws Exception {
+        // a value with a comma (safe for the fast parser, but URL-encoded when the query is
+        // rebuilt) must also normalize the same regardless of key order
+        String out1 = URISupport.normalizeUri("smtp://localhost?subject=Hello,World&username=davsclaus");
+        String out2 = URISupport.normalizeUri("smtp://localhost?username=davsclaus&subject=Hello,World");
+
+        assertThat(out1).isEqualTo(out2);
+        assertThat(out1).isEqualTo("smtp://localhost?subject=Hello%2CWorld&username=davsclaus");
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentIsIdempotent() throws Exception {
+        // normalizing an already-normalized uri must return the exact same string
+        String out1 = URISupport.normalizeUri("kafka:mytopic?groupId=mygroup&brokers=localhost:19092");
+        String out2 = URISupport.normalizeUri(out1);
+
+        assertThat(out2).isEqualTo(out1);
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentWithRawValue() throws Exception {
+        // RAW() values must not be further encoded, regardless of key order
+        String out1 = URISupport.normalizeUri("kafka:mytopic?password=RAW(p@ss:word)&username=scott");
+        String out2 = URISupport.normalizeUri("kafka:mytopic?username=scott&password=RAW(p@ss:word)");
+
+        assertThat(out1).isEqualTo(out2);
+        assertThat(out1).isEqualTo("kafka://mytopic?password=RAW(p@ss:word)&username=scott");
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentWithDualParametersAndColonValue() throws Exception {
+        // duplicate keys (list values) combined with a value that needs encoding
+        String out1 = URISupport.normalizeUri("smtp://localhost?to=foo:1&to=bar:2&from=me");
+        String out2 = URISupport.normalizeUri("smtp://localhost?from=me&to=foo:1&to=bar:2");
+
+        assertThat(out1).isEqualTo(out2);
+        assertThat(out1).isEqualTo("smtp://localhost?from=me&to=foo%3A1&to=bar%3A2");
+    }
+
+    @Test
     public void testSanitizeAccessToken() {
         String out1 = URISupport
                 .sanitizeUri("google-sheets-stream://spreadsheets?accessToken=MY_TOKEN&clientId=foo&clientSecret=MY_SECRET");

--- a/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
+++ b/core/camel-util/src/test/java/org/apache/camel/util/URISupportTest.java
@@ -197,8 +197,9 @@ public class URISupportTest {
     public void testNormalizeEndpointWithEqualSignInParameter() throws Exception {
         String out = URISupport.normalizeUri("jms:queue:foo?selector=somekey='somevalue'&foo=bar");
         assertNotNull(out);
-        // Camel will safe encode the URI
-        assertEquals("jms://queue:foo?foo=bar&selector=somekey%3D%27somevalue%27", out);
+        // Camel will safe encode the URI - '=' stays escaped as it is structurally significant in
+        // the query syntax, but the single quotes (legal unescaped in a URI query) are left as-is
+        assertEquals("jms://queue:foo?foo=bar&selector=somekey%3D'somevalue'", out);
     }
 
     @Test
@@ -264,12 +265,13 @@ public class URISupportTest {
     @Test
     public void testNormalizeEndpointUriOrderIndependentWithColonValue() throws Exception {
         // CAMEL-24524: a value containing a colon (eg host:port) must normalize the same way
-        // regardless of whether the original parameter order already happened to be alphabetical
+        // regardless of whether the original parameter order already happened to be alphabetical.
+        // ':' is legal unescaped in a URI query (RFC 3986 pchar) so it must not be percent-encoded.
         String out1 = URISupport.normalizeUri("kafka:mytopic?brokers=localhost:19092&groupId=mygroup");
         String out2 = URISupport.normalizeUri("kafka:mytopic?groupId=mygroup&brokers=localhost:19092");
 
         assertThat(out1).isEqualTo(out2);
-        assertThat(out1).isEqualTo("kafka://mytopic?brokers=localhost%3A19092&groupId=mygroup");
+        assertThat(out1).isEqualTo("kafka://mytopic?brokers=localhost:19092&groupId=mygroup");
     }
 
     @Test
@@ -283,7 +285,7 @@ public class URISupportTest {
                 "kafka:mytopic?clientId=myclient&brokers=localhost:19092&groupId=mygroup",
                 "kafka:mytopic?clientId=myclient&groupId=mygroup&brokers=localhost:19092" };
 
-        String expected = "kafka://mytopic?brokers=localhost%3A19092&clientId=myclient&groupId=mygroup";
+        String expected = "kafka://mytopic?brokers=localhost:19092&clientId=myclient&groupId=mygroup";
         for (String uri : permutations) {
             assertThat(URISupport.normalizeUri(uri)).as("normalizing: " + uri).isEqualTo(expected);
         }
@@ -291,20 +293,35 @@ public class URISupportTest {
 
     @Test
     public void testNormalizeEndpointUriOrderIndependentSingleParameterWithColonValue() throws Exception {
-        // CAMEL-24524: the single-parameter shortcut must also encode the value consistently
+        // CAMEL-24524: the single-parameter shortcut must also normalize the value consistently
         String out = URISupport.normalizeUri("kafka:mytopic?brokers=localhost:19092");
-        assertThat(out).isEqualTo("kafka://mytopic?brokers=localhost%3A19092");
+        assertThat(out).isEqualTo("kafka://mytopic?brokers=localhost:19092");
     }
 
     @Test
     public void testNormalizeEndpointUriOrderIndependentWithCommaValue() throws Exception {
-        // a value with a comma (safe for the fast parser, but URL-encoded when the query is
-        // rebuilt) must also normalize the same regardless of key order
+        // a value with a comma (safe for the fast parser, and legal unescaped in a URI query)
+        // must also normalize the same regardless of key order, without being percent-encoded
         String out1 = URISupport.normalizeUri("smtp://localhost?subject=Hello,World&username=davsclaus");
         String out2 = URISupport.normalizeUri("smtp://localhost?username=davsclaus&subject=Hello,World");
 
         assertThat(out1).isEqualTo(out2);
-        assertThat(out1).isEqualTo("smtp://localhost?subject=Hello%2CWorld&username=davsclaus");
+        assertThat(out1).isEqualTo("smtp://localhost?subject=Hello,World&username=davsclaus");
+    }
+
+    @Test
+    public void testNormalizeEndpointUriOrderIndependentWithSlashValue() throws Exception {
+        // CAMEL-24524 follow-up: a value with a slash (eg a MIME type such as
+        // produces=application/json, as built by camel-rest-openapi's RestOpenApiEndpoint) must not
+        // be percent-encoded - '/' is legal unescaped in a URI query (RFC 3986 pchar). This previously
+        // broke RestOpenApiEndpointV3Test#shouldNotCrossContaminateProducersForSameOperation once the
+        // fast-path normalizer started always re-encoding the query, even when the keys ("host",
+        // "produces") were already in alphabetical order.
+        String out1 = URISupport.normalizeUri("foo:bar?host=http://petstore.example.com&produces=application/json");
+        String out2 = URISupport.normalizeUri("foo:bar?produces=application/json&host=http://petstore.example.com");
+
+        assertThat(out1).isEqualTo(out2);
+        assertThat(out1).isEqualTo("foo://bar?host=http://petstore.example.com&produces=application/json");
     }
 
     @Test
@@ -328,12 +345,12 @@ public class URISupportTest {
 
     @Test
     public void testNormalizeEndpointUriOrderIndependentWithDualParametersAndColonValue() throws Exception {
-        // duplicate keys (list values) combined with a value that needs encoding
+        // duplicate keys (list values) combined with a colon value, which is legal unescaped
         String out1 = URISupport.normalizeUri("smtp://localhost?to=foo:1&to=bar:2&from=me");
         String out2 = URISupport.normalizeUri("smtp://localhost?from=me&to=foo:1&to=bar:2");
 
         assertThat(out1).isEqualTo(out2);
-        assertThat(out1).isEqualTo("smtp://localhost?from=me&to=foo%3A1&to=bar%3A2");
+        assertThat(out1).isEqualTo("smtp://localhost?from=me&to=foo:1&to=bar:2");
     }
 
     @Test

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -143,6 +143,65 @@ The component camel-threadpoolfactory-vertx was deprecated in 4.21. The componen
 
 `camel-zeebe` component was deprecated in 4.19 and has a straightforward replacement with `camel-camunda`. It is removed in 4.23.
 
+=== camel-core - endpoint URI normalization is now order-independent
+
+`URISupport.normalizeUri()` computes the endpoint registry cache key so that two logically identical
+endpoint URIs (differing only in query parameter order) resolve to a single shared `Endpoint`. A fast-path
+optimization only re-encoded query parameter values when the parameter keys were *not* already in
+alphabetical order, so two semantically identical URIs could normalize to two different strings whenever a
+value needed encoding (for example a colon in a `host:port` value) - depending purely on whether the
+original, incidental parameter order happened to already be sorted. `CamelContext.getEndpoint()` would then
+silently create a duplicate `Endpoint` (and duplicate producers/consumers, connections, threads) instead of
+reusing the cached one, with no error or log warning.
+
+Normalization is now always order-independent. As part of the fix, the encoding applied when rebuilding the
+query string is also less aggressive: characters that are legal unescaped in a URI query per RFC 3986
+(`:`, `/`, `,`, `'`, etc. - for example a MIME type such as `produces=application/json`, or a `host:port`
+value) are no longer percent-encoded, while `&` and `=` remain escaped inside a value since they are
+structurally significant in Camel's own `key=value&key=value` query syntax.
+
+Code that asserts a literal, fully-normalized endpoint URI string containing one of those characters in a
+query value may need to update the expected string to the (now consistently) unencoded form.
+
+=== camel-core - property placeholders in pollEnrich
+
+Camel 4.22 stopped resolving property placeholders (`{{...}}`) on the _per-message evaluated_
+recipient for `toD` and `enrich`, and said that aligning `pollEnrich` was deferred to a follow-up.
+This is that follow-up: a `{{...}}` token that appears only in the value produced at runtime by the
+`pollEnrich` expression is now treated as a literal part of the endpoint URI instead of being
+expanded.
+
+Like `toD` and `enrich`, `pollEnrich` resolves its static endpoint URI at build time, so a
+placeholder belongs there:
+
+[source,java]
+----
+.pollEnrich("file:{{inbox}}", 5000)
+----
+
+`recipientList`, `routingSlip` and `dynamicRouter` are unchanged. Their recipient is supplied
+entirely at runtime and may legitimately carry a placeholder that comes from configuration, so they
+continue to resolve `{{...}}` in the computed recipient.
+
+=== camel-core - XmlConverter SAX parser factory
+
+`XmlConverter.createSAXParserFactory()` now also disables external parameter entities and external
+DTD loading:
+
+* `http://xml.org/sax/features/external-parameter-entities` = `false`
+* `http://apache.org/xml/features/nonvalidating/load-external-dtd` = `false`
+
+It previously set only `FEATURE_SECURE_PROCESSING` and `external-general-entities=false`, while
+`createDocumentBuilderFactory()` in the same class already blocked external resource resolution more
+thoroughly. Both factories are reachable from a converted message body — `toSAXSource` is a
+registered converter, and the SAXSource route is tried first for bodies reaching camel-xslt — so the
+two should not disagree.
+
+Documents carrying an internal DTD subset still parse: `disallow-doctype-decl` is deliberately not
+set here, because that would reject input that parses today. Routes that genuinely need to resolve
+an external DTD or parameter entity through this converter must supply their own
+`SAXParserFactory`.
+
 === camel-a2a - webhook URL address classification
 
 Push notification webhook URLs are now classified by the address the host resolves to, using the
@@ -233,25 +292,6 @@ The `CamelAzureEventGridDataVersion` header (`EventGridConstants.DATA_VERSION`) 
 component publishes events in the CloudEvents schema, which has no `dataVersion` attribute (that field
 belongs to the legacy Event Grid event schema), so the header was read but never applied to the
 published event. Remove any use of that header; there is no CloudEvents equivalent.
-=== camel-core - property placeholders in pollEnrich
-
-Camel 4.22 stopped resolving property placeholders (`{{...}}`) on the _per-message evaluated_
-recipient for `toD` and `enrich`, and said that aligning `pollEnrich` was deferred to a follow-up.
-This is that follow-up: a `{{...}}` token that appears only in the value produced at runtime by the
-`pollEnrich` expression is now treated as a literal part of the endpoint URI instead of being
-expanded.
-
-Like `toD` and `enrich`, `pollEnrich` resolves its static endpoint URI at build time, so a
-placeholder belongs there:
-
-[source,java]
-----
-.pollEnrich("file:{{inbox}}", 5000)
-----
-
-`recipientList`, `routingSlip` and `dynamicRouter` are unchanged. Their recipient is supplied
-entirely at runtime and may legitimately carry a placeholder that comes from configuration, so they
-continue to resolve `{{...}}` in the computed recipient.
 
 === camel-hazelcast
 
@@ -359,25 +399,6 @@ now also stops the route.
 Routes that relied on steps after these processors running for unauthenticated requests must be
 restructured. The authenticated paths are unchanged: a successfully authenticated request continues
 through the rest of the route exactly as before, and `OAuthLogoutProcessor` is unchanged.
-
-=== camel-core - XmlConverter SAX parser factory
-
-`XmlConverter.createSAXParserFactory()` now also disables external parameter entities and external
-DTD loading:
-
-* `http://xml.org/sax/features/external-parameter-entities` = `false`
-* `http://apache.org/xml/features/nonvalidating/load-external-dtd` = `false`
-
-It previously set only `FEATURE_SECURE_PROCESSING` and `external-general-entities=false`, while
-`createDocumentBuilderFactory()` in the same class already blocked external resource resolution more
-thoroughly. Both factories are reachable from a converted message body — `toSAXSource` is a
-registered converter, and the SAXSource route is tried first for bodies reaching camel-xslt — so the
-two should not disagree.
-
-Documents carrying an internal DTD subset still parse: `disallow-doctype-decl` is deliberately not
-set here, because that would reject input that parses today. Routes that genuinely need to resolve
-an external DTD or parameter entity through this converter must supply their own
-`SAXParserFactory`.
 
 === camel-netty-http
 


### PR DESCRIPTION
## Summary

`URISupport.normalizeUri()` is used to compute the endpoint registry cache key so that two logically identical endpoint URIs (differing only in query parameter order) resolve to a single shared `Endpoint`. This held true in general, but the fast normalizer path (`buildReorderingParameters()`) only rebuilt the query string - which is also the only place where parameter values get URL-encoded - when it detected the parameter keys were **not** already alphabetically ordered.

As a result, two semantically identical URIs could normalize to two different strings whenever a value needed URL-encoding (eg a colon in a `host:port` value), depending purely on whether the original, incidental parameter order happened to already be sorted:

```
kafka:mytopic?brokers=localhost:19092&groupId=mygroup   -> kafka://mytopic?brokers=localhost:19092&groupId=mygroup   (not encoded, keys already sorted)
kafka:mytopic?groupId=mygroup&brokers=localhost:19092   -> kafka://mytopic?brokers=localhost%3A19092&groupId=mygroup (encoded, keys needed reordering)
```

Since these two outputs differ, `CamelContext.getEndpoint()` would silently create a **duplicate endpoint** (and thus duplicate producers/consumers, connections, threads) instead of reusing the cached one - with no error or log warning.

See [CAMEL-24524](https://issues.apache.org/jira/browse/CAMEL-24524) for the full root-cause analysis (this was an unintended side effect of a performance optimization added in CAMEL-14648, not a deliberate design decision).

## Fix, take 2: encoding scoped to what's actually unsafe

The first version of this fix made the fast path always rebuild the query via the existing `createQueryString()`/`URLEncoder.encode()` path, matching the legacy/complex normalizer. That fixed the order-dependency, but `URLEncoder` is `application/x-www-form-urlencoded` encoding - far more aggressive than a URI actually requires - and it started percent-encoding characters that are legal unescaped in a URI query per RFC 3986 `pchar` (`:`, `/`, `,`, etc.), even when nothing needed reordering. This broke CI: `camel-rest-openapi`'s `RestOpenApiEndpointV3Test` builds endpoint URIs like `rest:get:...?host=...&produces=application/json`, and since `host`/`produces` are already alphabetically sorted, the always-rebuild change started turning `produces=application/json` into `produces=application%2Fjson`, breaking a literal substring match on the endpoint URI.

`buildReorderingParameters()` now rebuilds the query using `UnsafeUriCharactersEncoder` (Camel's existing lightweight, RFC 3986-aware escaper, already used elsewhere in the framework) instead of `URLEncoder`, additionally escaping `&` and `=` since those remain structurally significant in Camel's own `key=value&key=value` query syntax. Net effect: `:`, `/`, `,`, `'` etc. stay literal (matching what most of the codebase already assumes), while `&`, `=`, and the traditionally unsafe characters (space, quotes, brackets, etc.) stay escaped, and the output is still fully order-independent.

## Test plan

- [x] Added regression tests in `URISupportTest` covering: colon values with 2 and 3 parameters in all orderings, single-parameter colon values, comma values, duplicate/list-valued keys with colon values, `RAW(...)` values (must remain unaffected), idempotency of double-normalization, and a new slash-value test (`produces=application/json`) mirroring the `camel-rest-openapi` regression.
- [x] Updated the existing colon/comma/list-value assertions to reflect the less aggressive (but still order-independent) encoding.
- [x] `mvn test` passes in `core/camel-util` (full suite, including 8 new/updated order-independence tests).
- [x] `RestOpenApiEndpointV3Test` (the CI failure) now passes.
- [x] `RestEndpointTest`, `RestComponentTest`, `CustomEndpointUriFactoryTest`, and a broader `*Uri*Test`/`*Endpoint*Test` sweep in `core/camel-core` pass unaffected.
- [x] `DefaultEndpointRegistryTest` in `core/camel-core` (endpoint caching) passes unaffected.

_Claude Code on behalf of davsclaus_

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
