### PR TITLE
CAMEL-24529: camel-djl - close the loaded ZooModel when the producer stops

### DIFF
--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/DJLProducer.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/DJLProducer.java
@@ -36,4 +36,10 @@ public class DJLProducer extends DefaultProducer {
     public void process(Exchange exchange) throws Exception {
         this.predictor.process(exchange);
     }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        this.predictor.close();
+    }
 }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/AbstractPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/AbstractPredictor.java
@@ -29,6 +29,15 @@ public abstract class AbstractPredictor {
 
     public abstract void process(Exchange exchange) throws Exception;
 
+    /**
+     * Releases any resources held by this predictor, such as a model loaded from the DJL model zoo. Called when the
+     * owning producer is stopped. The default implementation does nothing; predictors that keep a long-lived model
+     * override this method to close it.
+     */
+    public void close() {
+        // no-op by default
+    }
+
     protected DJLEndpoint getEndpoint() {
         return endpoint;
     }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/audio/ZooAudioPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/audio/ZooAudioPredictor.java
@@ -74,4 +74,11 @@ public class ZooAudioPredictor extends AbstractPredictor {
             throw new RuntimeCamelException("Could not process input or output", e);
         }
     }
+
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+    }
 }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/cv/AbstractCvZooPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/cv/AbstractCvZooPredictor.java
@@ -55,4 +55,11 @@ public abstract class AbstractCvZooPredictor<T> extends AbstractPredictor {
             throw new RuntimeCamelException("Could not process input or output", e);
         }
     }
+
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+    }
 }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/cv/ZooImageGenerationPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/cv/ZooImageGenerationPredictor.java
@@ -73,4 +73,11 @@ public class ZooImageGenerationPredictor extends AbstractPredictor {
             throw new RuntimeCamelException("Could not process input or output", e);
         }
     }
+
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+    }
 }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/nlp/AbstractNlpZooPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/nlp/AbstractNlpZooPredictor.java
@@ -52,4 +52,11 @@ public abstract class AbstractNlpZooPredictor<T> extends AbstractPredictor {
             throw new RuntimeCamelException("Could not process input or output", e);
         }
     }
+
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+    }
 }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/nlp/ZooQuestionAnswerPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/nlp/ZooQuestionAnswerPredictor.java
@@ -82,4 +82,11 @@ public class ZooQuestionAnswerPredictor extends AbstractPredictor {
             throw new RuntimeCamelException("Could not process input or output", e);
         }
     }
+
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+    }
 }

--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/timeseries/ZooForecastingPredictor.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/model/timeseries/ZooForecastingPredictor.java
@@ -74,4 +74,11 @@ public class ZooForecastingPredictor extends AbstractPredictor {
             throw new RuntimeCamelException("Could not process input or output", e);
         }
     }
+
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+    }
 }

--- a/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/DJLProducerTest.java
+++ b/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/DJLProducerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.djl;
+
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class DJLProducerTest {
+
+    // Stopping the producer must release the predictor so a zoo model does not leak native memory across
+    // restart/redeploy (DJLProducer.doStop -> AbstractPredictor.close). For the custom (model-less) predictor
+    // path close() is the inherited no-op, so stopping must complete without error. The zoo predictors close
+    // their loaded model in their own close() overrides.
+    @Test
+    void stoppingProducerReleasesPredictor() {
+        DJLEndpoint endpoint = new DJLEndpoint("djl:tabular/linear_regression", null, "tabular/linear_regression");
+        endpoint.setCamelContext(new DefaultCamelContext());
+        endpoint.setModel("MyModel");
+        endpoint.setTranslator("MyTranslator");
+
+        assertDoesNotThrow(() -> {
+            DJLProducer producer = new DJLProducer(endpoint);
+            producer.start();
+            producer.stop();
+        });
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24529](https://issues.apache.org/jira/browse/CAMEL-24529)

## Problem
Every `Zoo*Predictor` loads a `ZooModel` via `ModelZoo.loadModel(...)` in its constructor and holds it
for the lifetime of the producer:

```java
this.model = ModelZoo.loadModel(criteria);
```

Nothing ever closed that model — `DJLProducer` had no `doStop()` and `AbstractPredictor` had no close
hook. A `ZooModel` owns native memory and file handles (the loaded engine model), so on every route
stop or redeploy the model was leaked. Long-running deployments that restart routes accumulate native
memory until the process is killed.

## Fix
- Add a `close()` lifecycle method to `AbstractPredictor`, a **no-op by default** so the custom
  predictors (which hold no long-lived model, looking one up per exchange) are unaffected.
- Override `close()` to close the held model in the zoo predictors and their two base classes
  (`AbstractCvZooPredictor`, `AbstractNlpZooPredictor` cover the CV/NLP zoo predictors;
  `ZooQuestionAnswerPredictor`, `ZooAudioPredictor`, `ZooImageGenerationPredictor`,
  `ZooForecastingPredictor` hold their own model).
- `DJLProducer.doStop()` now calls `predictor.close()`.

## Testing
- New `DJLProducerTest` verifies that starting and stopping the producer (which invokes
  `doStop -> predictor.close()`) completes without error on the custom, model-less path.
- The zoo predictors' `close()` overrides close the model behind an inspection-level guard
  (`if (model != null) model.close()`); loading a real zoo model to assert the native close requires
  network access and is out of scope for a unit test.
- `mvn -Psourcecheck validate` green.

_Claude Code on behalf of oscerd_