### PR TITLE
CAMEL-24439: camel-shiro - verify the presented credentials on every exchange

### DIFF
--- a/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityProcessor.java
+++ b/components/camel-shiro/src/main/java/org/apache/camel/component/shiro/security/ShiroSecurityProcessor.java
@@ -130,24 +130,21 @@ public class ShiroSecurityProcessor extends DelegateAsyncProcessor {
     }
 
     private void authenticateUser(Subject currentUser, ShiroSecurityToken securityToken) {
-        boolean authenticated = currentUser.isAuthenticated();
-        boolean sameUser = securityToken.getUsername().equals(currentUser.getPrincipal());
-        LOG.trace("Authenticated: {}, same Username: {}", authenticated, sameUser);
+        // The login is not skipped when the thread-bound subject already carries the same principal name.
+        // A matching username says nothing about the password presented with this exchange, and with
+        // alwaysReauthenticate=false the subject is deliberately long-lived on a shared worker thread, so
+        // skipping would let a wrong password through for as long as that subject stays bound.
+        LOG.trace("Authenticating {} (subject currently authenticated: {})",
+                securityToken.getUsername(), currentUser.isAuthenticated());
 
-        if (!authenticated || !sameUser) {
-            UsernamePasswordToken token = new UsernamePasswordToken(securityToken.getUsername(), securityToken.getPassword());
-            if (policy.isAlwaysReauthenticate()) {
-                token.setRememberMe(false);
-            } else {
-                token.setRememberMe(true);
-            }
+        UsernamePasswordToken token = new UsernamePasswordToken(securityToken.getUsername(), securityToken.getPassword());
+        token.setRememberMe(!policy.isAlwaysReauthenticate());
 
-            try {
-                currentUser.login(token);
-                LOG.debug("Current user {} successfully authenticated", currentUser.getPrincipal());
-            } catch (AuthenticationException ae) {
-                throw new AuthenticationException("Authentication Failed.", ae.getCause());
-            }
+        try {
+            currentUser.login(token);
+            LOG.debug("Current user {} successfully authenticated", currentUser.getPrincipal());
+        } catch (AuthenticationException ae) {
+            throw new AuthenticationException("Authentication Failed.", ae.getCause());
         }
     }
 

--- a/components/camel-shiro/src/test/java/org/apache/camel/component/shiro/security/ShiroAuthenticationCredentialAlwaysCheckedTest.java
+++ b/components/camel-shiro/src/test/java/org/apache/camel/component/shiro/security/ShiroAuthenticationCredentialAlwaysCheckedTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.shiro.security;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.IncorrectCredentialsException;
+import org.apache.shiro.authc.LockedAccountException;
+import org.apache.shiro.authc.UnknownAccountException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * With {@code alwaysReauthenticate=false} the Shiro subject stays bound to the thread between exchanges, which is the
+ * point of the option. The password carried by each exchange still has to be verified: a username that happens to match
+ * the bound subject's principal is not evidence about the credentials presented this time.
+ */
+class ShiroAuthenticationCredentialAlwaysCheckedTest extends CamelTestSupport {
+
+    @EndpointInject("mock:success")
+    protected MockEndpoint successEndpoint;
+
+    @EndpointInject("mock:authenticationException")
+    protected MockEndpoint failureEndpoint;
+
+    private final byte[] passPhrase = {
+            (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B,
+            (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, (byte) 0x0F,
+            (byte) 0x10, (byte) 0x11, (byte) 0x12, (byte) 0x13,
+            (byte) 0x14, (byte) 0x15, (byte) 0x16, (byte) 0x17 };
+
+    @Test
+    void aWrongPasswordIsRejectedEvenAfterTheSameUserAuthenticated() throws Exception {
+        successEndpoint.expectedMessageCount(1);
+        failureEndpoint.expectedMessageCount(1);
+
+        // Authenticates and leaves the subject bound to this thread
+        template.send("direct:secureEndpoint", injector("ringo", "starr"));
+        // Same username, wrong password - must not ride the bound subject through
+        template.send("direct:secureEndpoint", injector("ringo", "not-starr"));
+
+        successEndpoint.assertIsSatisfied();
+        failureEndpoint.assertIsSatisfied();
+    }
+
+    private TestShiroSecurityTokenInjector injector(String user, String password) {
+        return new TestShiroSecurityTokenInjector(new ShiroSecurityToken(user, password), passPhrase);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        final ShiroSecurityPolicy securityPolicy
+                = new ShiroSecurityPolicy("./src/test/resources/securityconfig.ini", passPhrase, false);
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                onException(UnknownAccountException.class, IncorrectCredentialsException.class,
+                        LockedAccountException.class, AuthenticationException.class).to("mock:authenticationException");
+
+                from("direct:secureEndpoint").policy(securityPolicy).to("mock:success");
+            }
+        };
+    }
+
+    private static class TestShiroSecurityTokenInjector extends ShiroSecurityTokenInjector {
+
+        TestShiroSecurityTokenInjector(ShiroSecurityToken shiroSecurityToken, byte[] bytes) {
+            super(shiroSecurityToken, bytes);
+        }
+
+        @Override
+        public void process(Exchange exchange) {
+            exchange.getIn().setHeader(ShiroSecurityConstants.SHIRO_SECURITY_TOKEN, encrypt());
+            exchange.getIn().setBody("Beatle Mania");
+        }
+    }
+}

--- a/components/camel-shiro/src/test/java/org/apache/camel/component/shiro/security/ShiroAuthenticationCredentialAlwaysCheckedTest.java
+++ b/components/camel-shiro/src/test/java/org/apache/camel/component/shiro/security/ShiroAuthenticationCredentialAlwaysCheckedTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.shiro.security;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -34,17 +36,13 @@ import org.junit.jupiter.api.Test;
  */
 class ShiroAuthenticationCredentialAlwaysCheckedTest extends CamelTestSupport {
 
+    private static final byte[] TEST_KEY = "0123456789abcdef".getBytes(StandardCharsets.US_ASCII);
+
     @EndpointInject("mock:success")
     protected MockEndpoint successEndpoint;
 
     @EndpointInject("mock:authenticationException")
     protected MockEndpoint failureEndpoint;
-
-    private final byte[] passPhrase = {
-            (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B,
-            (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, (byte) 0x0F,
-            (byte) 0x10, (byte) 0x11, (byte) 0x12, (byte) 0x13,
-            (byte) 0x14, (byte) 0x15, (byte) 0x16, (byte) 0x17 };
 
     @Test
     void aWrongPasswordIsRejectedEvenAfterTheSameUserAuthenticated() throws Exception {
@@ -61,13 +59,13 @@ class ShiroAuthenticationCredentialAlwaysCheckedTest extends CamelTestSupport {
     }
 
     private TestShiroSecurityTokenInjector injector(String user, String password) {
-        return new TestShiroSecurityTokenInjector(new ShiroSecurityToken(user, password), passPhrase);
+        return new TestShiroSecurityTokenInjector(new ShiroSecurityToken(user, password), TEST_KEY);
     }
 
     @Override
     protected RouteBuilder createRouteBuilder() {
         final ShiroSecurityPolicy securityPolicy
-                = new ShiroSecurityPolicy("./src/test/resources/securityconfig.ini", passPhrase, false);
+                = new ShiroSecurityPolicy("./src/test/resources/securityconfig.ini", TEST_KEY, false);
 
         return new RouteBuilder() {
             @Override

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -535,6 +535,7 @@ camel.routeController.enabled = true
 camel.routeController.backOffDelay = 2000
 camel.routeController.backOffMaxDelay = 60000
 ----
+
 === camel-http
 
 The OAuth2 client-credentials token cache was keyed on the request URI, the client id and the client

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -535,7 +535,6 @@ camel.routeController.enabled = true
 camel.routeController.backOffDelay = 2000
 camel.routeController.backOffMaxDelay = 60000
 ----
-
 === camel-http
 
 The OAuth2 client-credentials token cache was keyed on the request URI, the client id and the client
@@ -702,3 +701,19 @@ inherit values set on `defaultInstance`, and `defaultInstance` itself remains un
 
 Routes that compared unmarshalled bodies by identity, or that mutated one body expecting the change to
 be visible on another, must be updated.
+
+=== camel-shiro
+
+`ShiroSecurityProcessor` used to skip the Shiro `login()` call — and therefore the credential check —
+when the thread-bound subject was already authenticated for the same username as the incoming
+`ShiroSecurityToken`. The check conflated "same principal name" with "same credentials", so once a user
+had authenticated on a worker thread, a later exchange presenting that username with any password was
+accepted for as long as the subject stayed bound.
+
+The default `alwaysReauthenticate=true` masked this, because the processor calls `logout()` after each
+exchange. With `alwaysReauthenticate=false` — a documented option, which also sets `rememberMe(true)` to
+keep subjects long-lived — the skip was reachable.
+
+`login()` is now called for every exchange with the credentials that exchange presented. Deployments
+using `alwaysReauthenticate=false` will see one realm lookup per exchange where previously matching
+usernames reused the bound subject; correctness aside, that is the same cost the default already pays.


### PR DESCRIPTION
Fixes [CAMEL-24439](https://issues.apache.org/jira/browse/CAMEL-24439).

ShiroSecurityProcessor.authenticateUser() called login() only when the thread-bound
subject was not already authenticated for the same username as the incoming
ShiroSecurityToken:

    if (!authenticated || !sameUser) { ... currentUser.login(token); }

That conflates "same principal name" with "same credentials". Once a user had
authenticated on a worker thread, a later exchange presenting that username with any
password was accepted for as long as the subject stayed bound, because the password
was never checked.

The default alwaysReauthenticate=true masks it, since the processor calls logout() in a
finally block after each exchange. With alwaysReauthenticate=false the skip is
reachable, and that mode deliberately sets rememberMe(true) to keep subjects
long-lived on Camel's shared worker threads.

Call login() for every exchange with the credentials that exchange presented. Shiro
offers no way to compare presented credentials against a bound subject, so the
principal-name comparison could not be made sound and is removed rather than narrowed.

The added test sends a valid token for ringo, then the same username with a wrong
password on the same thread; without the fix both reach mock:success.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: Andrea Cosentino <ancosen@gmail.com>

## Verification

Rebased onto current `main` at `3a6c27bfae04`, preserving both the upstream and PR-specific Camel 4.23 migration-guide entries. `ShiroAuthenticationCredentialAlwaysCheckedTest` (1 test) passes on Temurin JDK 25. Maven also completed license formatting, formatter, import sorting, compilation, and component metadata generation with no uncommitted-file drift.

_Claude Code on behalf of oscerd_
