### PR TITLE
chore: bump mvnd install version to 1.0.6

### DIFF
--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -25,7 +25,7 @@ inputs:
   version:
     description: 'The version of the maven daemon to install'
     required: true
-    default: '1.0.5'
+    default: '1.0.6'
   distribution:
     description: 'The maven distribution to use'
     required: true


### PR DESCRIPTION
## Summary
- CI's `install-mvnd` composite action failed with a 404 downloading mvnd 1.0.5 from `downloads.apache.org` (see https://github.com/apache/camel/actions/runs/33257660303/job/99118945966?pr=25886)
- Apache's release mirror only serves the latest release per project; now that mvnd 1.0.6 (and 2.0.0) shipped, 1.0.5 was pruned from `downloads.apache.org` and moved to the archive
- Bump the action's default `version` input from `1.0.5` to `1.0.6`, confirmed available on `downloads.apache.org` with a matching `.sha256`

## Test plan
- [x] Verified `https://downloads.apache.org/maven/mvnd/1.0.6/maven-mvnd-1.0.6-linux-amd64.zip` and its `.sha256` both return 200
- [ ] CI green on this PR

_Claude Code on behalf of 