### PR TITLE
CAMEL-24530: camel-djl - close the InputStream opened from File/Path bodies in DJLConverter

### DIFF
--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/DJLConverter.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/DJLConverter.java
@@ -48,12 +48,16 @@ public class DJLConverter {
 
     @Converter
     public static Image toImage(File file) throws IOException {
-        return toImage(new FileInputStream(file));
+        try (InputStream inputStream = new FileInputStream(file)) {
+            return toImage(inputStream);
+        }
     }
 
     @Converter
     public static Image toImage(Path path) throws IOException {
-        return toImage(Files.newInputStream(path));
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            return toImage(inputStream);
+        }
     }
 
     @Converter
@@ -105,12 +109,16 @@ public class DJLConverter {
 
     @Converter
     public static Audio toAudio(File file) throws IOException {
-        return toAudio(new FileInputStream(file));
+        try (InputStream inputStream = new FileInputStream(file)) {
+            return toAudio(inputStream);
+        }
     }
 
     @Converter
     public static Audio toAudio(Path path) throws IOException {
-        return toAudio(Files.newInputStream(path));
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            return toAudio(inputStream);
+        }
     }
 
     @Converter

--- a/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/DJLConverterTest.java
+++ b/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/DJLConverterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.djl;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import ai.djl.modality.cv.Image;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DJLConverterTest {
+
+    private static final String IMAGE_RESOURCE = "/data/detect/kitten.jpg";
+
+    // Converting from a File opens a stream internally; it must be closed (try-with-resources) so the
+    // file descriptor is not leaked per conversion. The conversion must still return a valid Image.
+    @Test
+    void toImageFromFileReturnsImageWithoutLeakingStream() throws Exception {
+        File file = new File(DJLConverterTest.class.getResource(IMAGE_RESOURCE).toURI());
+        Image image = DJLConverter.toImage(file);
+        assertNotNull(image);
+        assertTrue(image.getWidth() > 0 && image.getHeight() > 0);
+    }
+
+    @Test
+    void toImageFromPathReturnsImageWithoutLeakingStream() throws Exception {
+        Path path = Path.of(DJLConverterTest.class.getResource(IMAGE_RESOURCE).toURI());
+        Image image = DJLConverter.toImage(path);
+        assertNotNull(image);
+        assertTrue(image.getWidth() > 0 && image.getHeight() > 0);
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24530](https://issues.apache.org/jira/browse/CAMEL-24530)

## Problem
`DJLConverter` opens a stream from `File`/`Path` bodies and never closes it:

```java
public static Image toImage(File file) throws IOException {
    return toImage(new FileInputStream(file));   // stream never closed
}
```

The same applies to `toImage(Path)`, `toAudio(File)` and `toAudio(Path)`. The `InputStream` overload
they delegate to reads the image/audio via `ImageFactory` / `AudioFactory` `fromInputStream(...)`,
which does **not** close the stream. Every conversion of a `File` or `Path` body therefore leaks a
file descriptor — under load (a file/FTP route feeding DJL) this exhausts the process's descriptors.

## Fix
Wrap the self-opened stream in try-with-resources in the four `File`/`Path` converter methods so the
descriptor is always released after the image/audio has been read into memory. The `InputStream`
overloads are intentionally left unchanged: they receive a **caller-owned** stream and must not close
it.

## Testing
- New `DJLConverterTest` verifies `toImage(File)` and `toImage(Path)` return a valid image (exercising
  the try-with-resources path). The audio methods are structurally identical.
- `mvn -Psourcecheck validate` green.

_Claude Code on behalf of oscerd_