### PR TITLE
chore: document Develocity local build-cache gotcha in building.adoc

### DIFF
--- a/docs/main/modules/contributing/pages/building.adoc
+++ b/docs/main/modules/contributing/pages/building.adoc
@@ -50,6 +50,28 @@ Camel committers and experienced Camel contributors are may also use Maven Daemo
 To build Camel maven has to be configured to use more memory, which is done automatically via
 the `.mvn/jvm.config` file.
 
+[NOTE]
+====
+The build uses the Develocity Maven extension (`.mvn/extensions.xml`), which enables a *local*
+build cache by default (`.mvn/develocity.xml`) so incremental local builds can reuse unchanged
+module outputs. Remote caching is always disabled. If you rebuild a module and your changes don't
+seem to take effect -- for example a jar in `~/.m2` doesn't reflect a source change you just
+made -- disable the local cache for that build to force a real compile:
+
+[source,bash]
+----
+mvn clean install -Pfastinstall -Ddevelocity.cache.local.enabled=false
+----
+
+To disable it for every local build without changing the command line each time, set it once via
+an environment variable (e.g. in your shell profile):
+
+[source,bash]
+----
+export MAVEN_OPTS="$MAVEN_OPTS -Ddevelocity.cache.local.enabled=false"
+----
+====
+
 == A normal build
 
 Beware this runs all the unit tests which takes many hours.


### PR DESCRIPTION
## Summary
- The Develocity Maven extension enables a local build cache by default outside CI (`.mvn/develocity.xml`). It can silently serve a stale jar from `~/.m2` after a source change, which looks exactly like an unfixed bug.
- Documents how to spot/avoid it: a one-off `-Ddevelocity.cache.local.enabled=false` flag, or a persistent `MAVEN_OPTS` env var override.

No JIRA needed — documentation only, no behavior change.

_Claude Code on behalf of davsclaus_