### PR TITLE
CAMEL-24448: camel-keycloak - reject an introspection result that carries no issuer

### DIFF
--- a/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessor.java
+++ b/components/camel-keycloak/src/main/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessor.java
@@ -375,7 +375,11 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
     }
 
     /**
-     * Validates the issuer from an introspection result.
+     * Validates the issuer from an introspection result. A token whose "iss" claim is missing is rejected: issuer
+     * validation is opt-in, so an operator who turned it on is asking for tokens from other issuers to be refused, and
+     * a response that carries no issuer is not evidence that the token came from the expected one. RFC 7662 makes "iss"
+     * optional in an introspection response, so this is reachable wherever the introspection endpoint is a broker, a
+     * gateway or a minimal implementation rather than the realm that issued the token.
      */
     private void validateIssuerFromIntrospection(
             KeycloakTokenIntrospector.IntrospectionResult introspectionResult, Exchange exchange)
@@ -384,8 +388,12 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
         Object issuerClaim = introspectionResult.getClaim("iss");
 
         if (issuerClaim == null) {
-            LOG.warn("Token introspection result does not contain issuer claim");
-            return;
+            LOG.error("SECURITY: Token introspection result does not contain an issuer claim, expected '{}'",
+                    expectedIssuer);
+            throw new CamelAuthorizationException(
+                    String.format("Token issuer missing: expected '%s' but the introspection result carries no issuer",
+                            expectedIssuer),
+                    exchange);
         }
 
         String actualIssuer = issuerClaim.toString();
@@ -401,7 +409,7 @@ public class KeycloakSecurityProcessor extends DelegateProcessor {
     }
 
     /**
-     * Validates the audience from an introspection result. Unlike issuer validation, a token whose "aud" claim is
+     * Validates the audience from an introspection result. As with issuer validation, a token whose "aud" claim is
      * missing is rejected: the whole point of this check is to reject tokens that were not issued for this policy's
      * client(s).
      */

--- a/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessorTest.java
+++ b/components/camel-keycloak/src/test/java/org/apache/camel/component/keycloak/security/KeycloakSecurityProcessorTest.java
@@ -121,6 +121,73 @@ class KeycloakSecurityProcessorTest {
         assertFalse(routeReached.get(), "Route body must not be reached for an inactive token");
     }
 
+    /**
+     * Issuer validation is opt-in, so an operator who enabled it is asking for tokens from other issuers to be refused.
+     * RFC 7662 makes "iss" optional in an introspection response, so an introspection endpoint that is a broker, a
+     * gateway, or a minimal implementation can return an active token with no issuer - which is not evidence that the
+     * token came from the expected one.
+     */
+    @Test
+    void testActiveIntrospectionWithoutIssuerClaimRejected() throws Exception {
+        KeycloakTokenIntrospector introspector = introspectorReturning(Map.of("active", true));
+
+        KeycloakSecurityPolicy policy = introspectionPolicy(introspector);
+        policy.setValidateIssuer(true);
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        CamelAuthorizationException e
+                = assertThrows(CamelAuthorizationException.class, () -> processor.process(bearer("x")));
+        assertTrue(e.getMessage().contains("Token issuer missing"), "unexpected message: " + e.getMessage());
+        assertFalse(routeReached.get(), "Route body must not be reached for a token with no issuer");
+    }
+
+    @Test
+    void testActiveIntrospectionWithTheExpectedIssuerAccepted() throws Exception {
+        // getExpectedIssuer() is derived as serverUrl + "/realms/" + realm
+        String issuer = "http://localhost:8080/realms/test-realm";
+        KeycloakTokenIntrospector introspector = introspectorReturning(Map.of("active", true, "iss", issuer));
+
+        KeycloakSecurityPolicy policy = introspectionPolicy(introspector);
+        policy.setValidateIssuer(true);
+
+        AtomicBoolean routeReached = new AtomicBoolean(false);
+        KeycloakSecurityProcessor processor = new KeycloakSecurityProcessor(e -> routeReached.set(true), policy);
+
+        processor.process(bearer("x"));
+        assertTrue(routeReached.get(), "Route body must be reached for a token from the expected issuer");
+    }
+
+    private static KeycloakTokenIntrospector introspectorReturning(Map<String, Object> claims) {
+        return new KeycloakTokenIntrospector(
+                "http://localhost:8080", "test-realm", "test-client", "test-secret", (TokenCache) null) {
+            @Override
+            public IntrospectionResult introspect(String token) {
+                return new IntrospectionResult(claims);
+            }
+        };
+    }
+
+    private static KeycloakSecurityPolicy introspectionPolicy(KeycloakTokenIntrospector introspector) {
+        KeycloakSecurityPolicy policy = new KeycloakSecurityPolicy() {
+            @Override
+            public boolean isUseTokenIntrospection() {
+                return true;
+            }
+
+            @Override
+            public KeycloakTokenIntrospector getTokenIntrospector() {
+                return introspector;
+            }
+        };
+        policy.setServerUrl("http://localhost:8080");
+        policy.setRealm("test-realm");
+        policy.setClientId("test-client");
+        policy.setClientSecret("test-secret");
+        return policy;
+    }
+
     @Test
     void testTokenMissingExpectedAudienceRejectedLocalJwt() throws Exception {
         String issuer = "http://localhost:8080/realms/test-realm";

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -491,3 +491,18 @@ is truncated rather than recreated and would otherwise keep its original permiss
 
 Deployments where another account legitimately reads these files — a sidecar or a backup agent running as
 a different user — need to run as the owner, or use a group-aware key store instead.
+=== camel-keycloak
+
+When `validateIssuer` is enabled and the token is checked by introspection, an introspection response
+carrying no `iss` claim used to log a warning and pass. It is now rejected with
+`Token issuer missing: expected '<issuer>' but the introspection result carries no issuer`.
+
+Issuer validation is opt-in, so an operator who enabled it is asking for tokens from other issuers to be
+refused, and a response with no issuer is not evidence that the token came from the expected one. RFC 7662
+makes `iss` optional in an introspection response, so this is reachable wherever the introspection
+endpoint is a broker, a gateway, or a minimal implementation rather than the realm that issued the token.
+Audience validation already behaved this way; the two are now consistent.
+
+Deployments whose introspection endpoint omits `iss` must either have it include the claim, or turn
+`validateIssuer` off. The locally verified JWT path is unaffected — it uses Keycloak's own
+`TokenVerifier.RealmUrlCheck`.


### PR DESCRIPTION
Fixes [CAMEL-24448](https://issues.apache.org/jira/browse/CAMEL-24448).

validateIssuerFromIntrospection() logged a warning and returned successfully when the
introspection response had no "iss" claim, so the configured issuer was not checked at
all in that case.

Issuer validation runs only behind policy.isValidateIssuer(), so an operator who enabled
it is asking for tokens from other issuers to be refused - and a response carrying no
issuer is not evidence that the token came from the expected one. RFC 7662 makes "iss"
optional in an introspection response, which makes this reachable wherever the
introspection endpoint is a broker, a gateway, or a minimal implementation rather than
the realm that issued the token.

Reject it, the way the adjacent audience check already rejects a missing "aud". That
check's javadoc drew the contrast ("Unlike issuer validation...") when it was added under
CAMEL-23875 without giving a reason for the difference; the two are now consistent and
the javadoc is updated to say so.

The locally verified JWT path is unaffected - it delegates to Keycloak's own
TokenVerifier.RealmUrlCheck.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: Andrea Cosentino <ancosen@gmail.com>
\n## Verification\n\n3 files changed, including 1 test file(s). Module build with \`-am\` is green on current main, no generated-file drift. Verified against the pre-fix code when the change was written.

_Claude Code on behalf of oscerd_