### PR TITLE
camel-google fixes backport to camel-4.18.x (CAMEL-24344, CAMEL-24345)

### DIFF
--- a/components/camel-google/camel-google-mail/pom.xml
+++ b/components/camel-google/camel-google-mail/pom.xml
@@ -150,6 +150,11 @@
             <artifactId>commons-codec</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumer.java
+++ b/components/camel-google/camel-google-mail/src/main/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumer.java
@@ -92,7 +92,8 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
 
         if (c.getMessages() != null) {
             for (Message message : c.getMessages()) {
-                Message mess = getClient().users().messages().get("me", message.getId()).setFormat("FULL").execute();
+                Message mess
+                        = getClient().users().messages().get("me", message.getId()).setFormat(messageFormat()).execute();
                 Exchange exchange = createExchange(getEndpoint().getExchangePattern(), mess);
                 answer.add(exchange);
             }
@@ -167,8 +168,12 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
      * Strategy when processing the exchange failed.
      */
     protected void processRollback(Exchange exchange, String unreadLabelId) {
+        if (!getConfiguration().isMarkAsRead()) {
+            // the mail was never marked as read, so there is nothing to roll back
+            return;
+        }
         try {
-            LOG.warn("Exchange failed, so rolling back mail {} to un {}", exchange, unreadLabelId);
+            LOG.warn("Exchange failed, so marking mail {} as unread again", exchange);
 
             List<String> add = new ArrayList<>();
             add.add(unreadLabelId);
@@ -176,7 +181,8 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
             getClient().users().messages()
                     .modify("me", exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_ID, String.class), mods).execute();
         } catch (Exception e) {
-            getExceptionHandler().handleException("Error occurred mark as read mail. This exception is ignored.", exchange, e);
+            getExceptionHandler().handleException("Error occurred marking the mail as unread. This exception is ignored.",
+                    exchange, e);
         }
     }
 
@@ -188,15 +194,50 @@ public class GoogleMailStreamConsumer extends ScheduledBatchPollingConsumer {
         if (getConfiguration().isRaw()) {
             message.setBody(mail.getRaw());
         } else {
-            List<MessagePart> parts = mail.getPayload().getParts();
-            if (parts != null && parts.get(0).getBody().getData() != null) {
-                byte[] bodyBytes = Base64.decodeBase64(parts.get(0).getBody().getData().trim());
-                String body = new String(bodyBytes, StandardCharsets.UTF_8);
+            String body = extractBody(mail.getPayload());
+            if (body != null) {
                 message.setBody(body);
             }
         }
-        configureHeaders(message, mail.getPayload().getHeaders());
+        if (mail.getPayload() != null && mail.getPayload().getHeaders() != null) {
+            configureHeaders(message, mail.getPayload().getHeaders());
+        }
         return exchange;
+    }
+
+    /**
+     * The message format the consumer has to ask for. The raw field of a message is only populated when the RAW format
+     * is requested, the payload only when the FULL format is.
+     */
+    String messageFormat() {
+        return getConfiguration().isRaw() ? "RAW" : "FULL";
+    }
+
+    /**
+     * Returns the decoded content of the first part carrying data, walking into nested multiparts. A message that is
+     * not multipart at all keeps its content directly on the payload.
+     */
+    private String extractBody(MessagePart part) {
+        if (part == null) {
+            return null;
+        }
+
+        if (part.getBody() != null && part.getBody().getData() != null) {
+            byte[] bodyBytes = Base64.decodeBase64(part.getBody().getData().trim());
+            return new String(bodyBytes, StandardCharsets.UTF_8);
+        }
+
+        List<MessagePart> parts = part.getParts();
+        if (parts != null) {
+            for (MessagePart child : parts) {
+                String body = extractBody(child);
+                if (body != null) {
+                    return body;
+                }
+            }
+        }
+
+        return null;
     }
 
     private void configureHeaders(org.apache.camel.Message message, List<MessagePartHeader> headers) {

--- a/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerBodyTest.java
+++ b/components/camel-google/camel-google-mail/src/test/java/org/apache/camel/component/google/mail/stream/GoogleMailStreamConsumerBodyTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.mail.stream;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import com.google.api.client.util.Base64;
+import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.MessagePart;
+import com.google.api.services.gmail.model.MessagePartBody;
+import com.google.api.services.gmail.model.MessagePartHeader;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Verifies how the stream consumer turns a Gmail message into an exchange: which format it asks the API for, and where
+ * it picks the body up from.
+ */
+class GoogleMailStreamConsumerBodyTest {
+
+    private DefaultCamelContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    private GoogleMailStreamConsumer consumer(boolean raw) throws Exception {
+        if (context != null) {
+            context.stop();
+        }
+        context = new DefaultCamelContext();
+        context.start();
+        GoogleMailStreamEndpoint endpoint = context.getEndpoint(
+                "google-mail-stream://index?clientId=id&clientSecret=secret&raw=" + raw,
+                GoogleMailStreamEndpoint.class);
+        return new GoogleMailStreamConsumer(endpoint, exchange -> {
+        }, "UNREAD", List.of());
+    }
+
+    private static MessagePartBody body(String content) {
+        return new MessagePartBody().setData(Base64.encodeBase64URLSafeString(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void theRawOptionAsksForTheRawFormat() throws Exception {
+        // the raw field of a message is only returned for the RAW format, asking for FULL always left it null
+        assertThat(consumer(true).messageFormat()).isEqualTo("RAW");
+        assertThat(consumer(false).messageFormat()).isEqualTo("FULL");
+    }
+
+    @Test
+    void aNonMultipartMessageKeepsItsBody() throws Exception {
+        Message mail = new Message().setId("1").setThreadId("t1")
+                .setPayload(new MessagePart().setMimeType("text/plain").setBody(body("plain content")));
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getBody()).isEqualTo("plain content");
+    }
+
+    @Test
+    void aMultipartMessageUsesTheFirstPartCarryingData() throws Exception {
+        Message mail = new Message().setId("2").setPayload(new MessagePart().setMimeType("multipart/alternative")
+                .setParts(List.of(
+                        new MessagePart().setMimeType("multipart/mixed")
+                                .setParts(List.of(new MessagePart().setMimeType("text/plain").setBody(body("nested")))),
+                        new MessagePart().setMimeType("text/html").setBody(body("<p>html</p>")))));
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getBody()).isEqualTo("nested");
+    }
+
+    @Test
+    void aMessageWithoutPayloadIsNotAFailure() throws Exception {
+        Message mail = new Message().setId("3");
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getBody()).isNull();
+        assertThat(exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_ID)).isEqualTo("3");
+    }
+
+    @Test
+    void headersAreMappedWhenPresent() throws Exception {
+        Message mail = new Message().setId("4").setPayload(new MessagePart()
+                .setBody(body("content"))
+                .setHeaders(List.of(
+                        new MessagePartHeader().setName("Subject").setValue("a subject"),
+                        new MessagePartHeader().setName("From").setValue("someone@example.org"))));
+
+        Exchange exchange = consumer(false).createExchange(ExchangePattern.InOnly, mail);
+
+        assertThat(exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_SUBJECT)).isEqualTo("a subject");
+        assertThat(exchange.getIn().getHeader(GoogleMailStreamConstants.MAIL_FROM)).isEqualTo("someone@example.org");
+    }
+
+    @Test
+    void aPayloadWithoutHeadersIsNotAFailure() throws Exception {
+        Message mail = new Message().setId("5").setPayload(new MessagePart().setBody(body("content")));
+
+        assertThatCode(() -> consumer(false).createExchange(ExchangePattern.InOnly, mail)).doesNotThrowAnyException();
+    }
+}

--- a/components/camel-google/camel-google-vertexai/pom.xml
+++ b/components/camel-google/camel-google-vertexai/pom.xml
@@ -99,5 +99,10 @@
             <artifactId>camel-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/camel-google/camel-google-vertexai/src/main/java/org/apache/camel/component/google/vertexai/GoogleVertexAIOperations.java
+++ b/components/camel-google/camel-google-vertexai/src/main/java/org/apache/camel/component/google/vertexai/GoogleVertexAIOperations.java
@@ -30,7 +30,8 @@ public enum GoogleVertexAIOperations {
     generateText,
 
     /**
-     * Generate chat response using Gemini models with conversation history.
+     * Generate a chat response using Gemini models. Alias of {@link #generateText}: the request is built from the same
+     * prompt and configuration, the operation name only documents the intent of the route.
      */
     generateChat,
 
@@ -50,7 +51,8 @@ public enum GoogleVertexAIOperations {
     generateEmbeddings,
 
     /**
-     * Generate code using Gemini or code-specialized models.
+     * Generate code using Gemini or code-specialized models. Alias of {@link #generateText}: the model is selected with
+     * the modelId option, the operation name only documents the intent of the route.
      */
     generateCode,
 

--- a/components/camel-google/camel-google-vertexai/src/main/java/org/apache/camel/component/google/vertexai/GoogleVertexAIProducer.java
+++ b/components/camel-google/camel-google-vertexai/src/main/java/org/apache/camel/component/google/vertexai/GoogleVertexAIProducer.java
@@ -38,6 +38,7 @@ public class GoogleVertexAIProducer extends DefaultProducer {
 
     private static final Logger LOG = LoggerFactory.getLogger(GoogleVertexAIProducer.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String JSON_MIME_TYPE = "application/json";
 
     private final GoogleVertexAIEndpoint endpoint;
 
@@ -260,7 +261,8 @@ public class GoogleVertexAIProducer extends DefaultProducer {
         }
 
         throw new IllegalArgumentException(
-                "Request body must be a JSON String, Map, or plain text prompt. Got: " + body.getClass().getName());
+                "Request body must be a JSON String, Map, or plain text prompt. Got: "
+                                           + (body == null ? "no body" : body.getClass().getName()));
     }
 
     /**
@@ -355,7 +357,7 @@ public class GoogleVertexAIProducer extends DefaultProducer {
         return prompt;
     }
 
-    private GenerateContentConfig buildConfig(Exchange exchange) {
+    GenerateContentConfig buildConfig(Exchange exchange) {
         GoogleVertexAIConfiguration config = endpoint.getConfiguration();
 
         GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
@@ -399,6 +401,10 @@ public class GoogleVertexAIProducer extends DefaultProducer {
         }
         if (candidateCount != null) {
             configBuilder.candidateCount(candidateCount);
+        }
+
+        if (config.isJsonMode()) {
+            configBuilder.responseMimeType(JSON_MIME_TYPE);
         }
 
         return configBuilder.build();

--- a/components/camel-google/camel-google-vertexai/src/test/java/org/apache/camel/component/google/vertexai/GoogleVertexAIProducerOptionsTest.java
+++ b/components/camel-google/camel-google-vertexai/src/test/java/org/apache/camel/component/google/vertexai/GoogleVertexAIProducerOptionsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.vertexai;
+
+import com.google.genai.types.GenerateContentConfig;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the producer applies the options that describe the shape of the request and of the response. Uses
+ * direct object construction to avoid starting the endpoint (which requires Google Cloud credentials).
+ */
+class GoogleVertexAIProducerOptionsTest {
+
+    private DefaultCamelContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    private GoogleVertexAIProducer producer(GoogleVertexAIConfiguration config) {
+        context = new DefaultCamelContext();
+        GoogleVertexAIComponent component = new GoogleVertexAIComponent(context);
+        GoogleVertexAIEndpoint endpoint
+                = new GoogleVertexAIEndpoint("google-vertexai:my-project:us-central1:gemini-2.0-flash", component, config);
+        return new GoogleVertexAIProducer(endpoint);
+    }
+
+    @Test
+    void jsonModeAsksTheModelForJson() {
+        GoogleVertexAIConfiguration config = new GoogleVertexAIConfiguration();
+        config.setJsonMode(true);
+        GenerateContentConfig result = producer(config).buildConfig(new DefaultExchange(context));
+
+        assertThat(result.responseMimeType()).contains("application/json");
+    }
+
+    @Test
+    void jsonModeIsOffByDefault() {
+        GoogleVertexAIConfiguration config = new GoogleVertexAIConfiguration();
+        GenerateContentConfig result = producer(config).buildConfig(new DefaultExchange(context));
+
+        assertThat(result.responseMimeType()).isEmpty();
+    }
+}


### PR DESCRIPTION
Backport to `camel-4.18.x` of the two camel-google audit fixes that never reached this branch. Both are
already on `main` and on `camel-4.22.x` — they predate the 4.22.0 cut, so no 4.22.x backport is needed.

### CAMEL-24344 — camel-google-mail: `raw=true` returns the message

Cherry-pick of e8dc6b8 (#25357).

The `google-mail-stream` consumer always asked the Gmail API for the `FULL` message format, but the `raw`
field is only populated for the `RAW` format, so `raw=true` always produced a `null` body. The non-raw path
only looked at the first element of `getParts()`, so a message that is not multipart carried no body and a
nested multipart yielded nothing. A failed exchange also marked the mail as unread again even when
`markAsRead` had never been enabled.

**Behaviour change**: with `raw=true` the Gmail API does not return the parsed `payload`, so
`CamelGoogleMailStreamSubject`, `...From`, `...To`, `...Cc`, `...Bcc` and `...MessageId` stop being set —
those values are part of the RFC 2822 content that now reaches the body. `...Id`, `...ThreadId` and
`...LabelIds` are unaffected. The 4.18.5 upgrade-guide note is added on `main` in a companion PR, since the
guides for every release line live there.

### CAMEL-24345 — camel-google-vertexai: `jsonMode` is applied

**Partial backport, hand-ported rather than cherry-picked.** On `main` the fix applies both
`streamOutputMode` and `jsonMode`. On this branch `generateChatStreaming` is still
`throw new UnsupportedOperationException("Streaming is not yet implemented")`, so `streamOutputMode` cannot
be applied without backporting the streaming feature itself — that half is deliberately left out, and the
option stays inert here.

What is backported:

* `jsonMode=true` now sets the response MIME type of the request to `application/json`. The option was
  declared and documented but never read.
* `buildRawPredictRequestBody` no longer throws a `NullPointerException` when the exchange carries no body.
* `generateChat` and `generateCode` are documented as aliases of `generateText`, which is what they already
  do on this branch too.

The test is trimmed to the two `jsonMode` cases and builds the endpoint directly instead of resolving it on
a started context, so it does not need Google credentials — the shape #25391 settled on `main`.

`org.assertj:assertj-core` had to be added as a test dependency to `camel-google-mail` (`main` already has
it, so the cherry-pick carried no pom change) and to `camel-google-vertexai`.

### Verification

* `mvn clean install` on `components/camel-google/camel-google-mail` and on
  `components/camel-google/camel-google-vertexai`, both green.
* `GoogleMailStreamConsumerBodyTest` — 6 tests, and `GoogleVertexAIProducerOptionsTest` — 2 tests, all pass.
  The vertexai test was also run with `CLOUDSDK_CONFIG` pointed at an empty directory and
  `GOOGLE_APPLICATION_CREDENTIALS` cleared, to confirm it does not silently depend on local credentials.
* Full reactor `mvn clean install -DskipTests -Dquickly` from the root of the branch, green, with no
  generated-file drift.

---
_Claude Code on behalf of oscerd_
