### PR TITLE
(test) Align Docling integration expectations

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/docling-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/docling-component.adoc
@@ -350,9 +350,10 @@ YAML::
 Docling recognizes page headers and footers (page numbers, copyright lines, running titles, footnotes, and similar
 content) during OCR, classifying them as page _furniture_ in docling's `FURNITURE` content layer.
 
-Since docling v1.30.0, page furniture (headers and footers) is included in the default body export (Markdown, text
-and HTML). Earlier versions excluded the `FURNITURE` layer, so header and footer text was omitted from the converted
-output even though the OCR engine read it correctly.
+Docling's Markdown, text and HTML exports include only the `BODY` layer by default, so header and footer text is
+omitted from the converted output even though the OCR engine read it correctly. When using `useDoclingServe=true`,
+the component cannot currently include the `FURNITURE` layer because docling-serve does not expose a content-layer
+selection option. This is tracked in https://github.com/docling-project/docling-serve/issues/271[docling-serve#271].
 
 === Using headers to control processing
 
@@ -1327,4 +1328,3 @@ YAML::
 3. **Set appropriate timeouts**: Adjust `asyncTimeout` based on your largest expected document size. The default 5 minutes is suitable for most documents.
 
 4. **Monitor with logging**: Use DEBUG level logging to monitor API calls and async task status.
-

--- a/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
+++ b/components/camel-ai/camel-docling/src/main/docs/docling-component.adoc
@@ -350,9 +350,10 @@ YAML::
 Docling recognizes page headers and footers (page numbers, copyright lines, running titles, footnotes, and similar
 content) during OCR, classifying them as page _furniture_ in docling's `FURNITURE` content layer.
 
-Since docling v1.30.0, page furniture (headers and footers) is included in the default body export (Markdown, text
-and HTML). Earlier versions excluded the `FURNITURE` layer, so header and footer text was omitted from the converted
-output even though the OCR engine read it correctly.
+Docling's Markdown, text and HTML exports include only the `BODY` layer by default, so header and footer text is
+omitted from the converted output even though the OCR engine read it correctly. When using `useDoclingServe=true`,
+the component cannot currently include the `FURNITURE` layer because docling-serve does not expose a content-layer
+selection option. This is tracked in https://github.com/docling-project/docling-serve/issues/271[docling-serve#271].
 
 === Using headers to control processing
 
@@ -1327,4 +1328,3 @@ YAML::
 3. **Set appropriate timeouts**: Adjust `asyncTimeout` based on your largest expected document size. The default 5 minutes is suitable for most documents.
 
 4. **Monitor with logging**: Use DEBUG level logging to monitor API calls and async task status.
-

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/MetadataExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/MetadataExtractionIT.java
@@ -65,13 +65,14 @@ class MetadataExtractionIT extends DoclingITestSupport {
         DocumentMetadata metadata = template.requestBody("direct:extract-metadata",
                 testFile.toString(), DocumentMetadata.class);
 
-        assertNotNull(metadata, "Metadata should not be null");
-        assertNotNull(metadata.getFileName(), "File name should be extracted");
-        assertTrue(metadata.getFileSizeBytes() > 0, "File size should be greater than 0");
-        assertNotNull(metadata.getFilePath(), "File path should be set");
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getFileName()).isNotNull();
+        assertThat(metadata.getFileSizeBytes()).isPositive();
+        assertThat(metadata.getFilePath()).isNotNull();
         assertThat(metadata.getPageCount()).isEqualTo(5);
         assertThat(metadata.getFormat()).isEqualTo("application/pdf");
-        assertThat(metadata.getTitle()).isEqualTo("The Evolution of the Word Processor");
+        // Docling classifies the leading heading in this fixture as a section header, not a document title.
+        assertThat(metadata.getTitle()).isNull();
         assertThat(metadata.getDocumentType()).isEqualTo("PDF");
 
         LOG.info("Successfully extracted metadata: {}", metadata);

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
@@ -175,13 +175,15 @@ class OcrExtractionIT extends CamelTestSupport {
         boolean foundFirst = resultLower.contains("first");
         boolean foundSecond = resultLower.contains("second");
 
-        assertTrue(foundFirst && foundSecond,
-                "OCR should extract at least some of the expected text. Got: " + result);
+        assertThat(foundFirst && foundSecond)
+                .as("OCR should extract at least some of the expected text. Got: %s", result)
+                .isTrue();
 
-        // Since docling v1.30.0, page furniture (headers/footers) is included in the default body export.
+        // Docling recognizes the footer but classifies it as page furniture, which the default body export excludes.
         boolean foundFooter = resultLower.contains("footer");
-        assertTrue(foundFooter,
-                "Footer text (page furniture) should be included in the docling body export since v1.30.0. Got: " + result);
+        assertThat(foundFooter)
+                .as("Footer text should be excluded from the default body export. Got: %s", result)
+                .isFalse();
 
         LOG.info("OCR extraction with multiple text blocks result:\n{}", result);
         LOG.info("Successfully extracted text from image with multiple text blocks");


### PR DESCRIPTION
## Summary

- align the PDF metadata test with Docling classifying the fixture heading as `section_header`, rather than `title`
- align the OCR footer test with the default BODY-only text export behavior
- correct the component documentation and generated catalog copy, including the open upstream docling-serve issue #271

This follows the Docling upgrade merged in #25603.

## Testing

- `mvn -DskipTests install`
- `mvn '-Dit.test=*IT' -DskipITs=false failsafe:integration-test failsafe:verify` (49 tests)

_AI-generated by Codex on behalf of @Croway._