### PR TITLE
chore: update GreeterClientTest for camel-cxf muteException default

### DIFF
--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/security/GreeterClientTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/security/GreeterClientTest.java
@@ -118,12 +118,9 @@ public class GreeterClientTest {
             fail("should fail");
         } catch (Exception ex) {
             assertTrue(ex instanceof SOAPFaultException, "Get a wrong type exception.");
-            assertTrue(ex.getMessage().startsWith("Cannot access the processor which has been protected."),
-                    "Get a wrong exception message");
-            assertTrue(
-                    ex.getMessage().endsWith(
-                            "Caused by: [org.springframework.security.authorization.AuthorizationDeniedException - Access Denied]"),
-                    "Get a wrong exception message");
+            // CxfEndpoint's muteException consumer option defaults to true (CAMEL-24477): an undeclared
+            // route failure - such as this authorization denial - no longer leaks its message to the caller.
+            assertEquals("Exchange processing failed", ex.getMessage(), "Get a wrong exception message");
         }
     }
 


### PR DESCRIPTION
## Summary
- `CAMEL-24477` (already merged, #25742) changed `CxfEndpoint`'s `muteException` consumer option to default to `true`: an undeclared route failure no longer leaks its internal exception message in the SOAP fault returned to the caller.
- `GreeterClientTest.testServiceWithNotAuthorizedUser` (inherited by `GreeterClientCxfMessageTest`) asserted on the old, pre-hardening leaked message. Updated it to assert the new, documented `"Exchange processing failed"` fault message instead.

No JIRA needed — due to security hardening already merged and documented in the 4.23 upgrade guide; this just catches the test up to already-intended behavior, not a bug fix.

## Test plan
- [x] `mvn test -Dtest=GreeterClientTest,GreeterClientCxfMessageTest` in `tests/camel-itest` — both pass

_Claude Code on behalf of davsclaus_