### PR TITLE
CAMEL-24479: camel-yaml-dsl - Restore additionalProperties:false for explicit expression/inline-hosted definitions

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -610,11 +610,25 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
      * @param inlineDefinitions    The name of the definitions that has inline option enabled
      */
     private void postProcessInheritance(Set<String> inheritedDefinitions, Set<String> inlineDefinitions) {
-        // additionalProperties=false prevents inheritance with allOf/anyOf/oneOf
-        // Remove it to be true by default
+        // additionalProperties=false prevents inheritance with allOf/anyOf/oneOf, so it needs to be removed
+        // to allow a type such as ExpressionDefinition to be inlined directly onto a host's own closed schema
+        // (e.g. filter: { simple: "...", steps: [...] } merges ExpressionDefinition's properties onto
+        // FilterDefinition). But the very same type is also used standalone, referenced by its own named
+        // property (e.g. the explicit filter: { expression: { simple: "..." } } form) - if additionalProperties
+        // is removed from the shared definition itself, that explicit, non-inlined usage loses its closedness
+        // too and silently accepts unknown/duplicate properties (CAMEL-24479).
+        //
+        // Clone the definition instead of mutating it in place: the open clone is only substituted into the
+        // bare $ref oneOf/anyOf branches used for inlining, while the original definition - referenced by
+        // every named property - stays closed.
+        Map<String, String> inlineClones = new HashMap<>();
         for (String inherited : inheritedDefinitions) {
-            ObjectNode node = definitions.withObject("/" + inherited);
-            node.remove("additionalProperties");
+            ObjectNode original = definitions.withObject("/" + inherited);
+            String cloneName = inherited + "$Inline";
+            ObjectNode clone = original.deepCopy();
+            clone.remove("additionalProperties");
+            definitions.set(cloneName, clone);
+            inlineClones.put(inherited, cloneName);
         }
 
         // Redeclare the inherited properties
@@ -630,9 +644,9 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
             if (temp.has("anyOf")) {
                 final var definition = temp;
                 StreamSupport.stream(temp.withArray("anyOf").spliterator(), false)
-                        .forEach(group -> postProcessComposition(name, definition, group, inheritedDefinitions));
+                        .forEach(group -> postProcessComposition(name, definition, group, inheritedDefinitions, inlineClones));
             } else {
-                postProcessComposition(name, temp, temp, inheritedDefinitions);
+                postProcessComposition(name, temp, temp, inheritedDefinitions, inlineClones);
             }
         });
     }
@@ -650,7 +664,8 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
     }
 
     private void postProcessComposition(
-            String name, JsonNode definition, JsonNode inherited, Set<String> inheritedDefinitions) {
+            String name, JsonNode definition, JsonNode inherited, Set<String> inheritedDefinitions,
+            Map<String, String> inlineClones) {
         ArrayNode composition = extractComposition(inherited);
         if (composition == null) {
             return;
@@ -674,7 +689,7 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                         .filter(prop -> !definition.withObject("/properties").has(prop.getKey()))
                         .forEach(prop -> definition.withObject("/properties").putObject(prop.getKey()));
             }
-            postProcessComposition(name, definition, compositionEntry, inheritedDefinitions);
+            postProcessComposition(name, definition, compositionEntry, inheritedDefinitions, inlineClones);
 
             if (!compositionEntry.has("$ref")) {
                 continue;
@@ -683,8 +698,13 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
             if (!inheritedDefinitions.contains(parentName)) {
                 continue;
             }
-            JsonNode parent = definitions.withObject("/" + parentName);
-            postProcessComposition(parentName, definition, parent, inheritedDefinitions);
+            // This is a bare $ref composition branch (no wrapping "properties"), i.e. the type is being
+            // inlined directly onto the host's own schema - repoint it to the open clone so the host's
+            // sibling properties aren't rejected, without touching the original (still closed) definition.
+            String cloneName = inlineClones.get(parentName);
+            ((ObjectNode) compositionEntry).put("$ref", "#/items/definitions/" + cloneName);
+            JsonNode parent = definitions.withObject("/" + cloneName);
+            postProcessComposition(parentName, definition, parent, inheritedDefinitions, inlineClones);
             parent
                     .withObject("/properties")
                     .properties()

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/java/org/apache/camel/dsl/yaml/validator/YamlValidatorTest.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/java/org/apache/camel/dsl/yaml/validator/YamlValidatorTest.java
@@ -86,4 +86,26 @@ public class YamlValidatorTest {
         Assertions.assertFalse(report.isEmpty());
         Assertions.assertTrue(report.stream().anyMatch(error -> error.getMessage().contains("parserStep")));
     }
+
+    @Test
+    public void testInlineExpressionObjectFormStillValidates() throws Exception {
+        // Guards the fix for CAMEL-24479: restoring additionalProperties:false on ExpressionDefinition
+        // must not break the inline shorthand merge (filter: { groovy: {...} } without an "expression:"
+        // wrapper), which relies on ExpressionDefinition's properties being redeclared onto FilterDefinition.
+        var report = validator.validate(new File("src/test/resources/inline-expression-object.yaml"));
+        Assertions.assertTrue(report.isEmpty(), "Inline expression object form should still pass validation but got: "
+                                                + report.stream().map(e -> e.getMessage()).toList());
+    }
+
+    @Test
+    public void testUnknownPropertyInExpressionBlockFailsValidation() throws Exception {
+        // CAMEL-24479: an explicit "expression: {...}" wrapper block with an unknown property (hello) must
+        // be rejected. Before the fix, ExpressionDefinition's schema had lost its additionalProperties:false
+        // as a side effect of also supporting inline expression shorthands (e.g. filter: { simple: "..." }),
+        // so unknown/duplicate properties were silently accepted whenever any single valid language was present.
+        var report = validator.validate(new File("src/test/resources/CAMEL-24479.yaml"));
+        Assertions.assertFalse(report.isEmpty(), "Unknown property 'hello' in the expression block should be reported");
+        Assertions.assertTrue(report.stream().anyMatch(e -> e.getMessage().contains("hello")),
+                "Should identify the unknown property 'hello', got: " + report.stream().map(e -> e.getMessage()).toList());
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/CAMEL-24479.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/CAMEL-24479.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- route:
+    id: route-from-jb
+    description: On message
+    nodePrefixId: route-from-jb
+    from:
+      id: from-e92e
+      description: From JB
+      uri: vertx
+      variableReceive: message
+      parameters:
+        address: EVENTS_FROM_JB
+        pubSub: true
+      steps:
+        - choice:
+            id: choice-5f68
+            when:
+              - id: when-8c1e
+                expression:
+                  groovy:
+                    id: simple-4df51
+                    expression: ${variable.message[messageType]} == "ACK"
+                  simple: {}
+                  hello: world2
+                steps:
+                  - setVariable:
+                      id: setVariable-7f68
+                      description: Set Ack
+                      name: ack
+                      expression:
+                        groovy:
+                          id: groovy-e040
+                          expression: '"hello"'

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/inline-expression-object.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/inline-expression-object.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - filter:
+            groovy:
+              expression: "true"
+            steps:
+              - to: mock:result

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -307,6 +307,7 @@
       },
       "org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string"
@@ -1158,7 +1159,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -1313,7 +1314,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -1473,7 +1474,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -2171,7 +2172,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -2421,7 +2422,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -2994,7 +2995,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4068,7 +4069,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4532,7 +4533,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4784,7 +4785,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4905,7 +4906,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -5495,7 +5496,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6242,7 +6243,7 @@
           "additionalProperties" : false,
           "anyOf" : [ {
             "oneOf" : [ {
-              "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
             }, {
               "not" : {
                 "anyOf" : [ {
@@ -6524,7 +6525,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6662,7 +6663,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6840,7 +6841,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7021,7 +7022,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7165,7 +7166,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7346,7 +7347,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7489,7 +7490,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -8003,7 +8004,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -8550,7 +8551,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -9234,7 +9235,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -9394,7 +9395,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -13402,6 +13403,7 @@
       },
       "org.apache.camel.model.language.ExpressionDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -17744,6 +17746,305 @@
           "predicateValidator" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.validator.PredicateValidatorDefinition"
           }
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition$Inline" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "note" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          },
+          "variableReceive" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.language.ExpressionDefinition$Inline" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "constant" ],
+            "properties" : {
+              "constant" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csimple" ],
+            "properties" : {
+              "csimple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.CSimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "datasonnet" ],
+            "properties" : {
+              "datasonnet" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.DatasonnetExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "exchangeProperty" ],
+            "properties" : {
+              "exchangeProperty" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "groovy" ],
+            "properties" : {
+              "groovy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.GroovyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "header" ],
+            "properties" : {
+              "header" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7terser" ],
+            "properties" : {
+              "hl7terser" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jactl" ],
+            "properties" : {
+              "jactl" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JactlExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "java" ],
+            "properties" : {
+              "java" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "joor" ],
+            "properties" : {
+              "joor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JoorExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jq" ],
+            "properties" : {
+              "jq" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "js" ],
+            "properties" : {
+              "js" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaScriptExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonpath" ],
+            "properties" : {
+              "jsonpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "language" ],
+            "properties" : {
+              "language" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.LanguageExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "method" ],
+            "properties" : {
+              "method" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MethodCallExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mvel" ],
+            "properties" : {
+              "mvel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MvelExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ognl" ],
+            "properties" : {
+              "ognl" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.OgnlExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "python" ],
+            "properties" : {
+              "python" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.PythonExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "python3" ],
+            "properties" : {
+              "python3" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.Python3Expression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "quickjs" ],
+            "properties" : {
+              "quickjs" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.QuickjsExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ref" ],
+            "properties" : {
+              "ref" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.RefExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "simple" ],
+            "properties" : {
+              "simple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "spel" ],
+            "properties" : {
+              "spel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SpELExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tokenize" ],
+            "properties" : {
+              "tokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.TokenizerExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "variable" ],
+            "properties" : {
+              "variable" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.VariableExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "wasm" ],
+            "properties" : {
+              "wasm" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.WasmExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xpath" ],
+            "properties" : {
+              "xpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xquery" ],
+            "properties" : {
+              "xquery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XQueryExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xtokenize" ],
+            "properties" : {
+              "xtokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "jactl" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "python3" : { },
+          "quickjs" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { }
         }
       }
     },


### PR DESCRIPTION
## Summary

`camel validate yaml` (classic/default mode, no `--canonical`) silently accepts an `expression:` block containing an unknown property and two mutually-exclusive language choices at once, reporting `Validation success` when it should fail. Reproduced with the reporter's actual attachment content (a `choice`/`when` with `expression: { groovy: {...}, simple: {}, hello: world2 }`).

## Root cause

`GenerateYamlSchemaMojo`'s `postProcessInheritance`/`postProcessComposition` strip `additionalProperties: false` from any definition reused via the `__extends` "inline shorthand" mechanism — e.g. `ExpressionDefinition`, which is inlined directly onto `filter`/`resequence`/`onException`/... so that `filter: { simple: "..." }` works without an explicit `expression:` wrapper. That relaxation is required for the ["extending closed schemas"](https://json-schema.org/understanding-json-schema/reference/object.html#extending-closed-schemas) pattern already referenced in the code's own comment — a `$ref`'d schema merged directly onto a closed host must itself be open, or the host's own sibling properties (`id`, `steps`, ...) would be rejected.

The bug: this removal mutated the single, shared `ExpressionDefinition` definition in place, so the *same* type also lost its closedness when referenced independently via its own named property (the explicit `expression: { groovy: {...} }` form used by ~15 EIPs). Once open, `oneOf` only needs one alternative (`groovy`) to structurally match; unrelated extra keys (`hello`) or a second, incomplete alternative (`simple: {}`) are invisible to the validator since nothing restricts additional properties anymore.

Confirmed by instrumenting the raw `com.networknt.schema` validator directly (bypassing `YamlValidator`'s own noise-filtering) — the underlying schema itself accepted the document with zero errors before this fix.

## Fix

Clone the definition instead of mutating it in place in `postProcessInheritance`: only the clone (named `<Type>$Inline`) loses `additionalProperties`, and only the bare `$ref` `oneOf`/`anyOf` composition branches used for inlining get repointed to it. The original definition — referenced by every explicit named property (`expression: {...}`) — keeps its `additionalProperties: false`.

This is fully generic: it applies to every type in `inheritedDefinitions`, not just `ExpressionDefinition` (the generated schema shows the same clone-and-repoint treatment applied to `OutputAwareFromDefinition` too).

Canonical mode (`--canonical`) was already unaffected by this bug, since it disables the `__extends` inline mechanism entirely and always requires the explicit wrapper form.

## Test plan

- [x] Reproduced the reported bug end-to-end with the local `camel` CLI (`camel validate yaml`) using the reporter's actual attachment content, before and after the fix
- [x] Confirmed inline shorthand forms (`filter: { simple: "..." }`, `filter: { groovy: {...} }`) still validate correctly after the fix
- [x] Added `YamlValidatorTest#testUnknownPropertyInExpressionBlockFailsValidation` using the reporter's file (`CAMEL-24479.yaml`)
- [x] Added `YamlValidatorTest#testInlineExpressionObjectFormStillValidates` guarding the inline-merge mechanism against regression
- [x] `mvn test` in `camel-yaml-dsl-validator`, `camel-yaml-dsl`, `camel-yaml-dsl-maven-plugin`, `camel-yaml-dsl-deserializers`
- [x] Full root `mvn clean install -DskipTests` (mandatory sanity build) — no unexpected regen drift

---
_Claude Code on behalf of @davsclaus_

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>