### PR TITLE
[backport camel-4.22.x] CAMEL-24479: camel-yaml-dsl - Restore additionalProperties:false for explicit expression/inline-hosted definitions

### DIFF
--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -610,11 +610,25 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
      * @param inlineDefinitions    The name of the definitions that has inline option enabled
      */
     private void postProcessInheritance(Set<String> inheritedDefinitions, Set<String> inlineDefinitions) {
-        // additionalProperties=false prevents inheritance with allOf/anyOf/oneOf
-        // Remove it to be true by default
+        // additionalProperties=false prevents inheritance with allOf/anyOf/oneOf, so it needs to be removed
+        // to allow a type such as ExpressionDefinition to be inlined directly onto a host's own closed schema
+        // (e.g. filter: { simple: "...", steps: [...] } merges ExpressionDefinition's properties onto
+        // FilterDefinition). But the very same type is also used standalone, referenced by its own named
+        // property (e.g. the explicit filter: { expression: { simple: "..." } } form) - if additionalProperties
+        // is removed from the shared definition itself, that explicit, non-inlined usage loses its closedness
+        // too and silently accepts unknown/duplicate properties (CAMEL-24479).
+        //
+        // Clone the definition instead of mutating it in place: the open clone is only substituted into the
+        // bare $ref oneOf/anyOf branches used for inlining, while the original definition - referenced by
+        // every named property - stays closed.
+        Map<String, String> inlineClones = new HashMap<>();
         for (String inherited : inheritedDefinitions) {
-            ObjectNode node = definitions.withObject("/" + inherited);
-            node.remove("additionalProperties");
+            ObjectNode original = definitions.withObject("/" + inherited);
+            String cloneName = inherited + "$Inline";
+            ObjectNode clone = original.deepCopy();
+            clone.remove("additionalProperties");
+            definitions.set(cloneName, clone);
+            inlineClones.put(inherited, cloneName);
         }
 
         // Redeclare the inherited properties
@@ -630,9 +644,9 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
             if (temp.has("anyOf")) {
                 final var definition = temp;
                 StreamSupport.stream(temp.withArray("anyOf").spliterator(), false)
-                        .forEach(group -> postProcessComposition(name, definition, group, inheritedDefinitions));
+                        .forEach(group -> postProcessComposition(name, definition, group, inheritedDefinitions, inlineClones));
             } else {
-                postProcessComposition(name, temp, temp, inheritedDefinitions);
+                postProcessComposition(name, temp, temp, inheritedDefinitions, inlineClones);
             }
         });
     }
@@ -650,7 +664,8 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
     }
 
     private void postProcessComposition(
-            String name, JsonNode definition, JsonNode inherited, Set<String> inheritedDefinitions) {
+            String name, JsonNode definition, JsonNode inherited, Set<String> inheritedDefinitions,
+            Map<String, String> inlineClones) {
         ArrayNode composition = extractComposition(inherited);
         if (composition == null) {
             return;
@@ -674,7 +689,7 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                         .filter(prop -> !definition.withObject("/properties").has(prop.getKey()))
                         .forEach(prop -> definition.withObject("/properties").putObject(prop.getKey()));
             }
-            postProcessComposition(name, definition, compositionEntry, inheritedDefinitions);
+            postProcessComposition(name, definition, compositionEntry, inheritedDefinitions, inlineClones);
 
             if (!compositionEntry.has("$ref")) {
                 continue;
@@ -683,8 +698,13 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
             if (!inheritedDefinitions.contains(parentName)) {
                 continue;
             }
-            JsonNode parent = definitions.withObject("/" + parentName);
-            postProcessComposition(parentName, definition, parent, inheritedDefinitions);
+            // This is a bare $ref composition branch (no wrapping "properties"), i.e. the type is being
+            // inlined directly onto the host's own schema - repoint it to the open clone so the host's
+            // sibling properties aren't rejected, without touching the original (still closed) definition.
+            String cloneName = inlineClones.get(parentName);
+            ((ObjectNode) compositionEntry).put("$ref", "#/items/definitions/" + cloneName);
+            JsonNode parent = definitions.withObject("/" + cloneName);
+            postProcessComposition(parentName, definition, parent, inheritedDefinitions, inlineClones);
             parent
                     .withObject("/properties")
                     .properties()

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/java/org/apache/camel/dsl/yaml/validator/YamlValidatorTest.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/java/org/apache/camel/dsl/yaml/validator/YamlValidatorTest.java
@@ -86,4 +86,26 @@ public class YamlValidatorTest {
         Assertions.assertFalse(report.isEmpty());
         Assertions.assertTrue(report.stream().anyMatch(error -> error.getMessage().contains("parserStep")));
     }
+
+    @Test
+    public void testInlineExpressionObjectFormStillValidates() throws Exception {
+        // Guards the fix for CAMEL-24479: restoring additionalProperties:false on ExpressionDefinition
+        // must not break the inline shorthand merge (filter: { groovy: {...} } without an "expression:"
+        // wrapper), which relies on ExpressionDefinition's properties being redeclared onto FilterDefinition.
+        var report = validator.validate(new File("src/test/resources/inline-expression-object.yaml"));
+        Assertions.assertTrue(report.isEmpty(), "Inline expression object form should still pass validation but got: "
+                                                + report.stream().map(e -> e.getMessage()).toList());
+    }
+
+    @Test
+    public void testUnknownPropertyInExpressionBlockFailsValidation() throws Exception {
+        // CAMEL-24479: an explicit "expression: {...}" wrapper block with an unknown property (hello) must
+        // be rejected. Before the fix, ExpressionDefinition's schema had lost its additionalProperties:false
+        // as a side effect of also supporting inline expression shorthands (e.g. filter: { simple: "..." }),
+        // so unknown/duplicate properties were silently accepted whenever any single valid language was present.
+        var report = validator.validate(new File("src/test/resources/CAMEL-24479.yaml"));
+        Assertions.assertFalse(report.isEmpty(), "Unknown property 'hello' in the expression block should be reported");
+        Assertions.assertTrue(report.stream().anyMatch(e -> e.getMessage().contains("hello")),
+                "Should identify the unknown property 'hello', got: " + report.stream().map(e -> e.getMessage()).toList());
+    }
 }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/CAMEL-24479.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/CAMEL-24479.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- route:
+    id: route-from-jb
+    description: On message
+    nodePrefixId: route-from-jb
+    from:
+      id: from-e92e
+      description: From JB
+      uri: vertx
+      variableReceive: message
+      parameters:
+        address: EVENTS_FROM_JB
+        pubSub: true
+      steps:
+        - choice:
+            id: choice-5f68
+            when:
+              - id: when-8c1e
+                expression:
+                  groovy:
+                    id: simple-4df51
+                    expression: ${variable.message[messageType]} == "ACK"
+                  simple: {}
+                  hello: world2
+                steps:
+                  - setVariable:
+                      id: setVariable-7f68
+                      description: Set Ack
+                      name: ack
+                      expression:
+                        groovy:
+                          id: groovy-e040
+                          expression: '"hello"'

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/inline-expression-object.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/inline-expression-object.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - filter:
+            groovy:
+              expression: "true"
+            steps:
+              - to: mock:result

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -307,6 +307,7 @@
       },
       "org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string"
@@ -1158,7 +1159,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -1307,7 +1308,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -1461,7 +1462,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -2131,7 +2132,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -2375,7 +2376,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -2942,7 +2943,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -3988,7 +3989,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4446,7 +4447,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4692,7 +4693,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -4807,7 +4808,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -5391,7 +5392,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6132,7 +6133,7 @@
           "additionalProperties" : false,
           "anyOf" : [ {
             "oneOf" : [ {
-              "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
             }, {
               "not" : {
                 "anyOf" : [ {
@@ -6408,7 +6409,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6540,7 +6541,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6712,7 +6713,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -6887,7 +6888,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7025,7 +7026,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7200,7 +7201,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7337,7 +7338,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -7845,7 +7846,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -8386,7 +8387,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -9046,7 +9047,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -9200,7 +9201,7 @@
         "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
-            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition$Inline"
           }, {
             "not" : {
               "anyOf" : [ {
@@ -13133,6 +13134,7 @@
       },
       "org.apache.camel.model.language.ExpressionDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "oneOf" : [ {
             "type" : "object",
@@ -17367,6 +17369,305 @@
           "predicateValidator" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.validator.PredicateValidatorDefinition"
           }
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition$Inline" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "note" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          },
+          "variableReceive" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.language.ExpressionDefinition$Inline" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "constant" ],
+            "properties" : {
+              "constant" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csimple" ],
+            "properties" : {
+              "csimple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.CSimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "datasonnet" ],
+            "properties" : {
+              "datasonnet" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.DatasonnetExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "exchangeProperty" ],
+            "properties" : {
+              "exchangeProperty" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "groovy" ],
+            "properties" : {
+              "groovy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.GroovyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "header" ],
+            "properties" : {
+              "header" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7terser" ],
+            "properties" : {
+              "hl7terser" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jactl" ],
+            "properties" : {
+              "jactl" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JactlExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "java" ],
+            "properties" : {
+              "java" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "joor" ],
+            "properties" : {
+              "joor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JoorExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jq" ],
+            "properties" : {
+              "jq" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "js" ],
+            "properties" : {
+              "js" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaScriptExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonpath" ],
+            "properties" : {
+              "jsonpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "language" ],
+            "properties" : {
+              "language" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.LanguageExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "method" ],
+            "properties" : {
+              "method" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MethodCallExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mvel" ],
+            "properties" : {
+              "mvel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MvelExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ognl" ],
+            "properties" : {
+              "ognl" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.OgnlExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "python" ],
+            "properties" : {
+              "python" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.PythonExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "python3" ],
+            "properties" : {
+              "python3" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.Python3Expression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "quickjs" ],
+            "properties" : {
+              "quickjs" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.QuickjsExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ref" ],
+            "properties" : {
+              "ref" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.RefExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "simple" ],
+            "properties" : {
+              "simple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "spel" ],
+            "properties" : {
+              "spel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SpELExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tokenize" ],
+            "properties" : {
+              "tokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.TokenizerExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "variable" ],
+            "properties" : {
+              "variable" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.VariableExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "wasm" ],
+            "properties" : {
+              "wasm" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.WasmExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xpath" ],
+            "properties" : {
+              "xpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xquery" ],
+            "properties" : {
+              "xquery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XQueryExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xtokenize" ],
+            "properties" : {
+              "xtokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "jactl" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "python3" : { },
+          "quickjs" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { }
         }
       }
     },


### PR DESCRIPTION
## Backport of #25841

Cherry-pick of #25841 onto `camel-4.22.x`.

**Original PR:** #25841 - CAMEL-24479: camel-yaml-dsl - Restore additionalProperties:false for explicit expression/inline-hosted definitions
**Original author:** @davsclaus
**Target branch:** `camel-4.22.x`

### Original description

`camel validate yaml` (classic/default mode, no `--canonical`) silently accepted an `expression:` block containing an unknown property and two mutually-exclusive language choices at once. `postProcessInheritance`/`postProcessComposition` stripped `additionalProperties: false` from the shared `ExpressionDefinition` schema in place when inlining it via `__extends`, which also stripped it from the definition's own explicit `expression: {...}` usage. Cloning the definition before stripping keeps the explicit form closed while inline shorthand stays open.

See #25841 for the full description and test plan.