### PR TITLE
CAMEL-24547: camel-jbang - Upgrade Camel Kamelets to 4.22.0

### DIFF
--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -22,7 +22,7 @@
 //JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.22.0}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.22.0}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.21.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.22.0}
 
 package main;
 

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -22,7 +22,7 @@
 //JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
 //DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.22.0}@pom
 //DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.22.0}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.21.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.22.0}
 
 package main;
 

--- a/dsl/camel-jbang/camel-launcher/pom.xml
+++ b/dsl/camel-jbang/camel-launcher/pom.xml
@@ -47,7 +47,7 @@
         <camel.surefire.forkTimeout>1200</camel.surefire.forkTimeout>
 
         <!-- Dependency versions -->
-        <camel-kamelets-version>4.20.0</camel-kamelets-version>
+        <camel-kamelets-version>4.22.0</camel-kamelets-version>
         <maven-version>3.9.16</maven-version>
         <plexus-interpolation-version>1.30.0</plexus-interpolation-version>
         <plexus-utils-version>4.1.0</plexus-utils-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,7 @@
         <californium-scandium-version>3.14.0</californium-scandium-version>
         <!-- jbang edit command which uses embedded kamelets catalog -->
         <camel-lsp-version>1.34.0</camel-lsp-version>
-        <camel-kamelets-catalog-version>4.21.0</camel-kamelets-catalog-version>
+        <camel-kamelets-catalog-version>4.22.0</camel-kamelets-catalog-version>
         <camunda-version>7.24.0</camunda-version>
         <camunda-client-java-version>8.9.17</camunda-client-java-version>
         <cassandra-driver-version>4.19.3</cassandra-driver-version>


### PR DESCRIPTION
## Motivation

[Apache Camel Kamelets 4.22.0](https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/4.22.0/) is on Maven Central, but the Camel CLI still pinned older Kamelets releases — and the four pins had drifted apart from one another (4.20.0, 4.21.0, 4.21.0, and 4.22.0 for the sibling Camel artifacts in the very same files).

JIRA: https://issues.apache.org/jira/browse/CAMEL-24547

## Changes

| File | Property / pin | Before | After |
|---|---|---|---|
| `parent/pom.xml` | `camel-kamelets-catalog-version` | 4.21.0 | **4.22.0** |
| `dsl/camel-jbang/camel-launcher/pom.xml` | `camel-kamelets-version` | 4.20.0 | **4.22.0** |
| `dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java` | `//DEPS …camel-kamelets` | 4.21.0 | **4.22.0** |
| `dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java` | `//DEPS …camel-kamelets` | 4.21.0 | **4.22.0** |

### Why each one matters

* **`camel-kamelets-catalog-version`** is the important one for `camel-jbang`. It is interpolated into two generated constants — `RuntimeType.KAMELETS_VERSION` (`camel-jbang-core`) and `KameletCatalogHelper.KAMELETS_VERSION` (`camel-kamelet-main`) — which are the fallback Kamelets version used by `camel run`, `camel export`, `camel catalog kamelet` and `camel doc` when `--kamelets-version` is not given and no `camel-kamelets` JAR is on the classpath. It also pins the catalog JAR embedded in the `camel-jbang-plugin-edit` plugin.
* **`camel-launcher`** bundles the `camel-kamelets` JAR into the launcher distribution; at 4.20.0 it was shipping a two-release-old Kamelets set.
* **`CamelJBang.java`** (both the `src/main/jbang` copy and the `dist` copy that `jbang-catalog.json` points at) already defaulted `camel-bom` and `camel-jbang-core` to 4.22.0 from CAMEL-24381, which could not raise Kamelets at the time because 4.22.0 had not been published yet.

## Deliberately not changed

* `dsl/camel-jbang/camel-jbang-container/build/Dockerfile` rewrites both `${camel.jbang.version:…}` and `${camel-kamelets.version:…}` to `${CAMEL_VERSION}` at image-build time, so it carries no pin to bump.
* The `4.14.1` / `4.18.0` versions in `camel-jbang-installation.adoc` are illustrative "pin a specific version" examples, not defaults.
* `TemplateHelperTest`'s `camel-kamelets:4.10.0` is an arbitrary test fixture, not a default.

## Testing

Full reactor build from the branch: `mvn clean install -DskipTests -Dquickly` → **BUILD SUCCESS**, 690/690 modules, 0 errors.

Verified afterwards:

* Both generated constants read `4.22.0`:
  * `dsl/camel-kamelet-main/target/generated-sources/java-templates/…/KameletCatalogHelper.java` → `KAMELETS_VERSION = "4.22.0"`
  * `dsl/camel-jbang/camel-jbang-core/target/generated-sources/java-templates/…/RuntimeType.java` → `KAMELETS_VERSION = "4.22.0"`
* `camel-launcher` resolves `org.apache.camel.kamelets:camel-kamelets:jar:4.22.0:compile` (`mvn dependency:tree`).
* `camel-jbang-plugin-edit` compiles against `camel-kamelets-catalog` 4.22.0.
* `git status` clean apart from the four intended files — no regenerated-file drift for CI to trip on.

---
_Claude Code on behalf of oscerd_
