### PR TITLE
chore(camel-test-infra-ibmmq): upgrade ibm.mq.container to 10.0.0.0-r3

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/test-infra/metadata.json
@@ -293,7 +293,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
   "version" : "4.23.0-SNAPSHOT",
-  "serviceVersion" : "10.0.0.0-r2",
+  "serviceVersion" : "10.0.0.0-r3",
   "uiSupported" : true
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
+++ b/test-infra/camel-test-infra-all/src/generated/resources/META-INF/metadata.json
@@ -293,7 +293,7 @@
   "groupId" : "org.apache.camel",
   "artifactId" : "camel-test-infra-ibmmq",
   "version" : "4.23.0-SNAPSHOT",
-  "serviceVersion" : "10.0.0.0-r2",
+  "serviceVersion" : "10.0.0.0-r3",
   "uiSupported" : true
 }, {
   "service" : "org.apache.camel.test.infra.aws.common.services.AWSInfraService",

--- a/test-infra/camel-test-infra-ibmmq/src/main/resources/org/apache/camel/test/infra/ibmmq/services/container.properties
+++ b/test-infra/camel-test-infra-ibmmq/src/main/resources/org/apache/camel/test/infra/ibmmq/services/container.properties
@@ -14,5 +14,5 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-ibm.mq.container=icr.io/ibm-messaging/mq:10.0.0.0-r2
+ibm.mq.container=icr.io/ibm-messaging/mq:10.0.0.0-r3
 ibm.mq.container.version.exclude=amd64,arm64,ppc64le,s390x,x86_64


### PR DESCRIPTION
This replaces #25292, which became unmergeable after the project version advanced from 4.22.0-SNAPSHOT to 4.23.0-SNAPSHOT.

## Changes

- Update icr.io/ibm-messaging/mq from 10.0.0.0-r2 to 10.0.0.0-r3.
- Regenerate both test-infra metadata copies against 4.23.0-SNAPSHOT.

## Verification

- python3 .github/actions/check-container-upgrade/test_update_metadata_version.py — 17 tests passed.
- camel-test-infra-ibmmq Maven install with tests skipped — passed.
- Both generated metadata files are byte-identical.
- IBM MQ JMS integration tests require native amd64 validation. On Apple Silicon, both r2 and r3 fail identically under amd64 emulation because the emulated CPU lacks x86-64-v3 support.

_Codex on behalf of @Croway_