### PR TITLE
CAMEL-24548 CAMEL-24549: Harden cloud storage download containment

### DIFF
--- a/components/camel-azure/camel-azure-common/src/main/java/org/apache/camel/component/azure/common/AzureFileNameHelper.java
+++ b/components/camel-azure/camel-azure-common/src/main/java/org/apache/camel/component/azure/common/AzureFileNameHelper.java
@@ -17,6 +17,9 @@
 package org.apache.camel.component.azure.common;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
 /**
@@ -44,10 +47,43 @@ public final class AzureFileNameHelper {
         final Path normalizedDir = new File(fileDir).toPath().normalize();
         final Path normalizedTarget = target.toPath().normalize();
         if (!normalizedTarget.startsWith(normalizedDir)) {
+            throw outsideDirectory(name, fileDir);
+        }
+
+        try {
+            final Path resolvedDir = resolveExistingPathSegments(new File(fileDir).toPath());
+            final Path resolvedTarget = resolveExistingPathSegments(target.toPath());
+            if (!resolvedTarget.startsWith(resolvedDir)) {
+                throw outsideDirectory(name, fileDir);
+            }
+        } catch (IOException e) {
             throw new IllegalArgumentException(
-                    "Cannot download to file '" + name
-                                               + "' as it resolves outside the configured fileDir directory: " + fileDir);
+                    "Cannot verify download path for file '" + name + "' within the configured fileDir directory: "
+                                               + fileDir,
+                    e);
         }
         return target;
+    }
+
+    private static Path resolveExistingPathSegments(Path path) throws IOException {
+        // Preserve the raw path segments here. Normalizing before resolving links changes the filesystem meaning of
+        // paths such as link/../file when link points to another directory.
+        final Path absolutePath = path.toAbsolutePath();
+        Path existingPath = absolutePath;
+        while (existingPath != null && !Files.exists(existingPath, LinkOption.NOFOLLOW_LINKS)) {
+            existingPath = existingPath.getParent();
+        }
+        if (existingPath == null) {
+            throw new IOException("No existing ancestor found for " + path);
+        }
+
+        final Path resolvedExistingPath = existingPath.toRealPath();
+        return resolvedExistingPath.resolve(existingPath.relativize(absolutePath)).normalize();
+    }
+
+    private static IllegalArgumentException outsideDirectory(String name, String fileDir) {
+        return new IllegalArgumentException(
+                "Cannot download to file '" + name
+                                            + "' as it resolves outside the configured fileDir directory: " + fileDir);
     }
 }

--- a/components/camel-azure/camel-azure-common/src/test/java/org/apache/camel/component/azure/common/AzureFileNameHelperTest.java
+++ b/components/camel-azure/camel-azure-common/src/test/java/org/apache/camel/component/azure/common/AzureFileNameHelperTest.java
@@ -17,6 +17,8 @@
 package org.apache.camel.component.azure.common;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -71,5 +73,29 @@ class AzureFileNameHelperTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> AzureFileNameHelper.resolveWithinDirectory(fileDir, "../workspace/secret"));
+    }
+
+    @Test
+    void shouldRejectSymbolicLinkResolvingOutsideDirectory(@TempDir Path parent) throws IOException {
+        Path downloadDir = Files.createDirectory(parent.resolve("downloads"));
+        Path outsideDir = Files.createDirectory(parent.resolve("outside"));
+        Files.createSymbolicLink(downloadDir.resolve("linked"), outsideDir);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> AzureFileNameHelper.resolveWithinDirectory(downloadDir.toString(), "linked/file.txt"));
+        assertTrue(exception.getMessage().contains("linked/file.txt"));
+        assertTrue(exception.getMessage().contains(downloadDir.toString()));
+    }
+
+    @Test
+    void shouldResolveParentSegmentAfterSymbolicLink(@TempDir Path parent) throws IOException {
+        Path downloadDir = Files.createDirectory(parent.resolve("downloads"));
+        Path outsideDir = Files.createDirectories(parent.resolve("outside/child"));
+        Files.createSymbolicLink(downloadDir.resolve("linked"), outsideDir);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> AzureFileNameHelper.resolveWithinDirectory(downloadDir.toString(), "linked/../file.txt"));
+        assertTrue(exception.getMessage().contains("linked/../file.txt"));
+        assertTrue(exception.getMessage().contains(downloadDir.toString()));
     }
 }

--- a/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageFileNameHelper.java
+++ b/components/camel-google/camel-google-storage/src/main/java/org/apache/camel/component/google/storage/GoogleCloudStorageFileNameHelper.java
@@ -17,6 +17,9 @@
 package org.apache.camel.component.google.storage;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
 /**
@@ -47,10 +50,44 @@ final class GoogleCloudStorageFileNameHelper {
         final Path normalizedDir = new File(downloadDirectory).toPath().normalize();
         final Path normalizedTarget = new File(resolvedPath).toPath().normalize();
         if (!normalizedTarget.startsWith(normalizedDir)) {
-            throw new IllegalArgumentException(
-                    "Cannot download to file '" + objectName
-                                               + "' as it resolves outside the configured downloadFileName directory: "
-                                               + downloadDirectory);
+            throw outsideDirectory(objectName, downloadDirectory);
         }
+
+        try {
+            final Path resolvedDir = resolveExistingPathSegments(new File(downloadDirectory).toPath());
+            final Path resolvedTarget = resolveExistingPathSegments(new File(resolvedPath).toPath());
+            if (!resolvedTarget.startsWith(resolvedDir)) {
+                throw outsideDirectory(objectName, downloadDirectory);
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Cannot verify download path for file '" + objectName
+                                               + "' within the configured downloadFileName directory: "
+                                               + downloadDirectory,
+                    e);
+        }
+    }
+
+    private static Path resolveExistingPathSegments(Path path) throws IOException {
+        // Preserve the raw path segments here. Normalizing before resolving links changes the filesystem meaning of
+        // paths such as link/../file when link points to another directory.
+        final Path absolutePath = path.toAbsolutePath();
+        Path existingPath = absolutePath;
+        while (existingPath != null && !Files.exists(existingPath, LinkOption.NOFOLLOW_LINKS)) {
+            existingPath = existingPath.getParent();
+        }
+        if (existingPath == null) {
+            throw new IOException("No existing ancestor found for " + path);
+        }
+
+        final Path resolvedExistingPath = existingPath.toRealPath();
+        return resolvedExistingPath.resolve(existingPath.relativize(absolutePath)).normalize();
+    }
+
+    private static IllegalArgumentException outsideDirectory(String objectName, String downloadDirectory) {
+        return new IllegalArgumentException(
+                "Cannot download to file '" + objectName
+                                            + "' as it resolves outside the configured downloadFileName directory: "
+                                            + downloadDirectory);
     }
 }

--- a/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/GoogleCloudStorageFileNameHelperTest.java
+++ b/components/camel-google/camel-google-storage/src/test/java/org/apache/camel/component/google/storage/GoogleCloudStorageFileNameHelperTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.camel.component.google.storage;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -79,5 +84,31 @@ class GoogleCloudStorageFileNameHelperTest {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> GoogleCloudStorageFileNameHelper.assertWithinDirectory(DIR,
                         DIR + "-evil/file.txt", "../gcs-download-evil/file.txt"));
+    }
+
+    @Test
+    void symbolicLinkResolvingOutsideDirectoryIsRejected(@TempDir Path parent) throws IOException {
+        Path downloadDir = Files.createDirectory(parent.resolve("downloads"));
+        Path outsideDir = Files.createDirectory(parent.resolve("outside"));
+        Path linkedPath = Files.createSymbolicLink(downloadDir.resolve("linked"), outsideDir);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> GoogleCloudStorageFileNameHelper.assertWithinDirectory(
+                        downloadDir.toString(), linkedPath.resolve("file.txt").toString(), "linked/file.txt"))
+                .withMessageContaining("linked/file.txt")
+                .withMessageContaining(downloadDir.toString());
+    }
+
+    @Test
+    void parentSegmentAfterSymbolicLinkIsResolvedByFilesystem(@TempDir Path parent) throws IOException {
+        Path downloadDir = Files.createDirectory(parent.resolve("downloads"));
+        Path outsideDir = Files.createDirectories(parent.resolve("outside/child"));
+        Path linkedPath = Files.createSymbolicLink(downloadDir.resolve("linked"), outsideDir);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> GoogleCloudStorageFileNameHelper.assertWithinDirectory(
+                        downloadDir.toString(), linkedPath.resolve("../file.txt").toString(), "linked/../file.txt"))
+                .withMessageContaining("linked/../file.txt")
+                .withMessageContaining(downloadDir.toString());
     }
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1097,3 +1097,16 @@ file. Converting a `String` to `Reader` itself, or to a non-file-backed subclass
 unaffected.
 
 `String` to `java.io.File` is unchanged: there the `String` genuinely is a path.
+
+=== camel-azure-storage-blob and camel-azure-storage-datalake
+
+Local downloads configured with `fileDir` now resolve existing filesystem path segments before checking
+that the destination remains inside the configured directory. Downloads through a symbolic link that
+resolves outside `fileDir` are rejected. Valid nested download paths continue to work.
+
+=== camel-google-storage
+
+Local downloads configured with a plain `downloadFileName` directory now resolve existing filesystem
+path segments before checking that the destination remains inside that directory. Downloads through a
+symbolic link that resolves outside the configured directory are rejected. Valid object names using `/`
+as a pseudo-directory separator continue to work.


### PR DESCRIPTION
This hardens local download path containment in the Azure Blob/DataLake and Google Storage components by resolving existing filesystem path segments before accepting a destination. It preserves valid nested paths while rejecting linked paths that resolve beyond the configured directory.

The change includes focused tests for direct linked paths and linked-path/parent-segment composition, plus 4.23 upgrade-guide notes. The branch has been rebased onto current `main`; concurrent upstream upgrade-guide additions were preserved while resolving the conflict.

JIRA:
- https://issues.apache.org/jira/browse/CAMEL-24548
- https://issues.apache.org/jira/browse/CAMEL-24549

Verification:
- Azure helper tests on current main: 8 passed
- Google helper and consumer path tests: 14 passed before the 4.23 rebase
- Current Google module verification cannot resolve locally absent `camel-google-common` and `camel-test-junit6` 4.23.0-SNAPSHOT artifacts; the full reactor path is independently blocked in unchanged `camel-xml-io` SchemaGen
- Rebased commit GPG signature: verified
- `git diff --check`: clean

Backport assessment:
- `camel-4.22.x`: recommended for both components; shared Azure helper exists
- `camel-4.18.x`: recommended for both components; Google is straightforward, while Azure requires adapting the change to the duplicated Blob/DataLake helpers

_Generated by Codex via OSS Helper on behalf of oscerd_

Co-authored-by: Codex <noreply@openai.com>