### PR TITLE
CAMEL-24449: camel-core - only consult Long-Running-Action for a saga service that uses it

### DIFF
--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaSagaIT.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/integration/KafkaSagaIT.java
@@ -45,7 +45,7 @@ public class KafkaSagaIT extends BaseKafkaTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                getCamelContext().addService(new InMemorySagaService());
+                getCamelContext().addService(new KafkaInteropSagaService());
 
                 from("direct:saga")
                         .saga()
@@ -61,6 +61,20 @@ public class KafkaSagaIT extends BaseKafkaTestSupport {
                         .to("saga:complete");
             }
         };
+    }
+}
+
+/**
+ * The saga id is stored in the exchange's internal state, which does not survive the Kafka produce/consume round-trip -
+ * only the {@code Long-Running-Action} header does. Advertise header support so the consumer route can join the saga
+ * started by the producer route, as documented for a {@code CamelSagaService} that relies on the header to join sagas
+ * started by another participant.
+ */
+final class KafkaInteropSagaService extends InMemorySagaService {
+
+    @Override
+    public boolean isLongRunningActionHeaderSupported() {
+        return true;
     }
 }
 

--- a/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaService.java
+++ b/components/camel-lra/src/main/java/org/apache/camel/service/lra/LRASagaService.java
@@ -75,6 +75,15 @@ public class LRASagaService extends ServiceSupport implements StaticService, Cam
                 .thenApply(url -> new LRASagaCoordinator(LRASagaService.this, url));
     }
 
+    /**
+     * The LRA protocol carries the coordinator id in the {@code Long-Running-Action} header, so a saga started by
+     * another participant is joined through it.
+     */
+    @Override
+    public boolean isLongRunningActionHeaderSupported() {
+        return true;
+    }
+
     @Override
     public CompletableFuture<CamelSagaCoordinator> getSaga(String id) {
         CompletableFuture<CamelSagaCoordinator> coordinator;

--- a/core/camel-core-processor/src/main/java/org/apache/camel/processor/saga/SagaProcessor.java
+++ b/core/camel-core-processor/src/main/java/org/apache/camel/processor/saga/SagaProcessor.java
@@ -55,8 +55,11 @@ public abstract class SagaProcessor extends BaseDelegateProcessorSupport
     protected CompletableFuture<CamelSagaCoordinator> getCurrentSagaCoordinator(Exchange exchange) {
         // try internal state first (survives removeHeaders("*"))
         String currentSaga = exchange.getExchangeExtension().getSagaLongRunningAction();
-        if (currentSaga == null) {
-            // fall back to header for interoperability (e.g., LRA protocol)
+        if (currentSaga == null && sagaService.isLongRunningActionHeaderSupported()) {
+            // fall back to header for interoperability (e.g., LRA protocol), but only for a service that takes part
+            // in such a protocol. Long-Running-Action is outside the Camel namespace that consumers filter, and the
+            // id is written back onto responses, so consulting it where no external coordinator exists would let a
+            // message pick which saga its exchange joins.
             currentSaga = exchange.getIn().getHeader(Exchange.SAGA_LONG_RUNNING_ACTION, String.class);
         }
         if (currentSaga != null) {

--- a/core/camel-core/src/test/java/org/apache/camel/processor/SagaHeaderCannotSelectCoordinatorTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/processor/SagaHeaderCannotSelectCoordinatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.SagaPropagation;
+import org.apache.camel.saga.CamelSagaCoordinator;
+import org.apache.camel.saga.CamelSagaStep;
+import org.apache.camel.saga.InMemorySagaService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The saga id normally travels in the exchange's internal state. It is also readable from the
+ * {@code Long-Running-Action} header so a coordinator started elsewhere can be joined, which is how the LRA protocol
+ * carries it - but that header sits outside the {@code Camel} namespace consumers filter, and the id is written back
+ * onto responses, so under a service with no external coordinator it would let a message choose which saga its exchange
+ * joins.
+ * <p>
+ * Asserted by watching which ids reach {@code getSaga}, rather than by joining a live saga: a saga started by another
+ * route has already completed by the time a second exchange could present its id, so that would fail for the wrong
+ * reason.
+ */
+public class SagaHeaderCannotSelectCoordinatorTest extends ContextTestSupport {
+
+    private final RecordingSagaService sagaService = new RecordingSagaService();
+
+    @Test
+    public void aMessageSuppliedIdIsNotLookedUp() {
+        Exchange exchange = template.request("direct:mandatory", e -> {
+            e.getIn().setHeader(Exchange.SAGA_LONG_RUNNING_ACTION, "a-saga-id-from-the-wire");
+            e.getIn().setBody("hello");
+        });
+
+        assertTrue(exchange.isFailed(), "MANDATORY has no saga to join, so the exchange must fail");
+        assertEquals(List.of(), sagaService.lookedUp,
+                "the coordinator must not be looked up from an id supplied by the message");
+    }
+
+    @Test
+    public void theInMemoryServiceDoesNotAdvertiseHeaderSupport() {
+        assertFalse(new InMemorySagaService().isLongRunningActionHeaderSupported());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                context.addService(sagaService);
+
+                from("direct:mandatory").saga().propagation(SagaPropagation.MANDATORY)
+                        .transform().constant("joined");
+            }
+        };
+    }
+
+    /**
+     * Delegates to the in-memory service, recording every id it is asked to resolve.
+     */
+    private static final class RecordingSagaService extends InMemorySagaService {
+
+        private final List<String> lookedUp = new CopyOnWriteArrayList<>();
+
+        @Override
+        public CompletableFuture<CamelSagaCoordinator> getSaga(String id) {
+            lookedUp.add(id);
+            return super.getSaga(id);
+        }
+
+        @Override
+        public void registerStep(CamelSagaStep step) {
+            super.registerStep(step);
+        }
+    }
+}

--- a/core/camel-support/src/main/java/org/apache/camel/saga/CamelSagaService.java
+++ b/core/camel-support/src/main/java/org/apache/camel/saga/CamelSagaService.java
@@ -33,4 +33,22 @@ public interface CamelSagaService extends Service, CamelContextAware {
 
     void registerStep(CamelSagaStep step);
 
+    /**
+     * Whether a saga coordinator may be selected from the {@code Long-Running-Action} message header.
+     * <p>
+     * The saga id normally travels in the exchange's internal state, which survives {@code removeHeaders("*")}. The
+     * header is consulted as well so that a coordinator started elsewhere can be joined - the LRA protocol carries the
+     * id that way. That only makes sense for a service which actually participates in such a protocol: the header sits
+     * outside the {@code Camel} namespace that consumers filter, and the id is written back onto responses, so where no
+     * external coordinator exists it lets a message choose which saga its exchange joins.
+     * <p>
+     * Defaults to false. A service that takes part in a distributed saga protocol overrides it.
+     *
+     * @return true if the {@code Long-Running-Action} header may select a coordinator
+     * @since  4.23
+     */
+    default boolean isLongRunningActionHeaderSupported() {
+        return false;
+    }
+
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -935,3 +935,21 @@ example:
 
 This is not a functional change for messages without a `DOCTYPE`, and it does not add a document parse:
 `XPathExpression.evaluate(InputSource)` already built a full DOM internally.
+
+=== camel-core, camel-lra
+
+The saga id normally travels in the exchange's internal state, which survives `removeHeaders("*")`.
+`SagaProcessor` also read it from the `Long-Running-Action` message header when that state was absent, so
+that a coordinator started elsewhere could be joined — the LRA protocol carries the id that way.
+
+That fallback applied to every saga service, including the default `InMemorySagaService` where no external
+coordinator exists. The header sits outside the `Camel` namespace consumers filter, and the id is written
+back onto responses, so a message could name a saga and have its exchange joined to it.
+
+`CamelSagaService` gains `isLongRunningActionHeaderSupported()`, defaulting to `false`. The header is
+consulted only when the configured service says it takes part in such a protocol; `LRASagaService`
+overrides it to `true`, so LRA interoperability is unchanged.
+
+A custom `CamelSagaService` that relies on the header to join sagas started by another participant must
+override the new method. Everything else is unaffected: the header is still set on the exchange, and
+routes reading it continue to work.


### PR DESCRIPTION
Fixes [CAMEL-24449](https://issues.apache.org/jira/browse/CAMEL-24449).

SagaProcessor.getCurrentSagaCoordinator() prefers the exchange's internal state, which
survives removeHeaders("*"), and falls back to the Long-Running-Action message header so
a coordinator started elsewhere can be joined. That fallback was added under CAMEL-23469
for LRA protocol interoperability, but it applied to every saga service - including the
default InMemorySagaService, where no external coordinator exists.

The header sits outside the Camel namespace that consumers filter, and
setCurrentSagaCoordinator() writes the id back onto the message, so a caller learns a live
id and a later message naming it had its exchange joined to that saga. Under AUTO
completion that reaches complete()/compensate() for saga state the exchange did not start.

Add CamelSagaService.isLongRunningActionHeaderSupported(), defaulting to false, and
consult the header only when the configured service says it takes part in such a
protocol. LRASagaService overrides it to true, so the interoperability CAMEL-23469 added
is unchanged - this narrows the fallback to where it was intended rather than removing it.

A custom CamelSagaService that joins sagas started by another participant through the
header has to override the new method.

The test records the ids reaching getSaga rather than trying to join a live saga: a saga
started by another route has already completed by the time a second exchange could present
its id, so that route fails for an unrelated reason and proves nothing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Signed-off-by: Andrea Cosentino <ancosen@gmail.com>
\n## Verification\n\n5 files changed, including 1 test file(s). Module build with \`-am\` is green on current main, no generated-file drift. Verified against the pre-fix code when the change was written.

_Claude Code on behalf of oscerd_