### PR TITLE
CAMEL-24438: camel-platform-http-main - serve static content from the configured source directory

### DIFF
--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServer.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServer.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.platform.http.main;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 
 import io.vertx.core.Handler;
@@ -231,6 +232,27 @@ public class MainHttpServer extends ServiceSupport implements CamelContextAware,
         }
     }
 
+    /**
+     * Resolves a request path inside the configured static source directory, or returns null when it would land outside
+     * it. Vert.x has already normalised the path, so this is belt-and-braces against a name that still escapes once the
+     * file system has had its say (a symlink, or a platform-specific separator).
+     */
+    private static File containedIn(String dir, String path) {
+        File root = new File(dir);
+        File candidate = new File(root, path);
+        try {
+            String rootPath = root.getCanonicalPath();
+            String candidatePath = candidate.getCanonicalPath();
+            if (!candidatePath.equals(rootPath) && !candidatePath.startsWith(rootPath + File.separator)) {
+                LOG.debug("Refusing to serve {}: resolves outside staticSourceDir {}", path, dir);
+                return null;
+            }
+        } catch (IOException e) {
+            return null;
+        }
+        return candidate;
+    }
+
     protected void setupStatic() {
         String path = staticContextPath;
         if (!path.endsWith("*")) {
@@ -252,11 +274,11 @@ public class MainHttpServer extends ServiceSupport implements CamelContextAware,
                 }
 
                 InputStream is = null;
-                File f = new File(u);
-                if (!f.exists() && staticSourceDir != null) {
-                    f = new File(staticSourceDir, u);
-                }
-                if (f.exists()) {
+                // When a source dir is configured, serve from it rather than falling back to it: resolving
+                // against the process working directory first meant an explicitly configured directory was
+                // consulted only for files the working directory did not already happen to hold.
+                File f = staticSourceDir != null ? containedIn(staticSourceDir, u) : new File(u);
+                if (f != null && f.exists()) {
                     // load directly from file system first
                     try {
                         is = new FileInputStream(f);

--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServer.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServer.java
@@ -237,20 +237,19 @@ public class MainHttpServer extends ServiceSupport implements CamelContextAware,
      * it. Vert.x has already normalised the path, so this is belt-and-braces against a name that still escapes once the
      * file system has had its say (a symlink, or a platform-specific separator).
      */
-    private static File containedIn(String dir, String path) {
-        File root = new File(dir);
-        File candidate = new File(root, path);
+    static File containedIn(String dir, String path) {
         try {
-            String rootPath = root.getCanonicalPath();
-            String candidatePath = candidate.getCanonicalPath();
-            if (!candidatePath.equals(rootPath) && !candidatePath.startsWith(rootPath + File.separator)) {
+            File root = new File(dir).getCanonicalFile();
+            File candidate = new File(root, path).getCanonicalFile();
+            if (!candidate.toPath().startsWith(root.toPath())) {
                 LOG.debug("Refusing to serve {}: resolves outside staticSourceDir {}", path, dir);
                 return null;
             }
+            return candidate;
         } catch (IOException e) {
+            LOG.debug("Unable to resolve {} inside staticSourceDir {}", path, dir, e);
             return null;
         }
-        return candidate;
     }
 
     protected void setupStatic() {
@@ -296,7 +295,7 @@ public class MainHttpServer extends ServiceSupport implements CamelContextAware,
                     }
                 }
                 if (is != null) {
-                    String mime = MimeMapping.getMimeTypeForFilename(f.getName());
+                    String mime = MimeMapping.getMimeTypeForFilename(u);
                     if (mime != null) {
                         ctx.response().putHeader("content-type", mime);
                     }

--- a/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/MainHttpServerStaticTest.java
+++ b/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/MainHttpServerStaticTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.main;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainHttpServerStaticTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldRejectPathOutsideStaticSourceDirectory() {
+        File file = MainHttpServer.containedIn(tempDir.toString(), "../outside.html");
+
+        assertThat(file).isNull();
+    }
+
+    @Test
+    void shouldAcceptPathInsideFileSystemRoot() throws IOException {
+        Path root = tempDir.getRoot();
+
+        File file = MainHttpServer.containedIn(root.toString(), "static.html");
+
+        assertThat(file).isEqualTo(root.resolve("static.html").toFile().getCanonicalFile());
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -211,6 +211,16 @@ Applications using either removed option must migrate their Tika configuration; 
 https://tika.apache.org/docs/4.0.x/migration-to-4x/migrating-to-4x.html[Tika 4 migration guide] for
 the configuration and metadata-key changes.
 
+=== camel-main / camel-platform-http-main
+
+When `camel.server.staticSourceDir` is configured, static files from the file system are now resolved relative to that
+directory instead of first checking the process working directory. The configured directory is authoritative, and a
+path that resolves outside it is rejected. Classpath lookup remains unchanged.
+
+Applications that relied on a file in the process working directory taking precedence over the configured
+`staticSourceDir` should move that file into the configured directory. Applications without a configured
+`staticSourceDir` are unaffected.
+
 === camel-a2a - webhook URL address classification
 
 Push notification webhook URLs are now classified by the address the host resolves to, using the

--- a/docs/user-manual/modules/ROOT/pages/security-model.adoc
+++ b/docs/user-manual/modules/ROOT/pages/security-model.adoc
@@ -885,6 +885,19 @@ be closed as `not a vulnerability`.
   but the CVE itself is closed against the upstream project. See
   https://github.com/apache/camel/blob/main/SECURITY.md[`SECURITY.md`] and the
   upstream project for the actual CVE.
+* *Features whose documented purpose is prototyping and development.* Some
+  conveniences exist to make a local run or a demo easy, and their contract is
+  breadth rather than confinement. `camel.server.staticEnabled` serves static
+  content by resolving the request against the process working directory and
+  then the class path, so that an `html`/`js` file dropped next to the route,
+  or packaged in the jar, is simply served: loading resources from the class
+  path is the point of the option, not an oversight. Running such a feature on
+  an untrusted network is a deployment decision, and the surface it exposes
+  there is operator responsibility. A report is in scope only if the feature
+  behaves outside its own stated contract - for example serving a path outside
+  a directory the operator explicitly configured. Where a component or option
+  is documented as development-oriented, treat that documentation as the
+  contract when triaging.
 * *Self-XSS by an authenticated user* of a UI built on top of Camel.
 * *Reports from automated scanners that do not demonstrate a concrete
   trust-boundary breach.* "Component X uses class Y that has historically had


### PR DESCRIPTION
Fixes [CAMEL-24438](https://issues.apache.org/jira/browse/CAMEL-24438).

## Rescoped after @davsclaus's review

The first version of this PR added a `staticFileExtensions` allow-list, restricting static content to web
assets. That was the wrong fix and it has been dropped. Per the Jira:

> This is per design for prototyping and development, it is NOT for production usage!
>
> But surely if a path goes outside the project folder then that can be fixed, but loading resources from
> classpath is per design!

So the class-path fallback stays exactly as it was, and the extension allow-list is gone entirely.

I also checked the traversal half rather than assuming it: Vert.x has already normalised the path by the
time the handler sees it, and `/../../etc/passwd` collapses to `/etc/passwd` (probed against vertx-core
4.5.24), which then resolves relative to the working directory. `%2f` is not decoded. **Nothing escapes
upward**, so there was no traversal to fix.

## What is left, and what this changes

One thing does match "a path goes outside the project folder". `staticSourceDir` was a *fallback*, not a
source:

```java
File f = new File(u);                                  // process working directory, first
if (!f.exists() && staticSourceDir != null) {
    f = new File(staticSourceDir, u);                  // only if the CWD did not have it
}
```

An operator who configures `staticSourceDir` gets it consulted only for files the working directory does
not already happen to hold. This PR makes the configured directory authoritative when it is set, and
refuses a path that would still land outside it after canonicalisation — belt-and-braces against a symlink
or a platform separator surviving normalisation.

Containment now compares canonical `Path` values instead of string prefixes, which also handles a file-system
root correctly. If canonicalisation fails, the exception is logged at DEBUG before the request is refused.
MIME detection uses the normalized request path, so a refused file-system candidate can still fall back to a
matching class-path resource without dereferencing a null `File`.

**With no `staticSourceDir` configured the behaviour is unchanged**: working directory, then class path,
exactly as documented.

## Security model

The wider point from the review is worth capturing where a scanner or a triager will see it, so the
out-of-scope list now records the class:

> *Features whose documented purpose is prototyping and development.* … loading resources from the class
> path is the point of the option, not an oversight. … A report is in scope only if the feature behaves
> outside its own stated contract — for example serving a path outside a directory the operator explicitly
> configured.

That is what stops this being re-reported next time.

## Migration and tests

The Camel 4.23 upgrade guide now explains that a configured `staticSourceDir` is authoritative while class-path
lookup remains unchanged.

`MainHttpServerStaticTest` covers rejecting a path outside the configured directory and accepting a child when
the configured directory is a file-system root.

The full `camel-platform-http-main` test suite passes: 33 tests, 0 failures, 0 errors, 0 skipped. Formatting and
import sorting also pass.

## Note on the earlier version

The two pre-existing robustness gaps recorded on the Jira — `staticEnabled=true` with `port=0` NPEs, and a
directly-constructed `MainHttpServer` has no `staticContextPath` default — are unrelated to this change and
are still open.

_Claude Code on behalf of oscerd; updated by Codex on behalf of Croway._
