### PR TITLE
CAMEL-24514: camel-console - Use GET instead of POST for read-only dev consoles in OpenAPI spec

### DIFF
--- a/catalog/camel-catalog-console/src/generated/resources/META-INF/org/apache/camel/dev-console/catalog.json
+++ b/catalog/camel-catalog-console/src/generated/resources/META-INF/org/apache/camel/dev-console/catalog.json
@@ -6,6 +6,7 @@
     "title": "Catalog",
     "description": "Information about used Camel artifacts",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.catalog.console.CatalogConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-catalog-console",

--- a/components/camel-aws/camel-aws-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/aws-secrets.json
+++ b/components/camel-aws/camel-aws-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/aws-secrets.json
@@ -6,6 +6,7 @@
     "title": "AWS Secrets",
     "description": "AWS Secrets Manager",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.aws.secretsmanager.SecretsDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-aws-secrets-manager",

--- a/components/camel-aws/camel-aws2-s3/src/generated/resources/META-INF/org/apache/camel/dev-console/aws2-s3.json
+++ b/components/camel-aws/camel-aws2-s3/src/generated/resources/META-INF/org/apache/camel/dev-console/aws2-s3.json
@@ -6,6 +6,7 @@
     "title": "AWS S3",
     "description": "AWS S3 Consumer",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.aws2.s3.AWS2S3Console",
     "groupId": "org.apache.camel",
     "artifactId": "camel-aws2-s3",

--- a/components/camel-azure/camel-azure-key-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/azure-secrets.json
+++ b/components/camel-azure/camel-azure-key-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/azure-secrets.json
@@ -6,6 +6,7 @@
     "title": "Azure Key Vault Secrets",
     "description": "Azure Key Vault Secret Manager",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.azure.key.vault.AzureKeyVaultManagerDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-azure-key-vault",

--- a/components/camel-diagram/src/generated/resources/META-INF/org/apache/camel/dev-console/route-diagram.json
+++ b/components/camel-diagram/src/generated/resources/META-INF/org/apache/camel/dev-console/route-diagram.json
@@ -6,6 +6,7 @@
     "title": "Route Diagram",
     "description": "Visual route diagrams",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.diagram.DiagramDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-diagram",

--- a/components/camel-ftp/src/generated/resources/META-INF/org/apache/camel/dev-console/sftp.json
+++ b/components/camel-ftp/src/generated/resources/META-INF/org/apache/camel/dev-console/sftp.json
@@ -6,6 +6,7 @@
     "title": "SFTP",
     "description": "Secure FTP using JSCH",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.file.remote.SftpDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-ftp",

--- a/components/camel-google/camel-google-secret-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/gcp-secrets.json
+++ b/components/camel-google/camel-google-secret-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/gcp-secrets.json
@@ -6,6 +6,7 @@
     "title": "GCP Secrets",
     "description": "GCP Secret Manager",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.google.secret.manager.GoogleSecretManagerDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-google-secret-manager",

--- a/components/camel-groovy/src/generated/resources/META-INF/org/apache/camel/dev-console/groovy.json
+++ b/components/camel-groovy/src/generated/resources/META-INF/org/apache/camel/dev-console/groovy.json
@@ -6,6 +6,7 @@
     "title": "Groovy",
     "description": "Groovy Language",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.language.groovy.GroovyDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-groovy",

--- a/components/camel-hashicorp-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/hashicorp-secrets.json
+++ b/components/camel-hashicorp-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/hashicorp-secrets.json
@@ -6,6 +6,7 @@
     "title": "HashiCorp Secrets",
     "description": "HashiCorp Vault Secrets",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.hashicorp.vault.SecretsDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-hashicorp-vault",

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/ibm-secrets.json
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/ibm-secrets.json
@@ -6,6 +6,7 @@
     "title": "IBM Secrets",
     "description": "IBM Secrets Manager",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.ibm.secrets.manager.SecretsDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-ibm-secrets-manager",

--- a/components/camel-jfr/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr.json
+++ b/components/camel-jfr/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr.json
@@ -6,6 +6,7 @@
     "title": "JFR Runtime Instrumentation",
     "description": "Status and live control of camel-jfr runtime instrumentation",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.runtime.jfr.CamelJfrDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-jfr",

--- a/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
+++ b/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
@@ -83,6 +83,11 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
               "Status and live control of camel-jfr runtime instrumentation");
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
     private boolean isInstrumentationRegistered() {
         CamelContext ctx = getCamelContext();
         if (ctx == null) {

--- a/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
+++ b/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
@@ -49,7 +49,7 @@ import org.apache.camel.util.json.JsonObject;
  * @since 4.22
  */
 @DevConsole(name = "jfr", displayName = "JFR Runtime Instrumentation",
-            description = "Status and live control of camel-jfr runtime instrumentation")
+            description = "Status and live control of camel-jfr runtime instrumentation", readOnly = false)
 public class CamelJfrDevConsole extends AbstractDevConsole {
 
     @Metadata(label = "query", description = "Command to perform", javaType = "java.lang.String",
@@ -81,11 +81,6 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
     public CamelJfrDevConsole() {
         super("camel", "jfr", "JFR Runtime Instrumentation",
               "Status and live control of camel-jfr runtime instrumentation");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     private boolean isInstrumentationRegistered() {

--- a/components/camel-jfr/src/test/java/org/apache/camel/runtime/jfr/CamelJfrDevConsoleTest.java
+++ b/components/camel-jfr/src/test/java/org/apache/camel/runtime/jfr/CamelJfrDevConsoleTest.java
@@ -63,6 +63,12 @@ class CamelJfrDevConsoleTest extends CamelTestSupport {
     }
 
     @Test
+    void isNotReadOnly() {
+        // the console can enable/disable JFR events and trigger snapshots, so it must not be advertised as safe
+        assertThat(resolveConsole(context).isReadOnly()).isFalse();
+    }
+
+    @Test
     void statusReportsNotRegisteredByDefault() {
         // camel-jfr is on the classpath, but its runtime instrumentation is opt-in, so merely having the
         // recorder available must not install the hooks

--- a/components/camel-kafka/src/generated/resources/META-INF/org/apache/camel/dev-console/kafka.json
+++ b/components/camel-kafka/src/generated/resources/META-INF/org/apache/camel/dev-console/kafka.json
@@ -6,6 +6,7 @@
     "title": "Kafka",
     "description": "Apache Kafka",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.kafka.KafkaDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-kafka",

--- a/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-configmaps.json
+++ b/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-configmaps.json
@@ -6,6 +6,7 @@
     "title": "Kubernetes Config Maps",
     "description": "Kubernetes Cluster Config Maps",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.kubernetes.config_maps.vault.ConfigmapsDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-kubernetes",

--- a/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-secrets.json
+++ b/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-secrets.json
@@ -6,6 +6,7 @@
     "title": "Kubernetes Secrets",
     "description": "Kubernetes Cluster Secrets",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.kubernetes.secrets.vault.SecretsDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-kubernetes",

--- a/components/camel-micrometer/src/generated/resources/META-INF/org/apache/camel/dev-console/micrometer.json
+++ b/components/camel-micrometer/src/generated/resources/META-INF/org/apache/camel/dev-console/micrometer.json
@@ -6,6 +6,7 @@
     "title": "Micrometer",
     "description": "Display runtime metrics",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.micrometer.MicrometerConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-micrometer",

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/generated/resources/META-INF/org/apache/camel/dev-console/fault-tolerance.json
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/generated/resources/META-INF/org/apache/camel/dev-console/fault-tolerance.json
@@ -6,6 +6,7 @@
     "title": "MicroProfile Circuit Breaker",
     "description": "Display circuit breaker information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.microprofile.faulttolerance.FaultToleranceConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-microprofile-fault-tolerance",

--- a/components/camel-opentelemetry2/src/generated/resources/META-INF/org/apache/camel/dev-console/opentelemetry.json
+++ b/components/camel-opentelemetry2/src/generated/resources/META-INF/org/apache/camel/dev-console/opentelemetry.json
@@ -6,6 +6,7 @@
     "title": "OpenTelemetry Spans",
     "description": "OpenTelemetry span data captured in dev mode",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.opentelemetry2.OpenTelemetryDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-opentelemetry2",

--- a/components/camel-platform-http-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-http-server.json
+++ b/components/camel-platform-http-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-http-server.json
@@ -6,6 +6,7 @@
     "title": "Main HTTP Server",
     "description": "Camel Main HTTP Server",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.platform.http.main.MainHttpServerDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-platform-http-main",

--- a/components/camel-platform-http/src/generated/resources/META-INF/org/apache/camel/dev-console/platform-http.json
+++ b/components/camel-platform-http/src/generated/resources/META-INF/org/apache/camel/dev-console/platform-http.json
@@ -6,6 +6,7 @@
     "title": "Platform HTTP",
     "description": "Embedded HTTP Server",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.platform.http.PlatformHttpConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-platform-http",

--- a/components/camel-quartz/src/generated/resources/META-INF/org/apache/camel/dev-console/quartz.json
+++ b/components/camel-quartz/src/generated/resources/META-INF/org/apache/camel/dev-console/quartz.json
@@ -6,6 +6,7 @@
     "title": "Quartz",
     "description": "Quartz Scheduler",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.quartz.QuartzConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-quartz",

--- a/components/camel-resilience4j/src/generated/resources/META-INF/org/apache/camel/dev-console/resilience4j.json
+++ b/components/camel-resilience4j/src/generated/resources/META-INF/org/apache/camel/dev-console/resilience4j.json
@@ -6,6 +6,7 @@
     "title": "Resilience Circuit Breaker",
     "description": "Display circuit breaker information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.resilience4j.ResilienceConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-resilience4j",

--- a/components/camel-stub/src/generated/resources/META-INF/org/apache/camel/dev-console/stub.json
+++ b/components/camel-stub/src/generated/resources/META-INF/org/apache/camel/dev-console/stub.json
@@ -6,6 +6,7 @@
     "title": "Stub",
     "description": "Browse messages on stub endpoints",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.stub.StubConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-stub",

--- a/components/camel-vertx/camel-vertx-websocket/src/generated/resources/META-INF/org/apache/camel/dev-console/vertx-websocket.json
+++ b/components/camel-vertx/camel-vertx-websocket/src/generated/resources/META-INF/org/apache/camel/dev-console/vertx-websocket.json
@@ -6,6 +6,7 @@
     "title": "Vert.x WebSocket",
     "description": "Vert.x WebSocket consumer details",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.component.vertx.websocket.VertxWebsocketDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-vertx-websocket",

--- a/core/camel-api/src/generated/java/org/apache/camel/spi/annotations/DevConsole.java
+++ b/core/camel-api/src/generated/java/org/apache/camel/spi/annotations/DevConsole.java
@@ -51,4 +51,12 @@ public @interface DevConsole {
      */
     String description();
 
+    /**
+     * Whether this console is read-only (safe, and does not change any runtime state).
+     * <p/>
+     * Consoles that mutate state (such as starting/stopping a route, sending a message, or triggering a heap dump) must
+     * set this to {@code false}.
+     */
+    boolean readOnly() default true;
+
 }

--- a/core/camel-api/src/main/java/org/apache/camel/console/DevConsole.java
+++ b/core/camel-api/src/main/java/org/apache/camel/console/DevConsole.java
@@ -63,6 +63,19 @@ public interface DevConsole {
     boolean supportMediaType(MediaType mediaType);
 
     /**
+     * Whether this console is read-only (safe, and does not change any runtime state).
+     * <p/>
+     * Consoles that mutate state (such as starting/stopping a route, sending a message, or triggering a heap dump) must
+     * override this method to return {@code false}.
+     *
+     * @return true if read-only (the default), false if invoking this console changes runtime state.
+     * @since  4.23
+     */
+    default boolean isReadOnly() {
+        return true;
+    }
+
+    /**
      * Invokes and gets the output from this console.
      */
     default Object call(MediaType mediaType) {

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/activity.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/activity.json
@@ -6,6 +6,7 @@
     "title": "Camel Activity",
     "description": "Recent completed exchange activity",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ActivityDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/api.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/api.json
@@ -6,6 +6,7 @@
     "title": "API",
     "description": "OpenAPI specification for the dev console API",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ApiDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/bean.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/bean.json
@@ -6,6 +6,7 @@
     "title": "Bean",
     "description": "Displays Java beans from the registry",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.BeanDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/blocked.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/blocked.json
@@ -6,6 +6,7 @@
     "title": "Blocked Exchanges",
     "description": "Display blocked exchanges",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.BlockedConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/browse.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/browse.json
@@ -6,6 +6,7 @@
     "title": "Browse",
     "description": "Browse pending messages on Camel components",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.BrowseDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/circuit-breaker.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/circuit-breaker.json
@@ -6,6 +6,7 @@
     "title": "Circuit Breaker",
     "description": "Display circuit breaker information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.CircuitBreakerDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/consumer.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/consumer.json
@@ -6,6 +6,7 @@
     "title": "Consumers",
     "description": "Display information about Camel consumers",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ConsumerDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/context.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/context.json
@@ -6,6 +6,7 @@
     "title": "CamelContext",
     "description": "Overall information about the CamelContext",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ContextDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/datasource.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/datasource.json
@@ -6,6 +6,7 @@
     "title": "DataSource",
     "description": "Displays DataSource connection pool metrics",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.DataSourceDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/debug.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/debug.json
@@ -6,6 +6,7 @@
     "title": "Debug",
     "description": "Camel route debugger",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.DebugDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/endpoint.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/endpoint.json
@@ -6,6 +6,7 @@
     "title": "Endpoints",
     "description": "Endpoint Registry information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.EndpointDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/errors.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/errors.json
@@ -6,6 +6,7 @@
     "title": "Error Registry",
     "description": "Display captured routing errors",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ErrorRegistryConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/eval-language.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/eval-language.json
@@ -6,6 +6,7 @@
     "title": "Evaluate Language",
     "description": "Evaluate Language and display result",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.EvalLanguageDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/event.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/event.json
@@ -6,6 +6,7 @@
     "title": "Camel Events",
     "description": "The most recent Camel events",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.EventConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/gc.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/gc.json
@@ -6,6 +6,7 @@
     "title": "Garbage Collector",
     "description": "Displays Garbage Collector information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.GarbageCollectorDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/health.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/health.json
@@ -6,6 +6,7 @@
     "title": "Health Check",
     "description": "Health Check Status",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.HealthDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-dump.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-dump.json
@@ -6,6 +6,7 @@
     "title": "Heap Dump",
     "description": "Write a heap dump (.hprof) file for deep memory analysis",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.HeapDumpDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-histogram.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-histogram.json
@@ -6,6 +6,7 @@
     "title": "Heap Histogram",
     "description": "Displays class-level heap memory usage",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.HeapHistogramDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/inflight.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/inflight.json
@@ -6,6 +6,7 @@
     "title": "Inflight Exchanges",
     "description": "Display inflight exchanges",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.InflightConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/internal-tasks.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/internal-tasks.json
@@ -6,6 +6,7 @@
     "title": "Internal Tasks",
     "description": "Display information about internal tasks",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.TaskRegistryDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/java-security.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/java-security.json
@@ -6,6 +6,7 @@
     "title": "Java Security",
     "description": "Displays Java Security (JSSE) information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.JavaSecurityDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr-memory-leak.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr-memory-leak.json
@@ -6,6 +6,7 @@
     "title": "JFR Memory Leak",
     "description": "JFR-based old object sampling for memory leak diagnosis",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.JfrMemoryLeakDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jvm.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jvm.json
@@ -6,6 +6,7 @@
     "title": "JVM",
     "description": "Displays JVM information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.JvmDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/log.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/log.json
@@ -6,6 +6,7 @@
     "title": "Log",
     "description": "Logging framework",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.LogDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/memory.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/memory.json
@@ -6,6 +6,7 @@
     "title": "JVM Memory",
     "description": "Displays JVM memory information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.MemoryDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/message-history.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/message-history.json
@@ -6,6 +6,7 @@
     "title": "Message History",
     "description": "History of latest completed exchange",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.MessageHistoryDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor-detail.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor-detail.json
@@ -6,6 +6,7 @@
     "title": "Processor Detail",
     "description": "Show configured options for all processors in a route",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ProcessorDetailDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor.json
@@ -6,6 +6,7 @@
     "title": "Processor",
     "description": "Processor information",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.ProcessorDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/producer.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/producer.json
@@ -6,6 +6,7 @@
     "title": "Producers",
     "description": "Display information about Camel producers",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ProducerDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/properties.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/properties.json
@@ -6,6 +6,7 @@
     "title": "Properties",
     "description": "Displays the properties loaded by Camel",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.PropertiesDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/receive.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/receive.json
@@ -6,6 +6,7 @@
     "title": "Camel Receive",
     "description": "Consume messages from endpoints",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.ReceiveDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/reload.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/reload.json
@@ -6,6 +6,7 @@
     "title": "Reload",
     "description": "Console for reloading running Camel",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.ReloadDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest-spec.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest-spec.json
@@ -6,6 +6,7 @@
     "title": "Rest Spec",
     "description": "OpenAPI specification content for contract-first REST services",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.RestSpecDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest.json
@@ -6,6 +6,7 @@
     "title": "Rest",
     "description": "Rest DSL Registry information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.RestDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-controller.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-controller.json
@@ -6,6 +6,7 @@
     "title": "Route Controller",
     "description": "Route controller information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.RouteControllerConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-dump.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-dump.json
@@ -6,6 +6,7 @@
     "title": "Route Dump",
     "description": "Dump route in XML, YAML, or Java DSL format",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.RouteDumpDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-group.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-group.json
@@ -6,6 +6,7 @@
     "title": "Route Group",
     "description": "Route Group information",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.RouteGroupDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-structure.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-structure.json
@@ -6,6 +6,7 @@
     "title": "Route Structure",
     "description": "Dump route structure",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.RouteStructureDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-topology.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-topology.json
@@ -6,6 +6,7 @@
     "title": "Route Topology",
     "description": "Route topology showing inter-route connections",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.RouteTopologyDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route.json
@@ -6,6 +6,7 @@
     "title": "Route",
     "description": "Route information",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.RouteDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/send.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/send.json
@@ -6,6 +6,7 @@
     "title": "Camel Send",
     "description": "Send messages to endpoints",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.SendDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/service.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/service.json
@@ -6,6 +6,7 @@
     "title": "Services",
     "description": "Services used for network communication with clients",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ServiceDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/simple-language.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/simple-language.json
@@ -6,6 +6,7 @@
     "title": "Simple Language",
     "description": "Display simple language details",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.SimpleLanguageDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source.json
@@ -6,6 +6,7 @@
     "title": "Source",
     "description": "Dump route source code",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.SourceDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-query.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-query.json
@@ -6,6 +6,7 @@
     "title": "SQL Query",
     "description": "Execute SQL queries on DataSource beans",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.SqlQueryDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-trace.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-trace.json
@@ -6,6 +6,7 @@
     "title": "SQL Trace",
     "description": "Trace SQL query executions",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.SqlTraceDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/startup-recorder.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/startup-recorder.json
@@ -6,6 +6,7 @@
     "title": "Startup Recorder",
     "description": "Starting recording information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.StartupRecorderDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/system-properties.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/system-properties.json
@@ -6,6 +6,7 @@
     "title": "System Properties",
     "description": "Displays Java System Properties",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.SystemPropertiesDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/thread.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/thread.json
@@ -6,6 +6,7 @@
     "title": "Thread",
     "description": "Displays JVM Threads information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.ThreadDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/top.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/top.json
@@ -6,6 +6,7 @@
     "title": "Top Routes",
     "description": "Display the top routes",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.TopDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/trace.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/trace.json
@@ -6,6 +6,7 @@
     "title": "Camel Tracing",
     "description": "Trace routed messages",
     "deprecated": false,
+    "readOnly": false,
     "javaType": "org.apache.camel.impl.console.TraceDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/transformers.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/transformers.json
@@ -6,6 +6,7 @@
     "title": "Data Type Transformers",
     "description": "Data-type transformer information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.TransformerConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/type-converters.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/type-converters.json
@@ -6,6 +6,7 @@
     "title": "Type Converters",
     "description": "Camel Type Converter information",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.TypeConverterConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/variables.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/variables.json
@@ -6,6 +6,7 @@
     "title": "Variables",
     "description": "Displays variables",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.impl.console.VariablesDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ApiDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ApiDevConsole.java
@@ -82,15 +82,24 @@ public class ApiDevConsole extends AbstractDevConsole {
 
             for (org.apache.camel.console.DevConsole console : consoles) {
                 String id = console.getId();
-                JsonObject pathItem = new JsonObject();
-                JsonObject post = new JsonObject();
-                post.put("summary", console.getDisplayName());
-                post.put("description", console.getDescription());
-                post.put("operationId", id);
+                boolean readOnly = console.isReadOnly();
 
-                JsonObject requestBody = buildConsoleRequestBody(id);
-                if (requestBody != null) {
-                    post.put("requestBody", requestBody);
+                JsonObject pathItem = new JsonObject();
+                JsonObject operation = new JsonObject();
+                operation.put("summary", console.getDisplayName());
+                operation.put("description", console.getDescription());
+                operation.put("operationId", id);
+
+                if (readOnly) {
+                    JsonArray parameters = buildConsoleParameters(id);
+                    if (parameters != null) {
+                        operation.put("parameters", parameters);
+                    }
+                } else {
+                    JsonObject requestBody = buildConsoleRequestBody(id);
+                    if (requestBody != null) {
+                        operation.put("requestBody", requestBody);
+                    }
                 }
 
                 JsonObject responses = new JsonObject();
@@ -100,9 +109,9 @@ public class ApiDevConsole extends AbstractDevConsole {
                 responseContent.put("application/json", new JsonObject());
                 ok.put("content", responseContent);
                 responses.put("200", ok);
-                post.put("responses", responses);
+                operation.put("responses", responses);
 
-                pathItem.put("post", post);
+                pathItem.put(readOnly ? "get" : "post", operation);
                 paths.put("/q/dev/" + id, pathItem);
             }
         }
@@ -111,7 +120,12 @@ public class ApiDevConsole extends AbstractDevConsole {
         return Jsoner.prettyPrint(root.toJson());
     }
 
-    private JsonObject buildConsoleRequestBody(String consoleId) {
+    /**
+     * Loads and parses the option schema for the given console.
+     *
+     * @return the parsed options, or null if the console has no options or the schema could not be loaded
+     */
+    private JsonObject loadConsoleOptions(String consoleId) {
         try {
             String json = ((CatalogCamelContext) getCamelContext())
                     .getDevConsoleParameterJsonSchema(consoleId);
@@ -126,56 +140,106 @@ public class ApiDevConsole extends AbstractDevConsole {
             if (!(optionsObj instanceof JsonObject opts) || opts.isEmpty()) {
                 return null;
             }
-
-            JsonObject properties = new JsonObject();
-            JsonArray required = new JsonArray();
-            for (Map.Entry<String, Object> entry : opts.entrySet()) {
-                String name = entry.getKey();
-                if (!(entry.getValue() instanceof JsonObject opt)) {
-                    continue;
-                }
-                JsonObject prop = new JsonObject();
-                String type = opt.getString("type");
-                if (type != null) {
-                    prop.put("type", type);
-                }
-                String description = opt.getString("description");
-                if (description != null) {
-                    prop.put("description", description);
-                }
-                Object defaultValue = opt.get("defaultValue");
-                if (defaultValue != null) {
-                    prop.put("default", defaultValue);
-                }
-                Object enumValues = opt.get("enum");
-                if (enumValues instanceof JsonArray ea && !ea.isEmpty()) {
-                    prop.put("enum", enumValues);
-                }
-                properties.put(name, prop);
-
-                Boolean req = opt.getBoolean("required");
-                if (req != null && req) {
-                    required.add(name);
-                }
-            }
-
-            JsonObject schema = new JsonObject();
-            schema.put("type", "object");
-            schema.put("properties", properties);
-            if (!required.isEmpty()) {
-                schema.put("required", required);
-            }
-
-            JsonObject mediaType = new JsonObject();
-            mediaType.put("schema", schema);
-            JsonObject content = new JsonObject();
-            content.put("application/json", mediaType);
-            JsonObject requestBody = new JsonObject();
-            requestBody.put("content", content);
-            return requestBody;
+            return opts;
         } catch (Exception e) {
             // ignore
             return null;
         }
+    }
+
+    private JsonObject buildConsoleRequestBody(String consoleId) {
+        JsonObject opts = loadConsoleOptions(consoleId);
+        if (opts == null) {
+            return null;
+        }
+
+        JsonObject properties = new JsonObject();
+        JsonArray required = new JsonArray();
+        for (Map.Entry<String, Object> entry : opts.entrySet()) {
+            String name = entry.getKey();
+            if (!(entry.getValue() instanceof JsonObject opt)) {
+                continue;
+            }
+            JsonObject prop = new JsonObject();
+            String type = opt.getString("type");
+            if (type != null) {
+                prop.put("type", type);
+            }
+            String description = opt.getString("description");
+            if (description != null) {
+                prop.put("description", description);
+            }
+            Object defaultValue = opt.get("defaultValue");
+            if (defaultValue != null) {
+                prop.put("default", defaultValue);
+            }
+            Object enumValues = opt.get("enum");
+            if (enumValues instanceof JsonArray ea && !ea.isEmpty()) {
+                prop.put("enum", enumValues);
+            }
+            properties.put(name, prop);
+
+            Boolean req = opt.getBoolean("required");
+            if (req != null && req) {
+                required.add(name);
+            }
+        }
+
+        JsonObject schema = new JsonObject();
+        schema.put("type", "object");
+        schema.put("properties", properties);
+        if (!required.isEmpty()) {
+            schema.put("required", required);
+        }
+
+        JsonObject mediaType = new JsonObject();
+        mediaType.put("schema", schema);
+        JsonObject content = new JsonObject();
+        content.put("application/json", mediaType);
+        JsonObject requestBody = new JsonObject();
+        requestBody.put("content", content);
+        return requestBody;
+    }
+
+    private JsonArray buildConsoleParameters(String consoleId) {
+        JsonObject opts = loadConsoleOptions(consoleId);
+        if (opts == null) {
+            return null;
+        }
+
+        JsonArray parameters = new JsonArray();
+        for (Map.Entry<String, Object> entry : opts.entrySet()) {
+            String name = entry.getKey();
+            if (!(entry.getValue() instanceof JsonObject opt)) {
+                continue;
+            }
+            JsonObject param = new JsonObject();
+            param.put("name", name);
+            param.put("in", "query");
+            String description = opt.getString("description");
+            if (description != null) {
+                param.put("description", description);
+            }
+            Boolean req = opt.getBoolean("required");
+            param.put("required", req != null && req);
+
+            JsonObject schema = new JsonObject();
+            String type = opt.getString("type");
+            if (type != null) {
+                schema.put("type", type);
+            }
+            Object defaultValue = opt.get("defaultValue");
+            if (defaultValue != null) {
+                schema.put("default", defaultValue);
+            }
+            Object enumValues = opt.get("enum");
+            if (enumValues instanceof JsonArray ea && !ea.isEmpty()) {
+                schema.put("enum", enumValues);
+            }
+            param.put("schema", schema);
+
+            parameters.add(param);
+        }
+        return parameters.isEmpty() ? null : parameters;
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
@@ -41,7 +41,7 @@ import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
-@DevConsole(name = "debug", description = "Camel route debugger")
+@DevConsole(name = "debug", description = "Camel route debugger", readOnly = false)
 public class DebugDevConsole extends AbstractDevConsole {
 
     @Metadata(label = "query", description = "Action command to execute on the debugger", javaType = "java.lang.String")
@@ -59,11 +59,6 @@ public class DebugDevConsole extends AbstractDevConsole {
 
     public DebugDevConsole() {
         super("camel", "debug", "Debug", "Camel route debugger");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
@@ -62,6 +62,11 @@ public class DebugDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         String command = optionString(options, COMMAND);
         String breakpoint = optionString(options, BREAKPOINT);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EvalLanguageDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EvalLanguageDevConsole.java
@@ -56,6 +56,11 @@ public class EvalLanguageDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         StringBuilder sb = new StringBuilder();
 

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EvalLanguageDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EvalLanguageDevConsole.java
@@ -28,7 +28,8 @@ import org.apache.camel.support.MessageHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.json.JsonObject;
 
-@DevConsole(name = "eval-language", displayName = "Evaluate Language", description = "Evaluate Language and display result")
+@DevConsole(name = "eval-language", displayName = "Evaluate Language", description = "Evaluate Language and display result",
+            readOnly = false)
 public class EvalLanguageDevConsole extends AbstractDevConsole {
 
     @Metadata(label = "query", description = "The language to use", javaType = "java.lang.String", defaultValue = "simple")
@@ -53,11 +54,6 @@ public class EvalLanguageDevConsole extends AbstractDevConsole {
 
     public EvalLanguageDevConsole() {
         super("camel", "eval-language", "Evaluate Language", "Evaluate Language and display result");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapDumpDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapDumpDevConsole.java
@@ -33,7 +33,7 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.json.JsonObject;
 
 @DevConsole(name = "heap-dump", displayName = "Heap Dump",
-            description = "Write a heap dump (.hprof) file for deep memory analysis")
+            description = "Write a heap dump (.hprof) file for deep memory analysis", readOnly = false)
 @Configurer(extended = true)
 public class HeapDumpDevConsole extends AbstractDevConsole {
 
@@ -49,11 +49,6 @@ public class HeapDumpDevConsole extends AbstractDevConsole {
 
     public HeapDumpDevConsole() {
         super("jvm", "heap-dump", "Heap Dump", "Write a heap dump (.hprof) file for deep memory analysis");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapDumpDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapDumpDevConsole.java
@@ -52,6 +52,11 @@ public class HeapDumpDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         JsonObject json = doCallJson(options);
         String error = json.getString("error");

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
@@ -100,6 +100,11 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         JsonObject json = doCallJson(options);
         return json.toJson();

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * chains back to GC roots, enabling memory leak diagnosis.
  */
 @DevConsole(name = "jfr-memory-leak", displayName = "JFR Memory Leak",
-            description = "JFR-based old object sampling for memory leak diagnosis")
+            description = "JFR-based old object sampling for memory leak diagnosis", readOnly = false)
 @Configurer(extended = true)
 public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
 
@@ -97,11 +97,6 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
     public JfrMemoryLeakDevConsole() {
         super("jvm", "jfr-memory-leak", "JFR Memory Leak",
               "JFR-based old object sampling for memory leak diagnosis");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
@@ -42,7 +42,7 @@ import org.apache.camel.util.json.Jsoner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@DevConsole(name = "processor", description = "Processor information")
+@DevConsole(name = "processor", description = "Processor information", readOnly = false)
 public class ProcessorDevConsole extends AbstractDevConsole {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessorDevConsole.class);
@@ -62,11 +62,6 @@ public class ProcessorDevConsole extends AbstractDevConsole {
 
     public ProcessorDevConsole() {
         super("camel", "processor", "Processor", "Processor information");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
@@ -65,6 +65,11 @@ public class ProcessorDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         String action = optionString(options, ACTION);
         String filter = optionString(options, FILTER);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ReceiveDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ReceiveDevConsole.java
@@ -85,6 +85,11 @@ public class ReceiveDevConsole extends AbstractDevConsole {
         super("camel", "receive", "Camel Receive", "Consume messages from endpoints");
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
     public int getCapacity() {
         return capacity;
     }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ReceiveDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ReceiveDevConsole.java
@@ -47,7 +47,8 @@ import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
-@DevConsole(name = "receive", displayName = "Camel Receive", description = "Consume messages from endpoints")
+@DevConsole(name = "receive", displayName = "Camel Receive", description = "Consume messages from endpoints",
+            readOnly = false)
 @Configurer(extended = true)
 public class ReceiveDevConsole extends AbstractDevConsole {
 
@@ -83,11 +84,6 @@ public class ReceiveDevConsole extends AbstractDevConsole {
 
     public ReceiveDevConsole() {
         super("camel", "receive", "Camel Receive", "Consume messages from endpoints");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     public int getCapacity() {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ReloadDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ReloadDevConsole.java
@@ -49,6 +49,11 @@ public class ReloadDevConsole extends AbstractDevConsole {
         super("camel", "reload", "Reload", "Console for reloading running Camel");
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
     protected String doCallText(Map<String, Object> options) {
         boolean trigger = optionBoolean(options, RELOAD, false);
         boolean wait = optionBoolean(options, RELOAD_WAIT, false);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ReloadDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ReloadDevConsole.java
@@ -31,7 +31,7 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
-@DevConsole(name = "reload", description = "Console for reloading running Camel")
+@DevConsole(name = "reload", description = "Console for reloading running Camel", readOnly = false)
 public class ReloadDevConsole extends AbstractDevConsole {
 
     @Metadata(label = "query", description = "Option to trigger reloading", javaType = "java.lang.Boolean",
@@ -47,11 +47,6 @@ public class ReloadDevConsole extends AbstractDevConsole {
 
     public ReloadDevConsole() {
         super("camel", "reload", "Reload", "Console for reloading running Camel");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     protected String doCallText(Map<String, Object> options) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
@@ -71,6 +71,11 @@ public class RouteDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         String action = optionString(options, ACTION);
         String filter = optionString(options, FILTER);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
@@ -45,7 +45,7 @@ import org.apache.camel.util.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@DevConsole(name = "route", description = "Route information")
+@DevConsole(name = "route", description = "Route information", readOnly = false)
 public class RouteDevConsole extends AbstractDevConsole {
 
     private static final Logger LOG = LoggerFactory.getLogger(RouteDevConsole.class);
@@ -68,11 +68,6 @@ public class RouteDevConsole extends AbstractDevConsole {
 
     public RouteDevConsole() {
         super("camel", "route", "Route", "Route information");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
@@ -43,7 +43,7 @@ import org.apache.camel.util.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@DevConsole(name = "route-group", description = "Route Group information")
+@DevConsole(name = "route-group", description = "Route Group information", readOnly = false)
 public class RouteGroupDevConsole extends AbstractDevConsole {
 
     private static final Logger LOG = LoggerFactory.getLogger(RouteGroupDevConsole.class);
@@ -60,11 +60,6 @@ public class RouteGroupDevConsole extends AbstractDevConsole {
 
     public RouteGroupDevConsole() {
         super("camel", "route-group", "Route Group", "Route Group information");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
@@ -63,6 +63,11 @@ public class RouteGroupDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected String doCallText(Map<String, Object> options) {
         String action = optionString(options, ACTION);
         String filter = optionString(options, FILTER);

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SendDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SendDevConsole.java
@@ -43,7 +43,7 @@ import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
 import org.apache.camel.util.json.JsonObject;
 
-@DevConsole(name = "send", displayName = "Camel Send", description = "Send messages to endpoints")
+@DevConsole(name = "send", displayName = "Camel Send", description = "Send messages to endpoints", readOnly = false)
 @Configurer(extended = true)
 public class SendDevConsole extends AbstractDevConsole {
 
@@ -85,11 +85,6 @@ public class SendDevConsole extends AbstractDevConsole {
 
     public SendDevConsole() {
         super("camel", "send", "Camel Send", "Send messages to endpoints");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     @Override

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SendDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SendDevConsole.java
@@ -88,6 +88,11 @@ public class SendDevConsole extends AbstractDevConsole {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     protected void doInit() throws Exception {
         super.doInit();
         consumer = getCamelContext().createConsumerTemplate();

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlQueryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlQueryDevConsole.java
@@ -88,6 +88,11 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
         super("camel", "sql-query", "SQL Query", "Execute SQL queries on DataSource beans");
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
     public int getDefaultMaxRows() {
         return defaultMaxRows;
     }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlQueryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlQueryDevConsole.java
@@ -40,7 +40,8 @@ import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
-@DevConsole(name = "sql-query", displayName = "SQL Query", description = "Execute SQL queries on DataSource beans")
+@DevConsole(name = "sql-query", displayName = "SQL Query", description = "Execute SQL queries on DataSource beans",
+            readOnly = false)
 @Configurer(extended = true)
 public class SqlQueryDevConsole extends AbstractDevConsole {
 
@@ -86,11 +87,6 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
 
     public SqlQueryDevConsole() {
         super("camel", "sql-query", "SQL Query", "Execute SQL queries on DataSource beans");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     public int getDefaultMaxRows() {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TraceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TraceDevConsole.java
@@ -51,6 +51,11 @@ public class TraceDevConsole extends AbstractDevConsole {
         super("camel", "trace", "Camel Tracing", "Trace routed messages");
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
     public int getCapacity() {
         return capacity;
     }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TraceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TraceDevConsole.java
@@ -29,7 +29,7 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 
-@DevConsole(name = "trace", displayName = "Camel Tracing", description = "Trace routed messages")
+@DevConsole(name = "trace", displayName = "Camel Tracing", description = "Trace routed messages", readOnly = false)
 @Configurer(extended = true)
 public class TraceDevConsole extends AbstractDevConsole {
 
@@ -49,11 +49,6 @@ public class TraceDevConsole extends AbstractDevConsole {
 
     public TraceDevConsole() {
         super("camel", "trace", "Camel Tracing", "Trace routed messages");
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
     }
 
     public int getCapacity() {

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ApiDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ApiDevConsoleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.console.DevConsoleRegistry;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApiDevConsoleTest extends AbstractDevConsoleTest {
+
+    private JsonObject openApiPaths() {
+        DevConsoleRegistry dcr = context.getCamelContextExtension().getContextPlugin(DevConsoleRegistry.class);
+        dcr.loadDevConsoles();
+
+        DevConsole con = assertConsoleExists("api", "camel");
+        JsonObject root = callJson(con);
+        JsonObject paths = root.getJsonObject("paths");
+        assertThat(paths).isNotNull();
+        return paths;
+    }
+
+    @Test
+    public void testReadOnlyConsoleUsesGet() {
+        JsonObject paths = openApiPaths();
+
+        JsonObject contextPath = paths.getJsonObject("/q/dev/context");
+        assertThat(contextPath).as("context console path should exist").isNotNull();
+        assertThat(contextPath.getJsonObject("get")).as("context console should be declared as GET").isNotNull();
+        assertThat(contextPath.getJsonObject("post")).as("context console should not be declared as POST").isNull();
+    }
+
+    @Test
+    public void testMutatingConsoleUsesPost() {
+        JsonObject paths = openApiPaths();
+
+        JsonObject routePath = paths.getJsonObject("/q/dev/route");
+        assertThat(routePath).as("route console path should exist").isNotNull();
+        assertThat(routePath.getJsonObject("get")).as("route console should not be declared as GET").isNull();
+
+        JsonObject post = routePath.getJsonObject("post");
+        assertThat(post).as("route console should be declared as POST").isNotNull();
+        assertThat(post.get("requestBody")).as("route console POST should carry a requestBody").isNotNull();
+    }
+
+    @Test
+    public void testIsReadOnlyDefaults() {
+        assertThat(new ContextDevConsole().isReadOnly()).isTrue();
+        assertThat(new RouteDevConsole().isReadOnly()).isFalse();
+        assertThat(new EvalLanguageDevConsole().isReadOnly()).isFalse();
+        assertThat(new SendDevConsole().isReadOnly()).isFalse();
+    }
+}

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/dev-console/bean-model.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/dev-console/bean-model.json
@@ -6,6 +6,7 @@
     "title": "Bean Model",
     "description": "Displays beans from the DSL model",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.model.console.BeanModelDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-core-model",

--- a/core/camel-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-configuration.json
+++ b/core/camel-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-configuration.json
@@ -6,6 +6,7 @@
     "title": "Main Configuration",
     "description": "Display Camel startup configuration",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.main.MainConfigurationDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-main",

--- a/core/camel-support/src/main/java/org/apache/camel/support/console/AbstractDevConsole.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/console/AbstractDevConsole.java
@@ -62,6 +62,13 @@ public abstract class AbstractDevConsole extends ServiceSupport implements DevCo
     }
 
     @Override
+    public boolean isReadOnly() {
+        org.apache.camel.spi.annotations.DevConsole ann
+                = getClass().getAnnotation(org.apache.camel.spi.annotations.DevConsole.class);
+        return ann == null || ann.readOnly();
+    }
+
+    @Override
     public String getGroup() {
         return group;
     }

--- a/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jbang.json
+++ b/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jbang.json
@@ -6,6 +6,7 @@
     "title": "Camel CLI",
     "description": "Information about Camel CLI",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.jbang.console.JBangDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-jbang-console",

--- a/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source-dir.json
+++ b/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source-dir.json
@@ -6,6 +6,7 @@
     "title": "Source Directory",
     "description": "Information about Camel CLI source files",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.jbang.console.SourceDirDevConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-jbang-console",

--- a/dsl/camel-kamelet-main/src/generated/resources/META-INF/org/apache/camel/dev-console/dependency-downloader.json
+++ b/dsl/camel-kamelet-main/src/generated/resources/META-INF/org/apache/camel/dev-console/dependency-downloader.json
@@ -6,6 +6,7 @@
     "title": "Maven Dependency Downloader",
     "description": "Displays information about dependencies downloaded at runtime",
     "deprecated": false,
+    "readOnly": true,
     "javaType": "org.apache.camel.main.console.DependencyDownloaderConsole",
     "groupId": "org.apache.camel",
     "artifactId": "camel-kamelet-main",

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
@@ -83,6 +83,7 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
         private String displayName;
         private String description;
         private boolean deprecated;
+        private boolean readOnly = true;
         private final List<DevConsoleOptionModel> options = new ArrayList<>();
 
         public String getClassName() {
@@ -133,6 +134,14 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             this.deprecated = deprecated;
         }
 
+        public boolean isReadOnly() {
+            return readOnly;
+        }
+
+        public void setReadOnly(boolean readOnly) {
+            this.readOnly = readOnly;
+        }
+
         public List<DevConsoleOptionModel> getOptions() {
             return options;
         }
@@ -169,6 +178,7 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             model.setName(annotationValue(a, "name"));
             model.setDisplayName(annotationValue(a, "displayName"));
             model.setDescription(annotationValue(a, "description"));
+            model.setReadOnly(!"false".equals(annotationValue(a, "readOnly")));
             // skip default registry
             boolean skip = "default-registry".equals(model.getName());
             if (!skip) {
@@ -228,6 +238,7 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
         }
         jo.put("description", model.getDescription());
         jo.put("deprecated", model.isDeprecated());
+        jo.put("readOnly", model.isReadOnly());
         jo.put("javaType", model.getClassName());
         jo.put("groupId", project.getGroupId());
         jo.put("artifactId", project.getArtifactId());

--- a/tooling/spi-annotations/src/main/java/org/apache/camel/spi/annotations/DevConsole.java
+++ b/tooling/spi-annotations/src/main/java/org/apache/camel/spi/annotations/DevConsole.java
@@ -51,4 +51,12 @@ public @interface DevConsole {
      */
     String description();
 
+    /**
+     * Whether this console is read-only (safe, and does not change any runtime state).
+     * <p/>
+     * Consoles that mutate state (such as starting/stopping a route, sending a message, or triggering a heap dump) must
+     * set this to {@code false}.
+     */
+    boolean readOnly() default true;
+
 }


### PR DESCRIPTION
## Summary

`ApiDevConsole` (the `api` dev console) generates an OpenAPI 3.0 spec describing every `/q/dev/{id}` endpoint. Previously every path was hardcoded to `post`, even though `/q/dev` was originally GET-only at the transport layer and the vast majority of consoles are safe, read-only introspection endpoints. POST was only added later (CAMEL-24054) for a handful of consoles that need to pass an arbitrary/complex body.

This PR:

- Adds a `readOnly` attribute to the `@DevConsole` annotation (default `true`), so each console declares whether invoking it is safe or mutates runtime state.
- `AbstractDevConsole.isReadOnly()` reads this reflectively from the console's own annotation, so no per-console boilerplate is needed beyond the annotation attribute.
- `ApiDevConsole.buildOpenApi()` now generates a `get` operation (with query `parameters`) for read-only consoles, and keeps `post` (with a JSON `requestBody`) only for consoles that mutate state or need a complex body: `eval-language`, `send`, `sql-query`, `route`, `route-group`, `processor`, `trace`, `jfr-memory-leak`, `receive`, `debug`, `heap-dump`, `reload` (core), and `jfr` (camel-jfr).
- `GenerateDevConsoleMojo` now emits the `readOnly` flag into each console's generated catalog JSON (`dev-console/*.json`), so the classification is also available statically at build time — ahead of a planned release-time static OpenAPI doc generator that won't require a running `CamelContext`.
- Regenerated the catalog JSON for every module with a `@DevConsole` class (~26 modules) to pick up the new field.

No transport-level change: `ManagementHttpServer` already accepted both GET and POST identically before this change — this PR only fixes what the OpenAPI spec *advertises*.

## Test plan

- [x] `core/camel-console`: `mvn verify` — 142/142 tests pass, including new `ApiDevConsoleTest` (read-only console → `get`, mutating console → `post` + `requestBody`, `isReadOnly()` defaults).
- [x] `components/camel-jfr`: `mvn verify` — 34/34 tests pass, including a new `isReadOnly()` assertion on `CamelJfrDevConsole`.
- [x] `core/camel-api`, `core/camel-support`, `tooling/spi-annotations`, `tooling/maven/camel-package-maven-plugin`: build clean.
- [x] `mvn -Psourcecheck` clean on all directly-modified modules (formatting/import-order/license).
- [x] Regenerated and spot-checked `dev-console/*.json` across all ~26 affected modules: 82 files now carry `"readOnly"`, correctly `false` only for the 13 mutating consoles.

_Claude Sonnet 5 on behalf of @davsclaus_