### PR TITLE
CAMEL-24565: Authoritative typed response records for dev console OpenAPI response schemas

### DIFF
--- a/catalog/camel-catalog-console/src/generated/resources/META-INF/org/apache/camel/dev-console/catalog.json
+++ b/catalog/camel-catalog-console/src/generated/resources/META-INF/org/apache/camel/dev-console/catalog.json
@@ -11,6 +11,159 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-catalog-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "components": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string",
+              "description": "The Maven group ID"
+            },
+            "artifactId": {
+              "type": "string",
+              "description": "The Maven artifact ID"
+            },
+            "version": {
+              "type": "string",
+              "description": "The Maven version"
+            },
+            "level": {
+              "type": "string",
+              "description": "The support level, optionally suffixed with -deprecated"
+            },
+            "firstVersion": {
+              "type": "string",
+              "description": "The first Camel version the artifact was introduced in"
+            },
+            "title": {
+              "type": "string",
+              "description": "The artifact title"
+            },
+            "description": {
+              "type": "string",
+              "description": "The artifact description"
+            }
+          }
+        },
+        "description": "The components in use"
+      },
+      "dataformat": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string",
+              "description": "The Maven group ID"
+            },
+            "artifactId": {
+              "type": "string",
+              "description": "The Maven artifact ID"
+            },
+            "version": {
+              "type": "string",
+              "description": "The Maven version"
+            },
+            "level": {
+              "type": "string",
+              "description": "The support level, optionally suffixed with -deprecated"
+            },
+            "firstVersion": {
+              "type": "string",
+              "description": "The first Camel version the artifact was introduced in"
+            },
+            "title": {
+              "type": "string",
+              "description": "The artifact title"
+            },
+            "description": {
+              "type": "string",
+              "description": "The artifact description"
+            }
+          }
+        },
+        "description": "The data formats in use"
+      },
+      "languages": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string",
+              "description": "The Maven group ID"
+            },
+            "artifactId": {
+              "type": "string",
+              "description": "The Maven artifact ID"
+            },
+            "version": {
+              "type": "string",
+              "description": "The Maven version"
+            },
+            "level": {
+              "type": "string",
+              "description": "The support level, optionally suffixed with -deprecated"
+            },
+            "firstVersion": {
+              "type": "string",
+              "description": "The first Camel version the artifact was introduced in"
+            },
+            "title": {
+              "type": "string",
+              "description": "The artifact title"
+            },
+            "description": {
+              "type": "string",
+              "description": "The artifact description"
+            }
+          }
+        },
+        "description": "The languages in use"
+      },
+      "others": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string",
+              "description": "The Maven group ID"
+            },
+            "artifactId": {
+              "type": "string",
+              "description": "The Maven artifact ID"
+            },
+            "version": {
+              "type": "string",
+              "description": "The Maven version"
+            },
+            "level": {
+              "type": "string",
+              "description": "The support level, optionally suffixed with -deprecated"
+            },
+            "firstVersion": {
+              "type": "string",
+              "description": "The first Camel version the artifact was introduced in"
+            },
+            "title": {
+              "type": "string",
+              "description": "The artifact title"
+            },
+            "description": {
+              "type": "string",
+              "description": "The artifact description"
+            }
+          }
+        },
+        "description": "Other miscellaneous artifacts in use, discovered via the classpath"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog-console/src/main/java/org/apache/camel/catalog/console/CatalogConsole.java
+++ b/catalog/camel-catalog-console/src/main/java/org/apache/camel/catalog/console/CatalogConsole.java
@@ -23,15 +23,33 @@ import java.util.function.BiConsumer;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.tooling.model.ArtifactModel;
 import org.apache.camel.tooling.model.OtherModel;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "catalog", description = "Information about used Camel artifacts")
 @SuppressWarnings("java:S2160")
 public class CatalogConsole extends AbstractDevConsole {
+
+    public record ArtifactEntry(
+            @Metadata(description = "The Maven group ID") String groupId,
+            @Metadata(description = "The Maven artifact ID") String artifactId,
+            @Metadata(description = "The Maven version") String version,
+            @Metadata(description = "The support level, optionally suffixed with -deprecated") String level,
+            @Metadata(description = "The first Camel version the artifact was introduced in") String firstVersion,
+            @Metadata(description = "The artifact title") String title,
+            @Metadata(description = "The artifact description") String description) {
+    }
+
+    public record Response(
+            @Metadata(description = "The components in use") List<ArtifactEntry> components,
+            @Metadata(description = "The data formats in use") List<ArtifactEntry> dataformat,
+            @Metadata(description = "The languages in use") List<ArtifactEntry> languages,
+            @Metadata(description = "Other miscellaneous artifacts in use, discovered via the classpath") List<ArtifactEntry> others) {
+    }
 
     private static final String CP = System.getProperty("java.class.path");
     private final CamelCatalog catalog = new DefaultCamelCatalog(true);
@@ -73,16 +91,11 @@ public class CatalogConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        List<JsonObject> components = new ArrayList<>();
-        root.put("components", components);
-        List<JsonObject> dataformat = new ArrayList<>();
-        root.put("dataformat", dataformat);
-        List<JsonObject> languages = new ArrayList<>();
-        root.put("languages", languages);
-        List<JsonObject> others = new ArrayList<>();
-        root.put("others", others);
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<ArtifactEntry> components = new ArrayList<>();
+        List<ArtifactEntry> dataformat = new ArrayList<>();
+        List<ArtifactEntry> languages = new ArrayList<>();
+        List<ArtifactEntry> others = new ArrayList<>();
 
         getCamelContext().getComponentNames().forEach(n -> appendModel(catalog.componentModel(n), components));
         getCamelContext().getLanguageNames().forEach(n -> appendModel(catalog.languageModel(n), languages));
@@ -91,7 +104,8 @@ public class CatalogConsole extends AbstractDevConsole {
         // misc is harder to find as we need to find them via classpath
         evalMisc(others, CatalogConsole::appendModel);
 
-        return root;
+        Response response = new Response(components, dataformat, languages, others);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private ArtifactModel<?> findOtherModel(String artifactId) {
@@ -116,22 +130,15 @@ public class CatalogConsole extends AbstractDevConsole {
         }
     }
 
-    private static void appendModel(ArtifactModel<?> model, List<JsonObject> list) {
+    private static void appendModel(ArtifactModel<?> model, List<ArtifactEntry> list) {
         if (model != null) {
-            JsonObject jo = new JsonObject();
             String level = model.getSupportLevel().toString();
             if (model.isDeprecated()) {
                 level += "-deprecated";
             }
-            jo.put("groupId", model.getGroupId());
-            jo.put("artifactId", model.getArtifactId());
-            jo.put("version", model.getVersion());
-            jo.put("level", level);
-            jo.put("firstVersion", model.getFirstVersionShort());
-            jo.put("title", model.getTitle());
-            jo.put("description", model.getDescription());
-
-            list.add(jo);
+            list.add(new ArtifactEntry(
+                    model.getGroupId(), model.getArtifactId(), model.getVersion(), level,
+                    model.getFirstVersionShort(), model.getTitle(), model.getDescription()));
         }
     }
 }

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -15,7 +15,90 @@
 						"description": "Camel Activity output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"activityEnabled": {
+											"type": "boolean",
+											"description": "Whether activity tracking is enabled"
+										},
+										"activitySize": {
+											"type": "integer",
+											"description": "The maximum number of activity entries retained"
+										},
+										"activity": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"uid": {
+														"type": "integer",
+														"description": "Unique ID of the activity entry"
+													},
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when known)"
+													},
+													"fromEndpointUri": {
+														"type": "string",
+														"description": "The from endpoint URI (only present when known)"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds (only present when known)"
+													},
+													"elapsed": {
+														"type": "integer",
+														"description": "Elapsed time in milliseconds"
+													},
+													"failed": {
+														"type": "boolean",
+														"description": "Whether the exchange failed"
+													},
+													"exception": {
+														"type": "string",
+														"description": "The exception message (only present when the exchange failed)"
+													},
+													"endpointSends": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"endpointUri": {
+																	"type": "string",
+																	"description": "The endpoint URI"
+																},
+																"remoteEndpoint": {
+																	"type": "boolean",
+																	"description": "Whether the endpoint is remote"
+																},
+																"elapsed": {
+																	"type": "integer",
+																	"description": "Elapsed time in milliseconds"
+																}
+															},
+															"required": [
+																"remoteEndpoint",
+																"elapsed"
+															]
+														},
+														"description": "The endpoints this exchange was sent to (only present when any)"
+													}
+												},
+												"required": [
+													"uid",
+													"elapsed",
+													"failed"
+												]
+											},
+											"description": "The recent activity entries"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -141,7 +224,48 @@
 						"description": "Bean output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"beans": {
+											"type": "object",
+											"additionalProperties": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The bean name"
+													},
+													"type": {
+														"type": "string",
+														"description": "The bean class type"
+													},
+													"properties": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"name": {
+																	"type": "string",
+																	"description": "The property name"
+																},
+																"type": {
+																	"type": "string",
+																	"description": "The property type (only present when the value is not null)"
+																},
+																"value": {
+																	"description": "The property value"
+																}
+															}
+														},
+														"description": "The bean properties (only present when properties were requested and the bean has some)"
+													}
+												}
+											},
+											"description": "The beans, keyed by bean name"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -206,7 +330,46 @@
 						"description": "Blocked Exchanges output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"blocked": {
+											"type": "integer",
+											"description": "Number of blocked exchanges"
+										},
+										"exchanges": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"nodeId": {
+														"type": "string",
+														"description": "The node ID"
+													},
+													"duration": {
+														"type": "integer",
+														"description": "The wait duration in milliseconds"
+													}
+												},
+												"required": [
+													"duration"
+												]
+											},
+											"description": "The blocked exchanges (only present when there are any)"
+										}
+									},
+									"required": [
+										"blocked"
+									]
+								}
 							}
 						}
 					}
@@ -293,7 +456,55 @@
 						"description": "Browse output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"browse": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"endpointUri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"queueSize": {
+														"type": "integer",
+														"description": "Number of messages currently in the queue"
+													},
+													"limit": {
+														"type": "integer",
+														"description": "The maximum number of messages returned (only present when messages were dumped)"
+													},
+													"position": {
+														"type": "integer",
+														"description": "The starting position of the returned messages (only present when messages were dumped)"
+													},
+													"firstTimestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the first returned message (only present when available)"
+													},
+													"lastTimestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last returned message (only present when available)"
+													},
+													"messages": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"additionalProperties": true
+														},
+														"description": "The dumped messages, as opaque JSON objects (only present when messages were dumped and found)"
+													}
+												},
+												"required": [
+													"queueSize"
+												]
+											},
+											"description": "The browsed endpoints"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -360,7 +571,221 @@
 						"description": "Consumers output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"consumers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"uri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"state": {
+														"type": "string",
+														"description": "The consumer state"
+													},
+													"clazz": {
+														"type": "string",
+														"description": "The consumer service type"
+													},
+													"remote": {
+														"type": "boolean",
+														"description": "Whether the endpoint is remote"
+													},
+													"hosted": {
+														"type": "boolean",
+														"description": "Whether the consumer is a hosted service"
+													},
+													"inflight": {
+														"type": "integer",
+														"description": "Number of inflight exchanges"
+													},
+													"scheduled": {
+														"type": "boolean",
+														"description": "Whether the consumer is scheduled (a scheduled poll consumer or a timer consumer)"
+													},
+													"polling": {
+														"type": "boolean",
+														"description": "Whether currently polling (only present for scheduled poll consumers)"
+													},
+													"firstPollDone": {
+														"type": "boolean",
+														"description": "Whether the first poll has completed (only present for scheduled poll consumers)"
+													},
+													"schedulerStarted": {
+														"type": "boolean",
+														"description": "Whether the scheduler has started (only present for scheduled poll consumers)"
+													},
+													"schedulerClass": {
+														"type": "string",
+														"description": "The scheduler class name (only present for scheduled poll consumers)"
+													},
+													"repeatCount": {
+														"type": "integer",
+														"description": "The repeat count (only present for scheduled poll consumers)"
+													},
+													"fixedDelay": {
+														"type": "boolean",
+														"description": "Whether a fixed delay is used (only present for scheduled poll consumers)"
+													},
+													"initialDelay": {
+														"type": "integer",
+														"description": "The initial delay (only present for scheduled poll consumers)"
+													},
+													"delay": {
+														"type": "integer",
+														"description": "The delay (only present for scheduled poll consumers)"
+													},
+													"timeUnit": {
+														"type": "string",
+														"description": "The time unit of the delay (only present for scheduled poll consumers)"
+													},
+													"greedy": {
+														"type": "boolean",
+														"description": "Whether greedy scheduling is used (only present for scheduled poll consumers)"
+													},
+													"runningLoggingLevel": {
+														"type": "string",
+														"description": "The running logging level (only present for scheduled poll consumers or timer consumers)"
+													},
+													"totalCounter": {
+														"type": "integer",
+														"description": "Total number of polls (only present for scheduled poll consumers or timer consumers)"
+													},
+													"errorCounter": {
+														"type": "integer",
+														"description": "Number of failed polls (only present for scheduled poll consumers)"
+													},
+													"successCounter": {
+														"type": "integer",
+														"description": "Number of successful polls (only present for scheduled poll consumers)"
+													},
+													"backoffCounter": {
+														"type": "integer",
+														"description": "The backoff counter (only present for scheduled poll consumers)"
+													},
+													"backoffMultiplier": {
+														"type": "integer",
+														"description": "The backoff multiplier (only present for scheduled poll consumers)"
+													},
+													"backoffErrorThreshold": {
+														"type": "integer",
+														"description": "The backoff error threshold (only present for scheduled poll consumers)"
+													},
+													"backoffIdleThreshold": {
+														"type": "integer",
+														"description": "The backoff idle threshold (only present for scheduled poll consumers)"
+													},
+													"timerName": {
+														"type": "string",
+														"description": "The timer name (only present for camel-timer consumers)"
+													},
+													"fixedRate": {
+														"type": "boolean",
+														"description": "Whether a fixed rate is used (only present for camel-timer consumers)"
+													},
+													"period": {
+														"type": "integer",
+														"description": "The period (only present for camel-timer consumers)"
+													},
+													"statistics": {
+														"type": "object",
+														"properties": {
+															"idleSince": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds since the route has been idle"
+															},
+															"exchangesTotal": {
+																"type": "integer",
+																"description": "Total number of exchanges"
+															},
+															"exchangesFailed": {
+																"type": "integer",
+																"description": "Number of failed exchanges"
+															},
+															"exchangesInflight": {
+																"type": "integer",
+																"description": "Number of inflight exchanges"
+															},
+															"meanProcessingTime": {
+																"type": "integer",
+																"description": "Mean processing time in milliseconds"
+															},
+															"maxProcessingTime": {
+																"type": "integer",
+																"description": "Max processing time in milliseconds"
+															},
+															"minProcessingTime": {
+																"type": "integer",
+																"description": "Min processing time in milliseconds"
+															},
+															"p50ProcessingTime": {
+																"type": "integer",
+																"description": "50th percentile processing time in milliseconds (only present when available)"
+															},
+															"p95ProcessingTime": {
+																"type": "integer",
+																"description": "95th percentile processing time in milliseconds (only present when available)"
+															},
+															"p99ProcessingTime": {
+																"type": "integer",
+																"description": "99th percentile processing time in milliseconds (only present when available)"
+															},
+															"lastProcessingTime": {
+																"type": "integer",
+																"description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+															},
+															"deltaProcessingTime": {
+																"type": "integer",
+																"description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+															},
+															"lastCreatedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+															},
+															"lastCompletedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+															},
+															"lastFailureHandledExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+															},
+															"lastFailedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+															}
+														},
+														"required": [
+															"idleSince",
+															"exchangesTotal",
+															"exchangesFailed",
+															"exchangesInflight",
+															"meanProcessingTime",
+															"maxProcessingTime",
+															"minProcessingTime"
+														],
+														"description": "Runtime statistics for the route"
+													}
+												},
+												"required": [
+													"remote",
+													"hosted",
+													"inflight",
+													"scheduled"
+												]
+											},
+											"description": "The consumers"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -594,7 +1019,68 @@
 						"description": "DataSource output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"dataSources": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The registry bean name"
+													},
+													"type": {
+														"type": "string",
+														"description": "The DataSource implementation class"
+													},
+													"poolType": {
+														"type": "string",
+														"description": "The detected connection pool type: HikariCP, Agroal, or Unknown"
+													},
+													"poolName": {
+														"type": "string",
+														"description": "The pool name (HikariCP only)"
+													},
+													"maxPoolSize": {
+														"type": "integer",
+														"description": "The maximum pool size (only present once the pool is initialized)"
+													},
+													"active": {
+														"type": "integer",
+														"description": "Number of active connections (only present once the pool is initialized)"
+													},
+													"idle": {
+														"type": "integer",
+														"description": "Number of idle connections (only present once the pool is initialized)"
+													},
+													"total": {
+														"type": "integer",
+														"description": "Total number of connections (only present once the pool is initialized)"
+													},
+													"waiting": {
+														"type": "integer",
+														"description": "Number of threads awaiting a connection (HikariCP only)"
+													},
+													"maxUsed": {
+														"type": "integer",
+														"description": "Maximum number of connections used at once (Agroal only)"
+													},
+													"leakDetection": {
+														"type": "integer",
+														"description": "Number of leak detections (Agroal only)"
+													},
+													"created": {
+														"type": "integer",
+														"description": "Number of connections created (Agroal only)"
+													}
+												}
+											},
+											"description": "The DataSources"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -661,7 +1147,94 @@
 						"description": "Endpoints output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"size": {
+											"type": "integer",
+											"description": "Total number of endpoints"
+										},
+										"staticSize": {
+											"type": "integer",
+											"description": "Number of endpoints in the static registry"
+										},
+										"dynamicSize": {
+											"type": "integer",
+											"description": "Number of endpoints in the dynamic registry"
+										},
+										"maximumCacheSize": {
+											"type": "integer",
+											"description": "Maximum number of entries to store in the dynamic registry"
+										},
+										"endpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"uri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"remote": {
+														"type": "boolean",
+														"description": "Whether the endpoint is remote"
+													},
+													"stub": {
+														"type": "boolean",
+														"description": "Whether the endpoint is a stub endpoint"
+													},
+													"direction": {
+														"type": "string",
+														"description": "Whether the endpoint is used as input or output (in or out) (only present when runtime endpoint registry statistics are available)"
+													},
+													"hits": {
+														"type": "integer",
+														"description": "Usage of the endpoint (only present when runtime endpoint registry statistics are available)"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when runtime endpoint registry statistics are available and the endpoint is associated with a route)"
+													},
+													"minBodySize": {
+														"type": "integer",
+														"description": "Minimum message body size in bytes (only present when available)"
+													},
+													"maxBodySize": {
+														"type": "integer",
+														"description": "Maximum message body size in bytes (only present when available)"
+													},
+													"meanBodySize": {
+														"type": "integer",
+														"description": "Mean message body size in bytes (only present when available)"
+													},
+													"minHeadersSize": {
+														"type": "integer",
+														"description": "Minimum message headers size in bytes (only present when available)"
+													},
+													"maxHeadersSize": {
+														"type": "integer",
+														"description": "Maximum message headers size in bytes (only present when available)"
+													},
+													"meanHeadersSize": {
+														"type": "integer",
+														"description": "Mean message headers size in bytes (only present when available)"
+													}
+												},
+												"required": [
+													"remote",
+													"stub"
+												]
+											},
+											"description": "The endpoints"
+										}
+									},
+									"required": [
+										"size",
+										"staticSize",
+										"dynamicSize",
+										"maximumCacheSize"
+									]
+								}
 							}
 						}
 					}
@@ -735,7 +1308,40 @@
 						"description": "Error Registry output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"enabled": {
+											"type": "boolean",
+											"description": "Whether the error registry is enabled"
+										},
+										"size": {
+											"type": "integer",
+											"description": "Number of captured errors"
+										},
+										"maximumEntries": {
+											"type": "integer",
+											"description": "The maximum number of entries retained"
+										},
+										"timeToLive": {
+											"type": "string",
+											"description": "The time to live for entries"
+										},
+										"errors": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "The captured errors; shape depends on the underlying message implementation"
+										}
+									},
+									"required": [
+										"enabled",
+										"size",
+										"maximumEntries"
+									]
+								}
 							}
 						}
 					}
@@ -806,7 +1412,86 @@
 						"description": "Camel Events output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"events": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"type": {
+														"type": "string",
+														"description": "The event type"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds (only present when known)"
+													},
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID (only present for exchange events)"
+													},
+													"message": {
+														"type": "string",
+														"description": "The event's string representation"
+													}
+												}
+											},
+											"description": "The most recent Camel events (only present when there are any)"
+										},
+										"routeEvents": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"type": {
+														"type": "string",
+														"description": "The event type"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds (only present when known)"
+													},
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID (only present for exchange events)"
+													},
+													"message": {
+														"type": "string",
+														"description": "The event's string representation"
+													}
+												}
+											},
+											"description": "The most recent route events (only present when there are any)"
+										},
+										"exchangeEvents": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"type": {
+														"type": "string",
+														"description": "The event type"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds (only present when known)"
+													},
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID (only present for exchange events)"
+													},
+													"message": {
+														"type": "string",
+														"description": "The event's string representation"
+													}
+												}
+											},
+											"description": "The most recent exchange events (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -840,7 +1525,40 @@
 						"description": "Garbage Collector output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"garbageCollectors": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The garbage collector name"
+													},
+													"collectionCount": {
+														"type": "integer",
+														"description": "Number of collections"
+													},
+													"collectionTime": {
+														"type": "integer",
+														"description": "Total collection time in milliseconds"
+													},
+													"memoryPoolNames": {
+														"type": "string",
+														"description": "Comma separated list of memory pool names managed by this collector"
+													}
+												},
+												"required": [
+													"collectionCount",
+													"collectionTime"
+												]
+											},
+											"description": "The garbage collectors"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -986,7 +1704,9 @@
 													},
 													"details": {
 														"type": "object",
-														"additionalProperties": true,
+														"additionalProperties": {
+															"type": "string"
+														},
 														"description": "Additional health check specific details (only present when available)"
 													}
 												},
@@ -1071,7 +1791,53 @@
 						"description": "Heap Histogram output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"classes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"num": {
+														"type": "integer",
+														"description": "The class number"
+													},
+													"instances": {
+														"type": "integer",
+														"description": "Number of instances"
+													},
+													"bytes": {
+														"type": "integer",
+														"description": "Number of bytes used"
+													},
+													"className": {
+														"type": "string",
+														"description": "The class name"
+													}
+												},
+												"required": [
+													"num",
+													"instances",
+													"bytes"
+												]
+											},
+											"description": "The classes in the histogram"
+										},
+										"totalInstances": {
+											"type": "integer",
+											"description": "Total number of instances"
+										},
+										"totalBytes": {
+											"type": "integer",
+											"description": "Total number of bytes"
+										}
+									},
+									"required": [
+										"totalInstances",
+										"totalBytes"
+									]
+								}
 							}
 						}
 					}
@@ -1217,7 +1983,53 @@
 						"description": "Java Security output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"securityProviders": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The provider name"
+													},
+													"version": {
+														"type": "string",
+														"description": "The provider version"
+													},
+													"info": {
+														"type": "string",
+														"description": "The provider info (only present when known)"
+													},
+													"services": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"type": {
+																	"type": "string",
+																	"description": "The service type"
+																},
+																"algorithm": {
+																	"type": "string",
+																	"description": "The algorithm"
+																},
+																"className": {
+																	"type": "string",
+																	"description": "The implementation class name"
+																}
+															}
+														},
+														"description": "The services offered by this provider (only present when any)"
+													}
+												}
+											},
+											"description": "The security providers (only present when any are registered)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1361,7 +2173,49 @@
 						"description": "JVM output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"vmName": {
+											"type": "string",
+											"description": "The JVM name"
+										},
+										"vmVersion": {
+											"type": "string",
+											"description": "The JVM version"
+										},
+										"vmVendor": {
+											"type": "string",
+											"description": "The JVM vendor"
+										},
+										"vmUptime": {
+											"type": "string",
+											"description": "The JVM uptime"
+										},
+										"pid": {
+											"type": "integer",
+											"description": "The process ID"
+										},
+										"inputArguments": {
+											"type": "string",
+											"description": "The JVM input arguments (only present when any are set)"
+										},
+										"bootClasspath": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The boot classpath entries (only present when supported)"
+										},
+										"classpath": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The classpath entries"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1492,7 +2346,67 @@
 						"description": "JVM Memory output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"heapMemoryInit": {
+											"type": "string",
+											"description": "Heap memory initial size"
+										},
+										"heapMemoryMax": {
+											"type": "string",
+											"description": "Heap memory max size"
+										},
+										"heapMemoryUsed": {
+											"type": "string",
+											"description": "Heap memory used"
+										},
+										"heapMemoryCommitted": {
+											"type": "string",
+											"description": "Heap memory committed"
+										},
+										"nonHeapMemoryInit": {
+											"type": "string",
+											"description": "Non-heap memory initial size"
+										},
+										"nonHeapMemoryMax": {
+											"type": "string",
+											"description": "Non-heap memory max size"
+										},
+										"nonHeapMemoryUsed": {
+											"type": "string",
+											"description": "Non-heap memory used"
+										},
+										"nonHeapMemoryCommitted": {
+											"type": "string",
+											"description": "Non-heap memory committed"
+										},
+										"oldGenUsed": {
+											"type": "string",
+											"description": "Old generation memory pool used (only present when such a pool exists)"
+										},
+										"oldGenCommitted": {
+											"type": "string",
+											"description": "Old generation memory pool committed (only present when such a pool exists)"
+										},
+										"oldGenMax": {
+											"type": "string",
+											"description": "Old generation memory pool max (only present when such a pool exists)"
+										},
+										"metaspaceUsed": {
+											"type": "string",
+											"description": "Metaspace memory pool used (only present when such a pool exists)"
+										},
+										"metaspaceCommitted": {
+											"type": "string",
+											"description": "Metaspace memory pool committed (only present when such a pool exists)"
+										},
+										"metaspaceMax": {
+											"type": "string",
+											"description": "Metaspace memory pool max (only present when such a pool exists)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1709,7 +2623,52 @@
 						"description": "Producers output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"producers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"uri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"state": {
+														"type": "string",
+														"description": "The producer state"
+													},
+													"clazz": {
+														"type": "string",
+														"description": "The producer service type"
+													},
+													"remote": {
+														"type": "boolean",
+														"description": "Whether the endpoint is remote"
+													},
+													"singleton": {
+														"type": "boolean",
+														"description": "Whether the producer is a singleton"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when known)"
+													},
+													"stepId": {
+														"type": "string",
+														"description": "The step ID (only present when known)"
+													}
+												},
+												"required": [
+													"remote",
+													"singleton"
+												]
+											},
+											"description": "The producers"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1726,7 +2685,55 @@
 						"description": "Properties output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"locations": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The locations properties are loaded from"
+										},
+										"properties": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"key": {
+														"type": "string",
+														"description": "The property key"
+													},
+													"value": {
+														"type": "string",
+														"description": "The property value (masked when sensitive)"
+													},
+													"originalValue": {
+														"type": "string",
+														"description": "The original unresolved value (only present when resolved via a properties function)"
+													},
+													"defaultValue": {
+														"type": "string",
+														"description": "The default value (only present when one was used)"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source that provided the value (only present when known)"
+													},
+													"location": {
+														"type": "string",
+														"description": "The location the value was loaded from (only present when known)"
+													},
+													"internal": {
+														"type": "boolean",
+														"description": "Whether the location is an internal Camel location (only present when location is known)"
+													}
+												}
+											},
+											"description": "The loaded properties (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1981,7 +2988,126 @@
 						"description": "Route Controller output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"controller": {
+											"type": "string",
+											"description": "The route controller implementation: SupervisingRouteController or DefaultRouteController"
+										},
+										"startingRoutes": {
+											"type": "boolean",
+											"description": "Whether routes are still starting (supervising controller only)"
+										},
+										"unhealthyRoutes": {
+											"type": "boolean",
+											"description": "Whether any route is unhealthy (supervising controller only)"
+										},
+										"totalRoutes": {
+											"type": "integer",
+											"description": "Total number of routes"
+										},
+										"startedRoutes": {
+											"type": "integer",
+											"description": "Number of started routes (supervising controller only)"
+										},
+										"restartingRoutes": {
+											"type": "integer",
+											"description": "Number of restarting routes (supervising controller only)"
+										},
+										"exhaustedRoutes": {
+											"type": "integer",
+											"description": "Number of exhausted routes (supervising controller only)"
+										},
+										"initialDelay": {
+											"type": "integer",
+											"description": "Initial delay in milliseconds before restarting (supervising controller only)"
+										},
+										"backoffDelay": {
+											"type": "integer",
+											"description": "Backoff delay in milliseconds (supervising controller only)"
+										},
+										"backoffMaxDelay": {
+											"type": "integer",
+											"description": "Maximum backoff delay in milliseconds (supervising controller only)"
+										},
+										"backoffMaxElapsedTime": {
+											"type": "integer",
+											"description": "Maximum elapsed time in milliseconds before giving up (supervising controller only)"
+										},
+										"backoffMaxAttempts": {
+											"type": "integer",
+											"description": "Maximum number of restart attempts (supervising controller only)"
+										},
+										"threadPoolSize": {
+											"type": "integer",
+											"description": "The size of the restart thread pool (supervising controller only)"
+										},
+										"unhealthyOnRestarting": {
+											"type": "boolean",
+											"description": "Whether a restarting route is considered unhealthy (supervising controller only)"
+										},
+										"unhealthyOnExhausted": {
+											"type": "boolean",
+											"description": "Whether an exhausted route is considered unhealthy (supervising controller only)"
+										},
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"status": {
+														"type": "string",
+														"description": "The route status"
+													},
+													"uri": {
+														"type": "string",
+														"description": "The route endpoint URI (sanitized)"
+													},
+													"attempts": {
+														"type": "integer",
+														"description": "Number of restart attempts (supervising controller only)"
+													},
+													"lastAttempt": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last restart attempt (supervising controller only)"
+													},
+													"nextAttempt": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the next restart attempt (supervising controller only)"
+													},
+													"elapsed": {
+														"type": "integer",
+														"description": "Elapsed time in milliseconds of the current restart attempt (supervising controller only)"
+													},
+													"supervising": {
+														"type": "string",
+														"description": "The supervising status (supervising controller only)"
+													},
+													"error": {
+														"type": "string",
+														"description": "The restart error message (only present when the route is failing)"
+													},
+													"stackTrace": {
+														"type": "array",
+														"items": {
+															"type": "string"
+														},
+														"description": "The restart error stack trace, one entry per line (only present when the route is failing and stack traces are requested)"
+													}
+												}
+											},
+											"description": "The routes"
+										}
+									},
+									"required": [
+										"totalRoutes"
+									]
+								}
 							}
 						}
 					}
@@ -2658,7 +3784,21 @@
 						"description": "System Properties output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"systemProperties": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": {
+													"type": "string"
+												}
+											},
+											"description": "The system properties, one single-entry map per property"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2687,7 +3827,82 @@
 						"description": "Thread output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"threadCount": {
+											"type": "integer",
+											"description": "Number of threads"
+										},
+										"daemonThreadCount": {
+											"type": "integer",
+											"description": "Number of daemon threads"
+										},
+										"totalStartedThreadCount": {
+											"type": "integer",
+											"description": "Total number of threads started since JVM start"
+										},
+										"peakThreadCount": {
+											"type": "integer",
+											"description": "Peak number of threads"
+										},
+										"threads": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "integer",
+														"description": "The thread ID"
+													},
+													"name": {
+														"type": "string",
+														"description": "The thread name"
+													},
+													"state": {
+														"type": "string",
+														"description": "The thread state"
+													},
+													"blockedCount": {
+														"type": "integer",
+														"description": "Number of times the thread has been blocked"
+													},
+													"blockedTime": {
+														"type": "integer",
+														"description": "Total time in milliseconds the thread has been blocked"
+													},
+													"waitedCount": {
+														"type": "integer",
+														"description": "Number of times the thread has waited"
+													},
+													"waitedTime": {
+														"type": "integer",
+														"description": "Total time in milliseconds the thread has waited"
+													},
+													"lockName": {
+														"type": "string",
+														"description": "The name of the lock the thread is waiting on (only present when applicable)"
+													},
+													"stackTrace": {
+														"type": "array",
+														"items": {
+															"type": "string"
+														},
+														"description": "The thread stack trace, one entry per line (only present when requested via the stackTrace option)"
+													}
+												},
+												"required": [
+													"id",
+													"blockedCount",
+													"blockedTime",
+													"waitedCount",
+													"waitedTime"
+												]
+											},
+											"description": "The threads"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -1395,7 +1395,24 @@
 						"description": "Evaluate Language output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"status": {
+											"type": "string",
+											"description": "The evaluation status, success or failed (only present when a template was given)"
+										},
+										"result": {
+											"type": "string",
+											"description": "The evaluation result (only present on success)"
+										},
+										"exception": {
+											"type": "object",
+											"additionalProperties": true,
+											"description": "The exception, as an opaque JSON object (only present on failure)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2667,7 +2684,175 @@
 						"description": "Processor output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"processors": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"id": {
+														"type": "string",
+														"description": "The processor ID"
+													},
+													"nodePrefixId": {
+														"type": "string",
+														"description": "The node prefix ID (only present when known)"
+													},
+													"description": {
+														"type": "string",
+														"description": "The processor description (only present when configured)"
+													},
+													"note": {
+														"type": "string",
+														"description": "The processor note (only present when configured)"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source location, optionally with a line number suffix (only present when known)"
+													},
+													"state": {
+														"type": "string",
+														"description": "The processor state"
+													},
+													"disabled": {
+														"type": "boolean",
+														"description": "Whether the processor is disabled (only present when known)"
+													},
+													"stepId": {
+														"type": "string",
+														"description": "The step ID (only present when known)"
+													},
+													"code": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"line": {
+																	"type": "integer",
+																	"description": "The source line number (only present when known)"
+																},
+																"code": {
+																	"type": "string",
+																	"description": "The source code line"
+																},
+																"match": {
+																	"type": "boolean",
+																	"description": "Whether this is the matched line (only present when true)"
+																}
+															}
+														},
+														"description": "A snippet of source code around the processor (only present when known)"
+													},
+													"processor": {
+														"type": "string",
+														"description": "The processor name"
+													},
+													"level": {
+														"type": "integer",
+														"description": "The processor level in the route tree"
+													},
+													"uri": {
+														"type": "string",
+														"description": "The destination URI, for processors that send to a destination (only present when applicable)"
+													},
+													"statistics": {
+														"type": "object",
+														"properties": {
+															"idleSince": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds since the processor has been idle"
+															},
+															"exchangesTotal": {
+																"type": "integer",
+																"description": "Total number of exchanges"
+															},
+															"exchangesFailed": {
+																"type": "integer",
+																"description": "Number of failed exchanges"
+															},
+															"exchangesInflight": {
+																"type": "integer",
+																"description": "Number of inflight exchanges"
+															},
+															"exchangesThroughput": {
+																"type": "string",
+																"description": "Messages per second throughput (only present when available)"
+															},
+															"meanProcessingTime": {
+																"type": "integer",
+																"description": "Mean processing time in milliseconds"
+															},
+															"maxProcessingTime": {
+																"type": "integer",
+																"description": "Max processing time in milliseconds"
+															},
+															"minProcessingTime": {
+																"type": "integer",
+																"description": "Min processing time in milliseconds"
+															},
+															"p50ProcessingTime": {
+																"type": "integer",
+																"description": "50th percentile processing time in milliseconds (only present when available)"
+															},
+															"p95ProcessingTime": {
+																"type": "integer",
+																"description": "95th percentile processing time in milliseconds (only present when available)"
+															},
+															"p99ProcessingTime": {
+																"type": "integer",
+																"description": "99th percentile processing time in milliseconds (only present when available)"
+															},
+															"lastProcessingTime": {
+																"type": "integer",
+																"description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+															},
+															"deltaProcessingTime": {
+																"type": "integer",
+																"description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+															},
+															"lastCreatedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+															},
+															"lastCompletedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+															},
+															"lastFailureHandledExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+															},
+															"lastFailedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+															}
+														},
+														"required": [
+															"idleSince",
+															"exchangesTotal",
+															"exchangesFailed",
+															"exchangesInflight",
+															"meanProcessingTime",
+															"maxProcessingTime",
+															"minProcessingTime"
+														],
+														"description": "Runtime statistics"
+													}
+												},
+												"required": [
+													"level"
+												]
+											},
+											"description": "The processors (only present when no action was requested)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3010,7 +3195,57 @@
 						"description": "Reload output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"reloadStrategies": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"className": {
+														"type": "string",
+														"description": "The reload strategy class name"
+													},
+													"reloaded": {
+														"type": "integer",
+														"description": "Number of successful reloads"
+													},
+													"failed": {
+														"type": "integer",
+														"description": "Number of failed reloads"
+													},
+													"lastError": {
+														"type": "object",
+														"properties": {
+															"message": {
+																"type": "string",
+																"description": "The error message"
+															},
+															"stackTrace": {
+																"type": "array",
+																"items": {
+																	"type": "string"
+																},
+																"description": "The error stack trace, one entry per line"
+															}
+														},
+														"description": "The last reload error (only present when a reload has failed)"
+													}
+												},
+												"required": [
+													"reloaded",
+													"failed"
+												]
+											},
+											"description": "The reload strategies (only present when not triggering a reload and at least one reload strategy is active)"
+										},
+										"status": {
+											"type": "string",
+											"description": "The reload status, reloading\/success\/failed (only present when triggering a reload)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -4073,7 +4308,45 @@
 						"description": "Camel Send output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"timestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds when the send was performed"
+										},
+										"status": {
+											"type": "string",
+											"description": "The send status, success\/error\/timeout"
+										},
+										"elapsed": {
+											"type": "integer",
+											"description": "Elapsed time in milliseconds"
+										},
+										"endpoint": {
+											"type": "string",
+											"description": "The endpoint URI (only present when known)"
+										},
+										"exception": {
+											"type": "object",
+											"additionalProperties": true,
+											"description": "The exception, as an opaque JSON object (only present on error)"
+										},
+										"exchangeId": {
+											"type": "string",
+											"description": "The exchange ID (only present when a response message is available)"
+										},
+										"message": {
+											"type": "object",
+											"additionalProperties": true,
+											"description": "The response message, as an opaque JSON object (only present when a response message is available)"
+										}
+									},
+									"required": [
+										"timestamp",
+										"elapsed"
+									]
+								}
 							}
 						}
 					}
@@ -4363,7 +4636,90 @@
 						"description": "SQL Query output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"status": {
+											"type": "string",
+											"description": "The execution status, success or error"
+										},
+										"message": {
+											"type": "string",
+											"description": "The error message (only present on error)"
+										},
+										"datasource": {
+											"type": "string",
+											"description": "The resolved DataSource bean name (only present once resolved)"
+										},
+										"availableDataSources": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The available DataSource bean names (only present when multiple exist and none was specified)"
+										},
+										"elapsed": {
+											"type": "integer",
+											"description": "Elapsed time in milliseconds (only present once a query attempt was made)"
+										},
+										"columns": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The column name"
+													},
+													"type": {
+														"type": "string",
+														"description": "The column SQL type name"
+													},
+													"primaryKey": {
+														"type": "boolean",
+														"description": "Whether the column is part of the primary key (only present when the query targets a single, editable table)"
+													}
+												}
+											},
+											"description": "The result set columns (only present for queries returning a result set)"
+										},
+										"rows": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "The result set rows, one opaque JSON object per row (only present for queries returning a result set)"
+										},
+										"rowCount": {
+											"type": "integer",
+											"description": "Number of rows returned (only present for queries returning a result set)"
+										},
+										"truncated": {
+											"type": "boolean",
+											"description": "Whether the result set was truncated by maxRows (only present for queries returning a result set)"
+										},
+										"updateCount": {
+											"type": "integer",
+											"description": "Number of rows affected (only present for queries\/updates not returning a result set)"
+										},
+										"tableName": {
+											"type": "string",
+											"description": "The single table the result set maps to (only present when the result is a single, editable table)"
+										},
+										"primaryKeys": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The primary key column names (only present when the result is a single, editable table)"
+										},
+										"editable": {
+											"type": "boolean",
+											"description": "Whether the result set rows can be edited (only present when true)"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -2295,7 +2295,18 @@
 						"description": "Log output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"levels": {
+											"type": "object",
+											"additionalProperties": {
+												"type": "string"
+											},
+											"description": "The logger names mapped to their log level (only present when available)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2435,7 +2446,23 @@
 						"description": "Message History output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"name": {
+											"type": "string",
+											"description": "The CamelContext name (only present when a backlog tracer is available)"
+										},
+										"traces": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "The latest completed message trace entries, as opaque JSON objects (only present when a backlog tracer is available)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2606,7 +2633,92 @@
 						"description": "Processor Detail output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routeId": {
+											"type": "string",
+											"description": "The route ID (only present when a specific route was requested)"
+										},
+										"processors": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "The processor ID"
+													},
+													"type": {
+														"type": "string",
+														"description": "The processor type (the XML element name, or 'from' for the route input)"
+													},
+													"endpointUri": {
+														"type": "string",
+														"description": "The endpoint URI (only present for the route input entry)"
+													},
+													"line": {
+														"type": "integer",
+														"description": "The source line number (only present when known)"
+													},
+													"options": {
+														"type": "object",
+														"additionalProperties": {
+															"type": "string"
+														},
+														"description": "The processor's configured options, as attribute\/child-element name to string value"
+													}
+												}
+											},
+											"description": "The route's processors (only present when a specific route was requested)"
+										},
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"processors": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"id": {
+																	"type": "string",
+																	"description": "The processor ID"
+																},
+																"type": {
+																	"type": "string",
+																	"description": "The processor type (the XML element name, or 'from' for the route input)"
+																},
+																"endpointUri": {
+																	"type": "string",
+																	"description": "The endpoint URI (only present for the route input entry)"
+																},
+																"line": {
+																	"type": "integer",
+																	"description": "The source line number (only present when known)"
+																},
+																"options": {
+																	"type": "object",
+																	"additionalProperties": {
+																		"type": "string"
+																	},
+																	"description": "The processor's configured options, as attribute\/child-element name to string value"
+																}
+															}
+														},
+														"description": "The route's processors, starting with the route input"
+													}
+												}
+											},
+											"description": "The route details for all routes (only present when routeId is * or omitted)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3535,7 +3647,63 @@
 						"description": "Services output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"services": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"component": {
+														"type": "string",
+														"description": "The Camel component"
+													},
+													"direction": {
+														"type": "string",
+														"description": "The direction (in or out)"
+													},
+													"hosted": {
+														"type": "boolean",
+														"description": "Whether the service is hosted in this Camel application"
+													},
+													"protocol": {
+														"type": "string",
+														"description": "The protocol the service is using (only present when known)"
+													},
+													"serviceUrl": {
+														"type": "string",
+														"description": "The remote address of the service (only present when known)"
+													},
+													"endpointUri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when known)"
+													},
+													"hits": {
+														"type": "integer",
+														"description": "Usage of the endpoint service"
+													},
+													"metadata": {
+														"type": "object",
+														"additionalProperties": {
+															"type": "string"
+														},
+														"description": "Additional metadata relevant to the service (only present when available)"
+													}
+												},
+												"required": [
+													"hosted",
+													"hits"
+												]
+											},
+											"description": "The services"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3606,7 +3774,56 @@
 						"description": "Source output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"from": {
+														"type": "string",
+														"description": "The route's endpoint URI"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source location (only present when known)"
+													},
+													"code": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"line": {
+																	"type": "integer",
+																	"description": "The line number"
+																},
+																"code": {
+																	"type": "string",
+																	"description": "The source code line"
+																},
+																"match": {
+																	"type": "boolean",
+																	"description": "Whether this is the matched line (only present when true)"
+																}
+															},
+															"required": [
+																"line"
+															]
+														},
+														"description": "The source code around the route (only present when resolvable)"
+													}
+												}
+											},
+											"description": "The routes"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -310,7 +310,40 @@
 						"description": "Circuit Breaker output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"circuitBreakers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"state": {
+														"type": "string",
+														"description": "The circuit breaker state"
+													},
+													"successfulCalls": {
+														"type": "integer",
+														"description": "Number of successful calls"
+													},
+													"failedCalls": {
+														"type": "integer",
+														"description": "Number of failed calls"
+													}
+												},
+												"required": [
+													"successfulCalls",
+													"failedCalls"
+												]
+											},
+											"description": "The circuit breakers"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -344,7 +377,207 @@
 						"description": "CamelContext output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"name": {
+											"type": "string",
+											"description": "The CamelContext name"
+										},
+										"description": {
+											"type": "string",
+											"description": "The CamelContext description (only present when configured)"
+										},
+										"profile": {
+											"type": "string",
+											"description": "The active profile (only present when configured)"
+										},
+										"version": {
+											"type": "string",
+											"description": "The Camel version"
+										},
+										"state": {
+											"type": "string",
+											"description": "The CamelContext state"
+										},
+										"phase": {
+											"type": "integer",
+											"description": "The CamelContext lifecycle phase"
+										},
+										"startTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds the CamelContext was started (only present once started)"
+										},
+										"uptime": {
+											"type": "integer",
+											"description": "Uptime in milliseconds"
+										},
+										"devMode": {
+											"type": "boolean",
+											"description": "Whether dev mode (live reload) is active"
+										},
+										"statistics": {
+											"type": "object",
+											"properties": {
+												"routesTotal": {
+													"type": "integer",
+													"description": "Total number of routes"
+												},
+												"routesStarted": {
+													"type": "integer",
+													"description": "Number of started routes"
+												},
+												"load01": {
+													"type": "string",
+													"description": "1 minute load average (only present when available)"
+												},
+												"load05": {
+													"type": "string",
+													"description": "5 minute load average (only present when available)"
+												},
+												"load15": {
+													"type": "string",
+													"description": "15 minute load average (only present when available)"
+												},
+												"exchangesThroughput": {
+													"type": "string",
+													"description": "Messages per second throughput (only present when available)"
+												},
+												"idleSince": {
+													"type": "integer",
+													"description": "Epoch time in milliseconds since the context has been idle"
+												},
+												"exchangesTotal": {
+													"type": "integer",
+													"description": "Total number of exchanges"
+												},
+												"exchangesFailed": {
+													"type": "integer",
+													"description": "Number of failed exchanges"
+												},
+												"exchangesInflight": {
+													"type": "integer",
+													"description": "Number of inflight exchanges"
+												},
+												"remoteExchangesTotal": {
+													"type": "integer",
+													"description": "Total number of remote exchanges"
+												},
+												"remoteExchangesFailed": {
+													"type": "integer",
+													"description": "Number of failed remote exchanges"
+												},
+												"remoteExchangesInflight": {
+													"type": "integer",
+													"description": "Number of inflight remote exchanges"
+												},
+												"meanProcessingTime": {
+													"type": "integer",
+													"description": "Mean processing time in milliseconds"
+												},
+												"maxProcessingTime": {
+													"type": "integer",
+													"description": "Max processing time in milliseconds"
+												},
+												"minProcessingTime": {
+													"type": "integer",
+													"description": "Min processing time in milliseconds"
+												},
+												"p50ProcessingTime": {
+													"type": "integer",
+													"description": "50th percentile processing time in milliseconds (only present when available)"
+												},
+												"p95ProcessingTime": {
+													"type": "integer",
+													"description": "95th percentile processing time in milliseconds (only present when available)"
+												},
+												"p99ProcessingTime": {
+													"type": "integer",
+													"description": "99th percentile processing time in milliseconds (only present when available)"
+												},
+												"lastProcessingTime": {
+													"type": "integer",
+													"description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+												},
+												"deltaProcessingTime": {
+													"type": "integer",
+													"description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+												},
+												"lastCreatedExchangeTimestamp": {
+													"type": "integer",
+													"description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+												},
+												"lastCompletedExchangeTimestamp": {
+													"type": "integer",
+													"description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+												},
+												"lastFailureHandledExchangeTimestamp": {
+													"type": "integer",
+													"description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+												},
+												"lastFailedExchangeTimestamp": {
+													"type": "integer",
+													"description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+												},
+												"reload": {
+													"type": "object",
+													"properties": {
+														"reloaded": {
+															"type": "integer",
+															"description": "Number of successful reloads"
+														},
+														"failed": {
+															"type": "integer",
+															"description": "Number of failed reloads"
+														},
+														"lastError": {
+															"type": "object",
+															"properties": {
+																"message": {
+																	"type": "string",
+																	"description": "The error message"
+																},
+																"stackTrace": {
+																	"type": "array",
+																	"items": {
+																		"type": "string"
+																	},
+																	"description": "The error stack trace, one entry per line"
+																}
+															},
+															"description": "The last reload error (only present when a reload has failed)"
+														}
+													},
+													"required": [
+														"reloaded",
+														"failed"
+													],
+													"description": "Reload statistics"
+												}
+											},
+											"required": [
+												"routesTotal",
+												"routesStarted",
+												"idleSince",
+												"exchangesTotal",
+												"exchangesFailed",
+												"exchangesInflight",
+												"remoteExchangesTotal",
+												"remoteExchangesFailed",
+												"remoteExchangesInflight",
+												"meanProcessingTime",
+												"maxProcessingTime",
+												"minProcessingTime"
+											],
+											"description": "Runtime statistics (only present when management is enabled)"
+										}
+									},
+									"required": [
+										"phase",
+										"uptime",
+										"devMode"
+									]
+								}
 							}
 						}
 					}
@@ -692,7 +925,87 @@
 						"description": "Health Check output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"up": {
+											"type": "boolean",
+											"description": "Whether the overall health status is up"
+										},
+										"ready": {
+											"type": "boolean",
+											"description": "Whether the readiness checks are up"
+										},
+										"live": {
+											"type": "boolean",
+											"description": "Whether the liveness checks are up"
+										},
+										"checks": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "The health check ID"
+													},
+													"group": {
+														"type": "string",
+														"description": "The health check group"
+													},
+													"up": {
+														"type": "boolean",
+														"description": "Whether the health check is up"
+													},
+													"state": {
+														"type": "string",
+														"description": "The health check state"
+													},
+													"enabled": {
+														"type": "boolean",
+														"description": "Whether the health check is enabled"
+													},
+													"readiness": {
+														"type": "boolean",
+														"description": "Whether the health check is a readiness check"
+													},
+													"liveness": {
+														"type": "boolean",
+														"description": "Whether the health check is a liveness check"
+													},
+													"message": {
+														"type": "string",
+														"description": "The failure message (only present when not up)"
+													},
+													"stackTrace": {
+														"type": "array",
+														"items": {
+															"type": "string"
+														},
+														"description": "The failure stack trace, one entry per line (only present when not up and an error is available)"
+													},
+													"details": {
+														"type": "object",
+														"additionalProperties": true,
+														"description": "Additional health check specific details (only present when available)"
+													}
+												},
+												"required": [
+													"up",
+													"enabled",
+													"readiness",
+													"liveness"
+												]
+											},
+											"description": "The individual health checks"
+										}
+									},
+									"required": [
+										"up",
+										"ready",
+										"live"
+									]
+								}
 							}
 						}
 					}
@@ -812,7 +1125,65 @@
 						"description": "Inflight Exchanges output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"inflight": {
+											"type": "integer",
+											"description": "Number of inflight exchanges"
+										},
+										"inflightBrowseEnabled": {
+											"type": "boolean",
+											"description": "Whether browsing inflight exchanges is enabled"
+										},
+										"exchanges": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID"
+													},
+													"fromRouteId": {
+														"type": "string",
+														"description": "The route ID where the exchange originated from"
+													},
+													"fromRemoteEndpoint": {
+														"type": "boolean",
+														"description": "Whether the exchange originated from a remote endpoint"
+													},
+													"atRouteId": {
+														"type": "string",
+														"description": "The route ID where the exchange currently is"
+													},
+													"nodeId": {
+														"type": "string",
+														"description": "The node ID where the exchange currently is"
+													},
+													"elapsed": {
+														"type": "integer",
+														"description": "Elapsed time in milliseconds since the exchange started"
+													},
+													"duration": {
+														"type": "integer",
+														"description": "Duration in milliseconds the exchange has been at the current node"
+													}
+												},
+												"required": [
+													"fromRemoteEndpoint",
+													"elapsed",
+													"duration"
+												]
+											},
+											"description": "The inflight exchanges (only present when browsing is enabled)"
+										}
+									},
+									"required": [
+										"inflight",
+										"inflightBrowseEnabled"
+									]
+								}
 							}
 						}
 					}
@@ -2431,7 +2802,80 @@
 						"description": "Type Converters output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"size": {
+											"type": "integer",
+											"description": "Number of registered type converters"
+										},
+										"exists": {
+											"type": "string",
+											"description": "Whether a type converter must exist or not"
+										},
+										"existsLoggingLevel": {
+											"type": "string",
+											"description": "Logging level used when a type converter does not exist"
+										},
+										"statistics": {
+											"type": "object",
+											"properties": {
+												"attemptCounter": {
+													"type": "integer",
+													"description": "Number of attempted conversions"
+												},
+												"hitCounter": {
+													"type": "integer",
+													"description": "Number of successful conversions (cache hit)"
+												},
+												"missCounter": {
+													"type": "integer",
+													"description": "Number of cache misses"
+												},
+												"failedCounter": {
+													"type": "integer",
+													"description": "Number of failed conversions"
+												},
+												"noopCounter": {
+													"type": "integer",
+													"description": "Number of noop conversions"
+												}
+											},
+											"required": [
+												"attemptCounter",
+												"hitCounter",
+												"missCounter",
+												"failedCounter",
+												"noopCounter"
+											],
+											"description": "Type converter usage statistics (only present when statistics are enabled)"
+										},
+										"converters": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"from": {
+														"type": "string",
+														"description": "The source type"
+													},
+													"to": {
+														"type": "string",
+														"description": "The target type"
+													},
+													"converterClass": {
+														"type": "string",
+														"description": "The type converter implementation class"
+													}
+												}
+											},
+											"description": "The registered type converters"
+										}
+									},
+									"required": [
+										"size"
+									]
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -1503,22 +1503,28 @@
 												"type": "object",
 												"properties": {
 													"groupId": {
-														"type": "string"
+														"type": "string",
+														"description": "The Maven group id"
 													},
 													"artifactId": {
-														"type": "string"
+														"type": "string",
+														"description": "The Maven artifact id"
 													},
 													"version": {
-														"type": "string"
+														"type": "string",
+														"description": "The Maven version"
 													},
 													"repoId": {
-														"type": "string"
+														"type": "string",
+														"description": "The Maven repository id the artifact was downloaded from"
 													},
 													"repoUrl": {
-														"type": "string"
+														"type": "string",
+														"description": "The Maven repository URL the artifact was downloaded from"
 													},
 													"elapsed": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The download time in milliseconds"
 													}
 												},
 												"required": [
@@ -2910,13 +2916,16 @@
 												"type": "object",
 												"properties": {
 													"name": {
-														"type": "string"
+														"type": "string",
+														"description": "The recording name"
 													},
 													"state": {
-														"type": "string"
+														"type": "string",
+														"description": "The recording state"
 													},
 													"destination": {
-														"type": "string"
+														"type": "string",
+														"description": "The recording destination file (only present when configured)"
 													}
 												}
 											},
@@ -2963,22 +2972,28 @@
 												"type": "object",
 												"properties": {
 													"total": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of spans"
 													},
 													"failed": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of failed spans"
 													},
 													"minMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The minimum duration in milliseconds"
 													},
 													"meanMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The mean duration in milliseconds"
 													},
 													"maxMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The maximum duration in milliseconds"
 													},
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id"
 													}
 												},
 												"required": [
@@ -2997,28 +3012,36 @@
 												"type": "object",
 												"properties": {
 													"total": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of spans"
 													},
 													"failed": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of failed spans"
 													},
 													"minMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The minimum duration in milliseconds"
 													},
 													"meanMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The mean duration in milliseconds"
 													},
 													"maxMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The maximum duration in milliseconds"
 													},
 													"processorId": {
-														"type": "string"
+														"type": "string",
+														"description": "The processor id"
 													},
 													"processorType": {
-														"type": "string"
+														"type": "string",
+														"description": "The processor type"
 													},
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id"
 													}
 												},
 												"required": [
@@ -3037,22 +3060,28 @@
 												"type": "object",
 												"properties": {
 													"total": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of spans"
 													},
 													"failed": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of failed spans"
 													},
 													"minMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The minimum duration in milliseconds"
 													},
 													"meanMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The mean duration in milliseconds"
 													},
 													"maxMs": {
-														"type": "number"
+														"type": "number",
+														"description": "The maximum duration in milliseconds"
 													},
 													"endpointUri": {
-														"type": "string"
+														"type": "string",
+														"description": "The endpoint URI"
 													}
 												},
 												"required": [
@@ -3071,19 +3100,24 @@
 												"type": "object",
 												"properties": {
 													"timestamp": {
-														"type": "string"
+														"type": "string",
+														"description": "The failure timestamp"
 													},
 													"exchangeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The exchange id"
 													},
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id"
 													},
 													"exceptionType": {
-														"type": "string"
+														"type": "string",
+														"description": "The exception type"
 													},
 													"exceptionMessage": {
-														"type": "string"
+														"type": "string",
+														"description": "The exception message"
 													}
 												}
 											},
@@ -3095,19 +3129,24 @@
 												"type": "object",
 												"properties": {
 													"timestamp": {
-														"type": "string"
+														"type": "string",
+														"description": "The redelivery timestamp"
 													},
 													"exchangeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The exchange id"
 													},
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id"
 													},
 													"attempt": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The redelivery attempt number"
 													},
 													"maxAttempts": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The maximum number of redelivery attempts"
 													}
 												},
 												"required": [
@@ -4049,7 +4088,8 @@
 									"type": "object",
 									"properties": {
 										"meterRegistryClass": {
-											"type": "string"
+											"type": "string",
+											"description": "The MeterRegistry implementation class name"
 										},
 										"counters": {
 											"type": "array",
@@ -4057,10 +4097,12 @@
 												"type": "object",
 												"properties": {
 													"name": {
-														"type": "string"
+														"type": "string",
+														"description": "The counter name"
 													},
 													"description": {
-														"type": "string"
+														"type": "string",
+														"description": "The counter description (only present when configured)"
 													},
 													"tags": {
 														"type": "array",
@@ -4068,13 +4110,16 @@
 															"type": "object",
 															"properties": {
 																"key": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag key"
 																},
 																"value": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag value"
 																}
 															}
-														}
+														},
+														"description": "The counter tags (only present when requested)"
 													},
 													"count": {
 														"description": "The counter value (integer when whole, decimal otherwise)"
@@ -4089,10 +4134,12 @@
 												"type": "object",
 												"properties": {
 													"name": {
-														"type": "string"
+														"type": "string",
+														"description": "The gauge name"
 													},
 													"description": {
-														"type": "string"
+														"type": "string",
+														"description": "The gauge description (only present when configured)"
 													},
 													"tags": {
 														"type": "array",
@@ -4100,16 +4147,20 @@
 															"type": "object",
 															"properties": {
 																"key": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag key"
 																},
 																"value": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag value"
 																}
 															}
-														}
+														},
+														"description": "The gauge tags (only present when requested)"
 													},
 													"value": {
-														"type": "number"
+														"type": "number",
+														"description": "The gauge value"
 													}
 												},
 												"required": [
@@ -4124,10 +4175,12 @@
 												"type": "object",
 												"properties": {
 													"name": {
-														"type": "string"
+														"type": "string",
+														"description": "The timer name"
 													},
 													"description": {
-														"type": "string"
+														"type": "string",
+														"description": "The timer description (only present when configured)"
 													},
 													"tags": {
 														"type": "array",
@@ -4135,25 +4188,32 @@
 															"type": "object",
 															"properties": {
 																"key": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag key"
 																},
 																"value": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag value"
 																}
 															}
-														}
+														},
+														"description": "The timer tags (only present when requested)"
 													},
 													"count": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of recorded events"
 													},
 													"mean": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The mean duration in milliseconds"
 													},
 													"max": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The maximum duration in milliseconds"
 													},
 													"total": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The total duration in milliseconds"
 													}
 												},
 												"required": [
@@ -4171,10 +4231,12 @@
 												"type": "object",
 												"properties": {
 													"name": {
-														"type": "string"
+														"type": "string",
+														"description": "The long task timer name"
 													},
 													"description": {
-														"type": "string"
+														"type": "string",
+														"description": "The long task timer description (only present when configured)"
 													},
 													"tags": {
 														"type": "array",
@@ -4182,25 +4244,32 @@
 															"type": "object",
 															"properties": {
 																"key": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag key"
 																},
 																"value": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag value"
 																}
 															}
-														}
+														},
+														"description": "The long task timer tags (only present when requested)"
 													},
 													"activeTasks": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of currently active tasks"
 													},
 													"mean": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The mean duration in milliseconds"
 													},
 													"max": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The maximum duration in milliseconds"
 													},
 													"duration": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The total duration of active tasks in milliseconds"
 													}
 												},
 												"required": [
@@ -4218,10 +4287,12 @@
 												"type": "object",
 												"properties": {
 													"name": {
-														"type": "string"
+														"type": "string",
+														"description": "The distribution summary name"
 													},
 													"description": {
-														"type": "string"
+														"type": "string",
+														"description": "The distribution summary description (only present when configured)"
 													},
 													"tags": {
 														"type": "array",
@@ -4229,25 +4300,32 @@
 															"type": "object",
 															"properties": {
 																"key": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag key"
 																},
 																"value": {
-																	"type": "string"
+																	"type": "string",
+																	"description": "The tag value"
 																}
 															}
-														}
+														},
+														"description": "The distribution summary tags (only present when requested)"
 													},
 													"count": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of recorded events"
 													},
 													"mean": {
-														"type": "number"
+														"type": "number",
+														"description": "The mean amount"
 													},
 													"max": {
-														"type": "number"
+														"type": "number",
+														"description": "The maximum amount"
 													},
 													"totalAmount": {
-														"type": "number"
+														"type": "number",
+														"description": "The total amount"
 													}
 												},
 												"required": [
@@ -4946,47 +5024,60 @@
 									"type": "object",
 									"properties": {
 										"schedulerName": {
-											"type": "string"
+											"type": "string",
+											"description": "The scheduler name"
 										},
 										"schedulerInstanceId": {
-											"type": "string"
+											"type": "string",
+											"description": "The scheduler instance id"
 										},
 										"quartzVersion": {
-											"type": "string"
+											"type": "string",
+											"description": "The Quartz version (only present when known)"
 										},
 										"runningSince": {
-											"type": "integer"
+											"type": "integer",
+											"description": "Epoch time in milliseconds the scheduler started running (only present when known)"
 										},
 										"totalCounter": {
-											"type": "integer"
+											"type": "integer",
+											"description": "The total number of jobs executed (only present when known)"
 										},
 										"started": {
-											"type": "boolean"
+											"type": "boolean",
+											"description": "Whether the scheduler is started (only present when known)"
 										},
 										"shutdown": {
-											"type": "boolean"
+											"type": "boolean",
+											"description": "Whether the scheduler is shutdown (only present when known)"
 										},
 										"inStandbyMode": {
-											"type": "boolean"
+											"type": "boolean",
+											"description": "Whether the scheduler is in standby mode (only present when known)"
 										},
 										"threadPoolClass": {
-											"type": "string"
+											"type": "string",
+											"description": "The thread pool class name (only present when known)"
 										},
 										"threadPoolSize": {
-											"type": "integer"
+											"type": "integer",
+											"description": "The thread pool size (only present when known)"
 										},
 										"jpbStoreClass": {
 											"type": "string",
-											"description": "The job store class name (field kept as jpbStoreClass for backwards compatibility)"
+											"description": "The job store class name (field kept as jpbStoreClass for backwards compatibility, only present when known)"
 										},
 										"jpbStoreClustered": {
-											"type": "boolean"
+											"type": "boolean",
+											"description": "Whether the job store is clustered (field kept as jpbStoreClustered for backwards compatibility, only present when known)"
 										},
 										"jpbStoreSupportsPersistence": {
-											"type": "boolean"
+											"type": "boolean",
+											"description": "Whether the job store supports persistence (field kept as jpbStoreSupportsPersistence for backwards compatibility, only present when known)"
 										},
 										"currentExecutingJobs": {
-											"type": "integer"
+											"type": "integer",
+											"description": "The number of currently executing jobs"
 										},
 										"jobs": {
 											"type": "array",
@@ -4994,40 +5085,52 @@
 												"type": "object",
 												"properties": {
 													"jobId": {
-														"type": "string"
+														"type": "string",
+														"description": "The job fire instance id"
 													},
 													"triggerType": {
-														"type": "string"
+														"type": "string",
+														"description": "The trigger type: cron or simple"
 													},
 													"cron": {
-														"type": "string"
+														"type": "string",
+														"description": "The cron expression (only present for a cron trigger)"
 													},
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id (only present when known)"
 													},
 													"uri": {
-														"type": "string"
+														"type": "string",
+														"description": "The endpoint URI (only present when a cron expression is set)"
 													},
 													"prevFireTime": {
-														"type": "integer"
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the previous fire time (only present when known)"
 													},
 													"fireTime": {
-														"type": "integer"
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the fire time (only present when known)"
 													},
 													"nextFireTime": {
-														"type": "integer"
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the next fire time (only present when known)"
 													},
 													"finalFireTime": {
-														"type": "integer"
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the final fire time (only present when known)"
 													},
 													"recovering": {
-														"type": "boolean"
+														"type": "boolean",
+														"description": "Whether the job is recovering"
 													},
 													"refireCount": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of times the job has been refired"
 													},
 													"misfireInstruction": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The trigger's misfire instruction"
 													}
 												},
 												"required": [
@@ -5044,16 +5147,20 @@
 												"type": "object",
 												"properties": {
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id (only present when known)"
 													},
 													"triggerType": {
-														"type": "string"
+														"type": "string",
+														"description": "The trigger type: cron or simple (only present when known)"
 													},
 													"cron": {
-														"type": "string"
+														"type": "string",
+														"description": "The cron expression (only present when known)"
 													},
 													"repeatInterval": {
-														"type": "string"
+														"type": "string",
+														"description": "The simple trigger repeat interval (only present when known)"
 													}
 												}
 											},
@@ -5285,73 +5392,91 @@
 												"type": "object",
 												"properties": {
 													"id": {
-														"type": "string"
+														"type": "string",
+														"description": "The circuit breaker id"
 													},
 													"routeId": {
-														"type": "string"
+														"type": "string",
+														"description": "The route id"
 													},
 													"state": {
-														"type": "string"
+														"type": "string",
+														"description": "The circuit breaker state"
 													},
 													"bufferedCalls": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of buffered calls"
 													},
 													"successfulCalls": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of successful calls"
 													},
 													"failedCalls": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of failed calls"
 													},
 													"notPermittedCalls": {
-														"type": "integer"
+														"type": "integer",
+														"description": "The number of not permitted calls"
 													},
 													"failureRate": {
-														"type": "number"
+														"type": "number",
+														"description": "The failure rate in percentage"
 													},
 													"configuration": {
 														"type": "object",
 														"properties": {
 															"failureRateThreshold": {
-																"type": "number"
+																"type": "number",
+																"description": "The failure rate threshold in percentage"
 															},
 															"slowCallRateThreshold": {
-																"type": "number"
+																"type": "number",
+																"description": "The slow call rate threshold in percentage"
 															},
 															"minimumNumberOfCalls": {
-																"type": "integer"
+																"type": "integer",
+																"description": "The minimum number of calls before the failure rate is calculated"
 															},
 															"permittedNumberOfCallsInHalfOpenState": {
-																"type": "integer"
+																"type": "integer",
+																"description": "The number of permitted calls when the circuit breaker is half open"
 															},
 															"slidingWindowSize": {
-																"type": "integer"
+																"type": "integer",
+																"description": "The sliding window size"
 															},
 															"slidingWindowType": {
-																"type": "string"
+																"type": "string",
+																"description": "The sliding window type"
 															},
 															"waitDurationInOpenState": {
-																"type": "integer"
+																"type": "integer",
+																"description": "The wait duration in the open state, in milliseconds"
 															},
 															"automaticTransitionFromOpenToHalfOpen": {
-																"type": "boolean"
+																"type": "boolean",
+																"description": "Whether the circuit breaker automatically transitions from open to half-open"
 															},
 															"bulkheadEnabled": {
-																"type": "boolean"
+																"type": "boolean",
+																"description": "Whether the bulkhead is enabled"
 															},
 															"bulkheadMaxConcurrentCalls": {
 																"type": "integer",
-																"description": "Only present when bulkheadEnabled is true"
+																"description": "The maximum concurrent calls allowed by the bulkhead (only present when bulkheadEnabled is true)"
 															},
 															"bulkheadMaxWaitDuration": {
 																"type": "integer",
-																"description": "Only present when bulkheadEnabled is true"
+																"description": "The maximum wait duration for the bulkhead in milliseconds (only present when bulkheadEnabled is true)"
 															},
 															"timeoutEnabled": {
-																"type": "boolean"
+																"type": "boolean",
+																"description": "Whether the timeout is enabled"
 															},
 															"timeoutDuration": {
 																"type": "integer",
-																"description": "Only present when timeoutEnabled is true"
+																"description": "The timeout duration in milliseconds (only present when timeoutEnabled is true)"
 															}
 														},
 														"required": [
@@ -5364,7 +5489,8 @@
 															"automaticTransitionFromOpenToHalfOpen",
 															"bulkheadEnabled",
 															"timeoutEnabled"
-														]
+														],
+														"description": "The circuit breaker configuration"
 													}
 												},
 												"required": [

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -1217,6 +1217,80 @@
 				}
 			}
 		},
+		"\/q\/dev\/dependency-downloader": {
+			"get": {
+				"summary": "Maven Dependency Downloader",
+				"description": "Displays information about dependencies downloaded at runtime",
+				"operationId": "dependency-downloader",
+				"responses": {
+					"200": {
+						"description": "Maven Dependency Downloader output",
+						"content": {
+							"application\/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"dependencies": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The downloaded dependency class-path entries (only present when the application classloader manages downloads)"
+										},
+										"offline": {
+											"type": "boolean",
+											"description": "Whether downloading is disabled (only present when a downloader is active)"
+										},
+										"fresh": {
+											"type": "boolean",
+											"description": "Whether fresh downloads are forced (only present when a downloader is active)"
+										},
+										"verbose": {
+											"type": "boolean",
+											"description": "Whether verbose logging is enabled (only present when a downloader is active)"
+										},
+										"repos": {
+											"type": "string",
+											"description": "The extra Maven repositories (only present when a downloader is active)"
+										},
+										"downloads": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"groupId": {
+														"type": "string"
+													},
+													"artifactId": {
+														"type": "string"
+													},
+													"version": {
+														"type": "string"
+													},
+													"repoId": {
+														"type": "string"
+													},
+													"repoUrl": {
+														"type": "string"
+													},
+													"elapsed": {
+														"type": "integer"
+													}
+												},
+												"required": [
+													"elapsed"
+												]
+											},
+											"description": "The downloaded artifacts (only present when a downloader is active)"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"\/q\/dev\/endpoint": {
 			"get": {
 				"summary": "Endpoints",
@@ -1706,7 +1780,27 @@
 						"description": "HashiCorp Secrets output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"host": {
+											"type": "string",
+											"description": "The Vault host (only present when configured)"
+										},
+										"port": {
+											"type": "string",
+											"description": "The Vault port (only present when configured)"
+										},
+										"scheme": {
+											"type": "string",
+											"description": "The Vault scheme (only present when configured)"
+										},
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when configured)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2211,6 +2305,31 @@
 				}
 			}
 		},
+		"\/q\/dev\/jbang": {
+			"get": {
+				"summary": "Camel CLI",
+				"description": "Information about Camel CLI",
+				"operationId": "jbang",
+				"responses": {
+					"200": {
+						"description": "Camel CLI output",
+						"content": {
+							"application\/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"version": {
+											"type": "string",
+											"description": "The JBang version (only present when known)"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"\/q\/dev\/jfr": {
 			"post": {
 				"summary": "JFR Runtime Instrumentation",
@@ -2498,7 +2617,45 @@
 						"description": "Main Configuration output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"configurations": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"key": {
+														"type": "string",
+														"description": "The configuration key"
+													},
+													"value": {
+														"description": "The configuration value (masked as xxxxxx when sensitive)"
+													},
+													"defaultValue": {
+														"description": "The default value (only present when known)"
+													},
+													"originalValue": {
+														"description": "The original, unresolved value (only present when known and not sensitive)"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source that provided the value (only present when known)"
+													},
+													"location": {
+														"type": "string",
+														"description": "The location the value came from (only present when known)"
+													},
+													"internal": {
+														"type": "boolean",
+														"description": "Whether the location is internal (only present when the location is known)"
+													}
+												}
+											},
+											"description": "The startup configurations (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2515,7 +2672,39 @@
 						"description": "Main HTTP Server output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"host": {
+											"type": "string",
+											"description": "The bind host (only present when the server is running)"
+										},
+										"port": {
+											"type": "integer",
+											"description": "The bind port (only present when the server is running)"
+										},
+										"path": {
+											"type": "string",
+											"description": "The context path (only present when the server is running)"
+										},
+										"maxBodySize": {
+											"type": "integer",
+											"description": "Maximum HTTP body size in bytes (only present when configured)"
+										},
+										"fileUploadEnabled": {
+											"type": "boolean",
+											"description": "Whether file upload is enabled (only present when the server is running)"
+										},
+										"fileUploadDirectory": {
+											"type": "string",
+											"description": "The file upload directory (only present when configured)"
+										},
+										"useGlobalSslContextParameters": {
+											"type": "boolean",
+											"description": "Whether global SSL context parameters are used (only present when the server is running)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -5055,7 +5244,16 @@
 						"description": "SFTP output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"config": {
+											"type": "object",
+											"additionalProperties": true,
+											"description": "The SFTP (JSCH) configuration"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -5189,6 +5387,34 @@
 										}
 									}
 								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"\/q\/dev\/source-dir": {
+			"get": {
+				"summary": "Source Directory",
+				"description": "Information about Camel CLI source files",
+				"operationId": "source-dir",
+				"parameters": [
+					{
+						"name": "source",
+						"in": "query",
+						"description": "Whether to show the source in the output",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Source Directory output",
+						"content": {
+							"application\/json": {
+								
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -215,7 +215,60 @@
 						"description": "Azure Key Vault Secrets output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when the Azure Key Vault properties function is active)"
+										},
+										"refreshEnabled": {
+											"type": "boolean",
+											"description": "Whether secret refresh is enabled (only present when configured)"
+										},
+										"refreshPeriod": {
+											"type": "integer",
+											"description": "The refresh period in milliseconds (only present when configured)"
+										},
+										"lastCheckTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last check (only present when known)"
+										},
+										"lastCheckAge": {
+											"type": "string",
+											"description": "Relative age of the last check (only present when known)"
+										},
+										"lastReloadTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last reload (only present when known)"
+										},
+										"lastReloadAge": {
+											"type": "string",
+											"description": "Relative age of the last reload (only present when known)"
+										},
+										"secrets": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The secret name"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last update (only present when known)"
+													},
+													"age": {
+														"type": "string",
+														"description": "Relative age of the last update (only present when known)"
+													}
+												}
+											},
+											"description": "The secrets in use (only present when the Azure Key Vault properties function is active)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -362,7 +415,92 @@
 						"description": "Bean Model output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"beans": {
+											"type": "object",
+											"additionalProperties": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The bean name"
+													},
+													"type": {
+														"type": "string",
+														"description": "The bean type"
+													},
+													"initMethod": {
+														"type": "string",
+														"description": "The init method name (only present when configured)"
+													},
+													"destroyMethod": {
+														"type": "string",
+														"description": "The destroy method name (only present when configured)"
+													},
+													"builderClass": {
+														"type": "string",
+														"description": "The builder class name (only present when configured)"
+													},
+													"builderMethod": {
+														"type": "string",
+														"description": "The builder method name (only present when configured)"
+													},
+													"factoryBean": {
+														"type": "string",
+														"description": "The factory bean name (only present when configured)"
+													},
+													"factoryMethod": {
+														"type": "string",
+														"description": "The factory method name (only present when configured)"
+													},
+													"modelProperties": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"name": {
+																	"type": "string",
+																	"description": "The property name"
+																},
+																"type": {
+																	"type": "string",
+																	"description": "The property value type (only present when the value is known)"
+																},
+																"value": {
+																	"description": "The property value"
+																}
+															}
+														},
+														"description": "The bean properties as declared in the DSL model (only present when there are any)"
+													},
+													"properties": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"name": {
+																	"type": "string",
+																	"description": "The property name"
+																},
+																"type": {
+																	"type": "string",
+																	"description": "The property value type (only present when the value is known)"
+																},
+																"value": {
+																	"description": "The property value"
+																}
+															}
+														},
+														"description": "The bean properties resolved from the running bean instance (only present when there are any)"
+													}
+												}
+											},
+											"description": "The beans keyed by bean name"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1887,7 +2025,60 @@
 						"description": "GCP Secrets output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when the GCP Secret Manager properties function is active)"
+										},
+										"refreshEnabled": {
+											"type": "boolean",
+											"description": "Whether secret refresh is enabled (only present when configured)"
+										},
+										"refreshPeriod": {
+											"type": "integer",
+											"description": "The refresh period in milliseconds (only present when configured)"
+										},
+										"lastCheckTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last check (only present when known)"
+										},
+										"lastCheckAge": {
+											"type": "string",
+											"description": "Relative age of the last check (only present when known)"
+										},
+										"lastReloadTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last reload (only present when known)"
+										},
+										"lastReloadAge": {
+											"type": "string",
+											"description": "Relative age of the last reload (only present when known)"
+										},
+										"secrets": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The secret name"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last update (only present when known)"
+													},
+													"age": {
+														"type": "string",
+														"description": "Relative age of the last update (only present when known)"
+													}
+												}
+											},
+											"description": "The secrets in use (only present when the GCP Secret Manager properties function is active)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2259,7 +2450,68 @@
 						"description": "IBM Secrets output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"serviceUrl": {
+											"type": "string",
+											"description": "The IBM Secrets Manager service URL (only present when configured)"
+										},
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when configured)"
+										},
+										"refreshEnabled": {
+											"type": "boolean",
+											"description": "Whether secret refresh is enabled (only present when configured)"
+										},
+										"eventStreamTopic": {
+											"type": "string",
+											"description": "The event stream topic (only present when refresh is enabled)"
+										},
+										"eventStreamBootstrapServers": {
+											"type": "string",
+											"description": "The event stream bootstrap servers (only present when refresh is enabled)"
+										},
+										"lastCheckTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last check (only present when known)"
+										},
+										"lastCheckAge": {
+											"type": "string",
+											"description": "Relative age of the last check (only present when known)"
+										},
+										"lastReloadTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last reload (only present when known)"
+										},
+										"lastReloadAge": {
+											"type": "string",
+											"description": "Relative age of the last reload (only present when known)"
+										},
+										"secrets": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The secret name"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last update (only present when known)"
+													},
+													"age": {
+														"type": "string",
+														"description": "Relative age of the last update (only present when known)"
+													}
+												}
+											},
+											"description": "The secrets in use (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -4697,7 +4949,19 @@
 						"description": "Route Diagram output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"text": {
+											"type": "string",
+											"description": "The rendered ASCII\/Unicode art diagram (only present for a text theme)"
+										},
+										"image": {
+											"type": "string",
+											"description": "The rendered diagram as a base64-encoded PNG image (only present for a non-text theme)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -6060,7 +6324,48 @@
 						"description": "Stub output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"queues": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The queue name"
+													},
+													"endpointUri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"max": {
+														"type": "integer",
+														"description": "The maximum queue size"
+													},
+													"size": {
+														"type": "integer",
+														"description": "The current queue size"
+													},
+													"messages": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"additionalProperties": true
+														},
+														"description": "The browsed messages (only present when browsing is enabled and there are any)"
+													}
+												},
+												"required": [
+													"max",
+													"size"
+												]
+											},
+											"description": "The stub queues"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -6768,7 +7073,73 @@
 						"description": "Vert.x WebSocket output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"hosts": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"host": {
+														"type": "string",
+														"description": "The host"
+													},
+													"paths": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"path": {
+																	"type": "string",
+																	"description": "The websocket path"
+																},
+																"peers": {
+																	"type": "array",
+																	"items": {
+																		"type": "object",
+																		"properties": {
+																			"id": {
+																				"type": "string",
+																				"description": "The peer connection id"
+																			},
+																			"path": {
+																				"type": "string",
+																				"description": "The websocket path"
+																			},
+																			"rawPath": {
+																				"type": "string",
+																				"description": "The raw websocket path"
+																			},
+																			"hostAddress": {
+																				"type": "string",
+																				"description": "The local host address"
+																			},
+																			"subProtocol": {
+																				"type": "string",
+																				"description": "The negotiated sub protocol (only present when known)"
+																			},
+																			"headers": {
+																				"type": "object",
+																				"additionalProperties": {
+																					"type": "string"
+																				},
+																				"description": "The connection headers (only present when includeHeaders is enabled)"
+																			}
+																		}
+																	},
+																	"description": "The connected peers"
+																}
+															}
+														},
+														"description": "The websocket paths served on this host"
+													}
+												}
+											},
+											"description": "The Vert.x WebSocket consumer hosts"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -3422,7 +3422,56 @@
 						"description": "Route Dump output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"from": {
+														"type": "string",
+														"description": "The route's endpoint URI"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source location (only present when known)"
+													},
+													"format": {
+														"type": "string",
+														"description": "The dump format, xml\/yaml\/java (only present when the dump succeeded)"
+													},
+													"code": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"line": {
+																	"type": "integer",
+																	"description": "The source line number, or -1 when not known"
+																},
+																"code": {
+																	"type": "string",
+																	"description": "The source code line"
+																}
+															},
+															"required": [
+																"line"
+															]
+														},
+														"description": "The dumped route source code (only present when the dump succeeded)"
+													}
+												}
+											},
+											"description": "The routes"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3737,7 +3786,37 @@
 						"description": "Simple Language output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"coreSize": {
+											"type": "integer",
+											"description": "Number of core simple functions"
+										},
+										"customSize": {
+											"type": "integer",
+											"description": "Number of custom simple functions"
+										},
+										"coreFunctions": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The core function names (only present when there are any)"
+										},
+										"customFunctions": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The custom function names (only present when there are any)"
+										}
+									},
+									"required": [
+										"coreSize",
+										"customSize"
+									]
+								}
 							}
 						}
 					}
@@ -3907,7 +3986,126 @@
 						"description": "SQL Trace output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"statements": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds when the statement was executed"
+													},
+													"exchangeId": {
+														"type": "string",
+														"description": "The exchange ID"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when known)"
+													},
+													"nodeId": {
+														"type": "string",
+														"description": "The processor node ID (only present when known)"
+													},
+													"location": {
+														"type": "string",
+														"description": "The source location of the processor (only present when known)"
+													},
+													"endpoint": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"query": {
+														"type": "string",
+														"description": "The SQL query (or the endpoint URI when the query could not be determined)"
+													},
+													"category": {
+														"type": "string",
+														"description": "The SQL statement category"
+													},
+													"duration": {
+														"type": "integer",
+														"description": "Duration in milliseconds"
+													},
+													"failed": {
+														"type": "boolean",
+														"description": "Whether the exchange failed"
+													},
+													"rowCount": {
+														"type": "integer",
+														"description": "Number of rows returned (only present when known)"
+													},
+													"updateCount": {
+														"type": "integer",
+														"description": "Number of rows updated (only present when known)"
+													}
+												},
+												"required": [
+													"timestamp",
+													"duration",
+													"failed"
+												]
+											},
+											"description": "The traced SQL statements, most recent first (only present when statements have been traced)"
+										},
+										"summary": {
+											"type": "object",
+											"properties": {
+												"totalQueries": {
+													"type": "integer",
+													"description": "Total number of queries"
+												},
+												"avgTime": {
+													"type": "integer",
+													"description": "Average duration in milliseconds"
+												},
+												"slowestTime": {
+													"type": "integer",
+													"description": "Slowest duration in milliseconds"
+												},
+												"slowCount": {
+													"type": "integer",
+													"description": "Number of queries considered slow (duration >= 100 ms)"
+												},
+												"failedCount": {
+													"type": "integer",
+													"description": "Number of failed queries"
+												},
+												"selectCount": {
+													"type": "integer",
+													"description": "Number of SELECT statements"
+												},
+												"insertCount": {
+													"type": "integer",
+													"description": "Number of INSERT statements"
+												},
+												"updateCount": {
+													"type": "integer",
+													"description": "Number of UPDATE statements"
+												},
+												"deleteCount": {
+													"type": "integer",
+													"description": "Number of DELETE statements"
+												}
+											},
+											"required": [
+												"totalQueries",
+												"avgTime",
+												"slowestTime",
+												"slowCount",
+												"failedCount",
+												"selectCount",
+												"insertCount",
+												"updateCount",
+												"deleteCount"
+											],
+											"description": "Summary statistics across the traced statements (only present when statements have been traced)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3924,7 +4122,59 @@
 						"description": "Startup Recorder output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"steps": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "integer",
+														"description": "The id of the step"
+													},
+													"parentId": {
+														"type": "integer",
+														"description": "The id of the parent step"
+													},
+													"level": {
+														"type": "integer",
+														"description": "The step level (sub step of previous steps)"
+													},
+													"name": {
+														"type": "string",
+														"description": "Name of the step (only present when known)"
+													},
+													"type": {
+														"type": "string",
+														"description": "The source class type of the step"
+													},
+													"description": {
+														"type": "string",
+														"description": "Description of the step"
+													},
+													"beginTime": {
+														"type": "integer",
+														"description": "The begin time (epoch milliseconds)"
+													},
+													"duration": {
+														"type": "integer",
+														"description": "The duration the step took, in milliseconds"
+													}
+												},
+												"required": [
+													"id",
+													"parentId",
+													"level",
+													"beginTime",
+													"duration"
+												]
+											},
+											"description": "The startup steps (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -4217,7 +4467,54 @@
 						"description": "Data Type Transformers output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"size": {
+											"type": "integer",
+											"description": "Total number of transformers"
+										},
+										"dynamicSize": {
+											"type": "integer",
+											"description": "Number of transformers in the dynamic registry"
+										},
+										"staticSize": {
+											"type": "integer",
+											"description": "Number of transformers in the static registry"
+										},
+										"maximumCacheSize": {
+											"type": "integer",
+											"description": "Maximum number of entries to store in the dynamic registry"
+										},
+										"transformers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The transformer name"
+													},
+													"from": {
+														"type": "string",
+														"description": "The from data type (only present when not any-type)"
+													},
+													"to": {
+														"type": "string",
+														"description": "The to data type (only present when not any-type)"
+													}
+												}
+											},
+											"description": "The transformers (only present when there are any)"
+										}
+									},
+									"required": [
+										"size",
+										"dynamicSize",
+										"staticSize",
+										"maximumCacheSize"
+									]
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -3178,7 +3178,294 @@
 						"description": "JFR Memory Leak output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"status": {
+											"type": "string",
+											"description": "The console status: recording, completed, compared, idle, or error"
+										},
+										"error": {
+											"type": "string",
+											"description": "An error message (only present when status is error)"
+										},
+										"note": {
+											"type": "string",
+											"description": "An informational note (only present for an idle query)"
+										},
+										"startTime": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds the recording started (only present while recording)"
+										},
+										"durationSeconds": {
+											"type": "integer",
+											"description": "The requested recording duration in seconds (only present when set)"
+										},
+										"elapsedMs": {
+											"type": "integer",
+											"description": "Elapsed time in milliseconds since the recording started (only present while recording)"
+										},
+										"remainingMs": {
+											"type": "integer",
+											"description": "Remaining time in milliseconds until auto-stop (only present when a duration was requested)"
+										},
+										"hasCachedResults": {
+											"type": "boolean",
+											"description": "Whether cached results are available (only present for a status query)"
+										},
+										"hasComparisonData": {
+											"type": "boolean",
+											"description": "Whether a previous recording is available for comparison (only present for a status query)"
+										},
+										"sampleCount": {
+											"type": "integer",
+											"description": "The number of aggregated samples (only present when results are available)"
+										},
+										"recordingDurationMs": {
+											"type": "integer",
+											"description": "The recording duration in milliseconds (only present when results are available)"
+										},
+										"recordingEndTime": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds the recording ended (only present when results are available)"
+										},
+										"rawSampleCount": {
+											"type": "integer",
+											"description": "The number of raw samples before aggregation (only present when results are available)"
+										},
+										"gcCount": {
+											"type": "integer",
+											"description": "The number of garbage collections observed (only present when results are available)"
+										},
+										"samples": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"allocationClass": {
+														"type": "string",
+														"description": "The allocated class name (only present when known)"
+													},
+													"allocationSize": {
+														"type": "integer",
+														"description": "The allocation size in bytes (only present when known)"
+													},
+													"lastKnownHeapUsage": {
+														"type": "integer",
+														"description": "The last known heap usage in bytes (only present when known)"
+													},
+													"arrayElements": {
+														"type": "integer",
+														"description": "The number of array elements (only present for arrays)"
+													},
+													"objectAge": {
+														"type": "integer",
+														"description": "The object age in milliseconds (only present when known)"
+													},
+													"allocationTime": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds when the object was allocated"
+													},
+													"stackTrace": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"method": {
+																	"type": "string",
+																	"description": "The fully qualified method name"
+																},
+																"line": {
+																	"type": "integer",
+																	"description": "The line number"
+																}
+															},
+															"required": [
+																"line"
+															]
+														},
+														"description": "The allocation stack trace (only present when requested)"
+													},
+													"referenceChain": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"type": {
+																	"type": "string",
+																	"description": "The type name (only present when known)"
+																},
+																"field": {
+																	"type": "string",
+																	"description": "The field name (only present when known)"
+																},
+																"description": {
+																	"type": "string",
+																	"description": "A description of the link (only present when known)"
+																}
+															}
+														},
+														"description": "The reference chain back to the GC root (only present when there is one)"
+													},
+													"count": {
+														"type": "integer",
+														"description": "The number of samples aggregated into this entry"
+													},
+													"sampledSize": {
+														"type": "integer",
+														"description": "The total sampled size in bytes across the aggregated samples"
+													}
+												},
+												"required": [
+													"allocationTime",
+													"count",
+													"sampledSize"
+												]
+											},
+											"description": "The aggregated samples (only present when results are available)"
+										},
+										"baseline": {
+											"type": "object",
+											"properties": {
+												"recordingDurationMs": {
+													"type": "integer",
+													"description": "The recording duration in milliseconds"
+												},
+												"sampleCount": {
+													"type": "integer",
+													"description": "The number of aggregated samples"
+												},
+												"gcCount": {
+													"type": "integer",
+													"description": "The number of garbage collections observed"
+												}
+											},
+											"required": [
+												"recordingDurationMs",
+												"sampleCount",
+												"gcCount"
+											],
+											"description": "The baseline recording info (only present for a comparison)"
+										},
+										"current": {
+											"type": "object",
+											"properties": {
+												"recordingDurationMs": {
+													"type": "integer",
+													"description": "The recording duration in milliseconds"
+												},
+												"sampleCount": {
+													"type": "integer",
+													"description": "The number of aggregated samples"
+												},
+												"gcCount": {
+													"type": "integer",
+													"description": "The number of garbage collections observed"
+												}
+											},
+											"required": [
+												"recordingDurationMs",
+												"sampleCount",
+												"gcCount"
+											],
+											"description": "The current recording info (only present for a comparison)"
+										},
+										"durationRatio": {
+											"type": "number",
+											"description": "The ratio of the current to the baseline recording duration (only present for a comparison)"
+										},
+										"comparisons": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"allocationClass": {
+														"type": "string",
+														"description": "The allocated class name"
+													},
+													"baselineSampledSize": {
+														"type": "integer",
+														"description": "The baseline sampled size in bytes"
+													},
+													"baselineCount": {
+														"type": "integer",
+														"description": "The baseline sample count"
+													},
+													"currentSampledSize": {
+														"type": "integer",
+														"description": "The current sampled size in bytes"
+													},
+													"currentCount": {
+														"type": "integer",
+														"description": "The current sample count"
+													},
+													"growthRatio": {
+														"type": "number",
+														"description": "The growth ratio between baseline and current sampled size"
+													},
+													"trend": {
+														"type": "string",
+														"description": "The trend: new, gone, growing, suspicious, shrinking, or stable"
+													},
+													"lowConfidence": {
+														"type": "boolean",
+														"description": "Whether the comparison has low statistical confidence"
+													},
+													"referenceChain": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"type": {
+																	"type": "string",
+																	"description": "The type name (only present when known)"
+																},
+																"field": {
+																	"type": "string",
+																	"description": "The field name (only present when known)"
+																},
+																"description": {
+																	"type": "string",
+																	"description": "A description of the link (only present when known)"
+																}
+															}
+														},
+														"description": "The reference chain back to the GC root (only present when there is one)"
+													},
+													"stackTrace": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"method": {
+																	"type": "string",
+																	"description": "The fully qualified method name"
+																},
+																"line": {
+																	"type": "integer",
+																	"description": "The line number"
+																}
+															},
+															"required": [
+																"line"
+															]
+														},
+														"description": "The allocation stack trace (only present when requested)"
+													}
+												},
+												"required": [
+													"baselineSampledSize",
+													"baselineCount",
+													"currentSampledSize",
+													"currentCount",
+													"growthRatio",
+													"lowConfidence"
+												]
+											},
+											"description": "The per-class comparisons, sorted by growth ratio descending (only present for a comparison)"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -2988,7 +2988,107 @@
 						"description": "Kafka output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"kafkaConsumers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route id"
+													},
+													"uri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"workers": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"threadId": {
+																	"type": "string",
+																	"description": "The worker thread id"
+																},
+																"state": {
+																	"type": "string",
+																	"description": "The worker state"
+																},
+																"lastError": {
+																	"type": "string",
+																	"description": "The worker last error (only present when not ready)"
+																},
+																"groupId": {
+																	"type": "string",
+																	"description": "The consumer group id (only present when known)"
+																},
+																"groupInstanceId": {
+																	"type": "string",
+																	"description": "The consumer group instance id (only present when known)"
+																},
+																"memberId": {
+																	"type": "string",
+																	"description": "The consumer member id (only present when known)"
+																},
+																"generationId": {
+																	"type": "integer",
+																	"description": "The consumer generation id (only present when known)"
+																},
+																"lastTopic": {
+																	"type": "string",
+																	"description": "The last consumed topic (only present when known)"
+																},
+																"lastPartition": {
+																	"type": "integer",
+																	"description": "The last consumed partition (only present when known)"
+																},
+																"lastOffset": {
+																	"type": "integer",
+																	"description": "The last consumed offset (only present when known)"
+																},
+																"committed": {
+																	"type": "array",
+																	"items": {
+																		"type": "object",
+																		"properties": {
+																			"topic": {
+																				"type": "string",
+																				"description": "The topic"
+																			},
+																			"partition": {
+																				"type": "integer",
+																				"description": "The partition"
+																			},
+																			"offset": {
+																				"type": "integer",
+																				"description": "The committed offset"
+																			},
+																			"epoch": {
+																				"type": "integer",
+																				"description": "The epoch"
+																			}
+																		},
+																		"required": [
+																			"partition",
+																			"offset",
+																			"epoch"
+																		]
+																	},
+																	"description": "The committed offsets (only present when requested and there are any)"
+																}
+															}
+														},
+														"description": "The consumer worker threads"
+													}
+												}
+											},
+											"description": "The Kafka consumers"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3055,7 +3155,40 @@
 						"description": "Kubernetes Secrets output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"masterUrl": {
+											"type": "string",
+											"description": "The Kubernetes master URL (only present when configured)"
+										},
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when configured)"
+										},
+										"refreshEnabled": {
+											"type": "boolean",
+											"description": "Whether secret refresh is enabled (only present when configured)"
+										},
+										"startCheckTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds the refresh task started (only present when known)"
+										},
+										"secrets": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The secret name"
+													}
+												}
+											},
+											"description": "The secrets in use"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3347,7 +3480,222 @@
 						"description": "Micrometer output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"meterRegistryClass": {
+											"type": "string"
+										},
+										"counters": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"description": {
+														"type": "string"
+													},
+													"tags": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string"
+																},
+																"value": {
+																	"type": "string"
+																}
+															}
+														}
+													},
+													"count": {
+														"description": "The counter value (integer when whole, decimal otherwise)"
+													}
+												}
+											},
+											"description": "Only present when there are any counters"
+										},
+										"gauges": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"description": {
+														"type": "string"
+													},
+													"tags": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string"
+																},
+																"value": {
+																	"type": "string"
+																}
+															}
+														}
+													},
+													"value": {
+														"type": "number"
+													}
+												},
+												"required": [
+													"value"
+												]
+											},
+											"description": "Only present when there are any gauges"
+										},
+										"timers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"description": {
+														"type": "string"
+													},
+													"tags": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string"
+																},
+																"value": {
+																	"type": "string"
+																}
+															}
+														}
+													},
+													"count": {
+														"type": "integer"
+													},
+													"mean": {
+														"type": "integer"
+													},
+													"max": {
+														"type": "integer"
+													},
+													"total": {
+														"type": "integer"
+													}
+												},
+												"required": [
+													"count",
+													"mean",
+													"max",
+													"total"
+												]
+											},
+											"description": "Only present when there are any timers"
+										},
+										"longTaskTimers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"description": {
+														"type": "string"
+													},
+													"tags": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string"
+																},
+																"value": {
+																	"type": "string"
+																}
+															}
+														}
+													},
+													"activeTasks": {
+														"type": "integer"
+													},
+													"mean": {
+														"type": "integer"
+													},
+													"max": {
+														"type": "integer"
+													},
+													"duration": {
+														"type": "integer"
+													}
+												},
+												"required": [
+													"activeTasks",
+													"mean",
+													"max",
+													"duration"
+												]
+											},
+											"description": "Only present when there are any long task timers"
+										},
+										"distribution": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"description": {
+														"type": "string"
+													},
+													"tags": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string"
+																},
+																"value": {
+																	"type": "string"
+																}
+															}
+														}
+													},
+													"count": {
+														"type": "integer"
+													},
+													"mean": {
+														"type": "number"
+													},
+													"max": {
+														"type": "number"
+													},
+													"totalAmount": {
+														"type": "number"
+													}
+												},
+												"required": [
+													"count",
+													"mean",
+													"max",
+													"totalAmount"
+												]
+											},
+											"description": "Only present when there are any distribution summaries"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3389,7 +3737,93 @@
 						"description": "OpenTelemetry Spans output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"enabled": {
+											"type": "boolean",
+											"description": "Whether the OpenTelemetry in-memory exporter is enabled"
+										},
+										"spanCount": {
+											"type": "integer",
+											"description": "The number of finished spans held (only present when not dumping spans)"
+										},
+										"capacity": {
+											"type": "integer",
+											"description": "The maximum number of spans held (only present when not dumping spans)"
+										},
+										"spans": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"traceId": {
+														"type": "string",
+														"description": "The trace id"
+													},
+													"spanId": {
+														"type": "string",
+														"description": "The span id"
+													},
+													"parentSpanId": {
+														"type": "string",
+														"description": "The parent span id (only present when known)"
+													},
+													"name": {
+														"type": "string",
+														"description": "The span name"
+													},
+													"kind": {
+														"type": "string",
+														"description": "The span kind"
+													},
+													"status": {
+														"type": "string",
+														"description": "The span status"
+													},
+													"startEpochNanos": {
+														"type": "integer",
+														"description": "Epoch time in nanoseconds when the span started"
+													},
+													"endEpochNanos": {
+														"type": "integer",
+														"description": "Epoch time in nanoseconds when the span ended"
+													},
+													"durationMs": {
+														"type": "integer",
+														"description": "The span duration in milliseconds"
+													},
+													"scopeName": {
+														"type": "string",
+														"description": "The instrumentation scope name (only present when known)"
+													},
+													"attributes": {
+														"type": "object",
+														"additionalProperties": true,
+														"description": "The span attributes (only present when there are any)"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route id this span belongs to (only present when known)"
+													},
+													"processorId": {
+														"type": "string",
+														"description": "The processor id this span belongs to (only present for processor spans)"
+													}
+												},
+												"required": [
+													"startEpochNanos",
+													"endEpochNanos",
+													"durationMs"
+												]
+											},
+											"description": "The dumped spans (only present when dumping spans)"
+										}
+									},
+									"required": [
+										"enabled"
+									]
+								}
 							}
 						}
 					}
@@ -3406,7 +3840,73 @@
 						"description": "Platform HTTP output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"server": {
+											"type": "string",
+											"description": "The server base URL (only present when the platform-http component is active)"
+										},
+										"endpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"url": {
+														"type": "string",
+														"description": "The full endpoint URL"
+													},
+													"path": {
+														"type": "string",
+														"description": "The endpoint path"
+													},
+													"verbs": {
+														"type": "string",
+														"description": "The HTTP verbs (only present when configured)"
+													},
+													"consumes": {
+														"type": "string",
+														"description": "The consumed media types (only present when configured)"
+													},
+													"produces": {
+														"type": "string",
+														"description": "The produced media types (only present when configured)"
+													}
+												}
+											},
+											"description": "The registered HTTP endpoints (only present when there are any)"
+										},
+										"managementEndpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"url": {
+														"type": "string",
+														"description": "The full endpoint URL"
+													},
+													"path": {
+														"type": "string",
+														"description": "The endpoint path"
+													},
+													"verbs": {
+														"type": "string",
+														"description": "The HTTP verbs (only present when configured)"
+													},
+													"consumes": {
+														"type": "string",
+														"description": "The consumed media types (only present when configured)"
+													},
+													"produces": {
+														"type": "string",
+														"description": "The produced media types (only present when configured)"
+													}
+												}
+											},
+											"description": "The registered HTTP management endpoints (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -4093,7 +4593,109 @@
 						"description": "Resilience Circuit Breaker output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"circuitBreakers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"routeId": {
+														"type": "string"
+													},
+													"state": {
+														"type": "string"
+													},
+													"bufferedCalls": {
+														"type": "integer"
+													},
+													"successfulCalls": {
+														"type": "integer"
+													},
+													"failedCalls": {
+														"type": "integer"
+													},
+													"notPermittedCalls": {
+														"type": "integer"
+													},
+													"failureRate": {
+														"type": "number"
+													},
+													"configuration": {
+														"type": "object",
+														"properties": {
+															"failureRateThreshold": {
+																"type": "number"
+															},
+															"slowCallRateThreshold": {
+																"type": "number"
+															},
+															"minimumNumberOfCalls": {
+																"type": "integer"
+															},
+															"permittedNumberOfCallsInHalfOpenState": {
+																"type": "integer"
+															},
+															"slidingWindowSize": {
+																"type": "integer"
+															},
+															"slidingWindowType": {
+																"type": "string"
+															},
+															"waitDurationInOpenState": {
+																"type": "integer"
+															},
+															"automaticTransitionFromOpenToHalfOpen": {
+																"type": "boolean"
+															},
+															"bulkheadEnabled": {
+																"type": "boolean"
+															},
+															"bulkheadMaxConcurrentCalls": {
+																"type": "integer",
+																"description": "Only present when bulkheadEnabled is true"
+															},
+															"bulkheadMaxWaitDuration": {
+																"type": "integer",
+																"description": "Only present when bulkheadEnabled is true"
+															},
+															"timeoutEnabled": {
+																"type": "boolean"
+															},
+															"timeoutDuration": {
+																"type": "integer",
+																"description": "Only present when timeoutEnabled is true"
+															}
+														},
+														"required": [
+															"failureRateThreshold",
+															"slowCallRateThreshold",
+															"minimumNumberOfCalls",
+															"permittedNumberOfCallsInHalfOpenState",
+															"slidingWindowSize",
+															"waitDurationInOpenState",
+															"automaticTransitionFromOpenToHalfOpen",
+															"bulkheadEnabled",
+															"timeoutEnabled"
+														]
+													}
+												},
+												"required": [
+													"bufferedCalls",
+													"successfulCalls",
+													"failedCalls",
+													"notPermittedCalls",
+													"failureRate"
+												]
+											},
+											"description": "The circuit breakers"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -5909,7 +6511,47 @@
 						"description": "Source Directory output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"dir": {
+											"type": "string",
+											"description": "The source directory (only present when a reload strategy is active)"
+										},
+										"files": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The file name"
+													},
+													"size": {
+														"type": "integer",
+														"description": "The file size in bytes"
+													},
+													"lastModified": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last modification"
+													},
+													"code": {
+														"type": "array",
+														"items": {
+															
+														},
+														"description": "The source code lines (only present when requested and available)"
+													}
+												},
+												"required": [
+													"size",
+													"lastModified"
+												]
+											},
+											"description": "The files in the source directory (only present when the directory is not empty)"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -149,7 +149,56 @@
 						"description": "AWS S3 output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"consumers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"bucket": {
+														"type": "string",
+														"description": "The S3 bucket name"
+													},
+													"accessKeys": {
+														"type": "boolean",
+														"description": "Whether static access keys are used"
+													},
+													"defaultCredentialsProvider": {
+														"type": "boolean",
+														"description": "Whether the default credentials provider is used"
+													},
+													"profileCredentialsProvider": {
+														"type": "boolean",
+														"description": "Whether the profile credentials provider is used"
+													},
+													"maxMessages": {
+														"type": "integer",
+														"description": "Maximum number of messages per poll"
+													},
+													"moveAfterRead": {
+														"type": "boolean",
+														"description": "Whether the object is moved after being read"
+													},
+													"deleteAfterRead": {
+														"type": "boolean",
+														"description": "Whether the object is deleted after being read"
+													}
+												},
+												"required": [
+													"accessKeys",
+													"defaultCredentialsProvider",
+													"profileCredentialsProvider",
+													"maxMessages",
+													"moveAfterRead",
+													"deleteAfterRead"
+												]
+											},
+											"description": "The AWS S3 consumers (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1679,7 +1728,99 @@
 						"description": "MicroProfile Circuit Breaker output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"circuitBreakers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "The circuit breaker ID"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"state": {
+														"type": "string",
+														"description": "The circuit breaker state"
+													},
+													"successfulCalls": {
+														"type": "integer",
+														"description": "Number of successful calls"
+													},
+													"failedCalls": {
+														"type": "integer",
+														"description": "Number of failed calls"
+													},
+													"notPermittedCalls": {
+														"type": "integer",
+														"description": "Number of not-permitted calls"
+													},
+													"configuration": {
+														"type": "object",
+														"properties": {
+															"delay": {
+																"type": "integer",
+																"description": "The delay in milliseconds"
+															},
+															"failureRatio": {
+																"type": "number",
+																"description": "The failure ratio"
+															},
+															"requestVolumeThreshold": {
+																"type": "integer",
+																"description": "The request volume threshold"
+															},
+															"successThreshold": {
+																"type": "integer",
+																"description": "The success threshold"
+															},
+															"bulkheadEnabled": {
+																"type": "boolean",
+																"description": "Whether the bulkhead is enabled"
+															},
+															"bulkheadMaxConcurrentCalls": {
+																"type": "integer",
+																"description": "The bulkhead maximum concurrent calls (only present when the bulkhead is enabled)"
+															},
+															"bulkheadWaitingTaskQueue": {
+																"type": "integer",
+																"description": "The bulkhead waiting task queue size (only present when the bulkhead is enabled)"
+															},
+															"timeoutEnabled": {
+																"type": "boolean",
+																"description": "Whether the timeout is enabled"
+															},
+															"timeoutDuration": {
+																"type": "integer",
+																"description": "The timeout duration in milliseconds (only present when the timeout is enabled)"
+															}
+														},
+														"required": [
+															"delay",
+															"failureRatio",
+															"requestVolumeThreshold",
+															"successThreshold",
+															"bulkheadEnabled",
+															"timeoutEnabled"
+														],
+														"description": "The circuit breaker configuration"
+													}
+												},
+												"required": [
+													"successfulCalls",
+													"failedCalls",
+													"notPermittedCalls"
+												]
+											},
+											"description": "The circuit breakers"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1763,7 +1904,64 @@
 						"description": "Groovy output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"compiler": {
+											"type": "object",
+											"properties": {
+												"scriptPattern": {
+													"type": "string",
+													"description": "The script file name pattern"
+												},
+												"compiledCounter": {
+													"type": "integer",
+													"description": "Number of scripts compiled"
+												},
+												"preloadedCounter": {
+													"type": "integer",
+													"description": "Number of scripts pre-loaded"
+												},
+												"classesSize": {
+													"type": "integer",
+													"description": "Number of compiled classes"
+												},
+												"compiledTime": {
+													"type": "integer",
+													"description": "Total compile time in milliseconds"
+												},
+												"recompileEnabled": {
+													"type": "boolean",
+													"description": "Whether re-compilation is enabled"
+												},
+												"lastCompilationTimestamp": {
+													"type": "integer",
+													"description": "Epoch time in milliseconds of the last compilation"
+												},
+												"workDir": {
+													"type": "string",
+													"description": "The work directory (only present when configured)"
+												},
+												"classes": {
+													"type": "array",
+													"items": {
+														"type": "string"
+													},
+													"description": "The compiled class names (only present when there are any)"
+												}
+											},
+											"required": [
+												"compiledCounter",
+												"preloadedCounter",
+												"classesSize",
+												"compiledTime",
+												"recompileEnabled",
+												"lastCompilationTimestamp"
+											],
+											"description": "The Groovy compiler information (only present when the compiler is active)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2555,7 +2753,40 @@
 						"description": "Kubernetes Config Maps output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"masterUrl": {
+											"type": "string",
+											"description": "The Kubernetes master URL (only present when known)"
+										},
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when known)"
+										},
+										"refreshEnabled": {
+											"type": "boolean",
+											"description": "Whether refreshing is enabled (only present when known)"
+										},
+										"startCheckTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds the refresh check started (only present when known)"
+										},
+										"configmaps": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The config map (secret) name"
+													}
+												}
+											},
+											"description": "The config maps in use"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -132,7 +132,64 @@
 						"description": "AWS Secrets output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"region": {
+											"type": "string",
+											"description": "The AWS region (only present when the AWS Secrets Manager properties function is active)"
+										},
+										"login": {
+											"type": "string",
+											"description": "The login method (only present when the AWS Secrets Manager properties function is active)"
+										},
+										"refreshEnabled": {
+											"type": "boolean",
+											"description": "Whether secret refresh is enabled (only present when configured)"
+										},
+										"refreshPeriod": {
+											"type": "integer",
+											"description": "The refresh period in milliseconds (only present when configured)"
+										},
+										"lastCheckTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last check (only present when known)"
+										},
+										"lastCheckAge": {
+											"type": "string",
+											"description": "Relative age of the last check (only present when known)"
+										},
+										"lastReloadTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last reload (only present when known)"
+										},
+										"lastReloadAge": {
+											"type": "string",
+											"description": "Relative age of the last reload (only present when known)"
+										},
+										"secrets": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The secret name"
+													},
+													"timestamp": {
+														"type": "integer",
+														"description": "Epoch time in milliseconds of the last update (only present when known)"
+													},
+													"age": {
+														"type": "string",
+														"description": "Relative age of the last update (only present when known)"
+													}
+												}
+											},
+											"description": "The secrets in use (only present when the AWS Secrets Manager properties function is active)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -2840,7 +2897,228 @@
 						"description": "JFR Runtime Instrumentation output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"runtimeEvents": {
+											"type": "boolean",
+											"description": "Whether camel-jfr runtime instrumentation is registered (status command)"
+										},
+										"recordings": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"state": {
+														"type": "string"
+													},
+													"destination": {
+														"type": "string"
+													}
+												}
+											},
+											"description": "The active JFR recordings (status command)"
+										},
+										"events": {
+											"type": "object",
+											"additionalProperties": {
+												"type": "boolean"
+											},
+											"description": "Whether each runtime event is enabled, keyed by short name (status command)"
+										},
+										"success": {
+											"type": "boolean",
+											"description": "Whether the toggle succeeded (enable\/disable command)"
+										},
+										"result": {
+											"type": "string",
+											"description": "The toggle result message (enable\/disable command)"
+										},
+										"jfc": {
+											"type": "string",
+											"description": "The generated jfc settings overlay (jfc command)"
+										},
+										"error": {
+											"type": "string",
+											"description": "An error message (jfc, snapshot, or unknown command)"
+										},
+										"snapshot": {
+											"type": "boolean",
+											"description": "Whether this is a snapshot response (snapshot command)"
+										},
+										"snapshotTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds the snapshot was taken (snapshot command)"
+										},
+										"eventCount": {
+											"type": "integer",
+											"description": "The number of matched events in the snapshot (snapshot command)"
+										},
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"total": {
+														"type": "integer"
+													},
+													"failed": {
+														"type": "integer"
+													},
+													"minMs": {
+														"type": "number"
+													},
+													"meanMs": {
+														"type": "number"
+													},
+													"maxMs": {
+														"type": "number"
+													},
+													"routeId": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"total",
+													"failed",
+													"minMs",
+													"meanMs",
+													"maxMs"
+												]
+											},
+											"description": "Per-route duration statistics (snapshot command)"
+										},
+										"processors": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"total": {
+														"type": "integer"
+													},
+													"failed": {
+														"type": "integer"
+													},
+													"minMs": {
+														"type": "number"
+													},
+													"meanMs": {
+														"type": "number"
+													},
+													"maxMs": {
+														"type": "number"
+													},
+													"processorId": {
+														"type": "string"
+													},
+													"processorType": {
+														"type": "string"
+													},
+													"routeId": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"total",
+													"failed",
+													"minMs",
+													"meanMs",
+													"maxMs"
+												]
+											},
+											"description": "Per-processor duration statistics (snapshot command)"
+										},
+										"endpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"total": {
+														"type": "integer"
+													},
+													"failed": {
+														"type": "integer"
+													},
+													"minMs": {
+														"type": "number"
+													},
+													"meanMs": {
+														"type": "number"
+													},
+													"maxMs": {
+														"type": "number"
+													},
+													"endpointUri": {
+														"type": "string"
+													}
+												},
+												"required": [
+													"total",
+													"failed",
+													"minMs",
+													"meanMs",
+													"maxMs"
+												]
+											},
+											"description": "Per-endpoint duration statistics (snapshot command)"
+										},
+										"failures": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"timestamp": {
+														"type": "string"
+													},
+													"exchangeId": {
+														"type": "string"
+													},
+													"routeId": {
+														"type": "string"
+													},
+													"exceptionType": {
+														"type": "string"
+													},
+													"exceptionMessage": {
+														"type": "string"
+													}
+												}
+											},
+											"description": "The most recent failures, newest first (snapshot command)"
+										},
+										"redeliveries": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"timestamp": {
+														"type": "string"
+													},
+													"exchangeId": {
+														"type": "string"
+													},
+													"routeId": {
+														"type": "string"
+													},
+													"attempt": {
+														"type": "integer"
+													},
+													"maxAttempts": {
+														"type": "integer"
+													}
+												},
+												"required": [
+													"attempt",
+													"maxAttempts"
+												]
+											},
+											"description": "The most recent redeliveries, newest first (snapshot command)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -4377,7 +4655,125 @@
 						"description": "Quartz output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"schedulerName": {
+											"type": "string"
+										},
+										"schedulerInstanceId": {
+											"type": "string"
+										},
+										"quartzVersion": {
+											"type": "string"
+										},
+										"runningSince": {
+											"type": "integer"
+										},
+										"totalCounter": {
+											"type": "integer"
+										},
+										"started": {
+											"type": "boolean"
+										},
+										"shutdown": {
+											"type": "boolean"
+										},
+										"inStandbyMode": {
+											"type": "boolean"
+										},
+										"threadPoolClass": {
+											"type": "string"
+										},
+										"threadPoolSize": {
+											"type": "integer"
+										},
+										"jpbStoreClass": {
+											"type": "string",
+											"description": "The job store class name (field kept as jpbStoreClass for backwards compatibility)"
+										},
+										"jpbStoreClustered": {
+											"type": "boolean"
+										},
+										"jpbStoreSupportsPersistence": {
+											"type": "boolean"
+										},
+										"currentExecutingJobs": {
+											"type": "integer"
+										},
+										"jobs": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"jobId": {
+														"type": "string"
+													},
+													"triggerType": {
+														"type": "string"
+													},
+													"cron": {
+														"type": "string"
+													},
+													"routeId": {
+														"type": "string"
+													},
+													"uri": {
+														"type": "string"
+													},
+													"prevFireTime": {
+														"type": "integer"
+													},
+													"fireTime": {
+														"type": "integer"
+													},
+													"nextFireTime": {
+														"type": "integer"
+													},
+													"finalFireTime": {
+														"type": "integer"
+													},
+													"recovering": {
+														"type": "boolean"
+													},
+													"refireCount": {
+														"type": "integer"
+													},
+													"misfireInstruction": {
+														"type": "integer"
+													}
+												},
+												"required": [
+													"recovering",
+													"refireCount",
+													"misfireInstruction"
+												]
+											},
+											"description": "Only present when there are any currently executing jobs"
+										},
+										"triggers": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string"
+													},
+													"triggerType": {
+														"type": "string"
+													},
+													"cron": {
+														"type": "string"
+													},
+													"repeatInterval": {
+														"type": "string"
+													}
+												}
+											},
+											"description": "Only present when there are any scheduled triggers"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -1130,7 +1130,87 @@
 						"description": "Debug output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"version": {
+											"type": "string",
+											"description": "The Camel version (only present when a backlog debugger is available)"
+										},
+										"enabled": {
+											"type": "boolean",
+											"description": "Whether the debugger is enabled (only present when a backlog debugger is available)"
+										},
+										"standby": {
+											"type": "boolean",
+											"description": "Whether the debugger is in standby mode (only present when a backlog debugger is available)"
+										},
+										"suspendedMode": {
+											"type": "boolean",
+											"description": "Whether suspended mode is active (only present when a backlog debugger is available)"
+										},
+										"fallbackTimeout": {
+											"type": "integer",
+											"description": "Fallback timeout in seconds (only present when a backlog debugger is available)"
+										},
+										"loggingLevel": {
+											"type": "string",
+											"description": "The logging level (only present when a backlog debugger is available)"
+										},
+										"includeExchangeProperties": {
+											"type": "boolean",
+											"description": "Whether exchange properties are included (only present when a backlog debugger is available)"
+										},
+										"includeFiles": {
+											"type": "boolean",
+											"description": "Whether file-based message bodies are included (only present when a backlog debugger is available)"
+										},
+										"includeStreams": {
+											"type": "boolean",
+											"description": "Whether streaming message bodies are included (only present when a backlog debugger is available)"
+										},
+										"maxChars": {
+											"type": "integer",
+											"description": "Maximum size of the message body to include (only present when a backlog debugger is available)"
+										},
+										"debugCounter": {
+											"type": "integer",
+											"description": "Total number of times a breakpoint has been hit (only present when a backlog debugger is available)"
+										},
+										"singleStepMode": {
+											"type": "boolean",
+											"description": "Whether single-step mode is active (only present when a backlog debugger is available)"
+										},
+										"breakpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"nodeId": {
+														"type": "string",
+														"description": "The breakpoint node ID"
+													},
+													"suspended": {
+														"type": "boolean",
+														"description": "Whether the breakpoint is currently suspended"
+													}
+												},
+												"required": [
+													"suspended"
+												]
+											},
+											"description": "The configured breakpoints (only present when there are any)"
+										},
+										"suspended": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "The suspended breakpoint messages, as opaque JSON objects enriched with source code and message history (only present when there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -1779,7 +1859,23 @@
 						"description": "Heap Dump output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"file": {
+											"type": "string",
+											"description": "The absolute path of the written heap dump file (only present on success)"
+										},
+										"size": {
+											"type": "integer",
+											"description": "The size in bytes of the written heap dump file (only present on success)"
+										},
+										"error": {
+											"type": "string",
+											"description": "The error message (only present on failure)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3157,7 +3253,70 @@
 						"description": "Camel Receive output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"messages": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "The dumped received messages, as opaque JSON objects (only present when dumping)"
+										},
+										"enabled": {
+											"type": "boolean",
+											"description": "Whether receiving is enabled (only present when not dumping)"
+										},
+										"total": {
+											"type": "integer",
+											"description": "Total number of messages received so far (only present when not dumping)"
+										},
+										"firstTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the first message in the last dump (only present when not dumping)"
+										},
+										"lastTimestamp": {
+											"type": "integer",
+											"description": "Epoch time in milliseconds of the last message in the last dump (only present when not dumping)"
+										},
+										"url": {
+											"type": "string",
+											"description": "The endpoint URI that receiving was started for (only present on success)"
+										},
+										"error": {
+											"type": "string",
+											"description": "The error message (only present on failure to start receiving)"
+										},
+										"stackTrace": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "The error stack trace, one entry per line (only present on failure to start receiving)"
+										},
+										"endpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"uri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"remote": {
+														"type": "boolean",
+														"description": "Whether the endpoint is remote"
+													}
+												},
+												"required": [
+													"remote"
+												]
+											},
+											"description": "The active consumer endpoints (only present when not dumping and there are any)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3279,7 +3438,80 @@
 						"description": "Rest output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"rests": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"url": {
+														"type": "string",
+														"description": "The absolute URL to the REST service"
+													},
+													"method": {
+														"type": "string",
+														"description": "The HTTP method"
+													},
+													"contractFirst": {
+														"type": "boolean",
+														"description": "Whether the REST service is contract-first"
+													},
+													"specification": {
+														"type": "boolean",
+														"description": "Whether this is the API contract specification (i.e. api-doc)"
+													},
+													"state": {
+														"type": "string",
+														"description": "The REST service state"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when known)"
+													},
+													"operationId": {
+														"type": "string",
+														"description": "The OpenAPI operation ID (only present for contract-first routes)"
+													},
+													"specificationUri": {
+														"type": "string",
+														"description": "The OpenAPI specification URI (only present for contract-first routes)"
+													},
+													"consumes": {
+														"type": "string",
+														"description": "The accepted media types (only present when known)"
+													},
+													"produces": {
+														"type": "string",
+														"description": "The returned media types (only present when known)"
+													},
+													"inType": {
+														"type": "string",
+														"description": "The input binding class name (only present when known)"
+													},
+													"outType": {
+														"type": "string",
+														"description": "The output binding class name (only present when known)"
+													},
+													"description": {
+														"type": "string",
+														"description": "The REST service description (only present when configured)"
+													},
+													"hits": {
+														"type": "integer",
+														"description": "Usage of the REST service (only present when greater than zero)"
+													}
+												},
+												"required": [
+													"contractFirst",
+													"specification"
+												]
+											},
+											"description": "The REST services (only present when a REST registry is available)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3307,7 +3539,32 @@
 						"description": "Rest Spec output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"specs": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"specificationUri": {
+														"type": "string",
+														"description": "The OpenAPI specification URI"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID (only present when known)"
+													},
+													"content": {
+														"type": "string",
+														"description": "The specification content (only present when it could be loaded)"
+													}
+												}
+											},
+											"description": "The OpenAPI specifications"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3358,7 +3615,369 @@
 						"description": "Route output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"group": {
+														"type": "string",
+														"description": "The route group (only present when known)"
+													},
+													"nodePrefixId": {
+														"type": "string",
+														"description": "The node prefix ID (only present when known)"
+													},
+													"description": {
+														"type": "string",
+														"description": "The route description (only present when configured)"
+													},
+													"note": {
+														"type": "string",
+														"description": "The route note (only present when configured)"
+													},
+													"createdByKamelet": {
+														"type": "boolean",
+														"description": "Whether the route was created by a Kamelet"
+													},
+													"createdByRouteTemplate": {
+														"type": "boolean",
+														"description": "Whether the route was created by a route template"
+													},
+													"from": {
+														"type": "string",
+														"description": "The route's endpoint URI"
+													},
+													"remote": {
+														"type": "boolean",
+														"description": "Whether the endpoint is remote"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source location (only present when known)"
+													},
+													"state": {
+														"type": "string",
+														"description": "The route state"
+													},
+													"supportsSuspension": {
+														"type": "boolean",
+														"description": "Whether the route supports suspension"
+													},
+													"uptime": {
+														"type": "string",
+														"description": "Route uptime, human readable text"
+													},
+													"lastError": {
+														"type": "object",
+														"properties": {
+															"phase": {
+																"type": "string",
+																"description": "The error phase"
+															},
+															"timestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds when the error happened"
+															},
+															"message": {
+																"type": "string",
+																"description": "The error message (only present when known)"
+															},
+															"stackTrace": {
+																"type": "array",
+																"items": {
+																	"type": "string"
+																},
+																"description": "The error stack trace, one entry per line (only present when known)"
+															}
+														},
+														"required": [
+															"timestamp"
+														],
+														"description": "The last lifecycle error (only present when one has occurred)"
+													},
+													"statistics": {
+														"type": "object",
+														"properties": {
+															"coverage": {
+																"type": "string",
+																"description": "Route coverage (only present when computable)"
+															},
+															"load01": {
+																"type": "string",
+																"description": "1 minute load average (only present when available)"
+															},
+															"load05": {
+																"type": "string",
+																"description": "5 minute load average (only present when available)"
+															},
+															"load15": {
+																"type": "string",
+																"description": "15 minute load average (only present when available)"
+															},
+															"exchangesThroughput": {
+																"type": "string",
+																"description": "Messages per second throughput (only present when available)"
+															},
+															"idleSince": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds since the route has been idle"
+															},
+															"exchangesTotal": {
+																"type": "integer",
+																"description": "Total number of exchanges"
+															},
+															"exchangesFailed": {
+																"type": "integer",
+																"description": "Number of failed exchanges"
+															},
+															"exchangesInflight": {
+																"type": "integer",
+																"description": "Number of inflight exchanges"
+															},
+															"meanProcessingTime": {
+																"type": "integer",
+																"description": "Mean processing time in milliseconds"
+															},
+															"maxProcessingTime": {
+																"type": "integer",
+																"description": "Max processing time in milliseconds"
+															},
+															"minProcessingTime": {
+																"type": "integer",
+																"description": "Min processing time in milliseconds"
+															},
+															"p50ProcessingTime": {
+																"type": "integer",
+																"description": "50th percentile processing time in milliseconds (only present when available)"
+															},
+															"p95ProcessingTime": {
+																"type": "integer",
+																"description": "95th percentile processing time in milliseconds (only present when available)"
+															},
+															"p99ProcessingTime": {
+																"type": "integer",
+																"description": "99th percentile processing time in milliseconds (only present when available)"
+															},
+															"lastProcessingTime": {
+																"type": "integer",
+																"description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+															},
+															"deltaProcessingTime": {
+																"type": "integer",
+																"description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+															},
+															"lastCreatedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+															},
+															"lastCompletedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+															},
+															"lastFailureHandledExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+															},
+															"lastFailedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+															}
+														},
+														"required": [
+															"idleSince",
+															"exchangesTotal",
+															"exchangesFailed",
+															"exchangesInflight",
+															"meanProcessingTime",
+															"maxProcessingTime",
+															"minProcessingTime"
+														],
+														"description": "Runtime statistics"
+													},
+													"processors": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"routeId": {
+																	"type": "string",
+																	"description": "The route ID"
+																},
+																"id": {
+																	"type": "string",
+																	"description": "The processor ID"
+																},
+																"nodePrefixId": {
+																	"type": "string",
+																	"description": "The node prefix ID (only present when known)"
+																},
+																"description": {
+																	"type": "string",
+																	"description": "The processor description (only present when configured)"
+																},
+																"note": {
+																	"type": "string",
+																	"description": "The processor note (only present when configured)"
+																},
+																"source": {
+																	"type": "string",
+																	"description": "The source location, optionally with a line number suffix (only present when known)"
+																},
+																"state": {
+																	"type": "string",
+																	"description": "The processor state"
+																},
+																"disabled": {
+																	"type": "boolean",
+																	"description": "Whether the processor is disabled (only present when known)"
+																},
+																"stepId": {
+																	"type": "string",
+																	"description": "The step ID (only present when known)"
+																},
+																"code": {
+																	"type": "array",
+																	"items": {
+																		"type": "object",
+																		"properties": {
+																			"line": {
+																				"type": "integer",
+																				"description": "The source line number (only present when known)"
+																			},
+																			"code": {
+																				"type": "string",
+																				"description": "The source code line"
+																			},
+																			"match": {
+																				"type": "boolean",
+																				"description": "Whether this is the matched line (only present when true)"
+																			}
+																		}
+																	},
+																	"description": "A snippet of source code around the processor (only present when known)"
+																},
+																"processor": {
+																	"type": "string",
+																	"description": "The processor name"
+																},
+																"level": {
+																	"type": "integer",
+																	"description": "The processor level in the route tree"
+																},
+																"uri": {
+																	"type": "string",
+																	"description": "The destination URI, for processors that send to a destination (only present when applicable)"
+																},
+																"statistics": {
+																	"type": "object",
+																	"properties": {
+																		"idleSince": {
+																			"type": "integer",
+																			"description": "Epoch time in milliseconds since the processor has been idle"
+																		},
+																		"exchangesTotal": {
+																			"type": "integer",
+																			"description": "Total number of exchanges"
+																		},
+																		"exchangesFailed": {
+																			"type": "integer",
+																			"description": "Number of failed exchanges"
+																		},
+																		"exchangesInflight": {
+																			"type": "integer",
+																			"description": "Number of inflight exchanges"
+																		},
+																		"exchangesThroughput": {
+																			"type": "string",
+																			"description": "Messages per second throughput (only present when available)"
+																		},
+																		"meanProcessingTime": {
+																			"type": "integer",
+																			"description": "Mean processing time in milliseconds"
+																		},
+																		"maxProcessingTime": {
+																			"type": "integer",
+																			"description": "Max processing time in milliseconds"
+																		},
+																		"minProcessingTime": {
+																			"type": "integer",
+																			"description": "Min processing time in milliseconds"
+																		},
+																		"p50ProcessingTime": {
+																			"type": "integer",
+																			"description": "50th percentile processing time in milliseconds (only present when available)"
+																		},
+																		"p95ProcessingTime": {
+																			"type": "integer",
+																			"description": "95th percentile processing time in milliseconds (only present when available)"
+																		},
+																		"p99ProcessingTime": {
+																			"type": "integer",
+																			"description": "99th percentile processing time in milliseconds (only present when available)"
+																		},
+																		"lastProcessingTime": {
+																			"type": "integer",
+																			"description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+																		},
+																		"deltaProcessingTime": {
+																			"type": "integer",
+																			"description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+																		},
+																		"lastCreatedExchangeTimestamp": {
+																			"type": "integer",
+																			"description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+																		},
+																		"lastCompletedExchangeTimestamp": {
+																			"type": "integer",
+																			"description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+																		},
+																		"lastFailureHandledExchangeTimestamp": {
+																			"type": "integer",
+																			"description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+																		},
+																		"lastFailedExchangeTimestamp": {
+																			"type": "integer",
+																			"description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+																		}
+																	},
+																	"required": [
+																		"idleSince",
+																		"exchangesTotal",
+																		"exchangesFailed",
+																		"exchangesInflight",
+																		"meanProcessingTime",
+																		"maxProcessingTime",
+																		"minProcessingTime"
+																	],
+																	"description": "Runtime statistics"
+																}
+															},
+															"required": [
+																"level"
+															]
+														},
+														"description": "The route's processors (only present when requested)"
+													}
+												},
+												"required": [
+													"createdByKamelet",
+													"createdByRouteTemplate",
+													"remote",
+													"supportsSuspension"
+												]
+											},
+											"description": "The routes (only present when no action was requested)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -5156,7 +5775,223 @@
 						"description": "Top Routes output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"from": {
+														"type": "string",
+														"description": "The route's endpoint URI"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source location (only present when known)"
+													},
+													"state": {
+														"type": "string",
+														"description": "The route state"
+													},
+													"uptime": {
+														"type": "string",
+														"description": "Route uptime, human readable text"
+													},
+													"statistics": {
+														"type": "object",
+														"properties": {
+															"exchangesTotal": {
+																"type": "integer",
+																"description": "Total number of exchanges"
+															},
+															"exchangesFailed": {
+																"type": "integer",
+																"description": "Number of failed exchanges"
+															},
+															"exchangesInflight": {
+																"type": "integer",
+																"description": "Number of inflight exchanges"
+															},
+															"meanProcessingTime": {
+																"type": "integer",
+																"description": "Mean processing time in milliseconds"
+															},
+															"maxProcessingTime": {
+																"type": "integer",
+																"description": "Max processing time in milliseconds"
+															},
+															"minProcessingTime": {
+																"type": "integer",
+																"description": "Min processing time in milliseconds"
+															},
+															"lastProcessingTime": {
+																"type": "integer",
+																"description": "Processing time in milliseconds of the last exchange"
+															},
+															"deltaProcessingTime": {
+																"type": "integer",
+																"description": "Difference in processing time in milliseconds since the previous exchange"
+															},
+															"totalProcessingTime": {
+																"type": "integer",
+																"description": "Total accumulated processing time in milliseconds"
+															},
+															"exchangesThroughput": {
+																"type": "string",
+																"description": "Messages per second throughput (only present when available)"
+															},
+															"p50ProcessingTime": {
+																"type": "integer",
+																"description": "50th percentile processing time in milliseconds (only present when available)"
+															},
+															"p95ProcessingTime": {
+																"type": "integer",
+																"description": "95th percentile processing time in milliseconds (only present when available)"
+															},
+															"p99ProcessingTime": {
+																"type": "integer",
+																"description": "99th percentile processing time in milliseconds (only present when available)"
+															}
+														},
+														"required": [
+															"exchangesTotal",
+															"exchangesFailed",
+															"exchangesInflight",
+															"meanProcessingTime",
+															"maxProcessingTime",
+															"minProcessingTime",
+															"lastProcessingTime",
+															"deltaProcessingTime",
+															"totalProcessingTime"
+														],
+														"description": "Runtime statistics"
+													}
+												}
+											},
+											"description": "The top routes (only present when no processor path was requested)"
+										},
+										"processors": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"processorId": {
+														"type": "string",
+														"description": "The processor ID"
+													},
+													"location": {
+														"type": "string",
+														"description": "The source location, optionally with a line number suffix (only present when known)"
+													},
+													"code": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"line": {
+																	"type": "integer",
+																	"description": "The source line number"
+																},
+																"match": {
+																	"type": "boolean",
+																	"description": "Whether this is the matched line (only present when true)"
+																},
+																"code": {
+																	"type": "string",
+																	"description": "The source code line"
+																}
+															},
+															"required": [
+																"line"
+															]
+														},
+														"description": "A snippet of source code around the processor (only present when known)"
+													},
+													"statistics": {
+														"type": "object",
+														"properties": {
+															"exchangesTotal": {
+																"type": "integer",
+																"description": "Total number of exchanges"
+															},
+															"exchangesFailed": {
+																"type": "integer",
+																"description": "Number of failed exchanges"
+															},
+															"exchangesInflight": {
+																"type": "integer",
+																"description": "Number of inflight exchanges"
+															},
+															"meanProcessingTime": {
+																"type": "integer",
+																"description": "Mean processing time in milliseconds"
+															},
+															"maxProcessingTime": {
+																"type": "integer",
+																"description": "Max processing time in milliseconds"
+															},
+															"minProcessingTime": {
+																"type": "integer",
+																"description": "Min processing time in milliseconds"
+															},
+															"lastProcessingTime": {
+																"type": "integer",
+																"description": "Processing time in milliseconds of the last exchange"
+															},
+															"deltaProcessingTime": {
+																"type": "integer",
+																"description": "Difference in processing time in milliseconds since the previous exchange"
+															},
+															"totalProcessingTime": {
+																"type": "integer",
+																"description": "Total accumulated processing time in milliseconds"
+															},
+															"exchangesThroughput": {
+																"type": "string",
+																"description": "Messages per second throughput (only present when available)"
+															},
+															"p50ProcessingTime": {
+																"type": "integer",
+																"description": "50th percentile processing time in milliseconds (only present when available)"
+															},
+															"p95ProcessingTime": {
+																"type": "integer",
+																"description": "95th percentile processing time in milliseconds (only present when available)"
+															},
+															"p99ProcessingTime": {
+																"type": "integer",
+																"description": "99th percentile processing time in milliseconds (only present when available)"
+															}
+														},
+														"required": [
+															"exchangesTotal",
+															"exchangesFailed",
+															"exchangesInflight",
+															"meanProcessingTime",
+															"maxProcessingTime",
+															"minProcessingTime",
+															"lastProcessingTime",
+															"deltaProcessingTime",
+															"totalProcessingTime"
+														],
+														"description": "Runtime statistics"
+													}
+												}
+											},
+											"description": "The top processors of a route (only present when a processor path was requested)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -5200,7 +6035,83 @@
 						"description": "Camel Tracing output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"enabled": {
+											"type": "boolean",
+											"description": "Whether tracing is enabled (only present when a backlog tracer is available)"
+										},
+										"traces": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "The traced messages, as opaque JSON objects (only present when dumping)"
+										},
+										"standby": {
+											"type": "boolean",
+											"description": "Whether the tracer is in standby mode (only present when not dumping)"
+										},
+										"counter": {
+											"type": "integer",
+											"description": "Total number of traced messages (only present when not dumping)"
+										},
+										"backlogSize": {
+											"type": "integer",
+											"description": "The current backlog size (only present when not dumping)"
+										},
+										"queueSize": {
+											"type": "integer",
+											"description": "The current queue size (only present when not dumping)"
+										},
+										"removeOnDump": {
+											"type": "boolean",
+											"description": "Whether messages are removed from the backlog when dumped (only present when not dumping)"
+										},
+										"traceFilter": {
+											"type": "string",
+											"description": "The trace filter (only present when configured)"
+										},
+										"tracePattern": {
+											"type": "string",
+											"description": "The trace pattern (only present when configured)"
+										},
+										"traceRests": {
+											"type": "boolean",
+											"description": "Whether rests are traced (only present when not dumping)"
+										},
+										"traceTemplates": {
+											"type": "boolean",
+											"description": "Whether route templates\/Kamelets are traced (only present when not dumping)"
+										},
+										"bodyMaxChars": {
+											"type": "integer",
+											"description": "Maximum size of the message body to include (only present when not dumping)"
+										},
+										"bodyIncludeFiles": {
+											"type": "boolean",
+											"description": "Whether file-based message bodies are included (only present when not dumping)"
+										},
+										"bodyIncludeStreams": {
+											"type": "boolean",
+											"description": "Whether streaming message bodies are included (only present when not dumping)"
+										},
+										"includeExchangeProperties": {
+											"type": "boolean",
+											"description": "Whether exchange properties are included (only present when not dumping)"
+										},
+										"includeExchangeVariables": {
+											"type": "boolean",
+											"description": "Whether exchange variables are included (only present when not dumping)"
+										},
+										"includeException": {
+											"type": "boolean",
+											"description": "Whether exceptions are included (only present when not dumping)"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -8082,7 +8082,44 @@
 						"description": "Variables output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"repositories": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "The variable repository id"
+													},
+													"variables": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string",
+																	"description": "The variable name"
+																},
+																"type": {
+																	"type": "string",
+																	"description": "The variable value type (only present when the value is known)"
+																},
+																"value": {
+																	"description": "The variable value (only present when known)"
+																}
+															}
+														},
+														"description": "The variables in this repository"
+													}
+												}
+											},
+											"description": "The variable repositories (only present when there are any with variables)"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles-openapi.json
@@ -1966,7 +1966,69 @@
 						"description": "Internal Tasks output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"tasks": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string",
+														"description": "The task name"
+													},
+													"status": {
+														"type": "string",
+														"description": "The task status"
+													},
+													"attempting": {
+														"type": "boolean",
+														"description": "Whether the task is currently attempting"
+													},
+													"attempts": {
+														"type": "integer",
+														"description": "The current number of iterations"
+													},
+													"delay": {
+														"type": "integer",
+														"description": "The current computed delay"
+													},
+													"elapsed": {
+														"type": "integer",
+														"description": "The current elapsed time"
+													},
+													"firstTime": {
+														"type": "integer",
+														"description": "The time the first attempt was performed"
+													},
+													"lastTime": {
+														"type": "integer",
+														"description": "The time the last attempt was performed"
+													},
+													"nextTime": {
+														"type": "integer",
+														"description": "The time the next attempt will be made"
+													},
+													"error": {
+														"type": "string",
+														"description": "The failure message (only present when known)"
+													}
+												},
+												"required": [
+													"attempting",
+													"attempts",
+													"delay",
+													"elapsed",
+													"firstTime",
+													"lastTime",
+													"nextTime"
+												]
+											},
+											"description": "The internal tasks"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3515,7 +3577,145 @@
 						"description": "Route Group output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routeGroups": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"group": {
+														"type": "string",
+														"description": "The route group ID"
+													},
+													"size": {
+														"type": "integer",
+														"description": "Number of routes in this group"
+													},
+													"state": {
+														"type": "string",
+														"description": "The route group state"
+													},
+													"uptime": {
+														"type": "string",
+														"description": "Route uptime, human readable text"
+													},
+													"routeIds": {
+														"type": "array",
+														"items": {
+															"type": "string"
+														},
+														"description": "The route IDs within this group"
+													},
+													"statistics": {
+														"type": "object",
+														"properties": {
+															"coverage": {
+																"type": "string",
+																"description": "Route coverage (only present when computable)"
+															},
+															"load01": {
+																"type": "string",
+																"description": "1 minute load average (only present when available)"
+															},
+															"load05": {
+																"type": "string",
+																"description": "5 minute load average (only present when available)"
+															},
+															"load15": {
+																"type": "string",
+																"description": "15 minute load average (only present when available)"
+															},
+															"exchangesThroughput": {
+																"type": "string",
+																"description": "Messages per second throughput (only present when available)"
+															},
+															"idleSince": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds since the route group has been idle"
+															},
+															"exchangesTotal": {
+																"type": "integer",
+																"description": "Total number of exchanges"
+															},
+															"exchangesFailed": {
+																"type": "integer",
+																"description": "Number of failed exchanges"
+															},
+															"exchangesInflight": {
+																"type": "integer",
+																"description": "Number of inflight exchanges"
+															},
+															"meanProcessingTime": {
+																"type": "integer",
+																"description": "Mean processing time in milliseconds"
+															},
+															"maxProcessingTime": {
+																"type": "integer",
+																"description": "Max processing time in milliseconds"
+															},
+															"minProcessingTime": {
+																"type": "integer",
+																"description": "Min processing time in milliseconds"
+															},
+															"p50ProcessingTime": {
+																"type": "integer",
+																"description": "50th percentile processing time in milliseconds (only present when available)"
+															},
+															"p95ProcessingTime": {
+																"type": "integer",
+																"description": "95th percentile processing time in milliseconds (only present when available)"
+															},
+															"p99ProcessingTime": {
+																"type": "integer",
+																"description": "99th percentile processing time in milliseconds (only present when available)"
+															},
+															"lastProcessingTime": {
+																"type": "integer",
+																"description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+															},
+															"deltaProcessingTime": {
+																"type": "integer",
+																"description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+															},
+															"lastCreatedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+															},
+															"lastCompletedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+															},
+															"lastFailureHandledExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+															},
+															"lastFailedExchangeTimestamp": {
+																"type": "integer",
+																"description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+															}
+														},
+														"required": [
+															"idleSince",
+															"exchangesTotal",
+															"exchangesFailed",
+															"exchangesInflight",
+															"meanProcessingTime",
+															"maxProcessingTime",
+															"minProcessingTime"
+														],
+														"description": "Runtime statistics"
+													}
+												},
+												"required": [
+													"size"
+												]
+											},
+											"description": "The route groups (only present when no action was requested)"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3572,7 +3772,90 @@
 						"description": "Route Structure output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"from": {
+														"type": "string",
+														"description": "The route's endpoint URI"
+													},
+													"source": {
+														"type": "string",
+														"description": "The source location (only present when known)"
+													},
+													"line": {
+														"type": "integer",
+														"description": "The source line number (only present when known)"
+													},
+													"description": {
+														"type": "string",
+														"description": "The route description (only present when configured)"
+													},
+													"code": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"line": {
+																	"type": "integer",
+																	"description": "The source line number, or a sequential counter when not known"
+																},
+																"type": {
+																	"type": "string",
+																	"description": "The processor type"
+																},
+																"id": {
+																	"type": "string",
+																	"description": "The processor ID"
+																},
+																"level": {
+																	"type": "integer",
+																	"description": "The nesting level"
+																},
+																"description": {
+																	"type": "string",
+																	"description": "The description (only present when known)"
+																},
+																"code": {
+																	"type": "string",
+																	"description": "The code representation of this processor"
+																},
+																"uri": {
+																	"type": "string",
+																	"description": "The endpoint URI (only present when this processor references an endpoint)"
+																},
+																"remote": {
+																	"type": "boolean",
+																	"description": "Whether the endpoint is remote (only present when true)"
+																},
+																"statistics": {
+																	"type": "object",
+																	"additionalProperties": true,
+																	"description": "Runtime statistics for this route or processor, as an opaque JSON object (only present when metrics were requested)"
+																}
+															},
+															"required": [
+																"line",
+																"level"
+															]
+														},
+														"description": "The route's structure, one entry per processor (only present when the dump succeeded)"
+													}
+												}
+											},
+											"description": "The routes"
+										}
+									}
+								}
 							}
 						}
 					}
@@ -3621,7 +3904,118 @@
 						"description": "Route Topology output",
 						"content": {
 							"application\/json": {
-								
+								"schema": {
+									"type": "object",
+									"properties": {
+										"nodes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"description": {
+														"type": "string",
+														"description": "The route description (only present when configured)"
+													},
+													"from": {
+														"type": "string",
+														"description": "The route's endpoint URI"
+													},
+													"fromScheme": {
+														"type": "string",
+														"description": "The route's endpoint scheme"
+													},
+													"nodeType": {
+														"type": "string",
+														"description": "The node type"
+													},
+													"exchangesTotal": {
+														"type": "integer",
+														"description": "Total number of exchanges (only present when metrics were requested and available)"
+													},
+													"exchangesFailed": {
+														"type": "integer",
+														"description": "Number of failed exchanges (only present when metrics were requested and available)"
+													}
+												}
+											},
+											"description": "The topology nodes (only present when a route topology dumper is available)"
+										},
+										"edges": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"fromRouteId": {
+														"type": "string",
+														"description": "The source route ID"
+													},
+													"toRouteId": {
+														"type": "string",
+														"description": "The target route ID"
+													},
+													"endpoint": {
+														"type": "string",
+														"description": "The endpoint URI connecting the two routes"
+													},
+													"connectionType": {
+														"type": "string",
+														"description": "The connection type"
+													}
+												}
+											},
+											"description": "The connections between nodes (only present when a route topology dumper is available)"
+										},
+										"externalEndpoints": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "The endpoint ID"
+													},
+													"uri": {
+														"type": "string",
+														"description": "The endpoint URI"
+													},
+													"scheme": {
+														"type": "string",
+														"description": "The endpoint scheme"
+													},
+													"direction": {
+														"type": "string",
+														"description": "The direction (in or out)"
+													},
+													"routeId": {
+														"type": "string",
+														"description": "The route ID"
+													},
+													"exchangesTotal": {
+														"type": "integer",
+														"description": "Total number of exchanges (only present when metrics were requested and available)"
+													},
+													"exchangesFailed": {
+														"type": "integer",
+														"description": "Number of failed exchanges (only present when metrics were requested and available)"
+													}
+												}
+											},
+											"description": "External systems the routes connect to (only present when requested and there are any)"
+										},
+										"routes": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"additionalProperties": true
+											},
+											"description": "Route structure data, as opaque JSON objects (only present when requested)"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles.properties
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles.properties
@@ -12,6 +12,7 @@ consumer
 context
 datasource
 debug
+dependency-downloader
 endpoint
 errors
 eval-language
@@ -28,6 +29,7 @@ ibm-secrets
 inflight
 internal-tasks
 java-security
+jbang
 jfr
 jfr-memory-leak
 jvm
@@ -64,6 +66,7 @@ service
 sftp
 simple-language
 source
+source-dir
 sql-query
 sql-trace
 startup-recorder

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/activity.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/activity.json
@@ -11,6 +11,90 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "activityEnabled": {
+        "type": "boolean",
+        "description": "Whether activity tracking is enabled"
+      },
+      "activitySize": {
+        "type": "integer",
+        "description": "The maximum number of activity entries retained"
+      },
+      "activity": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uid": {
+              "type": "integer",
+              "description": "Unique ID of the activity entry"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "fromEndpointUri": {
+              "type": "string",
+              "description": "The from endpoint URI (only present when known)"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "Elapsed time in milliseconds"
+            },
+            "failed": {
+              "type": "boolean",
+              "description": "Whether the exchange failed"
+            },
+            "exception": {
+              "type": "string",
+              "description": "The exception message (only present when the exchange failed)"
+            },
+            "endpointSends": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "endpointUri": {
+                    "type": "string",
+                    "description": "The endpoint URI"
+                  },
+                  "remoteEndpoint": {
+                    "type": "boolean",
+                    "description": "Whether the endpoint is remote"
+                  },
+                  "elapsed": {
+                    "type": "integer",
+                    "description": "Elapsed time in milliseconds"
+                  }
+                },
+                "required": [
+                  "remoteEndpoint",
+                  "elapsed"
+                ]
+              },
+              "description": "The endpoints this exchange was sent to (only present when any)"
+            }
+          },
+          "required": [
+            "uid",
+            "elapsed",
+            "failed"
+          ]
+        },
+        "description": "The recent activity entries"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/aws-secrets.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/aws-secrets.json
@@ -11,6 +11,64 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-aws-secrets-manager",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "region": {
+        "type": "string",
+        "description": "The AWS region (only present when the AWS Secrets Manager properties function is active)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when the AWS Secrets Manager properties function is active)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "refreshPeriod": {
+        "type": "integer",
+        "description": "The refresh period in milliseconds (only present when configured)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when the AWS Secrets Manager properties function is active)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/aws2-s3.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/aws2-s3.json
@@ -11,6 +11,56 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-aws2-s3",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "consumers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "bucket": {
+              "type": "string",
+              "description": "The S3 bucket name"
+            },
+            "accessKeys": {
+              "type": "boolean",
+              "description": "Whether static access keys are used"
+            },
+            "defaultCredentialsProvider": {
+              "type": "boolean",
+              "description": "Whether the default credentials provider is used"
+            },
+            "profileCredentialsProvider": {
+              "type": "boolean",
+              "description": "Whether the profile credentials provider is used"
+            },
+            "maxMessages": {
+              "type": "integer",
+              "description": "Maximum number of messages per poll"
+            },
+            "moveAfterRead": {
+              "type": "boolean",
+              "description": "Whether the object is moved after being read"
+            },
+            "deleteAfterRead": {
+              "type": "boolean",
+              "description": "Whether the object is deleted after being read"
+            }
+          },
+          "required": [
+            "accessKeys",
+            "defaultCredentialsProvider",
+            "profileCredentialsProvider",
+            "maxMessages",
+            "moveAfterRead",
+            "deleteAfterRead"
+          ]
+        },
+        "description": "The AWS S3 consumers (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/azure-secrets.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/azure-secrets.json
@@ -11,6 +11,60 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-azure-key-vault",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when the Azure Key Vault properties function is active)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "refreshPeriod": {
+        "type": "integer",
+        "description": "The refresh period in milliseconds (only present when configured)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when the Azure Key Vault properties function is active)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/bean-model.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/bean-model.json
@@ -57,6 +57,92 @@
       "defaultValue": true,
       "description": "Whether to include bean properties"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "beans": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The bean name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The bean type"
+            },
+            "initMethod": {
+              "type": "string",
+              "description": "The init method name (only present when configured)"
+            },
+            "destroyMethod": {
+              "type": "string",
+              "description": "The destroy method name (only present when configured)"
+            },
+            "builderClass": {
+              "type": "string",
+              "description": "The builder class name (only present when configured)"
+            },
+            "builderMethod": {
+              "type": "string",
+              "description": "The builder method name (only present when configured)"
+            },
+            "factoryBean": {
+              "type": "string",
+              "description": "The factory bean name (only present when configured)"
+            },
+            "factoryMethod": {
+              "type": "string",
+              "description": "The factory method name (only present when configured)"
+            },
+            "modelProperties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The property name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The property value type (only present when the value is known)"
+                  },
+                  "value": {
+                    "description": "The property value"
+                  }
+                }
+              },
+              "description": "The bean properties as declared in the DSL model (only present when there are any)"
+            },
+            "properties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The property name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The property value type (only present when the value is known)"
+                  },
+                  "value": {
+                    "description": "The property value"
+                  }
+                }
+              },
+              "description": "The bean properties resolved from the running bean instance (only present when there are any)"
+            }
+          }
+        },
+        "description": "The beans keyed by bean name"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/bean.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/bean.json
@@ -72,6 +72,48 @@
       "defaultValue": true,
       "description": "Whether to include bean properties"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "beans": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The bean name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The bean class type"
+            },
+            "properties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The property name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The property type (only present when the value is not null)"
+                  },
+                  "value": {
+                    "description": "The property value"
+                  }
+                }
+              },
+              "description": "The bean properties (only present when properties were requested and the bean has some)"
+            }
+          }
+        },
+        "description": "The beans, keyed by bean name"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/blocked.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/blocked.json
@@ -11,6 +11,46 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "blocked": {
+        "type": "integer",
+        "description": "Number of blocked exchanges"
+      },
+      "exchanges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "The node ID"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "The wait duration in milliseconds"
+            }
+          },
+          "required": [
+            "duration"
+          ]
+        },
+        "description": "The blocked exchanges (only present when there are any)"
+      }
+    },
+    "required": [
+      "blocked"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/browse.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/browse.json
@@ -116,6 +116,55 @@
       "secret": false,
       "description": "To receive N last messages from the tail"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "browse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "queueSize": {
+              "type": "integer",
+              "description": "Number of messages currently in the queue"
+            },
+            "limit": {
+              "type": "integer",
+              "description": "The maximum number of messages returned (only present when messages were dumped)"
+            },
+            "position": {
+              "type": "integer",
+              "description": "The starting position of the returned messages (only present when messages were dumped)"
+            },
+            "firstTimestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the first returned message (only present when available)"
+            },
+            "lastTimestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last returned message (only present when available)"
+            },
+            "messages": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": "The dumped messages, as opaque JSON objects (only present when messages were dumped and found)"
+            }
+          },
+          "required": [
+            "queueSize"
+          ]
+        },
+        "description": "The browsed endpoints"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/circuit-breaker.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/circuit-breaker.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "circuitBreakers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "state": {
+              "type": "string",
+              "description": "The circuit breaker state"
+            },
+            "successfulCalls": {
+              "type": "integer",
+              "description": "Number of successful calls"
+            },
+            "failedCalls": {
+              "type": "integer",
+              "description": "Number of failed calls"
+            }
+          },
+          "required": [
+            "successfulCalls",
+            "failedCalls"
+          ]
+        },
+        "description": "The circuit breakers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/consumer.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/consumer.json
@@ -11,6 +11,221 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "consumers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "state": {
+              "type": "string",
+              "description": "The consumer state"
+            },
+            "clazz": {
+              "type": "string",
+              "description": "The consumer service type"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "hosted": {
+              "type": "boolean",
+              "description": "Whether the consumer is a hosted service"
+            },
+            "inflight": {
+              "type": "integer",
+              "description": "Number of inflight exchanges"
+            },
+            "scheduled": {
+              "type": "boolean",
+              "description": "Whether the consumer is scheduled (a scheduled poll consumer or a timer consumer)"
+            },
+            "polling": {
+              "type": "boolean",
+              "description": "Whether currently polling (only present for scheduled poll consumers)"
+            },
+            "firstPollDone": {
+              "type": "boolean",
+              "description": "Whether the first poll has completed (only present for scheduled poll consumers)"
+            },
+            "schedulerStarted": {
+              "type": "boolean",
+              "description": "Whether the scheduler has started (only present for scheduled poll consumers)"
+            },
+            "schedulerClass": {
+              "type": "string",
+              "description": "The scheduler class name (only present for scheduled poll consumers)"
+            },
+            "repeatCount": {
+              "type": "integer",
+              "description": "The repeat count (only present for scheduled poll consumers)"
+            },
+            "fixedDelay": {
+              "type": "boolean",
+              "description": "Whether a fixed delay is used (only present for scheduled poll consumers)"
+            },
+            "initialDelay": {
+              "type": "integer",
+              "description": "The initial delay (only present for scheduled poll consumers)"
+            },
+            "delay": {
+              "type": "integer",
+              "description": "The delay (only present for scheduled poll consumers)"
+            },
+            "timeUnit": {
+              "type": "string",
+              "description": "The time unit of the delay (only present for scheduled poll consumers)"
+            },
+            "greedy": {
+              "type": "boolean",
+              "description": "Whether greedy scheduling is used (only present for scheduled poll consumers)"
+            },
+            "runningLoggingLevel": {
+              "type": "string",
+              "description": "The running logging level (only present for scheduled poll consumers or timer consumers)"
+            },
+            "totalCounter": {
+              "type": "integer",
+              "description": "Total number of polls (only present for scheduled poll consumers or timer consumers)"
+            },
+            "errorCounter": {
+              "type": "integer",
+              "description": "Number of failed polls (only present for scheduled poll consumers)"
+            },
+            "successCounter": {
+              "type": "integer",
+              "description": "Number of successful polls (only present for scheduled poll consumers)"
+            },
+            "backoffCounter": {
+              "type": "integer",
+              "description": "The backoff counter (only present for scheduled poll consumers)"
+            },
+            "backoffMultiplier": {
+              "type": "integer",
+              "description": "The backoff multiplier (only present for scheduled poll consumers)"
+            },
+            "backoffErrorThreshold": {
+              "type": "integer",
+              "description": "The backoff error threshold (only present for scheduled poll consumers)"
+            },
+            "backoffIdleThreshold": {
+              "type": "integer",
+              "description": "The backoff idle threshold (only present for scheduled poll consumers)"
+            },
+            "timerName": {
+              "type": "string",
+              "description": "The timer name (only present for camel-timer consumers)"
+            },
+            "fixedRate": {
+              "type": "boolean",
+              "description": "Whether a fixed rate is used (only present for camel-timer consumers)"
+            },
+            "period": {
+              "type": "integer",
+              "description": "The period (only present for camel-timer consumers)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the route has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics for the route"
+            }
+          },
+          "required": [
+            "remote",
+            "hosted",
+            "inflight",
+            "scheduled"
+          ]
+        },
+        "description": "The consumers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/context.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/context.json
@@ -11,6 +11,207 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The CamelContext name"
+      },
+      "description": {
+        "type": "string",
+        "description": "The CamelContext description (only present when configured)"
+      },
+      "profile": {
+        "type": "string",
+        "description": "The active profile (only present when configured)"
+      },
+      "version": {
+        "type": "string",
+        "description": "The Camel version"
+      },
+      "state": {
+        "type": "string",
+        "description": "The CamelContext state"
+      },
+      "phase": {
+        "type": "integer",
+        "description": "The CamelContext lifecycle phase"
+      },
+      "startTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the CamelContext was started (only present once started)"
+      },
+      "uptime": {
+        "type": "integer",
+        "description": "Uptime in milliseconds"
+      },
+      "devMode": {
+        "type": "boolean",
+        "description": "Whether dev mode (live reload) is active"
+      },
+      "statistics": {
+        "type": "object",
+        "properties": {
+          "routesTotal": {
+            "type": "integer",
+            "description": "Total number of routes"
+          },
+          "routesStarted": {
+            "type": "integer",
+            "description": "Number of started routes"
+          },
+          "load01": {
+            "type": "string",
+            "description": "1 minute load average (only present when available)"
+          },
+          "load05": {
+            "type": "string",
+            "description": "5 minute load average (only present when available)"
+          },
+          "load15": {
+            "type": "string",
+            "description": "15 minute load average (only present when available)"
+          },
+          "exchangesThroughput": {
+            "type": "string",
+            "description": "Messages per second throughput (only present when available)"
+          },
+          "idleSince": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds since the context has been idle"
+          },
+          "exchangesTotal": {
+            "type": "integer",
+            "description": "Total number of exchanges"
+          },
+          "exchangesFailed": {
+            "type": "integer",
+            "description": "Number of failed exchanges"
+          },
+          "exchangesInflight": {
+            "type": "integer",
+            "description": "Number of inflight exchanges"
+          },
+          "remoteExchangesTotal": {
+            "type": "integer",
+            "description": "Total number of remote exchanges"
+          },
+          "remoteExchangesFailed": {
+            "type": "integer",
+            "description": "Number of failed remote exchanges"
+          },
+          "remoteExchangesInflight": {
+            "type": "integer",
+            "description": "Number of inflight remote exchanges"
+          },
+          "meanProcessingTime": {
+            "type": "integer",
+            "description": "Mean processing time in milliseconds"
+          },
+          "maxProcessingTime": {
+            "type": "integer",
+            "description": "Max processing time in milliseconds"
+          },
+          "minProcessingTime": {
+            "type": "integer",
+            "description": "Min processing time in milliseconds"
+          },
+          "p50ProcessingTime": {
+            "type": "integer",
+            "description": "50th percentile processing time in milliseconds (only present when available)"
+          },
+          "p95ProcessingTime": {
+            "type": "integer",
+            "description": "95th percentile processing time in milliseconds (only present when available)"
+          },
+          "p99ProcessingTime": {
+            "type": "integer",
+            "description": "99th percentile processing time in milliseconds (only present when available)"
+          },
+          "lastProcessingTime": {
+            "type": "integer",
+            "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+          },
+          "deltaProcessingTime": {
+            "type": "integer",
+            "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+          },
+          "lastCreatedExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+          },
+          "lastCompletedExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+          },
+          "lastFailureHandledExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+          },
+          "lastFailedExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+          },
+          "reload": {
+            "type": "object",
+            "properties": {
+              "reloaded": {
+                "type": "integer",
+                "description": "Number of successful reloads"
+              },
+              "failed": {
+                "type": "integer",
+                "description": "Number of failed reloads"
+              },
+              "lastError": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "The error message"
+                  },
+                  "stackTrace": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "The error stack trace, one entry per line"
+                  }
+                },
+                "description": "The last reload error (only present when a reload has failed)"
+              }
+            },
+            "required": [
+              "reloaded",
+              "failed"
+            ],
+            "description": "Reload statistics"
+          }
+        },
+        "required": [
+          "routesTotal",
+          "routesStarted",
+          "idleSince",
+          "exchangesTotal",
+          "exchangesFailed",
+          "exchangesInflight",
+          "remoteExchangesTotal",
+          "remoteExchangesFailed",
+          "remoteExchangesInflight",
+          "meanProcessingTime",
+          "maxProcessingTime",
+          "minProcessingTime"
+        ],
+        "description": "Runtime statistics (only present when management is enabled)"
+      }
+    },
+    "required": [
+      "phase",
+      "uptime",
+      "devMode"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/datasource.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/datasource.json
@@ -11,6 +11,68 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "dataSources": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The registry bean name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The DataSource implementation class"
+            },
+            "poolType": {
+              "type": "string",
+              "description": "The detected connection pool type: HikariCP, Agroal, or Unknown"
+            },
+            "poolName": {
+              "type": "string",
+              "description": "The pool name (HikariCP only)"
+            },
+            "maxPoolSize": {
+              "type": "integer",
+              "description": "The maximum pool size (only present once the pool is initialized)"
+            },
+            "active": {
+              "type": "integer",
+              "description": "Number of active connections (only present once the pool is initialized)"
+            },
+            "idle": {
+              "type": "integer",
+              "description": "Number of idle connections (only present once the pool is initialized)"
+            },
+            "total": {
+              "type": "integer",
+              "description": "Total number of connections (only present once the pool is initialized)"
+            },
+            "waiting": {
+              "type": "integer",
+              "description": "Number of threads awaiting a connection (HikariCP only)"
+            },
+            "maxUsed": {
+              "type": "integer",
+              "description": "Maximum number of connections used at once (Agroal only)"
+            },
+            "leakDetection": {
+              "type": "integer",
+              "description": "Number of leak detections (Agroal only)"
+            },
+            "created": {
+              "type": "integer",
+              "description": "Number of connections created (Agroal only)"
+            }
+          }
+        },
+        "description": "The DataSources"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/debug.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/debug.json
@@ -85,6 +85,87 @@
       "secret": false,
       "description": "The position to step to"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "version": {
+        "type": "string",
+        "description": "The Camel version (only present when a backlog debugger is available)"
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether the debugger is enabled (only present when a backlog debugger is available)"
+      },
+      "standby": {
+        "type": "boolean",
+        "description": "Whether the debugger is in standby mode (only present when a backlog debugger is available)"
+      },
+      "suspendedMode": {
+        "type": "boolean",
+        "description": "Whether suspended mode is active (only present when a backlog debugger is available)"
+      },
+      "fallbackTimeout": {
+        "type": "integer",
+        "description": "Fallback timeout in seconds (only present when a backlog debugger is available)"
+      },
+      "loggingLevel": {
+        "type": "string",
+        "description": "The logging level (only present when a backlog debugger is available)"
+      },
+      "includeExchangeProperties": {
+        "type": "boolean",
+        "description": "Whether exchange properties are included (only present when a backlog debugger is available)"
+      },
+      "includeFiles": {
+        "type": "boolean",
+        "description": "Whether file-based message bodies are included (only present when a backlog debugger is available)"
+      },
+      "includeStreams": {
+        "type": "boolean",
+        "description": "Whether streaming message bodies are included (only present when a backlog debugger is available)"
+      },
+      "maxChars": {
+        "type": "integer",
+        "description": "Maximum size of the message body to include (only present when a backlog debugger is available)"
+      },
+      "debugCounter": {
+        "type": "integer",
+        "description": "Total number of times a breakpoint has been hit (only present when a backlog debugger is available)"
+      },
+      "singleStepMode": {
+        "type": "boolean",
+        "description": "Whether single-step mode is active (only present when a backlog debugger is available)"
+      },
+      "breakpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "nodeId": {
+              "type": "string",
+              "description": "The breakpoint node ID"
+            },
+            "suspended": {
+              "type": "boolean",
+              "description": "Whether the breakpoint is currently suspended"
+            }
+          },
+          "required": [
+            "suspended"
+          ]
+        },
+        "description": "The configured breakpoints (only present when there are any)"
+      },
+      "suspended": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The suspended breakpoint messages, as opaque JSON objects enriched with source code and message history (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/dependency-downloader.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/dependency-downloader.json
@@ -44,22 +44,28 @@
           "type": "object",
           "properties": {
             "groupId": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven group id"
             },
             "artifactId": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven artifact id"
             },
             "version": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven version"
             },
             "repoId": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven repository id the artifact was downloaded from"
             },
             "repoUrl": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven repository URL the artifact was downloaded from"
             },
             "elapsed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The download time in milliseconds"
             }
           },
           "required": [

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/dependency-downloader.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/dependency-downloader.json
@@ -1,0 +1,74 @@
+{
+  "console": {
+    "kind": "console",
+    "group": "camel-jbang",
+    "name": "dependency-downloader",
+    "title": "Maven Dependency Downloader",
+    "description": "Displays information about dependencies downloaded at runtime",
+    "deprecated": false,
+    "readOnly": true,
+    "javaType": "org.apache.camel.main.console.DependencyDownloaderConsole",
+    "groupId": "org.apache.camel",
+    "artifactId": "camel-kamelet-main",
+    "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "dependencies": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The downloaded dependency class-path entries (only present when the application classloader manages downloads)"
+      },
+      "offline": {
+        "type": "boolean",
+        "description": "Whether downloading is disabled (only present when a downloader is active)"
+      },
+      "fresh": {
+        "type": "boolean",
+        "description": "Whether fresh downloads are forced (only present when a downloader is active)"
+      },
+      "verbose": {
+        "type": "boolean",
+        "description": "Whether verbose logging is enabled (only present when a downloader is active)"
+      },
+      "repos": {
+        "type": "string",
+        "description": "The extra Maven repositories (only present when a downloader is active)"
+      },
+      "downloads": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "artifactId": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "repoId": {
+              "type": "string"
+            },
+            "repoUrl": {
+              "type": "string"
+            },
+            "elapsed": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "elapsed"
+          ]
+        },
+        "description": "The downloaded artifacts (only present when a downloader is active)"
+      }
+    }
+  }
+}
+

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/endpoint.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/endpoint.json
@@ -11,6 +11,94 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "size": {
+        "type": "integer",
+        "description": "Total number of endpoints"
+      },
+      "staticSize": {
+        "type": "integer",
+        "description": "Number of endpoints in the static registry"
+      },
+      "dynamicSize": {
+        "type": "integer",
+        "description": "Number of endpoints in the dynamic registry"
+      },
+      "maximumCacheSize": {
+        "type": "integer",
+        "description": "Maximum number of entries to store in the dynamic registry"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "stub": {
+              "type": "boolean",
+              "description": "Whether the endpoint is a stub endpoint"
+            },
+            "direction": {
+              "type": "string",
+              "description": "Whether the endpoint is used as input or output (in or out) (only present when runtime endpoint registry statistics are available)"
+            },
+            "hits": {
+              "type": "integer",
+              "description": "Usage of the endpoint (only present when runtime endpoint registry statistics are available)"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when runtime endpoint registry statistics are available and the endpoint is associated with a route)"
+            },
+            "minBodySize": {
+              "type": "integer",
+              "description": "Minimum message body size in bytes (only present when available)"
+            },
+            "maxBodySize": {
+              "type": "integer",
+              "description": "Maximum message body size in bytes (only present when available)"
+            },
+            "meanBodySize": {
+              "type": "integer",
+              "description": "Mean message body size in bytes (only present when available)"
+            },
+            "minHeadersSize": {
+              "type": "integer",
+              "description": "Minimum message headers size in bytes (only present when available)"
+            },
+            "maxHeadersSize": {
+              "type": "integer",
+              "description": "Maximum message headers size in bytes (only present when available)"
+            },
+            "meanHeadersSize": {
+              "type": "integer",
+              "description": "Mean message headers size in bytes (only present when available)"
+            }
+          },
+          "required": [
+            "remote",
+            "stub"
+          ]
+        },
+        "description": "The endpoints"
+      }
+    },
+    "required": [
+      "size",
+      "staticSize",
+      "dynamicSize",
+      "maximumCacheSize"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/errors.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/errors.json
@@ -98,6 +98,40 @@
       "defaultValue": false,
       "description": "Whether to include stack traces"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether the error registry is enabled"
+      },
+      "size": {
+        "type": "integer",
+        "description": "Number of captured errors"
+      },
+      "maximumEntries": {
+        "type": "integer",
+        "description": "The maximum number of entries retained"
+      },
+      "timeToLive": {
+        "type": "string",
+        "description": "The time to live for entries"
+      },
+      "errors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The captured errors; shape depends on the underlying message implementation"
+      }
+    },
+    "required": [
+      "enabled",
+      "size",
+      "maximumEntries"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/eval-language.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/eval-language.json
@@ -99,6 +99,24 @@
       "secret": false,
       "description": "Optional exchange variables"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "The evaluation status, success or failed (only present when a template was given)"
+      },
+      "result": {
+        "type": "string",
+        "description": "The evaluation result (only present on success)"
+      },
+      "exception": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The exception, as an opaque JSON object (only present on failure)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/event.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/event.json
@@ -11,6 +11,86 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "events": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The event type"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID (only present for exchange events)"
+            },
+            "message": {
+              "type": "string",
+              "description": "The event's string representation"
+            }
+          }
+        },
+        "description": "The most recent Camel events (only present when there are any)"
+      },
+      "routeEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The event type"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID (only present for exchange events)"
+            },
+            "message": {
+              "type": "string",
+              "description": "The event's string representation"
+            }
+          }
+        },
+        "description": "The most recent route events (only present when there are any)"
+      },
+      "exchangeEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The event type"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID (only present for exchange events)"
+            },
+            "message": {
+              "type": "string",
+              "description": "The event's string representation"
+            }
+          }
+        },
+        "description": "The most recent exchange events (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/fault-tolerance.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/fault-tolerance.json
@@ -11,6 +11,99 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-microprofile-fault-tolerance",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "circuitBreakers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The circuit breaker ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "state": {
+              "type": "string",
+              "description": "The circuit breaker state"
+            },
+            "successfulCalls": {
+              "type": "integer",
+              "description": "Number of successful calls"
+            },
+            "failedCalls": {
+              "type": "integer",
+              "description": "Number of failed calls"
+            },
+            "notPermittedCalls": {
+              "type": "integer",
+              "description": "Number of not-permitted calls"
+            },
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "delay": {
+                  "type": "integer",
+                  "description": "The delay in milliseconds"
+                },
+                "failureRatio": {
+                  "type": "number",
+                  "description": "The failure ratio"
+                },
+                "requestVolumeThreshold": {
+                  "type": "integer",
+                  "description": "The request volume threshold"
+                },
+                "successThreshold": {
+                  "type": "integer",
+                  "description": "The success threshold"
+                },
+                "bulkheadEnabled": {
+                  "type": "boolean",
+                  "description": "Whether the bulkhead is enabled"
+                },
+                "bulkheadMaxConcurrentCalls": {
+                  "type": "integer",
+                  "description": "The bulkhead maximum concurrent calls (only present when the bulkhead is enabled)"
+                },
+                "bulkheadWaitingTaskQueue": {
+                  "type": "integer",
+                  "description": "The bulkhead waiting task queue size (only present when the bulkhead is enabled)"
+                },
+                "timeoutEnabled": {
+                  "type": "boolean",
+                  "description": "Whether the timeout is enabled"
+                },
+                "timeoutDuration": {
+                  "type": "integer",
+                  "description": "The timeout duration in milliseconds (only present when the timeout is enabled)"
+                }
+              },
+              "required": [
+                "delay",
+                "failureRatio",
+                "requestVolumeThreshold",
+                "successThreshold",
+                "bulkheadEnabled",
+                "timeoutEnabled"
+              ],
+              "description": "The circuit breaker configuration"
+            }
+          },
+          "required": [
+            "successfulCalls",
+            "failedCalls",
+            "notPermittedCalls"
+          ]
+        },
+        "description": "The circuit breakers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/gc.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/gc.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "garbageCollectors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The garbage collector name"
+            },
+            "collectionCount": {
+              "type": "integer",
+              "description": "Number of collections"
+            },
+            "collectionTime": {
+              "type": "integer",
+              "description": "Total collection time in milliseconds"
+            },
+            "memoryPoolNames": {
+              "type": "string",
+              "description": "Comma separated list of memory pool names managed by this collector"
+            }
+          },
+          "required": [
+            "collectionCount",
+            "collectionTime"
+          ]
+        },
+        "description": "The garbage collectors"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/gcp-secrets.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/gcp-secrets.json
@@ -11,6 +11,60 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-google-secret-manager",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when the GCP Secret Manager properties function is active)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "refreshPeriod": {
+        "type": "integer",
+        "description": "The refresh period in milliseconds (only present when configured)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when the GCP Secret Manager properties function is active)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/groovy.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/groovy.json
@@ -11,6 +11,64 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-groovy",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "compiler": {
+        "type": "object",
+        "properties": {
+          "scriptPattern": {
+            "type": "string",
+            "description": "The script file name pattern"
+          },
+          "compiledCounter": {
+            "type": "integer",
+            "description": "Number of scripts compiled"
+          },
+          "preloadedCounter": {
+            "type": "integer",
+            "description": "Number of scripts pre-loaded"
+          },
+          "classesSize": {
+            "type": "integer",
+            "description": "Number of compiled classes"
+          },
+          "compiledTime": {
+            "type": "integer",
+            "description": "Total compile time in milliseconds"
+          },
+          "recompileEnabled": {
+            "type": "boolean",
+            "description": "Whether re-compilation is enabled"
+          },
+          "lastCompilationTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds of the last compilation"
+          },
+          "workDir": {
+            "type": "string",
+            "description": "The work directory (only present when configured)"
+          },
+          "classes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The compiled class names (only present when there are any)"
+          }
+        },
+        "required": [
+          "compiledCounter",
+          "preloadedCounter",
+          "classesSize",
+          "compiledTime",
+          "recompileEnabled",
+          "lastCompilationTimestamp"
+        ],
+        "description": "The Groovy compiler information (only present when the compiler is active)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/hashicorp-secrets.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/hashicorp-secrets.json
@@ -11,6 +11,27 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-hashicorp-vault",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "host": {
+        "type": "string",
+        "description": "The Vault host (only present when configured)"
+      },
+      "port": {
+        "type": "string",
+        "description": "The Vault port (only present when configured)"
+      },
+      "scheme": {
+        "type": "string",
+        "description": "The Vault scheme (only present when configured)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when configured)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/health.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/health.json
@@ -95,7 +95,9 @@
             },
             "details": {
               "type": "object",
-              "additionalProperties": true,
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "Additional health check specific details (only present when available)"
             }
           },

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/health.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/health.json
@@ -33,6 +33,87 @@
       "defaultValue": "default",
       "description": "Exposure level for health check details"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "up": {
+        "type": "boolean",
+        "description": "Whether the overall health status is up"
+      },
+      "ready": {
+        "type": "boolean",
+        "description": "Whether the readiness checks are up"
+      },
+      "live": {
+        "type": "boolean",
+        "description": "Whether the liveness checks are up"
+      },
+      "checks": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The health check ID"
+            },
+            "group": {
+              "type": "string",
+              "description": "The health check group"
+            },
+            "up": {
+              "type": "boolean",
+              "description": "Whether the health check is up"
+            },
+            "state": {
+              "type": "string",
+              "description": "The health check state"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether the health check is enabled"
+            },
+            "readiness": {
+              "type": "boolean",
+              "description": "Whether the health check is a readiness check"
+            },
+            "liveness": {
+              "type": "boolean",
+              "description": "Whether the health check is a liveness check"
+            },
+            "message": {
+              "type": "string",
+              "description": "The failure message (only present when not up)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The failure stack trace, one entry per line (only present when not up and an error is available)"
+            },
+            "details": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Additional health check specific details (only present when available)"
+            }
+          },
+          "required": [
+            "up",
+            "enabled",
+            "readiness",
+            "liveness"
+          ]
+        },
+        "description": "The individual health checks"
+      }
+    },
+    "required": [
+      "up",
+      "ready",
+      "live"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/heap-dump.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/heap-dump.json
@@ -42,6 +42,23 @@
       "secret": false,
       "description": "File name for the heap dump (without .hprof extension)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string",
+        "description": "The absolute path of the written heap dump file (only present on success)"
+      },
+      "size": {
+        "type": "integer",
+        "description": "The size in bytes of the written heap dump file (only present on success)"
+      },
+      "error": {
+        "type": "string",
+        "description": "The error message (only present on failure)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/heap-histogram.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/heap-histogram.json
@@ -28,6 +28,53 @@
       "defaultValue": 100,
       "description": "Limits the number of classes displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "classes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "num": {
+              "type": "integer",
+              "description": "The class number"
+            },
+            "instances": {
+              "type": "integer",
+              "description": "Number of instances"
+            },
+            "bytes": {
+              "type": "integer",
+              "description": "Number of bytes used"
+            },
+            "className": {
+              "type": "string",
+              "description": "The class name"
+            }
+          },
+          "required": [
+            "num",
+            "instances",
+            "bytes"
+          ]
+        },
+        "description": "The classes in the histogram"
+      },
+      "totalInstances": {
+        "type": "integer",
+        "description": "Total number of instances"
+      },
+      "totalBytes": {
+        "type": "integer",
+        "description": "Total number of bytes"
+      }
+    },
+    "required": [
+      "totalInstances",
+      "totalBytes"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/ibm-secrets.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/ibm-secrets.json
@@ -11,6 +11,68 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-ibm-secrets-manager",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "serviceUrl": {
+        "type": "string",
+        "description": "The IBM Secrets Manager service URL (only present when configured)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when configured)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "eventStreamTopic": {
+        "type": "string",
+        "description": "The event stream topic (only present when refresh is enabled)"
+      },
+      "eventStreamBootstrapServers": {
+        "type": "string",
+        "description": "The event stream bootstrap servers (only present when refresh is enabled)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/inflight.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/inflight.json
@@ -41,6 +41,65 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "inflight": {
+        "type": "integer",
+        "description": "Number of inflight exchanges"
+      },
+      "inflightBrowseEnabled": {
+        "type": "boolean",
+        "description": "Whether browsing inflight exchanges is enabled"
+      },
+      "exchanges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "fromRouteId": {
+              "type": "string",
+              "description": "The route ID where the exchange originated from"
+            },
+            "fromRemoteEndpoint": {
+              "type": "boolean",
+              "description": "Whether the exchange originated from a remote endpoint"
+            },
+            "atRouteId": {
+              "type": "string",
+              "description": "The route ID where the exchange currently is"
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "The node ID where the exchange currently is"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "Elapsed time in milliseconds since the exchange started"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "Duration in milliseconds the exchange has been at the current node"
+            }
+          },
+          "required": [
+            "fromRemoteEndpoint",
+            "elapsed",
+            "duration"
+          ]
+        },
+        "description": "The inflight exchanges (only present when browsing is enabled)"
+      }
+    },
+    "required": [
+      "inflight",
+      "inflightBrowseEnabled"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/internal-tasks.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/internal-tasks.json
@@ -11,6 +11,69 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "tasks": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The task name"
+            },
+            "status": {
+              "type": "string",
+              "description": "The task status"
+            },
+            "attempting": {
+              "type": "boolean",
+              "description": "Whether the task is currently attempting"
+            },
+            "attempts": {
+              "type": "integer",
+              "description": "The current number of iterations"
+            },
+            "delay": {
+              "type": "integer",
+              "description": "The current computed delay"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "The current elapsed time"
+            },
+            "firstTime": {
+              "type": "integer",
+              "description": "The time the first attempt was performed"
+            },
+            "lastTime": {
+              "type": "integer",
+              "description": "The time the last attempt was performed"
+            },
+            "nextTime": {
+              "type": "integer",
+              "description": "The time the next attempt will be made"
+            },
+            "error": {
+              "type": "string",
+              "description": "The failure message (only present when known)"
+            }
+          },
+          "required": [
+            "attempting",
+            "attempts",
+            "delay",
+            "elapsed",
+            "firstTime",
+            "lastTime",
+            "nextTime"
+          ]
+        },
+        "description": "The internal tasks"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/java-security.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/java-security.json
@@ -11,6 +11,53 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "securityProviders": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The provider name"
+            },
+            "version": {
+              "type": "string",
+              "description": "The provider version"
+            },
+            "info": {
+              "type": "string",
+              "description": "The provider info (only present when known)"
+            },
+            "services": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The service type"
+                  },
+                  "algorithm": {
+                    "type": "string",
+                    "description": "The algorithm"
+                  },
+                  "className": {
+                    "type": "string",
+                    "description": "The implementation class name"
+                  }
+                }
+              },
+              "description": "The services offered by this provider (only present when any)"
+            }
+          }
+        },
+        "description": "The security providers (only present when any are registered)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jbang.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jbang.json
@@ -1,0 +1,25 @@
+{
+  "console": {
+    "kind": "console",
+    "group": "camel-jbang",
+    "name": "jbang",
+    "title": "Camel CLI",
+    "description": "Information about Camel CLI",
+    "deprecated": false,
+    "readOnly": true,
+    "javaType": "org.apache.camel.jbang.console.JBangDevConsole",
+    "groupId": "org.apache.camel",
+    "artifactId": "camel-jbang-console",
+    "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "version": {
+        "type": "string",
+        "description": "The JBang version (only present when known)"
+      }
+    }
+  }
+}
+

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jfr-memory-leak.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jfr-memory-leak.json
@@ -95,6 +95,294 @@
       "defaultValue": false,
       "description": "Whether to include stack traces in the output"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "The console status: recording, completed, compared, idle, or error"
+      },
+      "error": {
+        "type": "string",
+        "description": "An error message (only present when status is error)"
+      },
+      "note": {
+        "type": "string",
+        "description": "An informational note (only present for an idle query)"
+      },
+      "startTime": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the recording started (only present while recording)"
+      },
+      "durationSeconds": {
+        "type": "integer",
+        "description": "The requested recording duration in seconds (only present when set)"
+      },
+      "elapsedMs": {
+        "type": "integer",
+        "description": "Elapsed time in milliseconds since the recording started (only present while recording)"
+      },
+      "remainingMs": {
+        "type": "integer",
+        "description": "Remaining time in milliseconds until auto-stop (only present when a duration was requested)"
+      },
+      "hasCachedResults": {
+        "type": "boolean",
+        "description": "Whether cached results are available (only present for a status query)"
+      },
+      "hasComparisonData": {
+        "type": "boolean",
+        "description": "Whether a previous recording is available for comparison (only present for a status query)"
+      },
+      "sampleCount": {
+        "type": "integer",
+        "description": "The number of aggregated samples (only present when results are available)"
+      },
+      "recordingDurationMs": {
+        "type": "integer",
+        "description": "The recording duration in milliseconds (only present when results are available)"
+      },
+      "recordingEndTime": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the recording ended (only present when results are available)"
+      },
+      "rawSampleCount": {
+        "type": "integer",
+        "description": "The number of raw samples before aggregation (only present when results are available)"
+      },
+      "gcCount": {
+        "type": "integer",
+        "description": "The number of garbage collections observed (only present when results are available)"
+      },
+      "samples": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "allocationClass": {
+              "type": "string",
+              "description": "The allocated class name (only present when known)"
+            },
+            "allocationSize": {
+              "type": "integer",
+              "description": "The allocation size in bytes (only present when known)"
+            },
+            "lastKnownHeapUsage": {
+              "type": "integer",
+              "description": "The last known heap usage in bytes (only present when known)"
+            },
+            "arrayElements": {
+              "type": "integer",
+              "description": "The number of array elements (only present for arrays)"
+            },
+            "objectAge": {
+              "type": "integer",
+              "description": "The object age in milliseconds (only present when known)"
+            },
+            "allocationTime": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds when the object was allocated"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "description": "The fully qualified method name"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "The line number"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The allocation stack trace (only present when requested)"
+            },
+            "referenceChain": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type name (only present when known)"
+                  },
+                  "field": {
+                    "type": "string",
+                    "description": "The field name (only present when known)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A description of the link (only present when known)"
+                  }
+                }
+              },
+              "description": "The reference chain back to the GC root (only present when there is one)"
+            },
+            "count": {
+              "type": "integer",
+              "description": "The number of samples aggregated into this entry"
+            },
+            "sampledSize": {
+              "type": "integer",
+              "description": "The total sampled size in bytes across the aggregated samples"
+            }
+          },
+          "required": [
+            "allocationTime",
+            "count",
+            "sampledSize"
+          ]
+        },
+        "description": "The aggregated samples (only present when results are available)"
+      },
+      "baseline": {
+        "type": "object",
+        "properties": {
+          "recordingDurationMs": {
+            "type": "integer",
+            "description": "The recording duration in milliseconds"
+          },
+          "sampleCount": {
+            "type": "integer",
+            "description": "The number of aggregated samples"
+          },
+          "gcCount": {
+            "type": "integer",
+            "description": "The number of garbage collections observed"
+          }
+        },
+        "required": [
+          "recordingDurationMs",
+          "sampleCount",
+          "gcCount"
+        ],
+        "description": "The baseline recording info (only present for a comparison)"
+      },
+      "current": {
+        "type": "object",
+        "properties": {
+          "recordingDurationMs": {
+            "type": "integer",
+            "description": "The recording duration in milliseconds"
+          },
+          "sampleCount": {
+            "type": "integer",
+            "description": "The number of aggregated samples"
+          },
+          "gcCount": {
+            "type": "integer",
+            "description": "The number of garbage collections observed"
+          }
+        },
+        "required": [
+          "recordingDurationMs",
+          "sampleCount",
+          "gcCount"
+        ],
+        "description": "The current recording info (only present for a comparison)"
+      },
+      "durationRatio": {
+        "type": "number",
+        "description": "The ratio of the current to the baseline recording duration (only present for a comparison)"
+      },
+      "comparisons": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "allocationClass": {
+              "type": "string",
+              "description": "The allocated class name"
+            },
+            "baselineSampledSize": {
+              "type": "integer",
+              "description": "The baseline sampled size in bytes"
+            },
+            "baselineCount": {
+              "type": "integer",
+              "description": "The baseline sample count"
+            },
+            "currentSampledSize": {
+              "type": "integer",
+              "description": "The current sampled size in bytes"
+            },
+            "currentCount": {
+              "type": "integer",
+              "description": "The current sample count"
+            },
+            "growthRatio": {
+              "type": "number",
+              "description": "The growth ratio between baseline and current sampled size"
+            },
+            "trend": {
+              "type": "string",
+              "description": "The trend: new, gone, growing, suspicious, shrinking, or stable"
+            },
+            "lowConfidence": {
+              "type": "boolean",
+              "description": "Whether the comparison has low statistical confidence"
+            },
+            "referenceChain": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type name (only present when known)"
+                  },
+                  "field": {
+                    "type": "string",
+                    "description": "The field name (only present when known)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A description of the link (only present when known)"
+                  }
+                }
+              },
+              "description": "The reference chain back to the GC root (only present when there is one)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "description": "The fully qualified method name"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "The line number"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The allocation stack trace (only present when requested)"
+            }
+          },
+          "required": [
+            "baselineSampledSize",
+            "baselineCount",
+            "currentSampledSize",
+            "currentCount",
+            "growthRatio",
+            "lowConfidence"
+          ]
+        },
+        "description": "The per-class comparisons, sorted by growth ratio descending (only present for a comparison)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jfr.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jfr.json
@@ -116,13 +116,16 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The recording name"
             },
             "state": {
-              "type": "string"
+              "type": "string",
+              "description": "The recording state"
             },
             "destination": {
-              "type": "string"
+              "type": "string",
+              "description": "The recording destination file (only present when configured)"
             }
           }
         },
@@ -169,22 +172,28 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans"
             },
             "failed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed spans"
             },
             "minMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The minimum duration in milliseconds"
             },
             "meanMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean duration in milliseconds"
             },
             "maxMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum duration in milliseconds"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             }
           },
           "required": [
@@ -203,28 +212,36 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans"
             },
             "failed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed spans"
             },
             "minMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The minimum duration in milliseconds"
             },
             "meanMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean duration in milliseconds"
             },
             "maxMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum duration in milliseconds"
             },
             "processorId": {
-              "type": "string"
+              "type": "string",
+              "description": "The processor id"
             },
             "processorType": {
-              "type": "string"
+              "type": "string",
+              "description": "The processor type"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             }
           },
           "required": [
@@ -243,22 +260,28 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans"
             },
             "failed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed spans"
             },
             "minMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The minimum duration in milliseconds"
             },
             "meanMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean duration in milliseconds"
             },
             "maxMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum duration in milliseconds"
             },
             "endpointUri": {
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint URI"
             }
           },
           "required": [
@@ -277,19 +300,24 @@
           "type": "object",
           "properties": {
             "timestamp": {
-              "type": "string"
+              "type": "string",
+              "description": "The failure timestamp"
             },
             "exchangeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The exchange id"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             },
             "exceptionType": {
-              "type": "string"
+              "type": "string",
+              "description": "The exception type"
             },
             "exceptionMessage": {
-              "type": "string"
+              "type": "string",
+              "description": "The exception message"
             }
           }
         },
@@ -301,19 +329,24 @@
           "type": "object",
           "properties": {
             "timestamp": {
-              "type": "string"
+              "type": "string",
+              "description": "The redelivery timestamp"
             },
             "exchangeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The exchange id"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             },
             "attempt": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The redelivery attempt number"
             },
             "maxAttempts": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The maximum number of redelivery attempts"
             }
           },
           "required": [

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jfr.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jfr.json
@@ -102,6 +102,228 @@
       "secret": false,
       "description": "Filter snapshot results to the given route id"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "runtimeEvents": {
+        "type": "boolean",
+        "description": "Whether camel-jfr runtime instrumentation is registered (status command)"
+      },
+      "recordings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "The active JFR recordings (status command)"
+      },
+      "events": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "description": "Whether each runtime event is enabled, keyed by short name (status command)"
+      },
+      "success": {
+        "type": "boolean",
+        "description": "Whether the toggle succeeded (enable\/disable command)"
+      },
+      "result": {
+        "type": "string",
+        "description": "The toggle result message (enable\/disable command)"
+      },
+      "jfc": {
+        "type": "string",
+        "description": "The generated jfc settings overlay (jfc command)"
+      },
+      "error": {
+        "type": "string",
+        "description": "An error message (jfc, snapshot, or unknown command)"
+      },
+      "snapshot": {
+        "type": "boolean",
+        "description": "Whether this is a snapshot response (snapshot command)"
+      },
+      "snapshotTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the snapshot was taken (snapshot command)"
+      },
+      "eventCount": {
+        "type": "integer",
+        "description": "The number of matched events in the snapshot (snapshot command)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "integer"
+            },
+            "minMs": {
+              "type": "number"
+            },
+            "meanMs": {
+              "type": "number"
+            },
+            "maxMs": {
+              "type": "number"
+            },
+            "routeId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "total",
+            "failed",
+            "minMs",
+            "meanMs",
+            "maxMs"
+          ]
+        },
+        "description": "Per-route duration statistics (snapshot command)"
+      },
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "integer"
+            },
+            "minMs": {
+              "type": "number"
+            },
+            "meanMs": {
+              "type": "number"
+            },
+            "maxMs": {
+              "type": "number"
+            },
+            "processorId": {
+              "type": "string"
+            },
+            "processorType": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "total",
+            "failed",
+            "minMs",
+            "meanMs",
+            "maxMs"
+          ]
+        },
+        "description": "Per-processor duration statistics (snapshot command)"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "integer"
+            },
+            "minMs": {
+              "type": "number"
+            },
+            "meanMs": {
+              "type": "number"
+            },
+            "maxMs": {
+              "type": "number"
+            },
+            "endpointUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "total",
+            "failed",
+            "minMs",
+            "meanMs",
+            "maxMs"
+          ]
+        },
+        "description": "Per-endpoint duration statistics (snapshot command)"
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string"
+            },
+            "exchangeId": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "exceptionType": {
+              "type": "string"
+            },
+            "exceptionMessage": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "The most recent failures, newest first (snapshot command)"
+      },
+      "redeliveries": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string"
+            },
+            "exchangeId": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "attempt": {
+              "type": "integer"
+            },
+            "maxAttempts": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "attempt",
+            "maxAttempts"
+          ]
+        },
+        "description": "The most recent redeliveries, newest first (snapshot command)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jvm.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/jvm.json
@@ -11,6 +11,49 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "vmName": {
+        "type": "string",
+        "description": "The JVM name"
+      },
+      "vmVersion": {
+        "type": "string",
+        "description": "The JVM version"
+      },
+      "vmVendor": {
+        "type": "string",
+        "description": "The JVM vendor"
+      },
+      "vmUptime": {
+        "type": "string",
+        "description": "The JVM uptime"
+      },
+      "pid": {
+        "type": "integer",
+        "description": "The process ID"
+      },
+      "inputArguments": {
+        "type": "string",
+        "description": "The JVM input arguments (only present when any are set)"
+      },
+      "bootClasspath": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The boot classpath entries (only present when supported)"
+      },
+      "classpath": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The classpath entries"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/kafka.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/kafka.json
@@ -28,6 +28,107 @@
       "defaultValue": false,
       "description": "Whether to include committed offset (sync operation to Kafka broker)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "kafkaConsumers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route id"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "workers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "threadId": {
+                    "type": "string",
+                    "description": "The worker thread id"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The worker state"
+                  },
+                  "lastError": {
+                    "type": "string",
+                    "description": "The worker last error (only present when not ready)"
+                  },
+                  "groupId": {
+                    "type": "string",
+                    "description": "The consumer group id (only present when known)"
+                  },
+                  "groupInstanceId": {
+                    "type": "string",
+                    "description": "The consumer group instance id (only present when known)"
+                  },
+                  "memberId": {
+                    "type": "string",
+                    "description": "The consumer member id (only present when known)"
+                  },
+                  "generationId": {
+                    "type": "integer",
+                    "description": "The consumer generation id (only present when known)"
+                  },
+                  "lastTopic": {
+                    "type": "string",
+                    "description": "The last consumed topic (only present when known)"
+                  },
+                  "lastPartition": {
+                    "type": "integer",
+                    "description": "The last consumed partition (only present when known)"
+                  },
+                  "lastOffset": {
+                    "type": "integer",
+                    "description": "The last consumed offset (only present when known)"
+                  },
+                  "committed": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "topic": {
+                          "type": "string",
+                          "description": "The topic"
+                        },
+                        "partition": {
+                          "type": "integer",
+                          "description": "The partition"
+                        },
+                        "offset": {
+                          "type": "integer",
+                          "description": "The committed offset"
+                        },
+                        "epoch": {
+                          "type": "integer",
+                          "description": "The epoch"
+                        }
+                      },
+                      "required": [
+                        "partition",
+                        "offset",
+                        "epoch"
+                      ]
+                    },
+                    "description": "The committed offsets (only present when requested and there are any)"
+                  }
+                }
+              },
+              "description": "The consumer worker threads"
+            }
+          }
+        },
+        "description": "The Kafka consumers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/kubernetes-configmaps.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/kubernetes-configmaps.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-kubernetes",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "masterUrl": {
+        "type": "string",
+        "description": "The Kubernetes master URL (only present when known)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when known)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether refreshing is enabled (only present when known)"
+      },
+      "startCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the refresh check started (only present when known)"
+      },
+      "configmaps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The config map (secret) name"
+            }
+          }
+        },
+        "description": "The config maps in use"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/kubernetes-secrets.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/kubernetes-secrets.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-kubernetes",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "masterUrl": {
+        "type": "string",
+        "description": "The Kubernetes master URL (only present when configured)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when configured)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "startCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the refresh task started (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            }
+          }
+        },
+        "description": "The secrets in use"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/log.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/log.json
@@ -11,6 +11,18 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "levels": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "The logger names mapped to their log level (only present when available)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/main-configuration.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/main-configuration.json
@@ -11,6 +11,45 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-main",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "configurations": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "The configuration key"
+            },
+            "value": {
+              "description": "The configuration value (masked as xxxxxx when sensitive)"
+            },
+            "defaultValue": {
+              "description": "The default value (only present when known)"
+            },
+            "originalValue": {
+              "description": "The original, unresolved value (only present when known and not sensitive)"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source that provided the value (only present when known)"
+            },
+            "location": {
+              "type": "string",
+              "description": "The location the value came from (only present when known)"
+            },
+            "internal": {
+              "type": "boolean",
+              "description": "Whether the location is internal (only present when the location is known)"
+            }
+          }
+        },
+        "description": "The startup configurations (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/main-http-server.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/main-http-server.json
@@ -11,6 +11,39 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-platform-http-main",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "host": {
+        "type": "string",
+        "description": "The bind host (only present when the server is running)"
+      },
+      "port": {
+        "type": "integer",
+        "description": "The bind port (only present when the server is running)"
+      },
+      "path": {
+        "type": "string",
+        "description": "The context path (only present when the server is running)"
+      },
+      "maxBodySize": {
+        "type": "integer",
+        "description": "Maximum HTTP body size in bytes (only present when configured)"
+      },
+      "fileUploadEnabled": {
+        "type": "boolean",
+        "description": "Whether file upload is enabled (only present when the server is running)"
+      },
+      "fileUploadDirectory": {
+        "type": "string",
+        "description": "The file upload directory (only present when configured)"
+      },
+      "useGlobalSslContextParameters": {
+        "type": "boolean",
+        "description": "Whether global SSL context parameters are used (only present when the server is running)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/memory.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/memory.json
@@ -11,6 +11,67 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "heapMemoryInit": {
+        "type": "string",
+        "description": "Heap memory initial size"
+      },
+      "heapMemoryMax": {
+        "type": "string",
+        "description": "Heap memory max size"
+      },
+      "heapMemoryUsed": {
+        "type": "string",
+        "description": "Heap memory used"
+      },
+      "heapMemoryCommitted": {
+        "type": "string",
+        "description": "Heap memory committed"
+      },
+      "nonHeapMemoryInit": {
+        "type": "string",
+        "description": "Non-heap memory initial size"
+      },
+      "nonHeapMemoryMax": {
+        "type": "string",
+        "description": "Non-heap memory max size"
+      },
+      "nonHeapMemoryUsed": {
+        "type": "string",
+        "description": "Non-heap memory used"
+      },
+      "nonHeapMemoryCommitted": {
+        "type": "string",
+        "description": "Non-heap memory committed"
+      },
+      "oldGenUsed": {
+        "type": "string",
+        "description": "Old generation memory pool used (only present when such a pool exists)"
+      },
+      "oldGenCommitted": {
+        "type": "string",
+        "description": "Old generation memory pool committed (only present when such a pool exists)"
+      },
+      "oldGenMax": {
+        "type": "string",
+        "description": "Old generation memory pool max (only present when such a pool exists)"
+      },
+      "metaspaceUsed": {
+        "type": "string",
+        "description": "Metaspace memory pool used (only present when such a pool exists)"
+      },
+      "metaspaceCommitted": {
+        "type": "string",
+        "description": "Metaspace memory pool committed (only present when such a pool exists)"
+      },
+      "metaspaceMax": {
+        "type": "string",
+        "description": "Metaspace memory pool max (only present when such a pool exists)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/message-history.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/message-history.json
@@ -28,6 +28,23 @@
       "defaultValue": 5,
       "description": "Number of source code lines around the location to include"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The CamelContext name (only present when a backlog tracer is available)"
+      },
+      "traces": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The latest completed message trace entries, as opaque JSON objects (only present when a backlog tracer is available)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/micrometer.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/micrometer.json
@@ -47,7 +47,8 @@
     "type": "object",
     "properties": {
       "meterRegistryClass": {
-        "type": "string"
+        "type": "string",
+        "description": "The MeterRegistry implementation class name"
       },
       "counters": {
         "type": "array",
@@ -55,10 +56,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The counter name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The counter description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -66,13 +69,16 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The counter tags (only present when requested)"
             },
             "count": {
               "description": "The counter value (integer when whole, decimal otherwise)"
@@ -87,10 +93,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The gauge name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The gauge description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -98,16 +106,20 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The gauge tags (only present when requested)"
             },
             "value": {
-              "type": "number"
+              "type": "number",
+              "description": "The gauge value"
             }
           },
           "required": [
@@ -122,10 +134,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The timer name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The timer description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -133,25 +147,32 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The timer tags (only present when requested)"
             },
             "count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of recorded events"
             },
             "mean": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The mean duration in milliseconds"
             },
             "max": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The maximum duration in milliseconds"
             },
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The total duration in milliseconds"
             }
           },
           "required": [
@@ -169,10 +190,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The long task timer name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The long task timer description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -180,25 +203,32 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The long task timer tags (only present when requested)"
             },
             "activeTasks": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of currently active tasks"
             },
             "mean": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The mean duration in milliseconds"
             },
             "max": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The maximum duration in milliseconds"
             },
             "duration": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The total duration of active tasks in milliseconds"
             }
           },
           "required": [
@@ -216,10 +246,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The distribution summary name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The distribution summary description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -227,25 +259,32 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The distribution summary tags (only present when requested)"
             },
             "count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of recorded events"
             },
             "mean": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean amount"
             },
             "max": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum amount"
             },
             "totalAmount": {
-              "type": "number"
+              "type": "number",
+              "description": "The total amount"
             }
           },
           "required": [

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/micrometer.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/micrometer.json
@@ -42,6 +42,222 @@
       "defaultValue": true,
       "description": "Whether to include tags"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "meterRegistryClass": {
+        "type": "string"
+      },
+      "counters": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "description": "The counter value (integer when whole, decimal otherwise)"
+            }
+          }
+        },
+        "description": "Only present when there are any counters"
+      },
+      "gauges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "value": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "value"
+          ]
+        },
+        "description": "Only present when there are any gauges"
+      },
+      "timers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "integer"
+            },
+            "max": {
+              "type": "integer"
+            },
+            "total": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "count",
+            "mean",
+            "max",
+            "total"
+          ]
+        },
+        "description": "Only present when there are any timers"
+      },
+      "longTaskTimers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "activeTasks": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "integer"
+            },
+            "max": {
+              "type": "integer"
+            },
+            "duration": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "activeTasks",
+            "mean",
+            "max",
+            "duration"
+          ]
+        },
+        "description": "Only present when there are any long task timers"
+      },
+      "distribution": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "totalAmount": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "mean",
+            "max",
+            "totalAmount"
+          ]
+        },
+        "description": "Only present when there are any distribution summaries"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/opentelemetry.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/opentelemetry.json
@@ -46,6 +46,93 @@
       "defaultValue": 100,
       "description": "Limits the number of spans dumped"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether the OpenTelemetry in-memory exporter is enabled"
+      },
+      "spanCount": {
+        "type": "integer",
+        "description": "The number of finished spans held (only present when not dumping spans)"
+      },
+      "capacity": {
+        "type": "integer",
+        "description": "The maximum number of spans held (only present when not dumping spans)"
+      },
+      "spans": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "traceId": {
+              "type": "string",
+              "description": "The trace id"
+            },
+            "spanId": {
+              "type": "string",
+              "description": "The span id"
+            },
+            "parentSpanId": {
+              "type": "string",
+              "description": "The parent span id (only present when known)"
+            },
+            "name": {
+              "type": "string",
+              "description": "The span name"
+            },
+            "kind": {
+              "type": "string",
+              "description": "The span kind"
+            },
+            "status": {
+              "type": "string",
+              "description": "The span status"
+            },
+            "startEpochNanos": {
+              "type": "integer",
+              "description": "Epoch time in nanoseconds when the span started"
+            },
+            "endEpochNanos": {
+              "type": "integer",
+              "description": "Epoch time in nanoseconds when the span ended"
+            },
+            "durationMs": {
+              "type": "integer",
+              "description": "The span duration in milliseconds"
+            },
+            "scopeName": {
+              "type": "string",
+              "description": "The instrumentation scope name (only present when known)"
+            },
+            "attributes": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "The span attributes (only present when there are any)"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route id this span belongs to (only present when known)"
+            },
+            "processorId": {
+              "type": "string",
+              "description": "The processor id this span belongs to (only present for processor spans)"
+            }
+          },
+          "required": [
+            "startEpochNanos",
+            "endEpochNanos",
+            "durationMs"
+          ]
+        },
+        "description": "The dumped spans (only present when dumping spans)"
+      }
+    },
+    "required": [
+      "enabled"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/platform-http.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/platform-http.json
@@ -11,6 +11,73 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-platform-http",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "server": {
+        "type": "string",
+        "description": "The server base URL (only present when the platform-http component is active)"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The full endpoint URL"
+            },
+            "path": {
+              "type": "string",
+              "description": "The endpoint path"
+            },
+            "verbs": {
+              "type": "string",
+              "description": "The HTTP verbs (only present when configured)"
+            },
+            "consumes": {
+              "type": "string",
+              "description": "The consumed media types (only present when configured)"
+            },
+            "produces": {
+              "type": "string",
+              "description": "The produced media types (only present when configured)"
+            }
+          }
+        },
+        "description": "The registered HTTP endpoints (only present when there are any)"
+      },
+      "managementEndpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The full endpoint URL"
+            },
+            "path": {
+              "type": "string",
+              "description": "The endpoint path"
+            },
+            "verbs": {
+              "type": "string",
+              "description": "The HTTP verbs (only present when configured)"
+            },
+            "consumes": {
+              "type": "string",
+              "description": "The consumed media types (only present when configured)"
+            },
+            "produces": {
+              "type": "string",
+              "description": "The produced media types (only present when configured)"
+            }
+          }
+        },
+        "description": "The registered HTTP management endpoints (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/processor-detail.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/processor-detail.json
@@ -27,6 +27,92 @@
       "secret": false,
       "description": "The route id to get processor details for (use * for all routes)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routeId": {
+        "type": "string",
+        "description": "The route ID (only present when a specific route was requested)"
+      },
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The processor ID"
+            },
+            "type": {
+              "type": "string",
+              "description": "The processor type (the XML element name, or 'from' for the route input)"
+            },
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI (only present for the route input entry)"
+            },
+            "line": {
+              "type": "integer",
+              "description": "The source line number (only present when known)"
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The processor's configured options, as attribute\/child-element name to string value"
+            }
+          }
+        },
+        "description": "The route's processors (only present when a specific route was requested)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "processors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The processor ID"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The processor type (the XML element name, or 'from' for the route input)"
+                  },
+                  "endpointUri": {
+                    "type": "string",
+                    "description": "The endpoint URI (only present for the route input entry)"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number (only present when known)"
+                  },
+                  "options": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "The processor's configured options, as attribute\/child-element name to string value"
+                  }
+                }
+              },
+              "description": "The route's processors, starting with the route input"
+            }
+          }
+        },
+        "description": "The route details for all routes (only present when routeId is * or omitted)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/processor.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/processor.json
@@ -61,6 +61,175 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "id": {
+              "type": "string",
+              "description": "The processor ID"
+            },
+            "nodePrefixId": {
+              "type": "string",
+              "description": "The node prefix ID (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The processor description (only present when configured)"
+            },
+            "note": {
+              "type": "string",
+              "description": "The processor note (only present when configured)"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location, optionally with a line number suffix (only present when known)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The processor state"
+            },
+            "disabled": {
+              "type": "boolean",
+              "description": "Whether the processor is disabled (only present when known)"
+            },
+            "stepId": {
+              "type": "string",
+              "description": "The step ID (only present when known)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number (only present when known)"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  },
+                  "match": {
+                    "type": "boolean",
+                    "description": "Whether this is the matched line (only present when true)"
+                  }
+                }
+              },
+              "description": "A snippet of source code around the processor (only present when known)"
+            },
+            "processor": {
+              "type": "string",
+              "description": "The processor name"
+            },
+            "level": {
+              "type": "integer",
+              "description": "The processor level in the route tree"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The destination URI, for processors that send to a destination (only present when applicable)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the processor has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          },
+          "required": [
+            "level"
+          ]
+        },
+        "description": "The processors (only present when no action was requested)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/producer.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/producer.json
@@ -11,6 +11,52 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "producers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "state": {
+              "type": "string",
+              "description": "The producer state"
+            },
+            "clazz": {
+              "type": "string",
+              "description": "The producer service type"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "singleton": {
+              "type": "boolean",
+              "description": "Whether the producer is a singleton"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "stepId": {
+              "type": "string",
+              "description": "The step ID (only present when known)"
+            }
+          },
+          "required": [
+            "remote",
+            "singleton"
+          ]
+        },
+        "description": "The producers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/properties.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/properties.json
@@ -11,6 +11,55 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "locations": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The locations properties are loaded from"
+      },
+      "properties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "The property key"
+            },
+            "value": {
+              "type": "string",
+              "description": "The property value (masked when sensitive)"
+            },
+            "originalValue": {
+              "type": "string",
+              "description": "The original unresolved value (only present when resolved via a properties function)"
+            },
+            "defaultValue": {
+              "type": "string",
+              "description": "The default value (only present when one was used)"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source that provided the value (only present when known)"
+            },
+            "location": {
+              "type": "string",
+              "description": "The location the value was loaded from (only present when known)"
+            },
+            "internal": {
+              "type": "boolean",
+              "description": "Whether the location is an internal Camel location (only present when location is known)"
+            }
+          }
+        },
+        "description": "The loaded properties (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/quartz.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/quartz.json
@@ -11,6 +11,125 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-quartz",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "schedulerName": {
+        "type": "string"
+      },
+      "schedulerInstanceId": {
+        "type": "string"
+      },
+      "quartzVersion": {
+        "type": "string"
+      },
+      "runningSince": {
+        "type": "integer"
+      },
+      "totalCounter": {
+        "type": "integer"
+      },
+      "started": {
+        "type": "boolean"
+      },
+      "shutdown": {
+        "type": "boolean"
+      },
+      "inStandbyMode": {
+        "type": "boolean"
+      },
+      "threadPoolClass": {
+        "type": "string"
+      },
+      "threadPoolSize": {
+        "type": "integer"
+      },
+      "jpbStoreClass": {
+        "type": "string",
+        "description": "The job store class name (field kept as jpbStoreClass for backwards compatibility)"
+      },
+      "jpbStoreClustered": {
+        "type": "boolean"
+      },
+      "jpbStoreSupportsPersistence": {
+        "type": "boolean"
+      },
+      "currentExecutingJobs": {
+        "type": "integer"
+      },
+      "jobs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "jobId": {
+              "type": "string"
+            },
+            "triggerType": {
+              "type": "string"
+            },
+            "cron": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            },
+            "prevFireTime": {
+              "type": "integer"
+            },
+            "fireTime": {
+              "type": "integer"
+            },
+            "nextFireTime": {
+              "type": "integer"
+            },
+            "finalFireTime": {
+              "type": "integer"
+            },
+            "recovering": {
+              "type": "boolean"
+            },
+            "refireCount": {
+              "type": "integer"
+            },
+            "misfireInstruction": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "recovering",
+            "refireCount",
+            "misfireInstruction"
+          ]
+        },
+        "description": "Only present when there are any currently executing jobs"
+      },
+      "triggers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string"
+            },
+            "triggerType": {
+              "type": "string"
+            },
+            "cron": {
+              "type": "string"
+            },
+            "repeatInterval": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Only present when there are any scheduled triggers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/quartz.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/quartz.json
@@ -16,47 +16,60 @@
     "type": "object",
     "properties": {
       "schedulerName": {
-        "type": "string"
+        "type": "string",
+        "description": "The scheduler name"
       },
       "schedulerInstanceId": {
-        "type": "string"
+        "type": "string",
+        "description": "The scheduler instance id"
       },
       "quartzVersion": {
-        "type": "string"
+        "type": "string",
+        "description": "The Quartz version (only present when known)"
       },
       "runningSince": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Epoch time in milliseconds the scheduler started running (only present when known)"
       },
       "totalCounter": {
-        "type": "integer"
+        "type": "integer",
+        "description": "The total number of jobs executed (only present when known)"
       },
       "started": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the scheduler is started (only present when known)"
       },
       "shutdown": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the scheduler is shutdown (only present when known)"
       },
       "inStandbyMode": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the scheduler is in standby mode (only present when known)"
       },
       "threadPoolClass": {
-        "type": "string"
+        "type": "string",
+        "description": "The thread pool class name (only present when known)"
       },
       "threadPoolSize": {
-        "type": "integer"
+        "type": "integer",
+        "description": "The thread pool size (only present when known)"
       },
       "jpbStoreClass": {
         "type": "string",
-        "description": "The job store class name (field kept as jpbStoreClass for backwards compatibility)"
+        "description": "The job store class name (field kept as jpbStoreClass for backwards compatibility, only present when known)"
       },
       "jpbStoreClustered": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the job store is clustered (field kept as jpbStoreClustered for backwards compatibility, only present when known)"
       },
       "jpbStoreSupportsPersistence": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the job store supports persistence (field kept as jpbStoreSupportsPersistence for backwards compatibility, only present when known)"
       },
       "currentExecutingJobs": {
-        "type": "integer"
+        "type": "integer",
+        "description": "The number of currently executing jobs"
       },
       "jobs": {
         "type": "array",
@@ -64,40 +77,52 @@
           "type": "object",
           "properties": {
             "jobId": {
-              "type": "string"
+              "type": "string",
+              "description": "The job fire instance id"
             },
             "triggerType": {
-              "type": "string"
+              "type": "string",
+              "description": "The trigger type: cron or simple"
             },
             "cron": {
-              "type": "string"
+              "type": "string",
+              "description": "The cron expression (only present for a cron trigger)"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id (only present when known)"
             },
             "uri": {
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint URI (only present when a cron expression is set)"
             },
             "prevFireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the previous fire time (only present when known)"
             },
             "fireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the fire time (only present when known)"
             },
             "nextFireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the next fire time (only present when known)"
             },
             "finalFireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the final fire time (only present when known)"
             },
             "recovering": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether the job is recovering"
             },
             "refireCount": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of times the job has been refired"
             },
             "misfireInstruction": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The trigger's misfire instruction"
             }
           },
           "required": [
@@ -114,16 +139,20 @@
           "type": "object",
           "properties": {
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id (only present when known)"
             },
             "triggerType": {
-              "type": "string"
+              "type": "string",
+              "description": "The trigger type: cron or simple (only present when known)"
             },
             "cron": {
-              "type": "string"
+              "type": "string",
+              "description": "The cron expression (only present when known)"
             },
             "repeatInterval": {
-              "type": "string"
+              "type": "string",
+              "description": "The simple trigger repeat interval (only present when known)"
             }
           }
         },

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/receive.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/receive.json
@@ -63,6 +63,70 @@
       "secret": false,
       "description": "Endpoint for where to receive messages (can also refer to a route id, endpoint pattern)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "messages": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The dumped received messages, as opaque JSON objects (only present when dumping)"
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether receiving is enabled (only present when not dumping)"
+      },
+      "total": {
+        "type": "integer",
+        "description": "Total number of messages received so far (only present when not dumping)"
+      },
+      "firstTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the first message in the last dump (only present when not dumping)"
+      },
+      "lastTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last message in the last dump (only present when not dumping)"
+      },
+      "url": {
+        "type": "string",
+        "description": "The endpoint URI that receiving was started for (only present on success)"
+      },
+      "error": {
+        "type": "string",
+        "description": "The error message (only present on failure to start receiving)"
+      },
+      "stackTrace": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The error stack trace, one entry per line (only present on failure to start receiving)"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            }
+          },
+          "required": [
+            "remote"
+          ]
+        },
+        "description": "The active consumer endpoints (only present when not dumping and there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/reload.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/reload.json
@@ -43,6 +43,57 @@
       "defaultValue": false,
       "description": "Option to wait for reloading to complete"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "reloadStrategies": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "description": "The reload strategy class name"
+            },
+            "reloaded": {
+              "type": "integer",
+              "description": "Number of successful reloads"
+            },
+            "failed": {
+              "type": "integer",
+              "description": "Number of failed reloads"
+            },
+            "lastError": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "description": "The error message"
+                },
+                "stackTrace": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The error stack trace, one entry per line"
+                }
+              },
+              "description": "The last reload error (only present when a reload has failed)"
+            }
+          },
+          "required": [
+            "reloaded",
+            "failed"
+          ]
+        },
+        "description": "The reload strategies (only present when not triggering a reload and at least one reload strategy is active)"
+      },
+      "status": {
+        "type": "string",
+        "description": "The reload status, reloading\/success\/failed (only present when triggering a reload)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/resilience4j.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/resilience4j.json
@@ -21,73 +21,91 @@
           "type": "object",
           "properties": {
             "id": {
-              "type": "string"
+              "type": "string",
+              "description": "The circuit breaker id"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             },
             "state": {
-              "type": "string"
+              "type": "string",
+              "description": "The circuit breaker state"
             },
             "bufferedCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of buffered calls"
             },
             "successfulCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of successful calls"
             },
             "failedCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed calls"
             },
             "notPermittedCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of not permitted calls"
             },
             "failureRate": {
-              "type": "number"
+              "type": "number",
+              "description": "The failure rate in percentage"
             },
             "configuration": {
               "type": "object",
               "properties": {
                 "failureRateThreshold": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "The failure rate threshold in percentage"
                 },
                 "slowCallRateThreshold": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "The slow call rate threshold in percentage"
                 },
                 "minimumNumberOfCalls": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The minimum number of calls before the failure rate is calculated"
                 },
                 "permittedNumberOfCallsInHalfOpenState": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The number of permitted calls when the circuit breaker is half open"
                 },
                 "slidingWindowSize": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The sliding window size"
                 },
                 "slidingWindowType": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "The sliding window type"
                 },
                 "waitDurationInOpenState": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The wait duration in the open state, in milliseconds"
                 },
                 "automaticTransitionFromOpenToHalfOpen": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the circuit breaker automatically transitions from open to half-open"
                 },
                 "bulkheadEnabled": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the bulkhead is enabled"
                 },
                 "bulkheadMaxConcurrentCalls": {
                   "type": "integer",
-                  "description": "Only present when bulkheadEnabled is true"
+                  "description": "The maximum concurrent calls allowed by the bulkhead (only present when bulkheadEnabled is true)"
                 },
                 "bulkheadMaxWaitDuration": {
                   "type": "integer",
-                  "description": "Only present when bulkheadEnabled is true"
+                  "description": "The maximum wait duration for the bulkhead in milliseconds (only present when bulkheadEnabled is true)"
                 },
                 "timeoutEnabled": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the timeout is enabled"
                 },
                 "timeoutDuration": {
                   "type": "integer",
-                  "description": "Only present when timeoutEnabled is true"
+                  "description": "The timeout duration in milliseconds (only present when timeoutEnabled is true)"
                 }
               },
               "required": [
@@ -100,7 +118,8 @@
                 "automaticTransitionFromOpenToHalfOpen",
                 "bulkheadEnabled",
                 "timeoutEnabled"
-              ]
+              ],
+              "description": "The circuit breaker configuration"
             }
           },
           "required": [

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/resilience4j.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/resilience4j.json
@@ -11,6 +11,109 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-resilience4j",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "circuitBreakers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "bufferedCalls": {
+              "type": "integer"
+            },
+            "successfulCalls": {
+              "type": "integer"
+            },
+            "failedCalls": {
+              "type": "integer"
+            },
+            "notPermittedCalls": {
+              "type": "integer"
+            },
+            "failureRate": {
+              "type": "number"
+            },
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "failureRateThreshold": {
+                  "type": "number"
+                },
+                "slowCallRateThreshold": {
+                  "type": "number"
+                },
+                "minimumNumberOfCalls": {
+                  "type": "integer"
+                },
+                "permittedNumberOfCallsInHalfOpenState": {
+                  "type": "integer"
+                },
+                "slidingWindowSize": {
+                  "type": "integer"
+                },
+                "slidingWindowType": {
+                  "type": "string"
+                },
+                "waitDurationInOpenState": {
+                  "type": "integer"
+                },
+                "automaticTransitionFromOpenToHalfOpen": {
+                  "type": "boolean"
+                },
+                "bulkheadEnabled": {
+                  "type": "boolean"
+                },
+                "bulkheadMaxConcurrentCalls": {
+                  "type": "integer",
+                  "description": "Only present when bulkheadEnabled is true"
+                },
+                "bulkheadMaxWaitDuration": {
+                  "type": "integer",
+                  "description": "Only present when bulkheadEnabled is true"
+                },
+                "timeoutEnabled": {
+                  "type": "boolean"
+                },
+                "timeoutDuration": {
+                  "type": "integer",
+                  "description": "Only present when timeoutEnabled is true"
+                }
+              },
+              "required": [
+                "failureRateThreshold",
+                "slowCallRateThreshold",
+                "minimumNumberOfCalls",
+                "permittedNumberOfCallsInHalfOpenState",
+                "slidingWindowSize",
+                "waitDurationInOpenState",
+                "automaticTransitionFromOpenToHalfOpen",
+                "bulkheadEnabled",
+                "timeoutEnabled"
+              ]
+            }
+          },
+          "required": [
+            "bufferedCalls",
+            "successfulCalls",
+            "failedCalls",
+            "notPermittedCalls",
+            "failureRate"
+          ]
+        },
+        "description": "The circuit breakers"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/rest-spec.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/rest-spec.json
@@ -27,6 +27,32 @@
       "secret": false,
       "description": "Filters specifications matching the given URI pattern"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "specs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "specificationUri": {
+              "type": "string",
+              "description": "The OpenAPI specification URI"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "content": {
+              "type": "string",
+              "description": "The specification content (only present when it could be loaded)"
+            }
+          }
+        },
+        "description": "The OpenAPI specifications"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/rest.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/rest.json
@@ -11,6 +11,80 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "rests": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The absolute URL to the REST service"
+            },
+            "method": {
+              "type": "string",
+              "description": "The HTTP method"
+            },
+            "contractFirst": {
+              "type": "boolean",
+              "description": "Whether the REST service is contract-first"
+            },
+            "specification": {
+              "type": "boolean",
+              "description": "Whether this is the API contract specification (i.e. api-doc)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The REST service state"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "operationId": {
+              "type": "string",
+              "description": "The OpenAPI operation ID (only present for contract-first routes)"
+            },
+            "specificationUri": {
+              "type": "string",
+              "description": "The OpenAPI specification URI (only present for contract-first routes)"
+            },
+            "consumes": {
+              "type": "string",
+              "description": "The accepted media types (only present when known)"
+            },
+            "produces": {
+              "type": "string",
+              "description": "The returned media types (only present when known)"
+            },
+            "inType": {
+              "type": "string",
+              "description": "The input binding class name (only present when known)"
+            },
+            "outType": {
+              "type": "string",
+              "description": "The output binding class name (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The REST service description (only present when configured)"
+            },
+            "hits": {
+              "type": "integer",
+              "description": "Usage of the REST service (only present when greater than zero)"
+            }
+          },
+          "required": [
+            "contractFirst",
+            "specification"
+          ]
+        },
+        "description": "The REST services (only present when a REST registry is available)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-controller.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-controller.json
@@ -43,6 +43,126 @@
       "defaultValue": true,
       "description": "Whether to include stack traces"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "controller": {
+        "type": "string",
+        "description": "The route controller implementation: SupervisingRouteController or DefaultRouteController"
+      },
+      "startingRoutes": {
+        "type": "boolean",
+        "description": "Whether routes are still starting (supervising controller only)"
+      },
+      "unhealthyRoutes": {
+        "type": "boolean",
+        "description": "Whether any route is unhealthy (supervising controller only)"
+      },
+      "totalRoutes": {
+        "type": "integer",
+        "description": "Total number of routes"
+      },
+      "startedRoutes": {
+        "type": "integer",
+        "description": "Number of started routes (supervising controller only)"
+      },
+      "restartingRoutes": {
+        "type": "integer",
+        "description": "Number of restarting routes (supervising controller only)"
+      },
+      "exhaustedRoutes": {
+        "type": "integer",
+        "description": "Number of exhausted routes (supervising controller only)"
+      },
+      "initialDelay": {
+        "type": "integer",
+        "description": "Initial delay in milliseconds before restarting (supervising controller only)"
+      },
+      "backoffDelay": {
+        "type": "integer",
+        "description": "Backoff delay in milliseconds (supervising controller only)"
+      },
+      "backoffMaxDelay": {
+        "type": "integer",
+        "description": "Maximum backoff delay in milliseconds (supervising controller only)"
+      },
+      "backoffMaxElapsedTime": {
+        "type": "integer",
+        "description": "Maximum elapsed time in milliseconds before giving up (supervising controller only)"
+      },
+      "backoffMaxAttempts": {
+        "type": "integer",
+        "description": "Maximum number of restart attempts (supervising controller only)"
+      },
+      "threadPoolSize": {
+        "type": "integer",
+        "description": "The size of the restart thread pool (supervising controller only)"
+      },
+      "unhealthyOnRestarting": {
+        "type": "boolean",
+        "description": "Whether a restarting route is considered unhealthy (supervising controller only)"
+      },
+      "unhealthyOnExhausted": {
+        "type": "boolean",
+        "description": "Whether an exhausted route is considered unhealthy (supervising controller only)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "status": {
+              "type": "string",
+              "description": "The route status"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The route endpoint URI (sanitized)"
+            },
+            "attempts": {
+              "type": "integer",
+              "description": "Number of restart attempts (supervising controller only)"
+            },
+            "lastAttempt": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last restart attempt (supervising controller only)"
+            },
+            "nextAttempt": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the next restart attempt (supervising controller only)"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "Elapsed time in milliseconds of the current restart attempt (supervising controller only)"
+            },
+            "supervising": {
+              "type": "string",
+              "description": "The supervising status (supervising controller only)"
+            },
+            "error": {
+              "type": "string",
+              "description": "The restart error message (only present when the route is failing)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The restart error stack trace, one entry per line (only present when the route is failing and stack traces are requested)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    },
+    "required": [
+      "totalRoutes"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-diagram.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-diagram.json
@@ -186,6 +186,19 @@
       "defaultValue": "transparent",
       "description": "Theme to use: dark, light, transparent, ascii, or unicode"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "text": {
+        "type": "string",
+        "description": "The rendered ASCII\/Unicode art diagram (only present for a text theme)"
+      },
+      "image": {
+        "type": "string",
+        "description": "The rendered diagram as a base64-encoded PNG image (only present for a non-text theme)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-dump.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-dump.json
@@ -75,6 +75,56 @@
       "defaultValue": false,
       "description": "Whether to expand URIs into separated key\/value parameters"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "format": {
+              "type": "string",
+              "description": "The dump format, xml\/yaml\/java (only present when the dump succeeded)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number, or -1 when not known"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The dumped route source code (only present when the dump succeeded)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-group.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-group.json
@@ -59,6 +59,145 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routeGroups": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "group": {
+              "type": "string",
+              "description": "The route group ID"
+            },
+            "size": {
+              "type": "integer",
+              "description": "Number of routes in this group"
+            },
+            "state": {
+              "type": "string",
+              "description": "The route group state"
+            },
+            "uptime": {
+              "type": "string",
+              "description": "Route uptime, human readable text"
+            },
+            "routeIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The route IDs within this group"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "coverage": {
+                  "type": "string",
+                  "description": "Route coverage (only present when computable)"
+                },
+                "load01": {
+                  "type": "string",
+                  "description": "1 minute load average (only present when available)"
+                },
+                "load05": {
+                  "type": "string",
+                  "description": "5 minute load average (only present when available)"
+                },
+                "load15": {
+                  "type": "string",
+                  "description": "15 minute load average (only present when available)"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the route group has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          },
+          "required": [
+            "size"
+          ]
+        },
+        "description": "The route groups (only present when no action was requested)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-structure.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-structure.json
@@ -71,6 +71,90 @@
       "defaultValue": false,
       "description": "Whether to include metrics such as number of messages processed (from JMX)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "line": {
+              "type": "integer",
+              "description": "The source line number (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The route description (only present when configured)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number, or a sequential counter when not known"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The processor type"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "The processor ID"
+                  },
+                  "level": {
+                    "type": "integer",
+                    "description": "The nesting level"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description (only present when known)"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The code representation of this processor"
+                  },
+                  "uri": {
+                    "type": "string",
+                    "description": "The endpoint URI (only present when this processor references an endpoint)"
+                  },
+                  "remote": {
+                    "type": "boolean",
+                    "description": "Whether the endpoint is remote (only present when true)"
+                  },
+                  "statistics": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Runtime statistics for this route or processor, as an opaque JSON object (only present when metrics were requested)"
+                  }
+                },
+                "required": [
+                  "line",
+                  "level"
+                ]
+              },
+              "description": "The route's structure, one entry per processor (only present when the dump succeeded)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-topology.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route-topology.json
@@ -58,6 +58,118 @@
       "defaultValue": false,
       "description": "Whether to include route structure data in the response"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "description": {
+              "type": "string",
+              "description": "The route description (only present when configured)"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "fromScheme": {
+              "type": "string",
+              "description": "The route's endpoint scheme"
+            },
+            "nodeType": {
+              "type": "string",
+              "description": "The node type"
+            },
+            "exchangesTotal": {
+              "type": "integer",
+              "description": "Total number of exchanges (only present when metrics were requested and available)"
+            },
+            "exchangesFailed": {
+              "type": "integer",
+              "description": "Number of failed exchanges (only present when metrics were requested and available)"
+            }
+          }
+        },
+        "description": "The topology nodes (only present when a route topology dumper is available)"
+      },
+      "edges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "fromRouteId": {
+              "type": "string",
+              "description": "The source route ID"
+            },
+            "toRouteId": {
+              "type": "string",
+              "description": "The target route ID"
+            },
+            "endpoint": {
+              "type": "string",
+              "description": "The endpoint URI connecting the two routes"
+            },
+            "connectionType": {
+              "type": "string",
+              "description": "The connection type"
+            }
+          }
+        },
+        "description": "The connections between nodes (only present when a route topology dumper is available)"
+      },
+      "externalEndpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The endpoint ID"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "scheme": {
+              "type": "string",
+              "description": "The endpoint scheme"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction (in or out)"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "exchangesTotal": {
+              "type": "integer",
+              "description": "Total number of exchanges (only present when metrics were requested and available)"
+            },
+            "exchangesFailed": {
+              "type": "integer",
+              "description": "Number of failed exchanges (only present when metrics were requested and available)"
+            }
+          }
+        },
+        "description": "External systems the routes connect to (only present when requested and there are any)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "Route structure data, as opaque JSON objects (only present when requested)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/route.json
@@ -76,6 +76,369 @@
       "defaultValue": false,
       "description": "Whether to include processors"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "group": {
+              "type": "string",
+              "description": "The route group (only present when known)"
+            },
+            "nodePrefixId": {
+              "type": "string",
+              "description": "The node prefix ID (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The route description (only present when configured)"
+            },
+            "note": {
+              "type": "string",
+              "description": "The route note (only present when configured)"
+            },
+            "createdByKamelet": {
+              "type": "boolean",
+              "description": "Whether the route was created by a Kamelet"
+            },
+            "createdByRouteTemplate": {
+              "type": "boolean",
+              "description": "Whether the route was created by a route template"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The route state"
+            },
+            "supportsSuspension": {
+              "type": "boolean",
+              "description": "Whether the route supports suspension"
+            },
+            "uptime": {
+              "type": "string",
+              "description": "Route uptime, human readable text"
+            },
+            "lastError": {
+              "type": "object",
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "description": "The error phase"
+                },
+                "timestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds when the error happened"
+                },
+                "message": {
+                  "type": "string",
+                  "description": "The error message (only present when known)"
+                },
+                "stackTrace": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The error stack trace, one entry per line (only present when known)"
+                }
+              },
+              "required": [
+                "timestamp"
+              ],
+              "description": "The last lifecycle error (only present when one has occurred)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "coverage": {
+                  "type": "string",
+                  "description": "Route coverage (only present when computable)"
+                },
+                "load01": {
+                  "type": "string",
+                  "description": "1 minute load average (only present when available)"
+                },
+                "load05": {
+                  "type": "string",
+                  "description": "5 minute load average (only present when available)"
+                },
+                "load15": {
+                  "type": "string",
+                  "description": "15 minute load average (only present when available)"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the route has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            },
+            "processors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "routeId": {
+                    "type": "string",
+                    "description": "The route ID"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "The processor ID"
+                  },
+                  "nodePrefixId": {
+                    "type": "string",
+                    "description": "The node prefix ID (only present when known)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The processor description (only present when configured)"
+                  },
+                  "note": {
+                    "type": "string",
+                    "description": "The processor note (only present when configured)"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "The source location, optionally with a line number suffix (only present when known)"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The processor state"
+                  },
+                  "disabled": {
+                    "type": "boolean",
+                    "description": "Whether the processor is disabled (only present when known)"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "The step ID (only present when known)"
+                  },
+                  "code": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "line": {
+                          "type": "integer",
+                          "description": "The source line number (only present when known)"
+                        },
+                        "code": {
+                          "type": "string",
+                          "description": "The source code line"
+                        },
+                        "match": {
+                          "type": "boolean",
+                          "description": "Whether this is the matched line (only present when true)"
+                        }
+                      }
+                    },
+                    "description": "A snippet of source code around the processor (only present when known)"
+                  },
+                  "processor": {
+                    "type": "string",
+                    "description": "The processor name"
+                  },
+                  "level": {
+                    "type": "integer",
+                    "description": "The processor level in the route tree"
+                  },
+                  "uri": {
+                    "type": "string",
+                    "description": "The destination URI, for processors that send to a destination (only present when applicable)"
+                  },
+                  "statistics": {
+                    "type": "object",
+                    "properties": {
+                      "idleSince": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds since the processor has been idle"
+                      },
+                      "exchangesTotal": {
+                        "type": "integer",
+                        "description": "Total number of exchanges"
+                      },
+                      "exchangesFailed": {
+                        "type": "integer",
+                        "description": "Number of failed exchanges"
+                      },
+                      "exchangesInflight": {
+                        "type": "integer",
+                        "description": "Number of inflight exchanges"
+                      },
+                      "exchangesThroughput": {
+                        "type": "string",
+                        "description": "Messages per second throughput (only present when available)"
+                      },
+                      "meanProcessingTime": {
+                        "type": "integer",
+                        "description": "Mean processing time in milliseconds"
+                      },
+                      "maxProcessingTime": {
+                        "type": "integer",
+                        "description": "Max processing time in milliseconds"
+                      },
+                      "minProcessingTime": {
+                        "type": "integer",
+                        "description": "Min processing time in milliseconds"
+                      },
+                      "p50ProcessingTime": {
+                        "type": "integer",
+                        "description": "50th percentile processing time in milliseconds (only present when available)"
+                      },
+                      "p95ProcessingTime": {
+                        "type": "integer",
+                        "description": "95th percentile processing time in milliseconds (only present when available)"
+                      },
+                      "p99ProcessingTime": {
+                        "type": "integer",
+                        "description": "99th percentile processing time in milliseconds (only present when available)"
+                      },
+                      "lastProcessingTime": {
+                        "type": "integer",
+                        "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                      },
+                      "deltaProcessingTime": {
+                        "type": "integer",
+                        "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                      },
+                      "lastCreatedExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                      },
+                      "lastCompletedExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                      },
+                      "lastFailureHandledExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                      },
+                      "lastFailedExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                      }
+                    },
+                    "required": [
+                      "idleSince",
+                      "exchangesTotal",
+                      "exchangesFailed",
+                      "exchangesInflight",
+                      "meanProcessingTime",
+                      "maxProcessingTime",
+                      "minProcessingTime"
+                    ],
+                    "description": "Runtime statistics"
+                  }
+                },
+                "required": [
+                  "level"
+                ]
+              },
+              "description": "The route's processors (only present when requested)"
+            }
+          },
+          "required": [
+            "createdByKamelet",
+            "createdByRouteTemplate",
+            "remote",
+            "supportsSuspension"
+          ]
+        },
+        "description": "The routes (only present when no action was requested)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/send.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/send.json
@@ -103,6 +103,45 @@
       "defaultValue": 20000,
       "description": "Timeout when using poll mode"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "timestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds when the send was performed"
+      },
+      "status": {
+        "type": "string",
+        "description": "The send status, success\/error\/timeout"
+      },
+      "elapsed": {
+        "type": "integer",
+        "description": "Elapsed time in milliseconds"
+      },
+      "endpoint": {
+        "type": "string",
+        "description": "The endpoint URI (only present when known)"
+      },
+      "exception": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The exception, as an opaque JSON object (only present on error)"
+      },
+      "exchangeId": {
+        "type": "string",
+        "description": "The exchange ID (only present when a response message is available)"
+      },
+      "message": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The response message, as an opaque JSON object (only present when a response message is available)"
+      }
+    },
+    "required": [
+      "timestamp",
+      "elapsed"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/service.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/service.json
@@ -11,6 +11,63 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "services": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "component": {
+              "type": "string",
+              "description": "The Camel component"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction (in or out)"
+            },
+            "hosted": {
+              "type": "boolean",
+              "description": "Whether the service is hosted in this Camel application"
+            },
+            "protocol": {
+              "type": "string",
+              "description": "The protocol the service is using (only present when known)"
+            },
+            "serviceUrl": {
+              "type": "string",
+              "description": "The remote address of the service (only present when known)"
+            },
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "hits": {
+              "type": "integer",
+              "description": "Usage of the endpoint service"
+            },
+            "metadata": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Additional metadata relevant to the service (only present when available)"
+            }
+          },
+          "required": [
+            "hosted",
+            "hits"
+          ]
+        },
+        "description": "The services"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/sftp.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/sftp.json
@@ -11,6 +11,16 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-ftp",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "config": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The SFTP (JSCH) configuration"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/simple-language.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/simple-language.json
@@ -11,6 +11,37 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "coreSize": {
+        "type": "integer",
+        "description": "Number of core simple functions"
+      },
+      "customSize": {
+        "type": "integer",
+        "description": "Number of custom simple functions"
+      },
+      "coreFunctions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The core function names (only present when there are any)"
+      },
+      "customFunctions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The custom function names (only present when there are any)"
+      }
+    },
+    "required": [
+      "coreSize",
+      "customSize"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/source-dir.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/source-dir.json
@@ -27,6 +27,47 @@
       "secret": false,
       "description": "Whether to show the source in the output"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "dir": {
+        "type": "string",
+        "description": "The source directory (only present when a reload strategy is active)"
+      },
+      "files": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The file name"
+            },
+            "size": {
+              "type": "integer",
+              "description": "The file size in bytes"
+            },
+            "lastModified": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last modification"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                
+              },
+              "description": "The source code lines (only present when requested and available)"
+            }
+          },
+          "required": [
+            "size",
+            "lastModified"
+          ]
+        },
+        "description": "The files in the source directory (only present when the directory is not empty)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/source-dir.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/source-dir.json
@@ -1,0 +1,32 @@
+{
+  "console": {
+    "kind": "console",
+    "group": "camel-jbang",
+    "name": "source-dir",
+    "title": "Source Directory",
+    "description": "Information about Camel CLI source files",
+    "deprecated": false,
+    "readOnly": true,
+    "javaType": "org.apache.camel.jbang.console.SourceDirDevConsole",
+    "groupId": "org.apache.camel",
+    "artifactId": "camel-jbang-console",
+    "version": "4.23.0-SNAPSHOT"
+  },
+  "options": {
+    "source": {
+      "index": 0,
+      "kind": "option",
+      "displayName": "Source",
+      "group": "query",
+      "label": "query",
+      "required": false,
+      "type": "boolean",
+      "javaType": "java.lang.Boolean",
+      "deprecated": false,
+      "autowired": false,
+      "secret": false,
+      "description": "Whether to show the source in the output"
+    }
+  }
+}
+

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/source.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/source.json
@@ -41,6 +41,56 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The line number"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  },
+                  "match": {
+                    "type": "boolean",
+                    "description": "Whether this is the matched line (only present when true)"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The source code around the route (only present when resolvable)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/sql-query.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/sql-query.json
@@ -132,6 +132,90 @@
       "secret": false,
       "description": "Table name for update-row action"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "The execution status, success or error"
+      },
+      "message": {
+        "type": "string",
+        "description": "The error message (only present on error)"
+      },
+      "datasource": {
+        "type": "string",
+        "description": "The resolved DataSource bean name (only present once resolved)"
+      },
+      "availableDataSources": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The available DataSource bean names (only present when multiple exist and none was specified)"
+      },
+      "elapsed": {
+        "type": "integer",
+        "description": "Elapsed time in milliseconds (only present once a query attempt was made)"
+      },
+      "columns": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The column name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The column SQL type name"
+            },
+            "primaryKey": {
+              "type": "boolean",
+              "description": "Whether the column is part of the primary key (only present when the query targets a single, editable table)"
+            }
+          }
+        },
+        "description": "The result set columns (only present for queries returning a result set)"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The result set rows, one opaque JSON object per row (only present for queries returning a result set)"
+      },
+      "rowCount": {
+        "type": "integer",
+        "description": "Number of rows returned (only present for queries returning a result set)"
+      },
+      "truncated": {
+        "type": "boolean",
+        "description": "Whether the result set was truncated by maxRows (only present for queries returning a result set)"
+      },
+      "updateCount": {
+        "type": "integer",
+        "description": "Number of rows affected (only present for queries\/updates not returning a result set)"
+      },
+      "tableName": {
+        "type": "string",
+        "description": "The single table the result set maps to (only present when the result is a single, editable table)"
+      },
+      "primaryKeys": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The primary key column names (only present when the result is a single, editable table)"
+      },
+      "editable": {
+        "type": "boolean",
+        "description": "Whether the result set rows can be edited (only present when true)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/sql-trace.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/sql-trace.json
@@ -11,6 +11,126 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "statements": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds when the statement was executed"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "The processor node ID (only present when known)"
+            },
+            "location": {
+              "type": "string",
+              "description": "The source location of the processor (only present when known)"
+            },
+            "endpoint": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "query": {
+              "type": "string",
+              "description": "The SQL query (or the endpoint URI when the query could not be determined)"
+            },
+            "category": {
+              "type": "string",
+              "description": "The SQL statement category"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "Duration in milliseconds"
+            },
+            "failed": {
+              "type": "boolean",
+              "description": "Whether the exchange failed"
+            },
+            "rowCount": {
+              "type": "integer",
+              "description": "Number of rows returned (only present when known)"
+            },
+            "updateCount": {
+              "type": "integer",
+              "description": "Number of rows updated (only present when known)"
+            }
+          },
+          "required": [
+            "timestamp",
+            "duration",
+            "failed"
+          ]
+        },
+        "description": "The traced SQL statements, most recent first (only present when statements have been traced)"
+      },
+      "summary": {
+        "type": "object",
+        "properties": {
+          "totalQueries": {
+            "type": "integer",
+            "description": "Total number of queries"
+          },
+          "avgTime": {
+            "type": "integer",
+            "description": "Average duration in milliseconds"
+          },
+          "slowestTime": {
+            "type": "integer",
+            "description": "Slowest duration in milliseconds"
+          },
+          "slowCount": {
+            "type": "integer",
+            "description": "Number of queries considered slow (duration >= 100 ms)"
+          },
+          "failedCount": {
+            "type": "integer",
+            "description": "Number of failed queries"
+          },
+          "selectCount": {
+            "type": "integer",
+            "description": "Number of SELECT statements"
+          },
+          "insertCount": {
+            "type": "integer",
+            "description": "Number of INSERT statements"
+          },
+          "updateCount": {
+            "type": "integer",
+            "description": "Number of UPDATE statements"
+          },
+          "deleteCount": {
+            "type": "integer",
+            "description": "Number of DELETE statements"
+          }
+        },
+        "required": [
+          "totalQueries",
+          "avgTime",
+          "slowestTime",
+          "slowCount",
+          "failedCount",
+          "selectCount",
+          "insertCount",
+          "updateCount",
+          "deleteCount"
+        ],
+        "description": "Summary statistics across the traced statements (only present when statements have been traced)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/startup-recorder.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/startup-recorder.json
@@ -11,6 +11,59 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "The id of the step"
+            },
+            "parentId": {
+              "type": "integer",
+              "description": "The id of the parent step"
+            },
+            "level": {
+              "type": "integer",
+              "description": "The step level (sub step of previous steps)"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the step (only present when known)"
+            },
+            "type": {
+              "type": "string",
+              "description": "The source class type of the step"
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of the step"
+            },
+            "beginTime": {
+              "type": "integer",
+              "description": "The begin time (epoch milliseconds)"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "The duration the step took, in milliseconds"
+            }
+          },
+          "required": [
+            "id",
+            "parentId",
+            "level",
+            "beginTime",
+            "duration"
+          ]
+        },
+        "description": "The startup steps (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/stub.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/stub.json
@@ -74,6 +74,48 @@
       "secret": false,
       "description": "Limits the number of messages dumped"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "queues": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The queue name"
+            },
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "max": {
+              "type": "integer",
+              "description": "The maximum queue size"
+            },
+            "size": {
+              "type": "integer",
+              "description": "The current queue size"
+            },
+            "messages": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": "The browsed messages (only present when browsing is enabled and there are any)"
+            }
+          },
+          "required": [
+            "max",
+            "size"
+          ]
+        },
+        "description": "The stub queues"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/system-properties.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/system-properties.json
@@ -11,6 +11,21 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "systemProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "description": "The system properties, one single-entry map per property"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/thread.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/thread.json
@@ -28,6 +28,82 @@
       "defaultValue": false,
       "description": "Whether to include thread stack traces"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "threadCount": {
+        "type": "integer",
+        "description": "Number of threads"
+      },
+      "daemonThreadCount": {
+        "type": "integer",
+        "description": "Number of daemon threads"
+      },
+      "totalStartedThreadCount": {
+        "type": "integer",
+        "description": "Total number of threads started since JVM start"
+      },
+      "peakThreadCount": {
+        "type": "integer",
+        "description": "Peak number of threads"
+      },
+      "threads": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "The thread ID"
+            },
+            "name": {
+              "type": "string",
+              "description": "The thread name"
+            },
+            "state": {
+              "type": "string",
+              "description": "The thread state"
+            },
+            "blockedCount": {
+              "type": "integer",
+              "description": "Number of times the thread has been blocked"
+            },
+            "blockedTime": {
+              "type": "integer",
+              "description": "Total time in milliseconds the thread has been blocked"
+            },
+            "waitedCount": {
+              "type": "integer",
+              "description": "Number of times the thread has waited"
+            },
+            "waitedTime": {
+              "type": "integer",
+              "description": "Total time in milliseconds the thread has waited"
+            },
+            "lockName": {
+              "type": "string",
+              "description": "The name of the lock the thread is waiting on (only present when applicable)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The thread stack trace, one entry per line (only present when requested via the stackTrace option)"
+            }
+          },
+          "required": [
+            "id",
+            "blockedCount",
+            "blockedTime",
+            "waitedCount",
+            "waitedTime"
+          ]
+        },
+        "description": "The threads"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/top.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/top.json
@@ -41,6 +41,223 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The route state"
+            },
+            "uptime": {
+              "type": "string",
+              "description": "Route uptime, human readable text"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange"
+                },
+                "totalProcessingTime": {
+                  "type": "integer",
+                  "description": "Total accumulated processing time in milliseconds"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                }
+              },
+              "required": [
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime",
+                "lastProcessingTime",
+                "deltaProcessingTime",
+                "totalProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          }
+        },
+        "description": "The top routes (only present when no processor path was requested)"
+      },
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "processorId": {
+              "type": "string",
+              "description": "The processor ID"
+            },
+            "location": {
+              "type": "string",
+              "description": "The source location, optionally with a line number suffix (only present when known)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number"
+                  },
+                  "match": {
+                    "type": "boolean",
+                    "description": "Whether this is the matched line (only present when true)"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "A snippet of source code around the processor (only present when known)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange"
+                },
+                "totalProcessingTime": {
+                  "type": "integer",
+                  "description": "Total accumulated processing time in milliseconds"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                }
+              },
+              "required": [
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime",
+                "lastProcessingTime",
+                "deltaProcessingTime",
+                "totalProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          }
+        },
+        "description": "The top processors of a route (only present when a processor path was requested)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/trace.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/trace.json
@@ -49,6 +49,83 @@
       "secret": false,
       "description": "Whether to enable or disable tracing"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether tracing is enabled (only present when a backlog tracer is available)"
+      },
+      "traces": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The traced messages, as opaque JSON objects (only present when dumping)"
+      },
+      "standby": {
+        "type": "boolean",
+        "description": "Whether the tracer is in standby mode (only present when not dumping)"
+      },
+      "counter": {
+        "type": "integer",
+        "description": "Total number of traced messages (only present when not dumping)"
+      },
+      "backlogSize": {
+        "type": "integer",
+        "description": "The current backlog size (only present when not dumping)"
+      },
+      "queueSize": {
+        "type": "integer",
+        "description": "The current queue size (only present when not dumping)"
+      },
+      "removeOnDump": {
+        "type": "boolean",
+        "description": "Whether messages are removed from the backlog when dumped (only present when not dumping)"
+      },
+      "traceFilter": {
+        "type": "string",
+        "description": "The trace filter (only present when configured)"
+      },
+      "tracePattern": {
+        "type": "string",
+        "description": "The trace pattern (only present when configured)"
+      },
+      "traceRests": {
+        "type": "boolean",
+        "description": "Whether rests are traced (only present when not dumping)"
+      },
+      "traceTemplates": {
+        "type": "boolean",
+        "description": "Whether route templates\/Kamelets are traced (only present when not dumping)"
+      },
+      "bodyMaxChars": {
+        "type": "integer",
+        "description": "Maximum size of the message body to include (only present when not dumping)"
+      },
+      "bodyIncludeFiles": {
+        "type": "boolean",
+        "description": "Whether file-based message bodies are included (only present when not dumping)"
+      },
+      "bodyIncludeStreams": {
+        "type": "boolean",
+        "description": "Whether streaming message bodies are included (only present when not dumping)"
+      },
+      "includeExchangeProperties": {
+        "type": "boolean",
+        "description": "Whether exchange properties are included (only present when not dumping)"
+      },
+      "includeExchangeVariables": {
+        "type": "boolean",
+        "description": "Whether exchange variables are included (only present when not dumping)"
+      },
+      "includeException": {
+        "type": "boolean",
+        "description": "Whether exceptions are included (only present when not dumping)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/transformers.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/transformers.json
@@ -11,6 +11,54 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "size": {
+        "type": "integer",
+        "description": "Total number of transformers"
+      },
+      "dynamicSize": {
+        "type": "integer",
+        "description": "Number of transformers in the dynamic registry"
+      },
+      "staticSize": {
+        "type": "integer",
+        "description": "Number of transformers in the static registry"
+      },
+      "maximumCacheSize": {
+        "type": "integer",
+        "description": "Maximum number of entries to store in the dynamic registry"
+      },
+      "transformers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The transformer name"
+            },
+            "from": {
+              "type": "string",
+              "description": "The from data type (only present when not any-type)"
+            },
+            "to": {
+              "type": "string",
+              "description": "The to data type (only present when not any-type)"
+            }
+          }
+        },
+        "description": "The transformers (only present when there are any)"
+      }
+    },
+    "required": [
+      "size",
+      "dynamicSize",
+      "staticSize",
+      "maximumCacheSize"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/type-converters.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/type-converters.json
@@ -11,6 +11,80 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "size": {
+        "type": "integer",
+        "description": "Number of registered type converters"
+      },
+      "exists": {
+        "type": "string",
+        "description": "Whether a type converter must exist or not"
+      },
+      "existsLoggingLevel": {
+        "type": "string",
+        "description": "Logging level used when a type converter does not exist"
+      },
+      "statistics": {
+        "type": "object",
+        "properties": {
+          "attemptCounter": {
+            "type": "integer",
+            "description": "Number of attempted conversions"
+          },
+          "hitCounter": {
+            "type": "integer",
+            "description": "Number of successful conversions (cache hit)"
+          },
+          "missCounter": {
+            "type": "integer",
+            "description": "Number of cache misses"
+          },
+          "failedCounter": {
+            "type": "integer",
+            "description": "Number of failed conversions"
+          },
+          "noopCounter": {
+            "type": "integer",
+            "description": "Number of noop conversions"
+          }
+        },
+        "required": [
+          "attemptCounter",
+          "hitCounter",
+          "missCounter",
+          "failedCounter",
+          "noopCounter"
+        ],
+        "description": "Type converter usage statistics (only present when statistics are enabled)"
+      },
+      "converters": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "The source type"
+            },
+            "to": {
+              "type": "string",
+              "description": "The target type"
+            },
+            "converterClass": {
+              "type": "string",
+              "description": "The type converter implementation class"
+            }
+          }
+        },
+        "description": "The registered type converters"
+      }
+    },
+    "required": [
+      "size"
+    ]
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/variables.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/variables.json
@@ -11,6 +11,44 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "repositories": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The variable repository id"
+            },
+            "variables": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "The variable name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The variable value type (only present when the value is known)"
+                  },
+                  "value": {
+                    "description": "The variable value (only present when known)"
+                  }
+                }
+              },
+              "description": "The variables in this repository"
+            }
+          }
+        },
+        "description": "The variable repositories (only present when there are any with variables)"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/vertx-websocket.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/dev-consoles/vertx-websocket.json
@@ -28,6 +28,73 @@
       "defaultValue": true,
       "description": "Whether to include WebSocket peer connection header details in the output"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "hosts": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "host": {
+              "type": "string",
+              "description": "The host"
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "The websocket path"
+                  },
+                  "peers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The peer connection id"
+                        },
+                        "path": {
+                          "type": "string",
+                          "description": "The websocket path"
+                        },
+                        "rawPath": {
+                          "type": "string",
+                          "description": "The raw websocket path"
+                        },
+                        "hostAddress": {
+                          "type": "string",
+                          "description": "The local host address"
+                        },
+                        "subProtocol": {
+                          "type": "string",
+                          "description": "The negotiated sub protocol (only present when known)"
+                        },
+                        "headers": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "The connection headers (only present when includeHeaders is enabled)"
+                        }
+                      }
+                    },
+                    "description": "The connected peers"
+                  }
+                }
+              },
+              "description": "The websocket paths served on this host"
+            }
+          }
+        },
+        "description": "The Vert.x WebSocket consumer hosts"
+      }
+    }
   }
 }
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others.properties
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others.properties
@@ -17,6 +17,7 @@ jandex
 jasypt
 java-io
 java-joor-dsl
+jbang-console
 jfr
 jsoup
 jta

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/jbang-console.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/others/jbang-console.json
@@ -1,0 +1,15 @@
+{
+  "other": {
+    "kind": "other",
+    "name": "jbang-console",
+    "title": "Jbang Console",
+    "description": "Camel CLI Console",
+    "deprecated": false,
+    "firstVersion": "3.21.0",
+    "label": "jbang",
+    "supportLevel": "Stable",
+    "groupId": "org.apache.camel",
+    "artifactId": "camel-jbang-console",
+    "version": "4.23.0-SNAPSHOT"
+  }
+}

--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1804,11 +1804,12 @@ public class CamelCatalogTest {
         Assertions.assertEquals("object", cbSchema.getString("type"));
         Assertions.assertNotNull(cbSchema.getJsonObject("properties").getJsonObject("circuitBreakers"));
 
-        // a console not yet migrated still has the empty placeholder
-        JsonObject log = paths.getJsonObject("/q/dev/log");
-        JsonObject logContent = log.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+        // variables is intentionally never migrated - it puts each repository ID as a dynamic top-level
+        // JSON key, which doesn't fit a fixed-field record, so it's a stable example of the empty placeholder
+        JsonObject variables = paths.getJsonObject("/q/dev/variables");
+        JsonObject variablesContent = variables.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
                 .getJsonObject("content").getJsonObject("application/json");
-        Assertions.assertTrue(logContent.isEmpty());
+        Assertions.assertTrue(variablesContent.isEmpty());
     }
 
     @Test

--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1804,12 +1804,13 @@ public class CamelCatalogTest {
         Assertions.assertEquals("object", cbSchema.getString("type"));
         Assertions.assertNotNull(cbSchema.getJsonObject("properties").getJsonObject("circuitBreakers"));
 
-        // variables is intentionally never migrated - it puts each repository ID as a dynamic top-level
-        // JSON key, which doesn't fit a fixed-field record, so it's a stable example of the empty placeholder
-        JsonObject variables = paths.getJsonObject("/q/dev/variables");
-        JsonObject variablesContent = variables.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+        // api is intentionally never migrated - its response IS a full OpenAPI document dynamically
+        // assembled from every registered console's model, not a fixed shape to describe, so it's a
+        // stable example of the empty placeholder
+        JsonObject api = paths.getJsonObject("/q/dev/api");
+        JsonObject apiContent = api.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
                 .getJsonObject("content").getJsonObject("application/json");
-        Assertions.assertTrue(variablesContent.isEmpty());
+        Assertions.assertTrue(apiContent.isEmpty());
     }
 
     @Test

--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1795,6 +1795,20 @@ public class CamelCatalogTest {
         JsonObject post = route.getJsonObject("post");
         Assertions.assertNotNull(post);
         Assertions.assertNotNull(post.getJsonObject("requestBody"));
+
+        // a console migrated to an authoritative typed Response record has a real response schema
+        JsonObject circuitBreaker = paths.getJsonObject("/q/dev/circuit-breaker");
+        JsonObject cbSchema = circuitBreaker.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+                .getJsonObject("content").getJsonObject("application/json").getJsonObject("schema");
+        Assertions.assertNotNull(cbSchema);
+        Assertions.assertEquals("object", cbSchema.getString("type"));
+        Assertions.assertNotNull(cbSchema.getJsonObject("properties").getJsonObject("circuitBreakers"));
+
+        // a console not yet migrated still has the empty placeholder
+        JsonObject jvm = paths.getJsonObject("/q/dev/jvm");
+        JsonObject jvmContent = jvm.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+                .getJsonObject("content").getJsonObject("application/json");
+        Assertions.assertTrue(jvmContent.isEmpty());
     }
 
     @Test

--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1805,10 +1805,10 @@ public class CamelCatalogTest {
         Assertions.assertNotNull(cbSchema.getJsonObject("properties").getJsonObject("circuitBreakers"));
 
         // a console not yet migrated still has the empty placeholder
-        JsonObject jvm = paths.getJsonObject("/q/dev/jvm");
-        JsonObject jvmContent = jvm.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+        JsonObject log = paths.getJsonObject("/q/dev/log");
+        JsonObject logContent = log.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
                 .getJsonObject("content").getJsonObject("application/json");
-        Assertions.assertTrue(jvmContent.isEmpty());
+        Assertions.assertTrue(logContent.isEmpty());
     }
 
     @Test

--- a/components/camel-aws/camel-aws-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/aws-secrets.json
+++ b/components/camel-aws/camel-aws-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/aws-secrets.json
@@ -11,6 +11,64 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-aws-secrets-manager",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "region": {
+        "type": "string",
+        "description": "The AWS region (only present when the AWS Secrets Manager properties function is active)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when the AWS Secrets Manager properties function is active)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "refreshPeriod": {
+        "type": "integer",
+        "description": "The refresh period in milliseconds (only present when configured)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when the AWS Secrets Manager properties function is active)"
+      }
+    }
   }
 }
 

--- a/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/SecretsDevConsole.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/main/java/org/apache/camel/component/aws/secretsmanager/SecretsDevConsole.java
@@ -23,14 +23,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.component.aws.secretsmanager.vault.CloudTrailReloadTriggerTask;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PeriodTaskScheduler;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.AwsVaultConfiguration;
 
 @DevConsole(name = "aws-secrets", displayName = "AWS Secrets", description = "AWS Secrets Manager")
@@ -38,6 +38,24 @@ public class SecretsDevConsole extends AbstractDevConsole {
 
     private SecretsManagerPropertiesFunction propertiesFunction;
     private CloudTrailReloadTriggerTask secretsRefreshTask;
+
+    public record SecretEntry(
+            @Metadata(description = "The secret name") String name,
+            @Metadata(description = "Epoch time in milliseconds of the last update (only present when known)") Long timestamp,
+            @Metadata(description = "Relative age of the last update (only present when known)") String age) {
+    }
+
+    public record Response(
+            @Metadata(description = "The AWS region (only present when the AWS Secrets Manager properties function is active)") String region,
+            @Metadata(description = "The login method (only present when the AWS Secrets Manager properties function is active)") String login,
+            @Metadata(description = "Whether secret refresh is enabled (only present when configured)") Boolean refreshEnabled,
+            @Metadata(description = "The refresh period in milliseconds (only present when configured)") Long refreshPeriod,
+            @Metadata(description = "Epoch time in milliseconds of the last check (only present when known)") Long lastCheckTimestamp,
+            @Metadata(description = "Relative age of the last check (only present when known)") String lastCheckAge,
+            @Metadata(description = "Epoch time in milliseconds of the last reload (only present when known)") Long lastReloadTimestamp,
+            @Metadata(description = "Relative age of the last reload (only present when known)") String lastReloadAge,
+            @Metadata(description = "The secrets in use (only present when the AWS Secrets Manager properties function is active)") List<SecretEntry> secrets) {
+    }
 
     public SecretsDevConsole() {
         super("camel", "aws-secrets", "AWS Secrets", "AWS Secrets Manager");
@@ -107,54 +125,64 @@ public class SecretsDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String region = null;
+        String login = null;
+        Boolean refreshEnabled = null;
+        Long refreshPeriod = null;
+        Long lastCheckTimestamp = null;
+        String lastCheckAge = null;
+        Long lastReloadTimestamp = null;
+        String lastReloadAge = null;
+        List<SecretEntry> secrets = null;
+
         if (propertiesFunction != null) {
-            root.put("region", propertiesFunction.getRegion());
+            region = propertiesFunction.getRegion();
             if (propertiesFunction.isDefaultCredentialsProvider()) {
-                root.put("login", "DefaultCredentialsProvider");
+                login = "DefaultCredentialsProvider";
             } else if (propertiesFunction.isProfleCredentialsProvider()) {
-                root.put("login", "ProfileCredentialsProvider");
+                login = "ProfileCredentialsProvider";
             } else {
-                root.put("login", "Access and Secret Keys");
+                login = "Access and Secret Keys";
             }
             AwsVaultConfiguration aws = getCamelContext().getVaultConfiguration().getAwsVaultConfiguration();
             if (aws != null) {
-                root.put("refreshEnabled", aws.isRefreshEnabled());
-                root.put("refreshPeriod", aws.getRefreshPeriod());
+                refreshEnabled = aws.isRefreshEnabled();
+                refreshPeriod = aws.getRefreshPeriod();
             }
             if (secretsRefreshTask != null) {
                 Instant last = secretsRefreshTask.getLastCheckTime();
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    root.put("lastCheckTimestamp", timestamp);
-                    root.put("lastCheckAge", TimeUtils.printSince(timestamp));
+                    lastCheckTimestamp = last.toEpochMilli();
+                    lastCheckAge = TimeUtils.printSince(lastCheckTimestamp);
                 }
                 last = secretsRefreshTask.getLastReloadTime();
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    root.put("lastReloadTimestamp", timestamp);
-                    root.put("lastReloadAge", TimeUtils.printSince(timestamp));
+                    lastReloadTimestamp = last.toEpochMilli();
+                    lastReloadAge = TimeUtils.printSince(lastReloadTimestamp);
                 }
             }
-            JsonArray arr = new JsonArray();
-            root.put("secrets", arr);
 
             List<String> sorted = new ArrayList<>(propertiesFunction.getSecrets());
             Collections.sort(sorted);
 
+            List<SecretEntry> arr = new ArrayList<>();
             for (String sec : sorted) {
-                JsonObject jo = new JsonObject();
-                jo.put("name", sec);
+                Long timestamp = null;
+                String age = null;
                 Instant last = secretsRefreshTask != null ? secretsRefreshTask.getUpdates().get(sec) : null;
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    jo.put("timestamp", timestamp);
-                    jo.put("age", TimeUtils.printSince(timestamp));
+                    timestamp = last.toEpochMilli();
+                    age = TimeUtils.printSince(timestamp);
                 }
-                arr.add(jo);
+                arr.add(new SecretEntry(sec, timestamp, age));
             }
+            secrets = arr;
         }
-        return root;
+
+        Response response = new Response(
+                region, login, refreshEnabled, refreshPeriod, lastCheckTimestamp, lastCheckAge, lastReloadTimestamp,
+                lastReloadAge, secrets);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/SecretsDevConsoleTest.java
+++ b/components/camel-aws/camel-aws-secrets-manager/src/test/java/org/apache/camel/component/aws/secretsmanager/SecretsDevConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws.secretsmanager;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SecretsDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testAwsSecretsConsoleNoPropertiesFunction() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("aws-secrets");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("aws-secrets", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-aws/camel-aws2-s3/src/generated/resources/META-INF/org/apache/camel/dev-console/aws2-s3.json
+++ b/components/camel-aws/camel-aws2-s3/src/generated/resources/META-INF/org/apache/camel/dev-console/aws2-s3.json
@@ -11,6 +11,56 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-aws2-s3",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "consumers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "bucket": {
+              "type": "string",
+              "description": "The S3 bucket name"
+            },
+            "accessKeys": {
+              "type": "boolean",
+              "description": "Whether static access keys are used"
+            },
+            "defaultCredentialsProvider": {
+              "type": "boolean",
+              "description": "Whether the default credentials provider is used"
+            },
+            "profileCredentialsProvider": {
+              "type": "boolean",
+              "description": "Whether the profile credentials provider is used"
+            },
+            "maxMessages": {
+              "type": "integer",
+              "description": "Maximum number of messages per poll"
+            },
+            "moveAfterRead": {
+              "type": "boolean",
+              "description": "Whether the object is moved after being read"
+            },
+            "deleteAfterRead": {
+              "type": "boolean",
+              "description": "Whether the object is deleted after being read"
+            }
+          },
+          "required": [
+            "accessKeys",
+            "defaultCredentialsProvider",
+            "profileCredentialsProvider",
+            "maxMessages",
+            "moveAfterRead",
+            "deleteAfterRead"
+          ]
+        },
+        "description": "The AWS S3 consumers (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Console.java
+++ b/components/camel-aws/camel-aws2-s3/src/main/java/org/apache/camel/component/aws2/s3/AWS2S3Console.java
@@ -23,12 +23,27 @@ import java.util.stream.Collectors;
 
 import org.apache.camel.Consumer;
 import org.apache.camel.Route;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "aws2-s3", displayName = "AWS S3", description = "AWS S3 Consumer")
 public class AWS2S3Console extends AbstractDevConsole {
+
+    public record ConsumerEntry(
+            @Metadata(description = "The S3 bucket name") String bucket,
+            @Metadata(description = "Whether static access keys are used") boolean accessKeys,
+            @Metadata(description = "Whether the default credentials provider is used") boolean defaultCredentialsProvider,
+            @Metadata(description = "Whether the profile credentials provider is used") boolean profileCredentialsProvider,
+            @Metadata(description = "Maximum number of messages per poll") int maxMessages,
+            @Metadata(description = "Whether the object is moved after being read") boolean moveAfterRead,
+            @Metadata(description = "Whether the object is deleted after being read") boolean deleteAfterRead) {
+    }
+
+    public record Response(
+            @Metadata(description = "The AWS S3 consumers (only present when there are any)") List<ConsumerEntry> consumers) {
+    }
 
     public AWS2S3Console() {
         super("camel", "aws2-s3", "AWS S3", "AWS S3 Consumer");
@@ -57,33 +72,25 @@ public class AWS2S3Console extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         List<Consumer> list = getCamelContext().getRoutes()
                 .stream().map(Route::getConsumer)
                 .filter(c -> c instanceof AWS2S3Consumer)
                 .collect(Collectors.toList());
 
-        List<JsonObject> arr = new ArrayList<>();
+        List<ConsumerEntry> arr = new ArrayList<>();
         for (Consumer c : list) {
             AWS2S3Consumer nc = (AWS2S3Consumer) c;
             AWS2S3Configuration conf = nc.getEndpoint().getConfiguration();
 
-            JsonObject jo = new JsonObject();
-            jo.put("bucket", conf.getBucketName());
-            jo.put("accessKeys", !conf.isUseDefaultCredentialsProvider() && !conf.isUseProfileCredentialsProvider());
-            jo.put("defaultCredentialsProvider", conf.isUseDefaultCredentialsProvider());
-            jo.put("profileCredentialsProvider", conf.isUseProfileCredentialsProvider());
-            jo.put("maxMessages", nc.getMaxMessagesPerPoll());
-            jo.put("moveAfterRead", conf.isMoveAfterRead());
-            jo.put("deleteAfterRead", conf.isDeleteAfterRead());
-            arr.add(jo);
-        }
-        if (!arr.isEmpty()) {
-            root.put("consumers", arr);
+            arr.add(new ConsumerEntry(
+                    conf.getBucketName(),
+                    !conf.isUseDefaultCredentialsProvider() && !conf.isUseProfileCredentialsProvider(),
+                    conf.isUseDefaultCredentialsProvider(), conf.isUseProfileCredentialsProvider(),
+                    nc.getMaxMessagesPerPoll(), conf.isMoveAfterRead(), conf.isDeleteAfterRead()));
         }
 
-        return root;
+        Response response = new Response(arr.isEmpty() ? null : arr);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/AWS2S3ConsoleTest.java
+++ b/components/camel-aws/camel-aws2-s3/src/test/java/org/apache/camel/component/aws2/s3/AWS2S3ConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.aws2.s3;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AWS2S3ConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testAws2S3ConsoleNoConsumers() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("aws2-s3");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("aws2-s3", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-azure/camel-azure-key-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/azure-secrets.json
+++ b/components/camel-azure/camel-azure-key-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/azure-secrets.json
@@ -11,6 +11,60 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-azure-key-vault",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when the Azure Key Vault properties function is active)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "refreshPeriod": {
+        "type": "integer",
+        "description": "The refresh period in milliseconds (only present when configured)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when the Azure Key Vault properties function is active)"
+      }
+    }
   }
 }
 

--- a/components/camel-azure/camel-azure-key-vault/src/main/java/org/apache/camel/component/azure/key/vault/AzureKeyVaultManagerDevConsole.java
+++ b/components/camel-azure/camel-azure-key-vault/src/main/java/org/apache/camel/component/azure/key/vault/AzureKeyVaultManagerDevConsole.java
@@ -22,14 +22,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PeriodTaskScheduler;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.AzureVaultConfiguration;
 
 @DevConsole(name = "azure-secrets", displayName = "Azure Key Vault Secrets", description = "Azure Key Vault Secret Manager")
@@ -37,6 +37,23 @@ public class AzureKeyVaultManagerDevConsole extends AbstractDevConsole {
 
     private KeyVaultPropertiesFunction propertiesFunction;
     private EventhubsReloadTriggerTask secretsRefreshTask;
+
+    public record SecretEntry(
+            @Metadata(description = "The secret name") String name,
+            @Metadata(description = "Epoch time in milliseconds of the last update (only present when known)") Long timestamp,
+            @Metadata(description = "Relative age of the last update (only present when known)") String age) {
+    }
+
+    public record Response(
+            @Metadata(description = "The login method (only present when the Azure Key Vault properties function is active)") String login,
+            @Metadata(description = "Whether secret refresh is enabled (only present when configured)") Boolean refreshEnabled,
+            @Metadata(description = "The refresh period in milliseconds (only present when configured)") Long refreshPeriod,
+            @Metadata(description = "Epoch time in milliseconds of the last check (only present when known)") Long lastCheckTimestamp,
+            @Metadata(description = "Relative age of the last check (only present when known)") String lastCheckAge,
+            @Metadata(description = "Epoch time in milliseconds of the last reload (only present when known)") Long lastReloadTimestamp,
+            @Metadata(description = "Relative age of the last reload (only present when known)") String lastReloadAge,
+            @Metadata(description = "The secrets in use (only present when the Azure Key Vault properties function is active)") List<SecretEntry> secrets) {
+    }
 
     public AzureKeyVaultManagerDevConsole() {
         super("camel", "azure-secrets", "Azure Key Vault Secrets", "Azure Key Vault Secret Manager");
@@ -99,47 +116,56 @@ public class AzureKeyVaultManagerDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String login = null;
+        Boolean refreshEnabled = null;
+        Long refreshPeriod = null;
+        Long lastCheckTimestamp = null;
+        String lastCheckAge = null;
+        Long lastReloadTimestamp = null;
+        String lastReloadAge = null;
+        List<SecretEntry> secrets = null;
+
         if (propertiesFunction != null) {
-            root.put("login", "Client Id/Client Secret");
+            login = "Client Id/Client Secret";
             AzureVaultConfiguration azure = getCamelContext().getVaultConfiguration().getAzureVaultConfiguration();
             if (azure != null) {
-                root.put("refreshEnabled", azure.isRefreshEnabled());
-                root.put("refreshPeriod", azure.getRefreshPeriod());
+                refreshEnabled = azure.isRefreshEnabled();
+                refreshPeriod = azure.getRefreshPeriod();
             }
             if (secretsRefreshTask != null) {
                 Instant last = secretsRefreshTask.getLastCheckTime();
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    root.put("lastCheckTimestamp", timestamp);
-                    root.put("lastCheckAge", TimeUtils.printSince(timestamp));
+                    lastCheckTimestamp = last.toEpochMilli();
+                    lastCheckAge = TimeUtils.printSince(lastCheckTimestamp);
                 }
                 last = secretsRefreshTask.getLastReloadTime();
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    root.put("lastReloadTimestamp", timestamp);
-                    root.put("lastReloadAge", TimeUtils.printSince(timestamp));
+                    lastReloadTimestamp = last.toEpochMilli();
+                    lastReloadAge = TimeUtils.printSince(lastReloadTimestamp);
                 }
             }
-            JsonArray arr = new JsonArray();
-            root.put("secrets", arr);
 
             List<String> sorted = new ArrayList<>(propertiesFunction.getSecrets());
             Collections.sort(sorted);
 
+            List<SecretEntry> arr = new ArrayList<>();
             for (String sec : sorted) {
-                JsonObject jo = new JsonObject();
-                jo.put("name", sec);
+                Long timestamp = null;
+                String age = null;
                 Instant last = secretsRefreshTask != null ? secretsRefreshTask.getUpdates().get(sec) : null;
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    jo.put("timestamp", timestamp);
-                    jo.put("age", TimeUtils.printSince(timestamp));
+                    timestamp = last.toEpochMilli();
+                    age = TimeUtils.printSince(timestamp);
                 }
-                arr.add(jo);
+                arr.add(new SecretEntry(sec, timestamp, age));
             }
+            secrets = arr;
         }
-        return root;
+
+        Response response = new Response(
+                login, refreshEnabled, refreshPeriod, lastCheckTimestamp, lastCheckAge, lastReloadTimestamp,
+                lastReloadAge, secrets);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-azure/camel-azure-key-vault/src/test/java/org/apache/camel/component/azure/key/vault/AzureKeyVaultManagerDevConsoleTest.java
+++ b/components/camel-azure/camel-azure-key-vault/src/test/java/org/apache/camel/component/azure/key/vault/AzureKeyVaultManagerDevConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.azure.key.vault;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AzureKeyVaultManagerDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testAzureSecretsConsoleNoPropertiesFunction() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("azure-secrets");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("azure-secrets", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-diagram/src/generated/resources/META-INF/org/apache/camel/dev-console/route-diagram.json
+++ b/components/camel-diagram/src/generated/resources/META-INF/org/apache/camel/dev-console/route-diagram.json
@@ -186,6 +186,19 @@
       "defaultValue": "transparent",
       "description": "Theme to use: dark, light, transparent, ascii, or unicode"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "text": {
+        "type": "string",
+        "description": "The rendered ASCII\/Unicode art diagram (only present for a text theme)"
+      },
+      "image": {
+        "type": "string",
+        "description": "The rendered diagram as a base64-encoded PNG image (only present for a non-text theme)"
+      }
+    }
   }
 }
 

--- a/components/camel-diagram/src/main/java/org/apache/camel/diagram/DiagramDevConsole.java
+++ b/components/camel-diagram/src/main/java/org/apache/camel/diagram/DiagramDevConsole.java
@@ -28,10 +28,15 @@ import org.apache.camel.spi.RouteDiagramDumper;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "route-diagram", group = "camel", displayName = "Route Diagram", description = "Visual route diagrams")
 public class DiagramDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The rendered ASCII/Unicode art diagram (only present for a text theme)") String text,
+            @Metadata(description = "The rendered diagram as a base64-encoded PNG image (only present for a non-text theme)") String image) {
+    }
 
     @Metadata(label = "query", description = "Filters the routes matching by route id, route uri, and source location",
               defaultValue = "*", javaType = "java.lang.String")
@@ -171,28 +176,27 @@ public class DiagramDevConsole extends AbstractDevConsole {
         boolean metric = optionBoolean(options, METRIC, true);
         boolean external = optionBoolean(options, EXTERNAL, true);
 
-        JsonObject root = new JsonObject();
+        String text = null;
+        String image = null;
         try {
             RouteDiagramDumper dumper = PluginHelper.getRouteDiagramDumper(getCamelContext());
             if ("topology".equalsIgnoreCase(mode)) {
                 return doCallTopologyJson(dumper, theme, nodeWidth, metric, fontSize, external);
             } else if (isTextTheme(theme)) {
-                String text = dumper.dumpRoutesAsAsciiArt(filter,
+                text = dumper.dumpRoutesAsAsciiArt(filter,
                         RouteDiagramDumper.NodeLabelMode.valueOf(nodeLabel.toUpperCase()),
                         nodeWidth, isUnicodeTheme(theme));
-                root.put("text", text);
             } else {
-                BufferedImage image = dumper.dumpRoutesAsImage(filter,
+                BufferedImage bufferedImage = dumper.dumpRoutesAsImage(filter,
                         RouteDiagramDumper.Theme.valueOf(theme.toUpperCase()),
                         metric, RouteDiagramDumper.NodeLabelMode.valueOf(nodeLabel.toUpperCase()), nodeWidth, fontSize);
-                String base64 = dumper.imageToBase64(image);
-                root.put("image", base64);
+                image = dumper.imageToBase64(bufferedImage);
             }
         } catch (Exception e) {
             // ignore
         }
 
-        return root;
+        return JsonRecordSupport.toJsonObject(new Response(text, image));
     }
 
     private String doCallTopologyText(
@@ -230,19 +234,18 @@ public class DiagramDevConsole extends AbstractDevConsole {
             RouteDiagramDumper dumper, String theme, int nodeWidth,
             boolean metric, int fontSize, boolean external)
             throws Exception {
-        JsonObject root = new JsonObject();
+        String text = null;
+        String image = null;
         if (isTextTheme(theme)) {
-            String text = dumper.dumpTopologyAsAsciiArt(nodeWidth, isUnicodeTheme(theme), external);
-            root.put("text", text);
+            text = dumper.dumpTopologyAsAsciiArt(nodeWidth, isUnicodeTheme(theme), external);
         } else {
-            BufferedImage image = dumper.dumpTopologyAsImage(
+            BufferedImage bufferedImage = dumper.dumpTopologyAsImage(
                     RouteDiagramDumper.Theme.valueOf(theme.toUpperCase()), metric, nodeWidth, fontSize, external);
-            if (image != null) {
-                String base64 = dumper.imageToBase64(image);
-                root.put("image", base64);
+            if (bufferedImage != null) {
+                image = dumper.imageToBase64(bufferedImage);
             }
         }
-        return root;
+        return JsonRecordSupport.toJsonObject(new Response(text, image));
     }
 
     private static final String WEB_COMPONENT_JS = loadWebComponentJs("camel-route-diagram.js");

--- a/components/camel-ftp/src/generated/resources/META-INF/org/apache/camel/dev-console/sftp.json
+++ b/components/camel-ftp/src/generated/resources/META-INF/org/apache/camel/dev-console/sftp.json
@@ -11,6 +11,16 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-ftp",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "config": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The SFTP (JSCH) configuration"
+      }
+    }
   }
 }
 

--- a/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpDevConsole.java
+++ b/components/camel-ftp/src/main/java/org/apache/camel/component/file/remote/SftpDevConsole.java
@@ -20,12 +20,16 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import com.jcraft.jsch.JSch;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "sftp", displayName = "SFTP", description = "Secure FTP using JSCH")
 public class SftpDevConsole extends AbstractDevConsole {
+
+    public record Response(@Metadata(description = "The SFTP (JSCH) configuration") Map<String, Object> config) {
+    }
 
     public SftpDevConsole() {
         super("camel", "sftp", "SFTP", "Secure FTP using JSCH");
@@ -50,18 +54,11 @@ public class SftpDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
         // sort configs
         Map<String, Object> map = new TreeMap<>(String::compareToIgnoreCase);
         map.putAll(JSch.getConfig());
 
-        JsonObject jo = new JsonObject();
-        for (var e : map.entrySet()) {
-            jo.put(e.getKey(), e.getValue());
-        }
-        root.put("config", jo);
-
-        return root;
+        Response response = new Response(map);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/SftpDevConsoleTest.java
+++ b/components/camel-ftp/src/test/java/org/apache/camel/component/file/remote/SftpDevConsoleTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.file.remote;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SftpDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testSftpConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sftp");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("sftp", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(out);
+    }
+
+    @Test
+    public void testSftpConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sftp");
+        assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+
+        JsonObject config = out.getJsonObject("config");
+        assertNotNull(config);
+        assertFalse(config.isEmpty());
+    }
+}

--- a/components/camel-google/camel-google-secret-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/gcp-secrets.json
+++ b/components/camel-google/camel-google-secret-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/gcp-secrets.json
@@ -11,6 +11,60 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-google-secret-manager",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when the GCP Secret Manager properties function is active)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "refreshPeriod": {
+        "type": "integer",
+        "description": "The refresh period in milliseconds (only present when configured)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when the GCP Secret Manager properties function is active)"
+      }
+    }
   }
 }
 

--- a/components/camel-google/camel-google-secret-manager/src/main/java/org/apache/camel/component/google/secret/manager/GoogleSecretManagerDevConsole.java
+++ b/components/camel-google/camel-google-secret-manager/src/main/java/org/apache/camel/component/google/secret/manager/GoogleSecretManagerDevConsole.java
@@ -23,14 +23,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.component.google.secret.manager.vault.PubsubReloadTriggerTask;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PeriodTaskScheduler;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.GcpVaultConfiguration;
 
 @DevConsole(name = "gcp-secrets", displayName = "GCP Secrets", description = "GCP Secret Manager")
@@ -38,6 +38,23 @@ public class GoogleSecretManagerDevConsole extends AbstractDevConsole {
 
     private GoogleSecretManagerPropertiesFunction propertiesFunction;
     private PubsubReloadTriggerTask secretsRefreshTask;
+
+    public record SecretEntry(
+            @Metadata(description = "The secret name") String name,
+            @Metadata(description = "Epoch time in milliseconds of the last update (only present when known)") Long timestamp,
+            @Metadata(description = "Relative age of the last update (only present when known)") String age) {
+    }
+
+    public record Response(
+            @Metadata(description = "The login method (only present when the GCP Secret Manager properties function is active)") String login,
+            @Metadata(description = "Whether secret refresh is enabled (only present when configured)") Boolean refreshEnabled,
+            @Metadata(description = "The refresh period in milliseconds (only present when configured)") Long refreshPeriod,
+            @Metadata(description = "Epoch time in milliseconds of the last check (only present when known)") Long lastCheckTimestamp,
+            @Metadata(description = "Relative age of the last check (only present when known)") String lastCheckAge,
+            @Metadata(description = "Epoch time in milliseconds of the last reload (only present when known)") Long lastReloadTimestamp,
+            @Metadata(description = "Relative age of the last reload (only present when known)") String lastReloadAge,
+            @Metadata(description = "The secrets in use (only present when the GCP Secret Manager properties function is active)") List<SecretEntry> secrets) {
+    }
 
     public GoogleSecretManagerDevConsole() {
         super("camel", "gcp-secrets", "GCP Secrets", "GCP Secret Manager");
@@ -104,51 +121,56 @@ public class GoogleSecretManagerDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String login = null;
+        Boolean refreshEnabled = null;
+        Long refreshPeriod = null;
+        Long lastCheckTimestamp = null;
+        String lastCheckAge = null;
+        Long lastReloadTimestamp = null;
+        String lastReloadAge = null;
+        List<SecretEntry> secrets = null;
+
         if (propertiesFunction != null) {
-            if (propertiesFunction.isUseDefaultInstance()) {
-                root.put("login", "Default Instance");
-            } else {
-                root.put("login", "Service Account Key File");
-            }
+            login = propertiesFunction.isUseDefaultInstance() ? "Default Instance" : "Service Account Key File";
             GcpVaultConfiguration gcp = getCamelContext().getVaultConfiguration().getGcpVaultConfiguration();
             if (gcp != null) {
-                root.put("refreshEnabled", gcp.isRefreshEnabled());
-                root.put("refreshPeriod", gcp.getRefreshPeriod());
+                refreshEnabled = gcp.isRefreshEnabled();
+                refreshPeriod = gcp.getRefreshPeriod();
             }
             if (secretsRefreshTask != null) {
                 Instant last = secretsRefreshTask.getLastCheckTime();
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    root.put("lastCheckTimestamp", timestamp);
-                    root.put("lastCheckAge", TimeUtils.printSince(timestamp));
+                    lastCheckTimestamp = last.toEpochMilli();
+                    lastCheckAge = TimeUtils.printSince(lastCheckTimestamp);
                 }
                 last = secretsRefreshTask.getLastReloadTime();
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    root.put("lastReloadTimestamp", timestamp);
-                    root.put("lastReloadAge", TimeUtils.printSince(timestamp));
+                    lastReloadTimestamp = last.toEpochMilli();
+                    lastReloadAge = TimeUtils.printSince(lastReloadTimestamp);
                 }
             }
-            JsonArray arr = new JsonArray();
-            root.put("secrets", arr);
 
             List<String> sorted = new ArrayList<>(propertiesFunction.getSecrets());
             Collections.sort(sorted);
 
+            List<SecretEntry> arr = new ArrayList<>();
             for (String sec : sorted) {
-                JsonObject jo = new JsonObject();
-                jo.put("name", sec);
+                Long timestamp = null;
+                String age = null;
                 Instant last = secretsRefreshTask != null ? secretsRefreshTask.getUpdates().get(sec) : null;
                 if (last != null) {
-                    long timestamp = last.toEpochMilli();
-                    jo.put("timestamp", timestamp);
-                    jo.put("age", TimeUtils.printSince(timestamp));
+                    timestamp = last.toEpochMilli();
+                    age = TimeUtils.printSince(timestamp);
                 }
-                arr.add(jo);
+                arr.add(new SecretEntry(sec, timestamp, age));
             }
+            secrets = arr;
         }
-        return root;
+
+        Response response = new Response(
+                login, refreshEnabled, refreshPeriod, lastCheckTimestamp, lastCheckAge, lastReloadTimestamp,
+                lastReloadAge, secrets);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-google/camel-google-secret-manager/src/test/java/org/apache/camel/component/google/secret/manager/GoogleSecretManagerDevConsoleTest.java
+++ b/components/camel-google/camel-google-secret-manager/src/test/java/org/apache/camel/component/google/secret/manager/GoogleSecretManagerDevConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.secret.manager;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GoogleSecretManagerDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testGcpSecretsConsoleNoPropertiesFunction() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("gcp-secrets");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("gcp-secrets", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-groovy/src/generated/resources/META-INF/org/apache/camel/dev-console/groovy.json
+++ b/components/camel-groovy/src/generated/resources/META-INF/org/apache/camel/dev-console/groovy.json
@@ -11,6 +11,64 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-groovy",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "compiler": {
+        "type": "object",
+        "properties": {
+          "scriptPattern": {
+            "type": "string",
+            "description": "The script file name pattern"
+          },
+          "compiledCounter": {
+            "type": "integer",
+            "description": "Number of scripts compiled"
+          },
+          "preloadedCounter": {
+            "type": "integer",
+            "description": "Number of scripts pre-loaded"
+          },
+          "classesSize": {
+            "type": "integer",
+            "description": "Number of compiled classes"
+          },
+          "compiledTime": {
+            "type": "integer",
+            "description": "Total compile time in milliseconds"
+          },
+          "recompileEnabled": {
+            "type": "boolean",
+            "description": "Whether re-compilation is enabled"
+          },
+          "lastCompilationTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds of the last compilation"
+          },
+          "workDir": {
+            "type": "string",
+            "description": "The work directory (only present when configured)"
+          },
+          "classes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The compiled class names (only present when there are any)"
+          }
+        },
+        "required": [
+          "compiledCounter",
+          "preloadedCounter",
+          "classesSize",
+          "compiledTime",
+          "recompileEnabled",
+          "lastCompilationTimestamp"
+        ],
+        "description": "The Groovy compiler information (only present when the compiler is active)"
+      }
+    }
   }
 }
 

--- a/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyDevConsole.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/language/groovy/GroovyDevConsole.java
@@ -16,16 +16,34 @@
  */
 package org.apache.camel.language.groovy;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "groovy", displayName = "Groovy", description = "Groovy Language")
 public class GroovyDevConsole extends AbstractDevConsole {
+
+    public record CompilerInfo(
+            @Metadata(description = "The script file name pattern") String scriptPattern,
+            @Metadata(description = "Number of scripts compiled") int compiledCounter,
+            @Metadata(description = "Number of scripts pre-loaded") int preloadedCounter,
+            @Metadata(description = "Number of compiled classes") int classesSize,
+            @Metadata(description = "Total compile time in milliseconds") long compiledTime,
+            @Metadata(description = "Whether re-compilation is enabled") boolean recompileEnabled,
+            @Metadata(description = "Epoch time in milliseconds of the last compilation") long lastCompilationTimestamp,
+            @Metadata(description = "The work directory (only present when configured)") String workDir,
+            @Metadata(description = "The compiled class names (only present when there are any)") List<String> classes) {
+    }
+
+    public record Response(
+            @Metadata(description = "The Groovy compiler information (only present when the compiler is active)") CompilerInfo compiler) {
+    }
 
     public GroovyDevConsole() {
         super("camel", "groovy", "Groovy", "Groovy Language");
@@ -61,28 +79,18 @@ public class GroovyDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+        CompilerInfo compilerInfo = null;
 
         DefaultGroovyScriptCompiler compiler = getCamelContext().hasService(DefaultGroovyScriptCompiler.class);
         if (compiler != null) {
-            JsonObject jo = new JsonObject();
-            jo.put("scriptPattern", compiler.getScriptPattern());
-            jo.put("compiledCounter", compiler.getCompileCounter());
-            jo.put("preloadedCounter", compiler.getPreloadedCounter());
-            jo.put("classesSize", compiler.getClassesSize());
-            jo.put("compiledTime", compiler.getCompileTime());
-            jo.put("recompileEnabled", compiler.isRecompileEnabled());
-            jo.put("lastCompilationTimestamp", compiler.getLastCompilationTimestamp());
-            if (compiler.getWorkDir() != null) {
-                jo.put("workDir", compiler.getWorkDir());
-            }
-            JsonArray arr = new JsonArray(compiler.compiledClassNames());
-            if (!arr.isEmpty()) {
-                jo.put("classes", arr);
-            }
-            root.put("compiler", jo);
+            List<String> classes = new ArrayList<>(compiler.compiledClassNames());
+            compilerInfo = new CompilerInfo(
+                    compiler.getScriptPattern(), compiler.getCompileCounter(), compiler.getPreloadedCounter(),
+                    compiler.getClassesSize(), compiler.getCompileTime(), compiler.isRecompileEnabled(),
+                    compiler.getLastCompilationTimestamp(), compiler.getWorkDir(), classes.isEmpty() ? null : classes);
         }
 
-        return root;
+        Response response = new Response(compilerInfo);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-groovy/src/test/java/org/apache/camel/language/groovy/GroovyDevConsoleTest.java
+++ b/components/camel-groovy/src/test/java/org/apache/camel/language/groovy/GroovyDevConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.groovy;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GroovyDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testGroovyConsoleNoCompiler() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("groovy");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("groovy", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-hashicorp-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/hashicorp-secrets.json
+++ b/components/camel-hashicorp-vault/src/generated/resources/META-INF/org/apache/camel/dev-console/hashicorp-secrets.json
@@ -11,6 +11,27 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-hashicorp-vault",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "host": {
+        "type": "string",
+        "description": "The Vault host (only present when configured)"
+      },
+      "port": {
+        "type": "string",
+        "description": "The Vault port (only present when configured)"
+      },
+      "scheme": {
+        "type": "string",
+        "description": "The Vault scheme (only present when configured)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when configured)"
+      }
+    }
   }
 }
 

--- a/components/camel-hashicorp-vault/src/main/java/org/apache/camel/component/hashicorp/vault/SecretsDevConsole.java
+++ b/components/camel-hashicorp-vault/src/main/java/org/apache/camel/component/hashicorp/vault/SecretsDevConsole.java
@@ -18,14 +18,22 @@ package org.apache.camel.component.hashicorp.vault;
 
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.HashicorpVaultConfiguration;
 
 @DevConsole(name = "hashicorp-secrets", displayName = "HashiCorp Secrets", description = "HashiCorp Vault Secrets")
 public class SecretsDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The Vault host (only present when configured)") String host,
+            @Metadata(description = "The Vault port (only present when configured)") String port,
+            @Metadata(description = "The Vault scheme (only present when configured)") String scheme,
+            @Metadata(description = "The login method (only present when configured)") String login) {
+    }
 
     private HashicorpVaultPropertiesFunction propertiesFunction;
 
@@ -62,15 +70,21 @@ public class SecretsDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String host = null;
+        String port = null;
+        String scheme = null;
+        String login = null;
+
         HashicorpVaultConfiguration hashicorp = getCamelContext().getVaultConfiguration().getHashicorpVaultConfiguration();
         if (hashicorp != null) {
-            root.put("host", hashicorp.getHost());
-            root.put("port", hashicorp.getPort());
-            root.put("scheme", hashicorp.getScheme());
-            root.put("login", "OAuth Token");
+            host = hashicorp.getHost();
+            port = hashicorp.getPort();
+            scheme = hashicorp.getScheme();
+            login = "OAuth Token";
         }
-        return root;
+
+        Response response = new Response(host, port, scheme, login);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/SecretsDevConsoleTest.java
+++ b/components/camel-hashicorp-vault/src/test/java/org/apache/camel/component/hashicorp/vault/SecretsDevConsoleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.hashicorp.vault;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.vault.HashicorpVaultConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SecretsDevConsoleTest extends CamelTestSupport {
+
+    @Override
+    protected org.apache.camel.CamelContext createCamelContext() throws Exception {
+        org.apache.camel.CamelContext ctx = super.createCamelContext();
+        HashicorpVaultConfiguration hashicorp = new HashicorpVaultConfiguration();
+        hashicorp.setHost("localhost");
+        hashicorp.setPort("8200");
+        hashicorp.setScheme("http");
+        ctx.getVaultConfiguration().setHashicorpVaultConfiguration(hashicorp);
+        return ctx;
+    }
+
+    @Test
+    public void testSecretsConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("hashicorp-secrets");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("hashicorp-secrets", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(out);
+    }
+
+    @Test
+    public void testSecretsConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("hashicorp-secrets");
+        assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertEquals("localhost", out.getString("host"));
+        assertEquals("8200", out.getString("port"));
+        assertEquals("http", out.getString("scheme"));
+        assertTrue(out.getString("login").contains("OAuth"));
+    }
+}

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/ibm-secrets.json
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/generated/resources/META-INF/org/apache/camel/dev-console/ibm-secrets.json
@@ -11,6 +11,68 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-ibm-secrets-manager",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "serviceUrl": {
+        "type": "string",
+        "description": "The IBM Secrets Manager service URL (only present when configured)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when configured)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "eventStreamTopic": {
+        "type": "string",
+        "description": "The event stream topic (only present when refresh is enabled)"
+      },
+      "eventStreamBootstrapServers": {
+        "type": "string",
+        "description": "The event stream bootstrap servers (only present when refresh is enabled)"
+      },
+      "lastCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last check (only present when known)"
+      },
+      "lastCheckAge": {
+        "type": "string",
+        "description": "Relative age of the last check (only present when known)"
+      },
+      "lastReloadTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last reload (only present when known)"
+      },
+      "lastReloadAge": {
+        "type": "string",
+        "description": "Relative age of the last reload (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last update (only present when known)"
+            },
+            "age": {
+              "type": "string",
+              "description": "Relative age of the last update (only present when known)"
+            }
+          }
+        },
+        "description": "The secrets in use (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/SecretsDevConsole.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/main/java/org/apache/camel/component/ibm/secrets/manager/SecretsDevConsole.java
@@ -23,14 +23,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.component.ibm.secrets.manager.vault.IBMEventStreamReloadTriggerTask;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PeriodTaskScheduler;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.IBMSecretsManagerVaultConfiguration;
 
 @DevConsole(name = "ibm-secrets", displayName = "IBM Secrets", description = "IBM Secrets Manager")
@@ -38,6 +38,25 @@ public class SecretsDevConsole extends AbstractDevConsole {
 
     private IBMSecretsManagerPropertiesFunction propertiesFunction;
     private IBMEventStreamReloadTriggerTask secretsRefreshTask;
+
+    public record SecretEntry(
+            @Metadata(description = "The secret name") String name,
+            @Metadata(description = "Epoch time in milliseconds of the last update (only present when known)") Long timestamp,
+            @Metadata(description = "Relative age of the last update (only present when known)") String age) {
+    }
+
+    public record Response(
+            @Metadata(description = "The IBM Secrets Manager service URL (only present when configured)") String serviceUrl,
+            @Metadata(description = "The login method (only present when configured)") String login,
+            @Metadata(description = "Whether secret refresh is enabled (only present when configured)") Boolean refreshEnabled,
+            @Metadata(description = "The event stream topic (only present when refresh is enabled)") String eventStreamTopic,
+            @Metadata(description = "The event stream bootstrap servers (only present when refresh is enabled)") String eventStreamBootstrapServers,
+            @Metadata(description = "Epoch time in milliseconds of the last check (only present when known)") Long lastCheckTimestamp,
+            @Metadata(description = "Relative age of the last check (only present when known)") String lastCheckAge,
+            @Metadata(description = "Epoch time in milliseconds of the last reload (only present when known)") Long lastReloadTimestamp,
+            @Metadata(description = "Relative age of the last reload (only present when known)") String lastReloadAge,
+            @Metadata(description = "The secrets in use (only present when there are any)") List<SecretEntry> secrets) {
+    }
 
     public SecretsDevConsole() {
         super("camel", "ibm-secrets", "IBM Secrets", "IBM Secrets Manager");
@@ -107,53 +126,63 @@ public class SecretsDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String serviceUrl = null;
+        String login = null;
+        Boolean refreshEnabled = null;
+        String eventStreamTopic = null;
+        String eventStreamBootstrapServers = null;
+        Long lastCheckTimestamp = null;
+        String lastCheckAge = null;
+        Long lastReloadTimestamp = null;
+        String lastReloadAge = null;
+        List<SecretEntry> secrets = null;
 
         if (propertiesFunction != null) {
             IBMSecretsManagerVaultConfiguration ibm
                     = getCamelContext().getVaultConfiguration().getIBMSecretsManagerVaultConfiguration();
             if (ibm != null) {
-                root.put("serviceUrl", ibm.getServiceUrl());
-                root.put("login", "IAM Token");
-                root.put("refreshEnabled", ibm.isRefreshEnabled());
+                serviceUrl = ibm.getServiceUrl();
+                login = "IAM Token";
+                refreshEnabled = ibm.isRefreshEnabled();
                 if (ibm.isRefreshEnabled()) {
-                    root.put("eventStreamTopic", ibm.getEventStreamTopic());
-                    root.put("eventStreamBootstrapServers", ibm.getEventStreamBootstrapServers());
+                    eventStreamTopic = ibm.getEventStreamTopic();
+                    eventStreamBootstrapServers = ibm.getEventStreamBootstrapServers();
                 }
             }
             if (secretsRefreshTask != null) {
                 Instant last = secretsRefreshTask.getLastCheckTime();
                 if (last != null) {
-                    root.put("lastCheckTimestamp", last.toEpochMilli());
-                    root.put("lastCheckAge", TimeUtils.printSince(last.toEpochMilli()));
+                    lastCheckTimestamp = last.toEpochMilli();
+                    lastCheckAge = TimeUtils.printSince(lastCheckTimestamp);
                 }
                 last = secretsRefreshTask.getLastReloadTime();
                 if (last != null) {
-                    root.put("lastReloadTimestamp", last.toEpochMilli());
-                    root.put("lastReloadAge", TimeUtils.printSince(last.toEpochMilli()));
+                    lastReloadTimestamp = last.toEpochMilli();
+                    lastReloadAge = TimeUtils.printSince(lastReloadTimestamp);
                 }
             }
 
-            JsonArray arr = new JsonArray();
             List<String> sorted = new ArrayList<>(propertiesFunction.getSecrets());
             Collections.sort(sorted);
 
+            List<SecretEntry> arr = new ArrayList<>();
             for (String sec : sorted) {
-                JsonObject jo = new JsonObject();
-                jo.put("name", sec);
+                Long timestamp = null;
+                String age = null;
                 Instant last = secretsRefreshTask != null ? secretsRefreshTask.getUpdates().get(sec) : null;
                 if (last != null) {
-                    jo.put("timestamp", last.toEpochMilli());
-                    jo.put("age", TimeUtils.printSince(last.toEpochMilli()));
+                    timestamp = last.toEpochMilli();
+                    age = TimeUtils.printSince(timestamp);
                 }
-                arr.add(jo);
+                arr.add(new SecretEntry(sec, timestamp, age));
             }
-            if (!arr.isEmpty()) {
-                root.put("secrets", arr);
-            }
+            secrets = arr.isEmpty() ? null : arr;
         }
 
-        return root;
+        Response response = new Response(
+                serviceUrl, login, refreshEnabled, eventStreamTopic, eventStreamBootstrapServers, lastCheckTimestamp,
+                lastCheckAge, lastReloadTimestamp, lastReloadAge, secrets);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-ibm/camel-ibm-secrets-manager/src/test/java/org/apache/camel/component/ibm/secrets/manager/SecretsDevConsoleTest.java
+++ b/components/camel-ibm/camel-ibm-secrets-manager/src/test/java/org/apache/camel/component/ibm/secrets/manager/SecretsDevConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ibm.secrets.manager;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SecretsDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testIbmSecretsConsoleNoPropertiesFunction() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("ibm-secrets");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("ibm-secrets", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-jfr/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr.json
+++ b/components/camel-jfr/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr.json
@@ -116,13 +116,16 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The recording name"
             },
             "state": {
-              "type": "string"
+              "type": "string",
+              "description": "The recording state"
             },
             "destination": {
-              "type": "string"
+              "type": "string",
+              "description": "The recording destination file (only present when configured)"
             }
           }
         },
@@ -169,22 +172,28 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans"
             },
             "failed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed spans"
             },
             "minMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The minimum duration in milliseconds"
             },
             "meanMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean duration in milliseconds"
             },
             "maxMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum duration in milliseconds"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             }
           },
           "required": [
@@ -203,28 +212,36 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans"
             },
             "failed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed spans"
             },
             "minMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The minimum duration in milliseconds"
             },
             "meanMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean duration in milliseconds"
             },
             "maxMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum duration in milliseconds"
             },
             "processorId": {
-              "type": "string"
+              "type": "string",
+              "description": "The processor id"
             },
             "processorType": {
-              "type": "string"
+              "type": "string",
+              "description": "The processor type"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             }
           },
           "required": [
@@ -243,22 +260,28 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans"
             },
             "failed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed spans"
             },
             "minMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The minimum duration in milliseconds"
             },
             "meanMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean duration in milliseconds"
             },
             "maxMs": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum duration in milliseconds"
             },
             "endpointUri": {
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint URI"
             }
           },
           "required": [
@@ -277,19 +300,24 @@
           "type": "object",
           "properties": {
             "timestamp": {
-              "type": "string"
+              "type": "string",
+              "description": "The failure timestamp"
             },
             "exchangeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The exchange id"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             },
             "exceptionType": {
-              "type": "string"
+              "type": "string",
+              "description": "The exception type"
             },
             "exceptionMessage": {
-              "type": "string"
+              "type": "string",
+              "description": "The exception message"
             }
           }
         },
@@ -301,19 +329,24 @@
           "type": "object",
           "properties": {
             "timestamp": {
-              "type": "string"
+              "type": "string",
+              "description": "The redelivery timestamp"
             },
             "exchangeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The exchange id"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             },
             "attempt": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The redelivery attempt number"
             },
             "maxAttempts": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The maximum number of redelivery attempts"
             }
           },
           "required": [

--- a/components/camel-jfr/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr.json
+++ b/components/camel-jfr/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr.json
@@ -102,6 +102,228 @@
       "secret": false,
       "description": "Filter snapshot results to the given route id"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "runtimeEvents": {
+        "type": "boolean",
+        "description": "Whether camel-jfr runtime instrumentation is registered (status command)"
+      },
+      "recordings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "The active JFR recordings (status command)"
+      },
+      "events": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "description": "Whether each runtime event is enabled, keyed by short name (status command)"
+      },
+      "success": {
+        "type": "boolean",
+        "description": "Whether the toggle succeeded (enable\/disable command)"
+      },
+      "result": {
+        "type": "string",
+        "description": "The toggle result message (enable\/disable command)"
+      },
+      "jfc": {
+        "type": "string",
+        "description": "The generated jfc settings overlay (jfc command)"
+      },
+      "error": {
+        "type": "string",
+        "description": "An error message (jfc, snapshot, or unknown command)"
+      },
+      "snapshot": {
+        "type": "boolean",
+        "description": "Whether this is a snapshot response (snapshot command)"
+      },
+      "snapshotTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the snapshot was taken (snapshot command)"
+      },
+      "eventCount": {
+        "type": "integer",
+        "description": "The number of matched events in the snapshot (snapshot command)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "integer"
+            },
+            "minMs": {
+              "type": "number"
+            },
+            "meanMs": {
+              "type": "number"
+            },
+            "maxMs": {
+              "type": "number"
+            },
+            "routeId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "total",
+            "failed",
+            "minMs",
+            "meanMs",
+            "maxMs"
+          ]
+        },
+        "description": "Per-route duration statistics (snapshot command)"
+      },
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "integer"
+            },
+            "minMs": {
+              "type": "number"
+            },
+            "meanMs": {
+              "type": "number"
+            },
+            "maxMs": {
+              "type": "number"
+            },
+            "processorId": {
+              "type": "string"
+            },
+            "processorType": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "total",
+            "failed",
+            "minMs",
+            "meanMs",
+            "maxMs"
+          ]
+        },
+        "description": "Per-processor duration statistics (snapshot command)"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "integer"
+            },
+            "minMs": {
+              "type": "number"
+            },
+            "meanMs": {
+              "type": "number"
+            },
+            "maxMs": {
+              "type": "number"
+            },
+            "endpointUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "total",
+            "failed",
+            "minMs",
+            "meanMs",
+            "maxMs"
+          ]
+        },
+        "description": "Per-endpoint duration statistics (snapshot command)"
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string"
+            },
+            "exchangeId": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "exceptionType": {
+              "type": "string"
+            },
+            "exceptionMessage": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "The most recent failures, newest first (snapshot command)"
+      },
+      "redeliveries": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string"
+            },
+            "exchangeId": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "attempt": {
+              "type": "integer"
+            },
+            "maxAttempts": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "attempt",
+            "maxAttempts"
+          ]
+        },
+        "description": "The most recent redeliveries, newest first (snapshot command)"
+      }
+    }
   }
 }
 

--- a/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
+++ b/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
@@ -77,26 +77,55 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
     private static final String ALL = "all";
     private static final int DEFAULT_LIMIT = 50;
 
-    public record RecordingEntry(String name, String state, String destination) {
+    public record RecordingEntry(
+            @Metadata(description = "The recording name") String name,
+            @Metadata(description = "The recording state") String state,
+            @Metadata(description = "The recording destination file (only present when configured)") String destination) {
     }
 
-    public record RouteStatEntry(long total, long failed, double minMs, double meanMs, double maxMs, String routeId) {
+    public record RouteStatEntry(
+            @Metadata(description = "The number of spans") long total,
+            @Metadata(description = "The number of failed spans") long failed,
+            @Metadata(description = "The minimum duration in milliseconds") double minMs,
+            @Metadata(description = "The mean duration in milliseconds") double meanMs,
+            @Metadata(description = "The maximum duration in milliseconds") double maxMs,
+            @Metadata(description = "The route id") String routeId) {
     }
 
     public record ProcessorStatEntry(
-            long total, long failed, double minMs, double meanMs, double maxMs, String processorId,
-            String processorType, String routeId) {
+            @Metadata(description = "The number of spans") long total,
+            @Metadata(description = "The number of failed spans") long failed,
+            @Metadata(description = "The minimum duration in milliseconds") double minMs,
+            @Metadata(description = "The mean duration in milliseconds") double meanMs,
+            @Metadata(description = "The maximum duration in milliseconds") double maxMs,
+            @Metadata(description = "The processor id") String processorId,
+            @Metadata(description = "The processor type") String processorType,
+            @Metadata(description = "The route id") String routeId) {
     }
 
     public record EndpointStatEntry(
-            long total, long failed, double minMs, double meanMs, double maxMs, String endpointUri) {
+            @Metadata(description = "The number of spans") long total,
+            @Metadata(description = "The number of failed spans") long failed,
+            @Metadata(description = "The minimum duration in milliseconds") double minMs,
+            @Metadata(description = "The mean duration in milliseconds") double meanMs,
+            @Metadata(description = "The maximum duration in milliseconds") double maxMs,
+            @Metadata(description = "The endpoint URI") String endpointUri) {
     }
 
     public record FailureEntry(
-            String timestamp, String exchangeId, String routeId, String exceptionType, String exceptionMessage) {
+            @Metadata(description = "The failure timestamp") String timestamp,
+            @Metadata(description = "The exchange id") String exchangeId,
+            @Metadata(description = "The route id") String routeId,
+            @Metadata(description = "The exception type") String exceptionType,
+            @Metadata(description = "The exception message") String exceptionMessage) {
     }
 
-    public record RedeliveryEntry(String timestamp, String exchangeId, String routeId, int attempt, int maxAttempts) {
+    public record RedeliveryEntry(
+            @Metadata(description = "The redelivery timestamp") String timestamp,
+            @Metadata(description = "The exchange id") String exchangeId,
+            @Metadata(description = "The route id") String routeId,
+            @Metadata(description = "The redelivery attempt number") int attempt,
+            @Metadata(description = "The maximum number of redelivery attempts") int maxAttempts) {
     }
 
     public record Response(

--- a/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
+++ b/components/camel-jfr/src/main/java/org/apache/camel/runtime/jfr/CamelJfrDevConsole.java
@@ -39,8 +39,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 /**
  * Reports whether the camel-jfr runtime instrumentation is installed, and allows its events to be turned on and off
@@ -77,6 +76,46 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
 
     private static final String ALL = "all";
     private static final int DEFAULT_LIMIT = 50;
+
+    public record RecordingEntry(String name, String state, String destination) {
+    }
+
+    public record RouteStatEntry(long total, long failed, double minMs, double meanMs, double maxMs, String routeId) {
+    }
+
+    public record ProcessorStatEntry(
+            long total, long failed, double minMs, double meanMs, double maxMs, String processorId,
+            String processorType, String routeId) {
+    }
+
+    public record EndpointStatEntry(
+            long total, long failed, double minMs, double meanMs, double maxMs, String endpointUri) {
+    }
+
+    public record FailureEntry(
+            String timestamp, String exchangeId, String routeId, String exceptionType, String exceptionMessage) {
+    }
+
+    public record RedeliveryEntry(String timestamp, String exchangeId, String routeId, int attempt, int maxAttempts) {
+    }
+
+    public record Response(
+            @Metadata(description = "Whether camel-jfr runtime instrumentation is registered (status command)") Boolean runtimeEvents,
+            @Metadata(description = "The active JFR recordings (status command)") List<RecordingEntry> recordings,
+            @Metadata(description = "Whether each runtime event is enabled, keyed by short name (status command)") Map<String, Boolean> events,
+            @Metadata(description = "Whether the toggle succeeded (enable/disable command)") Boolean success,
+            @Metadata(description = "The toggle result message (enable/disable command)") String result,
+            @Metadata(description = "The generated jfc settings overlay (jfc command)") String jfc,
+            @Metadata(description = "An error message (jfc, snapshot, or unknown command)") String error,
+            @Metadata(description = "Whether this is a snapshot response (snapshot command)") Boolean snapshot,
+            @Metadata(description = "Epoch time in milliseconds the snapshot was taken (snapshot command)") Long snapshotTimestamp,
+            @Metadata(description = "The number of matched events in the snapshot (snapshot command)") Integer eventCount,
+            @Metadata(description = "Per-route duration statistics (snapshot command)") List<RouteStatEntry> routes,
+            @Metadata(description = "Per-processor duration statistics (snapshot command)") List<ProcessorStatEntry> processors,
+            @Metadata(description = "Per-endpoint duration statistics (snapshot command)") List<EndpointStatEntry> endpoints,
+            @Metadata(description = "The most recent failures, newest first (snapshot command)") List<FailureEntry> failures,
+            @Metadata(description = "The most recent redeliveries, newest first (snapshot command)") List<RedeliveryEntry> redeliveries) {
+    }
 
     public CamelJfrDevConsole() {
         super("camel", "jfr", "JFR Runtime Instrumentation",
@@ -252,23 +291,13 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
         double maxMs() {
             return maxNanos / 1_000_000.0;
         }
-
-        JsonObject toJson() {
-            JsonObject jo = new JsonObject();
-            jo.put("total", count);
-            jo.put("failed", failed);
-            jo.put("minMs", round3(minMs()));
-            jo.put("meanMs", round3(meanMs()));
-            jo.put("maxMs", round3(maxMs()));
-            return jo;
-        }
     }
 
     private static double round3(double value) {
         return Math.round(value * 1000.0) / 1000.0;
     }
 
-    private JsonObject doSnapshot(Map<String, Object> options) {
+    private Response doSnapshot(Map<String, Object> options) {
         String routeIdFilter = optionString(options, ROUTE_ID);
         int limit = DEFAULT_LIMIT;
         String limitStr = optionString(options, LIMIT);
@@ -280,15 +309,22 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
             }
         }
 
-        JsonObject result = new JsonObject();
-        result.put("snapshot", true);
-        result.put("snapshotTimestamp", System.currentTimeMillis());
+        boolean snapshotFlag = true;
+        long snapshotTimestamp = System.currentTimeMillis();
+        String error = null;
+        Integer eventCount = null;
+        List<RouteStatEntry> routes = null;
+        List<ProcessorStatEntry> processors = null;
+        List<EndpointStatEntry> endpoints = null;
+        List<FailureEntry> failures = null;
+        List<RedeliveryEntry> redeliveries = null;
 
         Path tempFile = null;
         try (Recording snapshot = FlightRecorder.getFlightRecorder().takeSnapshot()) {
             if (snapshot.getSize() == 0) {
-                result.put("error", "no JFR data available: ensure a recording is active");
-                return result;
+                return new Response(
+                        null, null, null, null, null, null, "no JFR data available: ensure a recording is active",
+                        snapshotFlag, snapshotTimestamp, null, null, null, null, null, null);
             }
             tempFile = Files.createTempFile("camel-jfr-snapshot-", ".jfr");
             snapshot.dump(tempFile);
@@ -298,9 +334,9 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
             Map<String, String> processorTypes = new LinkedHashMap<>();
             Map<String, String> processorRoutes = new LinkedHashMap<>();
             Map<String, DurationStats> endpointStats = new LinkedHashMap<>();
-            List<JsonObject> failures = new ArrayList<>();
-            List<JsonObject> redeliveries = new ArrayList<>();
-            int eventCount = 0;
+            List<FailureEntry> failuresList = new ArrayList<>();
+            List<RedeliveryEntry> redeliveriesList = new ArrayList<>();
+            int eventCountVal = 0;
 
             String routeEventName = CamelJfrEvents.ROUTE.getEventName();
             String processorEventName = CamelJfrEvents.PROCESSOR.getEventName();
@@ -319,7 +355,7 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
                             long nanos = durationNanos(event);
                             boolean failed = event.getBoolean("failed");
                             routeStats.computeIfAbsent(routeId, k -> new DurationStats()).record(nanos, failed);
-                            eventCount++;
+                            eventCountVal++;
                         }
                     } else if (processorEventName.equals(eventName)) {
                         String routeId = event.getString("routeId");
@@ -330,95 +366,84 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
                             processorStats.computeIfAbsent(processorId, k -> new DurationStats()).record(nanos, failed);
                             processorTypes.putIfAbsent(processorId, event.getString("processorType"));
                             processorRoutes.putIfAbsent(processorId, routeId);
-                            eventCount++;
+                            eventCountVal++;
                         }
                     } else if (sendEventName.equals(eventName)) {
                         String endpointUri = event.getString("endpointUri");
                         long nanos = durationNanos(event);
                         boolean failed = event.getBoolean("failed");
                         endpointStats.computeIfAbsent(endpointUri, k -> new DurationStats()).record(nanos, failed);
-                        eventCount++;
+                        eventCountVal++;
                     } else if (failedEventName.equals(eventName)) {
                         String routeId = event.getString("routeId");
                         if (routeIdFilter == null || routeIdFilter.equals(routeId)) {
-                            JsonObject fo = new JsonObject();
-                            fo.put("timestamp", event.getStartTime().toString());
-                            fo.put("exchangeId", event.getString("exchangeId"));
-                            fo.put("routeId", routeId);
-                            fo.put("exceptionType", event.getString("exceptionType"));
-                            fo.put("exceptionMessage", event.getString("exceptionMessage"));
-                            failures.add(fo);
-                            eventCount++;
+                            failuresList.add(new FailureEntry(
+                                    event.getStartTime().toString(), event.getString("exchangeId"), routeId,
+                                    event.getString("exceptionType"), event.getString("exceptionMessage")));
+                            eventCountVal++;
                         }
                     } else if (redeliveryEventName.equals(eventName)) {
                         String routeId = event.getString("routeId");
                         if (routeIdFilter == null || routeIdFilter.equals(routeId)) {
-                            JsonObject ro = new JsonObject();
-                            ro.put("timestamp", event.getStartTime().toString());
-                            ro.put("exchangeId", event.getString("exchangeId"));
-                            ro.put("routeId", routeId);
-                            ro.put("attempt", event.getInt("attempt"));
-                            ro.put("maxAttempts", event.getInt("maxAttempts"));
-                            redeliveries.add(ro);
-                            eventCount++;
+                            redeliveriesList.add(new RedeliveryEntry(
+                                    event.getStartTime().toString(), event.getString("exchangeId"), routeId,
+                                    event.getInt("attempt"), event.getInt("maxAttempts")));
+                            eventCountVal++;
                         }
                     }
                 }
             }
 
-            result.put("eventCount", eventCount);
+            eventCount = eventCountVal;
 
             // routes — sorted by total descending
-            JsonArray routesJson = new JsonArray();
+            List<RouteStatEntry> routesList = new ArrayList<>();
             routeStats.entrySet().stream()
                     .sorted(Comparator.<Map.Entry<String, DurationStats>> comparingLong(e -> e.getValue().count).reversed())
                     .forEach(e -> {
-                        JsonObject jo = e.getValue().toJson();
-                        jo.put("routeId", e.getKey());
-                        routesJson.add(jo);
+                        DurationStats st = e.getValue();
+                        routesList.add(new RouteStatEntry(
+                                st.count, st.failed, round3(st.minMs()), round3(st.meanMs()), round3(st.maxMs()),
+                                e.getKey()));
                     });
-            result.put("routes", routesJson);
+            routes = routesList;
 
             // processors — sorted by mean duration descending (slowest first)
-            JsonArray processorsJson = new JsonArray();
+            List<ProcessorStatEntry> processorsList = new ArrayList<>();
             processorStats.entrySet().stream()
                     .sorted(Comparator.<Map.Entry<String, DurationStats>> comparingDouble(
                             e -> e.getValue().meanMs()).reversed())
                     .forEach(e -> {
-                        JsonObject jo = e.getValue().toJson();
-                        jo.put("processorId", e.getKey());
-                        jo.put("processorType", processorTypes.get(e.getKey()));
-                        jo.put("routeId", processorRoutes.get(e.getKey()));
-                        processorsJson.add(jo);
+                        DurationStats st = e.getValue();
+                        processorsList.add(new ProcessorStatEntry(
+                                st.count, st.failed, round3(st.minMs()), round3(st.meanMs()), round3(st.maxMs()),
+                                e.getKey(), processorTypes.get(e.getKey()), processorRoutes.get(e.getKey())));
                     });
-            result.put("processors", processorsJson);
+            processors = processorsList;
 
             // endpoints — sorted by total descending
-            JsonArray endpointsJson = new JsonArray();
+            List<EndpointStatEntry> endpointsList = new ArrayList<>();
             endpointStats.entrySet().stream()
                     .sorted(Comparator.<Map.Entry<String, DurationStats>> comparingLong(
                             e -> e.getValue().count).reversed())
                     .forEach(e -> {
-                        JsonObject jo = e.getValue().toJson();
-                        jo.put("endpointUri", e.getKey());
-                        endpointsJson.add(jo);
+                        DurationStats st = e.getValue();
+                        endpointsList.add(new EndpointStatEntry(
+                                st.count, st.failed, round3(st.minMs()), round3(st.meanMs()), round3(st.maxMs()),
+                                e.getKey()));
                     });
-            result.put("endpoints", endpointsJson);
+            endpoints = endpointsList;
 
             // failures — newest first, capped at limit
-            failures.sort(Comparator.comparing((JsonObject o) -> o.getString("timestamp")).reversed());
-            JsonArray failuresJson = new JsonArray();
-            failures.stream().limit(limit).forEach(failuresJson::add);
-            result.put("failures", failuresJson);
+            failuresList.sort(Comparator.comparing(FailureEntry::timestamp).reversed());
+            failures = failuresList.stream().limit(limit).toList();
 
             // redeliveries — newest first, capped at limit
-            redeliveries.sort(Comparator.comparing((JsonObject o) -> o.getString("timestamp")).reversed());
-            JsonArray redeliveriesJson = new JsonArray();
-            redeliveries.stream().limit(limit).forEach(redeliveriesJson::add);
-            result.put("redeliveries", redeliveriesJson);
+            redeliveriesList.sort(Comparator.comparing(RedeliveryEntry::timestamp).reversed());
+            redeliveries = redeliveriesList.stream().limit(limit).toList();
 
         } catch (IOException e) {
-            result.put("error", "failed to read JFR snapshot: " + e.getMessage());
+            error = "failed to read JFR snapshot: " + e.getMessage();
         } finally {
             if (tempFile != null) {
                 try {
@@ -428,7 +453,9 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
             }
         }
 
-        return result;
+        return new Response(
+                null, null, null, null, null, null, error, snapshotFlag, snapshotTimestamp, eventCount, routes,
+                processors, endpoints, failures, redeliveries);
     }
 
     private static long durationNanos(RecordedEvent event) {
@@ -450,7 +477,7 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
                     yield e.getMessage();
                 }
             }
-            case "snapshot" -> doSnapshot(options).toJson();
+            case "snapshot" -> JsonRecordSupport.toJsonObject(doSnapshot(options)).toJson();
             default -> unknownCommand(command);
         };
     }
@@ -458,44 +485,47 @@ public class CamelJfrDevConsole extends AbstractDevConsole {
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String command = optionString(options, COMMAND);
-        JsonObject root = new JsonObject();
-        switch (command != null ? command : "status") {
+        return switch (command != null ? command : "status") {
             case "status" -> {
-                root.put("runtimeEvents", isInstrumentationRegistered());
-                JsonArray recordingsJson = new JsonArray();
+                boolean runtimeEvents = isInstrumentationRegistered();
+                List<RecordingEntry> recordings = new ArrayList<>();
                 for (Recording recording : FlightRecorder.getFlightRecorder().getRecordings()) {
-                    JsonObject rec = new JsonObject();
-                    rec.put("name", recording.getName());
-                    rec.put("state", StringHelper.capitalize(recording.getState().toString().toLowerCase(java.util.Locale.US)));
-                    rec.put("destination",
-                            recording.getDestination() != null ? recording.getDestination().toString() : null);
-                    recordingsJson.add(rec);
+                    String destination = recording.getDestination() != null ? recording.getDestination().toString() : null;
+                    recordings.add(new RecordingEntry(
+                            recording.getName(),
+                            StringHelper.capitalize(recording.getState().toString().toLowerCase(java.util.Locale.US)),
+                            destination));
                 }
-                root.put("recordings", recordingsJson);
-                JsonObject events = new JsonObject();
+                Map<String, Boolean> events = new LinkedHashMap<>();
                 for (CamelJfrEvents event : CamelJfrEvents.values()) {
                     events.put(event.getShortName(), event.isEnabled());
                 }
-                root.put("events", events);
+                yield JsonRecordSupport.toJsonObject(new Response(
+                        runtimeEvents, recordings, events, null, null, null, null, null, null, null, null, null,
+                        null, null, null));
             }
             case "enable", "disable" -> {
                 ToggleResult result = doToggle(options, "enable".equals(command));
-                root.put("success", result.success());
-                root.put("result", result.message());
+                yield JsonRecordSupport.toJsonObject(new Response(
+                        null, null, null, result.success(), result.message(), null, null, null, null, null, null,
+                        null, null, null, null));
             }
             case "jfc" -> {
+                String jfc = null;
+                String error = null;
                 try {
-                    root.put("jfc", doJfc(options));
+                    jfc = doJfc(options);
                 } catch (IllegalArgumentException e) {
-                    root.put("error", e.getMessage());
+                    error = e.getMessage();
                 }
+                yield JsonRecordSupport.toJsonObject(new Response(
+                        null, null, null, null, null, jfc, error, null, null, null, null, null, null, null, null));
             }
-            case "snapshot" -> {
-                return doSnapshot(options);
-            }
-            default -> root.put("error", unknownCommand(command));
-        }
-        return root;
+            case "snapshot" -> JsonRecordSupport.toJsonObject(doSnapshot(options));
+            default -> JsonRecordSupport.toJsonObject(new Response(
+                    null, null, null, null, null, null, unknownCommand(command), null, null, null, null, null, null,
+                    null, null));
+        };
     }
 
     private static String unknownCommand(String command) {

--- a/components/camel-kafka/src/generated/resources/META-INF/org/apache/camel/dev-console/kafka.json
+++ b/components/camel-kafka/src/generated/resources/META-INF/org/apache/camel/dev-console/kafka.json
@@ -28,6 +28,107 @@
       "defaultValue": false,
       "description": "Whether to include committed offset (sync operation to Kafka broker)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "kafkaConsumers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route id"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "workers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "threadId": {
+                    "type": "string",
+                    "description": "The worker thread id"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The worker state"
+                  },
+                  "lastError": {
+                    "type": "string",
+                    "description": "The worker last error (only present when not ready)"
+                  },
+                  "groupId": {
+                    "type": "string",
+                    "description": "The consumer group id (only present when known)"
+                  },
+                  "groupInstanceId": {
+                    "type": "string",
+                    "description": "The consumer group instance id (only present when known)"
+                  },
+                  "memberId": {
+                    "type": "string",
+                    "description": "The consumer member id (only present when known)"
+                  },
+                  "generationId": {
+                    "type": "integer",
+                    "description": "The consumer generation id (only present when known)"
+                  },
+                  "lastTopic": {
+                    "type": "string",
+                    "description": "The last consumed topic (only present when known)"
+                  },
+                  "lastPartition": {
+                    "type": "integer",
+                    "description": "The last consumed partition (only present when known)"
+                  },
+                  "lastOffset": {
+                    "type": "integer",
+                    "description": "The last consumed offset (only present when known)"
+                  },
+                  "committed": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "topic": {
+                          "type": "string",
+                          "description": "The topic"
+                        },
+                        "partition": {
+                          "type": "integer",
+                          "description": "The partition"
+                        },
+                        "offset": {
+                          "type": "integer",
+                          "description": "The committed offset"
+                        },
+                        "epoch": {
+                          "type": "integer",
+                          "description": "The epoch"
+                        }
+                      },
+                      "required": [
+                        "partition",
+                        "offset",
+                        "epoch"
+                      ]
+                    },
+                    "description": "The committed offsets (only present when requested and there are any)"
+                  }
+                }
+              },
+              "description": "The consumer worker threads"
+            }
+          }
+        },
+        "description": "The Kafka consumers"
+      }
+    }
   }
 }
 

--- a/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaDevConsole.java
+++ b/components/camel-kafka/src/main/java/org/apache/camel/component/kafka/KafkaDevConsole.java
@@ -30,8 +30,7 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +44,36 @@ public class KafkaDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Whether to include committed offset (sync operation to Kafka broker)",
               defaultValue = "false", javaType = "java.lang.Boolean")
     public static final String COMMITTED = "committed";
+
+    public record CommittedEntry(
+            @Metadata(description = "The topic") String topic,
+            @Metadata(description = "The partition") int partition,
+            @Metadata(description = "The committed offset") long offset,
+            @Metadata(description = "The epoch") int epoch) {
+    }
+
+    public record WorkerEntry(
+            @Metadata(description = "The worker thread id") String threadId,
+            @Metadata(description = "The worker state") String state,
+            @Metadata(description = "The worker last error (only present when not ready)") String lastError,
+            @Metadata(description = "The consumer group id (only present when known)") String groupId,
+            @Metadata(description = "The consumer group instance id (only present when known)") String groupInstanceId,
+            @Metadata(description = "The consumer member id (only present when known)") String memberId,
+            @Metadata(description = "The consumer generation id (only present when known)") Integer generationId,
+            @Metadata(description = "The last consumed topic (only present when known)") String lastTopic,
+            @Metadata(description = "The last consumed partition (only present when known)") Integer lastPartition,
+            @Metadata(description = "The last consumed offset (only present when known)") Long lastOffset,
+            @Metadata(description = "The committed offsets (only present when requested and there are any)") List<CommittedEntry> committed) {
+    }
+
+    public record ConsumerEntry(
+            @Metadata(description = "The route id") String routeId,
+            @Metadata(description = "The endpoint URI") String uri,
+            @Metadata(description = "The consumer worker threads") List<WorkerEntry> workers) {
+    }
+
+    public record Response(@Metadata(description = "The Kafka consumers") List<ConsumerEntry> kafkaConsumers) {
+    }
 
     public KafkaDevConsole() {
         super("camel", "kafka", "Kafka", "Apache Kafka");
@@ -123,65 +152,61 @@ public class KafkaDevConsole extends AbstractDevConsole {
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         final boolean committed = optionBoolean(options, COMMITTED, false);
 
-        JsonObject root = new JsonObject();
-
-        List<JsonObject> list = new ArrayList<>();
-        root.put("kafkaConsumers", list);
+        List<ConsumerEntry> list = new ArrayList<>();
 
         for (Route route : getCamelContext().getRoutes()) {
             if (route.getConsumer() instanceof KafkaConsumer kc) {
-                JsonObject jo = new JsonObject();
-                jo.put("routeId", route.getRouteId());
-                jo.put("uri", route.getEndpoint().getEndpointUri());
-
-                JsonArray arr = new JsonArray();
-                jo.put("workers", arr);
+                List<WorkerEntry> workers = new ArrayList<>();
 
                 for (KafkaFetchRecords t : kc.tasks()) {
                     final DevConsoleMetricsCollector metricsCollector = t.getMetricsCollector();
 
-                    JsonObject wo = new JsonObject();
-                    arr.add(wo);
-                    wo.put("threadId", metricsCollector.getThreadId());
-                    wo.put("state", t.getState());
+                    String lastError = null;
                     TaskHealthState hs = t.healthState();
                     if (!hs.isReady()) {
-                        wo.put("lastError", hs.buildStateMessage());
+                        lastError = hs.buildStateMessage();
                     }
+                    String groupId = null;
+                    String groupInstanceId = null;
+                    String memberId = null;
+                    Integer generationId = null;
                     DefaultMetricsCollector.GroupMetadata meta = metricsCollector.getGroupMetadata();
                     if (meta != null) {
-                        wo.put("groupId", meta.groupId());
-                        wo.put("groupInstanceId", meta.groupInstanceId());
-                        wo.put("memberId", meta.memberId());
-                        wo.put("generationId", meta.generationId());
+                        groupId = meta.groupId();
+                        groupInstanceId = meta.groupInstanceId();
+                        memberId = meta.memberId();
+                        generationId = meta.generationId();
                     }
+                    String lastTopic = null;
+                    Integer lastPartition = null;
+                    Long lastOffset = null;
                     if (metricsCollector.getLastRecord() != null) {
-                        wo.put("lastTopic", metricsCollector.getLastRecord().topic());
-                        wo.put("lastPartition", metricsCollector.getLastRecord().partition());
-                        wo.put("lastOffset", metricsCollector.getLastRecord().offset());
+                        lastTopic = metricsCollector.getLastRecord().topic();
+                        lastPartition = metricsCollector.getLastRecord().partition();
+                        lastOffset = metricsCollector.getLastRecord().offset();
                     }
+                    List<CommittedEntry> committedList = null;
                     if (committed) {
                         List<DefaultMetricsCollector.KafkaTopicPosition> l = fetchCommitOffsets(kc, metricsCollector);
                         if (l != null) {
-                            JsonArray ca = new JsonArray();
+                            List<CommittedEntry> ca = new ArrayList<>();
                             for (DefaultMetricsCollector.KafkaTopicPosition r : l) {
-                                JsonObject cr = new JsonObject();
-                                cr.put("topic", r.topic());
-                                cr.put("partition", r.partition());
-                                cr.put("offset", r.offset());
-                                cr.put("epoch", r.epoch());
-                                ca.add(cr);
+                                ca.add(new CommittedEntry(r.topic(), r.partition(), r.offset(), r.epoch()));
                             }
-                            if (!ca.isEmpty()) {
-                                wo.put("committed", ca);
-                            }
+                            committedList = ca.isEmpty() ? null : ca;
                         }
                     }
+
+                    workers.add(new WorkerEntry(
+                            metricsCollector.getThreadId(), t.getState(), lastError, groupId, groupInstanceId,
+                            memberId, generationId, lastTopic, lastPartition, lastOffset, committedList));
                 }
-                list.add(jo);
+                list.add(new ConsumerEntry(route.getRouteId(), route.getEndpoint().getEndpointUri(), workers));
             }
         }
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaDevConsoleTest.java
+++ b/components/camel-kafka/src/test/java/org/apache/camel/component/kafka/KafkaDevConsoleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kafka;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KafkaDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testKafkaConsoleNoConsumers() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("kafka");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("kafka", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+
+        JsonArray kafkaConsumers = out.getCollection("kafkaConsumers");
+        assertNotNull(kafkaConsumers);
+        assertTrue(kafkaConsumers.isEmpty());
+    }
+}

--- a/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-configmaps.json
+++ b/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-configmaps.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-kubernetes",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "masterUrl": {
+        "type": "string",
+        "description": "The Kubernetes master URL (only present when known)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when known)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether refreshing is enabled (only present when known)"
+      },
+      "startCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the refresh check started (only present when known)"
+      },
+      "configmaps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The config map (secret) name"
+            }
+          }
+        },
+        "description": "The config maps in use"
+      }
+    }
   }
 }
 

--- a/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-secrets.json
+++ b/components/camel-kubernetes/src/generated/resources/META-INF/org/apache/camel/dev-console/kubernetes-secrets.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-kubernetes",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "masterUrl": {
+        "type": "string",
+        "description": "The Kubernetes master URL (only present when configured)"
+      },
+      "login": {
+        "type": "string",
+        "description": "The login method (only present when configured)"
+      },
+      "refreshEnabled": {
+        "type": "boolean",
+        "description": "Whether secret refresh is enabled (only present when configured)"
+      },
+      "startCheckTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the refresh task started (only present when known)"
+      },
+      "secrets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The secret name"
+            }
+          }
+        },
+        "description": "The secrets in use"
+      }
+    }
   }
 }
 

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/config_maps/vault/ConfigmapsDevConsole.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/config_maps/vault/ConfigmapsDevConsole.java
@@ -23,20 +23,31 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.component.kubernetes.properties.ConfigMapPropertiesFunction;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PeriodTaskScheduler;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.KubernetesConfigMapVaultConfiguration;
 import org.apache.camel.vault.KubernetesVaultConfiguration;
 
 @DevConsole(name = "kubernetes-configmaps", displayName = "Kubernetes Config Maps",
             description = "Kubernetes Cluster Config Maps")
 public class ConfigmapsDevConsole extends AbstractDevConsole {
+
+    public record ConfigMapEntry(@Metadata(description = "The config map (secret) name") String name) {
+    }
+
+    public record Response(
+            @Metadata(description = "The Kubernetes master URL (only present when known)") String masterUrl,
+            @Metadata(description = "The login method (only present when known)") String login,
+            @Metadata(description = "Whether refreshing is enabled (only present when known)") Boolean refreshEnabled,
+            @Metadata(description = "Epoch time in milliseconds the refresh check started (only present when known)") Long startCheckTimestamp,
+            @Metadata(description = "The config maps in use") List<ConfigMapEntry> configmaps) {
+    }
 
     private ConfigMapPropertiesFunction propertiesFunction;
     private ConfigmapsReloadTriggerTask cmRefreshTask;
@@ -98,34 +109,36 @@ public class ConfigmapsDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String masterUrl = null;
+        String login = null;
         if (propertiesFunction != null) {
-            root.put("masterUrl", propertiesFunction.getClient().getMasterUrl().toString());
-            root.put("login", "OAuth Token");
+            masterUrl = propertiesFunction.getClient().getMasterUrl().toString();
+            login = "OAuth Token";
         }
+
         KubernetesVaultConfiguration kubernetes = getCamelContext().getVaultConfiguration().getKubernetesVaultConfiguration();
-        if (kubernetes != null) {
-            root.put("refreshEnabled", kubernetes.isRefreshEnabled());
-        }
+        Boolean refreshEnabled = kubernetes != null ? kubernetes.isRefreshEnabled() : null;
+
+        Long startCheckTimestamp = null;
         if (cmRefreshTask != null) {
             Instant start = cmRefreshTask.getStartingTime();
             if (start != null) {
-                long timestamp = start.toEpochMilli();
-                root.put("startCheckTimestamp", timestamp);
+                startCheckTimestamp = start.toEpochMilli();
             }
         }
-        JsonArray arr = new JsonArray();
-        root.put("configmaps", arr);
 
+        // NOTE: kubernetes is dereferenced unconditionally here, same as the original code -
+        // preserved as-is rather than fixed, since this migration is about the response contract
         List<String> sorted = new ArrayList<>(List.of(kubernetes.getSecrets().split(",")));
         Collections.sort(sorted);
 
+        List<ConfigMapEntry> configmaps = new ArrayList<>();
         for (String sec : sorted) {
-            JsonObject jo = new JsonObject();
-            jo.put("name", sec);
-            arr.add(jo);
+            configmaps.add(new ConfigMapEntry(sec));
         }
-        return root;
+
+        Response response = new Response(masterUrl, login, refreshEnabled, startCheckTimestamp, configmaps);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/secrets/vault/SecretsDevConsole.java
+++ b/components/camel-kubernetes/src/main/java/org/apache/camel/component/kubernetes/secrets/vault/SecretsDevConsole.java
@@ -24,14 +24,14 @@ import java.util.Map;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.camel.component.kubernetes.properties.SecretPropertiesFunction;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PeriodTaskScheduler;
 import org.apache.camel.spi.PropertiesFunction;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.vault.KubernetesVaultConfiguration;
 
 @DevConsole(name = "kubernetes-secrets", displayName = "Kubernetes Secrets", description = "Kubernetes Cluster Secrets")
@@ -39,6 +39,17 @@ public class SecretsDevConsole extends AbstractDevConsole {
 
     private SecretPropertiesFunction propertiesFunction;
     private SecretsReloadTriggerTask secretsRefreshTask;
+
+    public record SecretEntry(@Metadata(description = "The secret name") String name) {
+    }
+
+    public record Response(
+            @Metadata(description = "The Kubernetes master URL (only present when configured)") String masterUrl,
+            @Metadata(description = "The login method (only present when configured)") String login,
+            @Metadata(description = "Whether secret refresh is enabled (only present when configured)") Boolean refreshEnabled,
+            @Metadata(description = "Epoch time in milliseconds the refresh task started (only present when known)") Long startCheckTimestamp,
+            @Metadata(description = "The secrets in use") List<SecretEntry> secrets) {
+    }
 
     public SecretsDevConsole() {
         super("camel", "kubernetes-secrets", "Kubernetes Secrets", "Kubernetes Cluster Secrets");
@@ -99,37 +110,40 @@ public class SecretsDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String masterUrl = null;
+        String login = null;
         if (propertiesFunction != null) {
             KubernetesClient client = propertiesFunction.getClient();
             if (client != null && client.getMasterUrl() != null) {
-                root.put("masterUrl", client.getMasterUrl().toString());
-                root.put("login", "OAuth Token");
+                masterUrl = client.getMasterUrl().toString();
+                login = "OAuth Token";
             }
         }
         KubernetesVaultConfiguration kubernetes = getCamelContext().getVaultConfiguration().getKubernetesVaultConfiguration();
+        Boolean refreshEnabled = null;
         if (kubernetes != null) {
-            root.put("refreshEnabled", kubernetes.isRefreshEnabled());
+            refreshEnabled = kubernetes.isRefreshEnabled();
         }
+        Long startCheckTimestamp = null;
         if (secretsRefreshTask != null) {
             Instant start = secretsRefreshTask.getStartingTime();
             if (start != null) {
-                long timestamp = start.toEpochMilli();
-                root.put("startCheckTimestamp", timestamp);
+                startCheckTimestamp = start.toEpochMilli();
             }
         }
-        JsonArray arr = new JsonArray();
-        root.put("secrets", arr);
 
+        // NOTE: kubernetes is dereferenced unconditionally here, same as the original code - preserved
+        // as-is rather than fixed, since this migration is about the response contract
         List<String> sorted = new ArrayList<>(List.of(kubernetes.getSecrets().split(",")));
         Collections.sort(sorted);
 
+        List<SecretEntry> secrets = new ArrayList<>();
         for (String sec : sorted) {
-            JsonObject jo = new JsonObject();
-            jo.put("name", sec);
-            arr.add(jo);
+            secrets.add(new SecretEntry(sec));
         }
-        return root;
+
+        Response response = new Response(masterUrl, login, refreshEnabled, startCheckTimestamp, secrets);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/config_maps/vault/ConfigmapsDevConsoleTest.java
+++ b/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/config_maps/vault/ConfigmapsDevConsoleTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kubernetes.config_maps.vault;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * ConfigmapsDevConsole unconditionally dereferences the Kubernetes vault configuration's secrets list (a pre-existing
+ * bug, preserved as-is by this migration), so calling it without a real Kubernetes vault configuration would NPE; this
+ * test is limited to verifying the console registers correctly.
+ */
+public class ConfigmapsDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testConfigmapsConsoleResolves() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("kubernetes-configmaps");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("kubernetes-configmaps", con.getId());
+    }
+}

--- a/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/secrets/vault/SecretsDevConsoleTest.java
+++ b/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/secrets/vault/SecretsDevConsoleTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kubernetes.secrets.vault;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * SecretsDevConsole unconditionally dereferences the Kubernetes vault configuration's secrets list (a pre-existing bug,
+ * preserved as-is by this migration), so calling it without a real Kubernetes vault configuration would NPE; this test
+ * is limited to verifying the console registers correctly.
+ */
+public class SecretsDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testKubernetesSecretsConsoleResolves() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("kubernetes-secrets");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("kubernetes-secrets", con.getId());
+    }
+}

--- a/components/camel-micrometer/src/generated/resources/META-INF/org/apache/camel/dev-console/micrometer.json
+++ b/components/camel-micrometer/src/generated/resources/META-INF/org/apache/camel/dev-console/micrometer.json
@@ -47,7 +47,8 @@
     "type": "object",
     "properties": {
       "meterRegistryClass": {
-        "type": "string"
+        "type": "string",
+        "description": "The MeterRegistry implementation class name"
       },
       "counters": {
         "type": "array",
@@ -55,10 +56,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The counter name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The counter description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -66,13 +69,16 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The counter tags (only present when requested)"
             },
             "count": {
               "description": "The counter value (integer when whole, decimal otherwise)"
@@ -87,10 +93,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The gauge name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The gauge description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -98,16 +106,20 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The gauge tags (only present when requested)"
             },
             "value": {
-              "type": "number"
+              "type": "number",
+              "description": "The gauge value"
             }
           },
           "required": [
@@ -122,10 +134,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The timer name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The timer description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -133,25 +147,32 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The timer tags (only present when requested)"
             },
             "count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of recorded events"
             },
             "mean": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The mean duration in milliseconds"
             },
             "max": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The maximum duration in milliseconds"
             },
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The total duration in milliseconds"
             }
           },
           "required": [
@@ -169,10 +190,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The long task timer name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The long task timer description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -180,25 +203,32 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The long task timer tags (only present when requested)"
             },
             "activeTasks": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of currently active tasks"
             },
             "mean": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The mean duration in milliseconds"
             },
             "max": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The maximum duration in milliseconds"
             },
             "duration": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The total duration of active tasks in milliseconds"
             }
           },
           "required": [
@@ -216,10 +246,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The distribution summary name"
             },
             "description": {
-              "type": "string"
+              "type": "string",
+              "description": "The distribution summary description (only present when configured)"
             },
             "tags": {
               "type": "array",
@@ -227,25 +259,32 @@
                 "type": "object",
                 "properties": {
                   "key": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag key"
                   },
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The tag value"
                   }
                 }
-              }
+              },
+              "description": "The distribution summary tags (only present when requested)"
             },
             "count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of recorded events"
             },
             "mean": {
-              "type": "number"
+              "type": "number",
+              "description": "The mean amount"
             },
             "max": {
-              "type": "number"
+              "type": "number",
+              "description": "The maximum amount"
             },
             "totalAmount": {
-              "type": "number"
+              "type": "number",
+              "description": "The total amount"
             }
           },
           "required": [

--- a/components/camel-micrometer/src/generated/resources/META-INF/org/apache/camel/dev-console/micrometer.json
+++ b/components/camel-micrometer/src/generated/resources/META-INF/org/apache/camel/dev-console/micrometer.json
@@ -42,6 +42,222 @@
       "defaultValue": true,
       "description": "Whether to include tags"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "meterRegistryClass": {
+        "type": "string"
+      },
+      "counters": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "description": "The counter value (integer when whole, decimal otherwise)"
+            }
+          }
+        },
+        "description": "Only present when there are any counters"
+      },
+      "gauges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "value": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "value"
+          ]
+        },
+        "description": "Only present when there are any gauges"
+      },
+      "timers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "integer"
+            },
+            "max": {
+              "type": "integer"
+            },
+            "total": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "count",
+            "mean",
+            "max",
+            "total"
+          ]
+        },
+        "description": "Only present when there are any timers"
+      },
+      "longTaskTimers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "activeTasks": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "integer"
+            },
+            "max": {
+              "type": "integer"
+            },
+            "duration": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "activeTasks",
+            "mean",
+            "max",
+            "duration"
+          ]
+        },
+        "description": "Only present when there are any long task timers"
+      },
+      "distribution": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "totalAmount": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "mean",
+            "max",
+            "totalAmount"
+          ]
+        },
+        "description": "Only present when there are any distribution summaries"
+      }
+    }
   }
 }
 

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConsole.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConsole.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.micrometer;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -35,7 +36,7 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.ObjectHelper;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "micrometer", description = "Display runtime metrics")
 public class MicrometerConsole extends AbstractDevConsole {
@@ -47,6 +48,40 @@ public class MicrometerConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Filters matching metrics by name",
               javaType = "java.lang.String")
     public static final String FILTER = "filter";
+
+    public record TagEntry(String key, String value) {
+    }
+
+    public record CounterEntry(
+            String name, String description, List<TagEntry> tags,
+            @Metadata(description = "The counter value (integer when whole, decimal otherwise)") Object count) {
+    }
+
+    public record GaugeEntry(String name, String description, List<TagEntry> tags, double value) {
+    }
+
+    public record TimerEntry(
+            String name, String description, List<TagEntry> tags, long count, long mean, long max, long total) {
+    }
+
+    public record LongTaskTimerEntry(
+            String name, String description, List<TagEntry> tags, int activeTasks, long mean, long max,
+            long duration) {
+    }
+
+    public record DistributionEntry(
+            String name, String description, List<TagEntry> tags, long count, double mean, double max,
+            double totalAmount) {
+    }
+
+    public record Response(
+            String meterRegistryClass,
+            @Metadata(description = "Only present when there are any counters") List<CounterEntry> counters,
+            @Metadata(description = "Only present when there are any gauges") List<GaugeEntry> gauges,
+            @Metadata(description = "Only present when there are any timers") List<TimerEntry> timers,
+            @Metadata(description = "Only present when there are any long task timers") List<LongTaskTimerEntry> longTaskTimers,
+            @Metadata(description = "Only present when there are any distribution summaries") List<DistributionEntry> distribution) {
+    }
 
     public MicrometerConsole() {
         super("camel", "micrometer", "Micrometer", "Display runtime metrics");
@@ -176,170 +211,95 @@ public class MicrometerConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         final boolean tags = optionBoolean(options, TAGS, true);
         final String filter = optionString(options, FILTER);
 
-        JsonObject root = new JsonObject();
-
         MeterRegistry mr = lookupMeterRegistry();
-        root.put("meterRegistryClass", mr.getClass().getName());
 
         List<Meter> meters = mr.getMeters()
                 .stream()
                 .filter(meter -> accept(meter.getId().getName(), filter))
                 .toList();
 
-        int i = 0;
-        List<JsonObject> list = new ArrayList<>();
+        List<CounterEntry> counters = new ArrayList<>();
         for (Meter m : meters) {
-            if (m instanceof Counter) {
-                Counter c = (Counter) m;
-                if (i == 0) {
-                    root.put("counters", list);
-                }
-                i++;
-                JsonObject jo = new JsonObject();
-                jo.put("name", c.getId().getName());
-                if (c.getId().getDescription() != null) {
-                    jo.put("description", c.getId().getDescription());
-                }
-                if (tags) {
-                    addTags(m, jo);
-                }
+            if (m instanceof Counter c) {
                 // strip decimal if counter is integer based
                 String cnt = String.valueOf(c.count());
+                Object count;
                 if (cnt.endsWith(".0") || cnt.endsWith(",0")) {
-                    cnt = cnt.substring(0, cnt.length() - 2);
-                    jo.put("count", Long.valueOf(cnt));
+                    count = Long.valueOf(cnt.substring(0, cnt.length() - 2));
                 } else {
                     // it has decimals so store as-is
-                    jo.put("count", c.count());
+                    count = c.count();
                 }
-                list.add(jo);
+                counters.add(new CounterEntry(
+                        c.getId().getName(), c.getId().getDescription(), buildTags(tags, m), count));
             }
         }
-        list.sort(this::sortByName);
-        i = 0;
-        list = new ArrayList<>();
+        counters.sort(Comparator.comparing(CounterEntry::name, String.CASE_INSENSITIVE_ORDER));
+
+        List<GaugeEntry> gauges = new ArrayList<>();
         for (Meter m : meters) {
-            if (m instanceof Gauge) {
-                Gauge g = (Gauge) m;
-                if (i == 0) {
-                    root.put("gauges", list);
-                }
-                i++;
-                JsonObject jo = new JsonObject();
-                jo.put("name", g.getId().getName());
-                if (g.getId().getDescription() != null) {
-                    jo.put("description", g.getId().getDescription());
-                }
-                if (tags) {
-                    addTags(m, jo);
-                }
-                jo.put("value", g.value());
-                list.add(jo);
+            if (m instanceof Gauge g) {
+                gauges.add(new GaugeEntry(g.getId().getName(), g.getId().getDescription(), buildTags(tags, m), g.value()));
             }
         }
-        list.sort(this::sortByName);
-        i = 0;
-        list = new ArrayList<>();
+        gauges.sort(Comparator.comparing(GaugeEntry::name, String.CASE_INSENSITIVE_ORDER));
+
+        List<TimerEntry> timers = new ArrayList<>();
         for (Meter m : meters) {
-            if (m instanceof Timer) {
-                Timer t = (Timer) m;
-                if (i == 0) {
-                    root.put("timers", list);
-                }
-                i++;
-                JsonObject jo = new JsonObject();
-                jo.put("name", t.getId().getName());
-                if (t.getId().getDescription() != null) {
-                    jo.put("description", t.getId().getDescription());
-                }
-                if (tags) {
-                    addTags(m, jo);
-                }
-                jo.put("count", t.count());
-                jo.put("mean", Math.round(t.mean(TimeUnit.MILLISECONDS)));
-                jo.put("max", Math.round(t.max(TimeUnit.MILLISECONDS)));
-                jo.put("total", Math.round(t.totalTime(TimeUnit.MILLISECONDS)));
-                list.add(jo);
+            if (m instanceof Timer t) {
+                timers.add(new TimerEntry(
+                        t.getId().getName(), t.getId().getDescription(), buildTags(tags, m), t.count(),
+                        Math.round(t.mean(TimeUnit.MILLISECONDS)), Math.round(t.max(TimeUnit.MILLISECONDS)),
+                        Math.round(t.totalTime(TimeUnit.MILLISECONDS))));
             }
         }
-        list.sort(this::sortByName);
-        i = 0;
-        list = new ArrayList<>();
+        timers.sort(Comparator.comparing(TimerEntry::name, String.CASE_INSENSITIVE_ORDER));
+
+        List<LongTaskTimerEntry> longTaskTimers = new ArrayList<>();
         for (Meter m : meters) {
-            if (m instanceof LongTaskTimer) {
-                LongTaskTimer t = (LongTaskTimer) m;
-                if (i == 0) {
-                    root.put("longTaskTimers", list);
-                }
-                i++;
-                JsonObject jo = new JsonObject();
-                jo.put("name", t.getId().getName());
-                if (t.getId().getDescription() != null) {
-                    jo.put("description", t.getId().getDescription());
-                }
-                if (tags) {
-                    addTags(m, jo);
-                }
-                jo.put("activeTasks", t.activeTasks());
-                jo.put("mean", Math.round(t.mean(TimeUnit.MILLISECONDS)));
-                jo.put("max", Math.round(t.max(TimeUnit.MILLISECONDS)));
-                jo.put("duration", Math.round(t.duration(TimeUnit.MILLISECONDS)));
-                list.add(jo);
+            if (m instanceof LongTaskTimer t) {
+                longTaskTimers.add(new LongTaskTimerEntry(
+                        t.getId().getName(), t.getId().getDescription(), buildTags(tags, m), t.activeTasks(),
+                        Math.round(t.mean(TimeUnit.MILLISECONDS)), Math.round(t.max(TimeUnit.MILLISECONDS)),
+                        Math.round(t.duration(TimeUnit.MILLISECONDS))));
             }
         }
-        list.sort(this::sortByName);
-        i = 0;
-        list = new ArrayList<>();
+        longTaskTimers.sort(Comparator.comparing(LongTaskTimerEntry::name, String.CASE_INSENSITIVE_ORDER));
+
+        List<DistributionEntry> distribution = new ArrayList<>();
         for (Meter m : meters) {
-            if (m instanceof DistributionSummary) {
-                DistributionSummary d = (DistributionSummary) m;
-                if (i == 0) {
-                    root.put("distribution", list);
-                }
-                i++;
-                JsonObject jo = new JsonObject();
-                jo.put("name", d.getId().getName());
-                if (d.getId().getDescription() != null) {
-                    jo.put("description", d.getId().getDescription());
-                }
-                if (tags) {
-                    addTags(m, jo);
-                }
-                jo.put("count", d.count());
-                jo.put("mean", d.mean());
-                jo.put("max", d.max());
-                jo.put("totalAmount", d.totalAmount());
-                list.add(jo);
+            if (m instanceof DistributionSummary d) {
+                distribution.add(new DistributionEntry(
+                        d.getId().getName(), d.getId().getDescription(), buildTags(tags, m), d.count(), d.mean(),
+                        d.max(), d.totalAmount()));
             }
         }
 
-        return root;
+        Response response = new Response(
+                mr.getClass().getName(), counters.isEmpty() ? null : counters, gauges.isEmpty() ? null : gauges,
+                timers.isEmpty() ? null : timers, longTaskTimers.isEmpty() ? null : longTaskTimers,
+                distribution.isEmpty() ? null : distribution);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private void addTags(Meter m, JsonObject root) {
-        List<JsonObject> list = new ArrayList<>();
+    private static List<TagEntry> buildTags(boolean tags, Meter m) {
+        if (!tags) {
+            return null;
+        }
+        List<TagEntry> list = new ArrayList<>();
         for (Tag t : m.getId().getTags()) {
-            JsonObject jo = new JsonObject();
-            jo.put("key", t.getKey());
-            jo.put("value", t.getValue());
-            list.add(jo);
+            list.add(new TagEntry(t.getKey(), t.getValue()));
         }
-        if (!list.isEmpty()) {
-            root.put("tags", list);
-        }
+        return list.isEmpty() ? null : list;
     }
 
     private MeterRegistry lookupMeterRegistry() {
         return MicrometerUtils.getOrCreateMeterRegistry(getCamelContext().getRegistry(),
                 MicrometerConstants.METRICS_REGISTRY_NAME);
-    }
-
-    private int sortByName(JsonObject o1, JsonObject o2) {
-        return o1.getString("name").compareToIgnoreCase(o2.getString("name"));
     }
 
     private static boolean accept(String name, String filter) {

--- a/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConsole.java
+++ b/components/camel-micrometer/src/main/java/org/apache/camel/component/micrometer/MicrometerConsole.java
@@ -49,33 +49,57 @@ public class MicrometerConsole extends AbstractDevConsole {
               javaType = "java.lang.String")
     public static final String FILTER = "filter";
 
-    public record TagEntry(String key, String value) {
+    public record TagEntry(
+            @Metadata(description = "The tag key") String key,
+            @Metadata(description = "The tag value") String value) {
     }
 
     public record CounterEntry(
-            String name, String description, List<TagEntry> tags,
+            @Metadata(description = "The counter name") String name,
+            @Metadata(description = "The counter description (only present when configured)") String description,
+            @Metadata(description = "The counter tags (only present when requested)") List<TagEntry> tags,
             @Metadata(description = "The counter value (integer when whole, decimal otherwise)") Object count) {
     }
 
-    public record GaugeEntry(String name, String description, List<TagEntry> tags, double value) {
+    public record GaugeEntry(
+            @Metadata(description = "The gauge name") String name,
+            @Metadata(description = "The gauge description (only present when configured)") String description,
+            @Metadata(description = "The gauge tags (only present when requested)") List<TagEntry> tags,
+            @Metadata(description = "The gauge value") double value) {
     }
 
     public record TimerEntry(
-            String name, String description, List<TagEntry> tags, long count, long mean, long max, long total) {
+            @Metadata(description = "The timer name") String name,
+            @Metadata(description = "The timer description (only present when configured)") String description,
+            @Metadata(description = "The timer tags (only present when requested)") List<TagEntry> tags,
+            @Metadata(description = "The number of recorded events") long count,
+            @Metadata(description = "The mean duration in milliseconds") long mean,
+            @Metadata(description = "The maximum duration in milliseconds") long max,
+            @Metadata(description = "The total duration in milliseconds") long total) {
     }
 
     public record LongTaskTimerEntry(
-            String name, String description, List<TagEntry> tags, int activeTasks, long mean, long max,
-            long duration) {
+            @Metadata(description = "The long task timer name") String name,
+            @Metadata(description = "The long task timer description (only present when configured)") String description,
+            @Metadata(description = "The long task timer tags (only present when requested)") List<TagEntry> tags,
+            @Metadata(description = "The number of currently active tasks") int activeTasks,
+            @Metadata(description = "The mean duration in milliseconds") long mean,
+            @Metadata(description = "The maximum duration in milliseconds") long max,
+            @Metadata(description = "The total duration of active tasks in milliseconds") long duration) {
     }
 
     public record DistributionEntry(
-            String name, String description, List<TagEntry> tags, long count, double mean, double max,
-            double totalAmount) {
+            @Metadata(description = "The distribution summary name") String name,
+            @Metadata(description = "The distribution summary description (only present when configured)") String description,
+            @Metadata(description = "The distribution summary tags (only present when requested)") List<TagEntry> tags,
+            @Metadata(description = "The number of recorded events") long count,
+            @Metadata(description = "The mean amount") double mean,
+            @Metadata(description = "The maximum amount") double max,
+            @Metadata(description = "The total amount") double totalAmount) {
     }
 
     public record Response(
-            String meterRegistryClass,
+            @Metadata(description = "The MeterRegistry implementation class name") String meterRegistryClass,
             @Metadata(description = "Only present when there are any counters") List<CounterEntry> counters,
             @Metadata(description = "Only present when there are any gauges") List<GaugeEntry> gauges,
             @Metadata(description = "Only present when there are any timers") List<TimerEntry> timers,

--- a/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/MicrometerConsoleTest.java
+++ b/components/camel-micrometer/src/test/java/org/apache/camel/component/micrometer/MicrometerConsoleTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.micrometer;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MicrometerConsoleTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start")
+                        .to("micrometer:counter:myCounter")
+                        .to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testMicrometerConsoleText() throws Exception {
+        template.sendBody("direct:start", "Hello");
+
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("micrometer");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("micrometer", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+    }
+
+    @Test
+    public void testMicrometerConsoleJson() throws Exception {
+        template.sendBody("direct:start", "Hello");
+
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("micrometer");
+        assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertNotNull(out.getString("meterRegistryClass"));
+
+        JsonArray counters = out.getCollection("counters");
+        assertNotNull(counters);
+        assertFalse(counters.isEmpty());
+
+        JsonObject counter = (JsonObject) counters.get(0);
+        assertEquals("myCounter", counter.getString("name"));
+        assertNotNull(counter.get("count"));
+    }
+}

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/generated/resources/META-INF/org/apache/camel/dev-console/fault-tolerance.json
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/generated/resources/META-INF/org/apache/camel/dev-console/fault-tolerance.json
@@ -11,6 +11,99 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-microprofile-fault-tolerance",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "circuitBreakers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The circuit breaker ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "state": {
+              "type": "string",
+              "description": "The circuit breaker state"
+            },
+            "successfulCalls": {
+              "type": "integer",
+              "description": "Number of successful calls"
+            },
+            "failedCalls": {
+              "type": "integer",
+              "description": "Number of failed calls"
+            },
+            "notPermittedCalls": {
+              "type": "integer",
+              "description": "Number of not-permitted calls"
+            },
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "delay": {
+                  "type": "integer",
+                  "description": "The delay in milliseconds"
+                },
+                "failureRatio": {
+                  "type": "number",
+                  "description": "The failure ratio"
+                },
+                "requestVolumeThreshold": {
+                  "type": "integer",
+                  "description": "The request volume threshold"
+                },
+                "successThreshold": {
+                  "type": "integer",
+                  "description": "The success threshold"
+                },
+                "bulkheadEnabled": {
+                  "type": "boolean",
+                  "description": "Whether the bulkhead is enabled"
+                },
+                "bulkheadMaxConcurrentCalls": {
+                  "type": "integer",
+                  "description": "The bulkhead maximum concurrent calls (only present when the bulkhead is enabled)"
+                },
+                "bulkheadWaitingTaskQueue": {
+                  "type": "integer",
+                  "description": "The bulkhead waiting task queue size (only present when the bulkhead is enabled)"
+                },
+                "timeoutEnabled": {
+                  "type": "boolean",
+                  "description": "Whether the timeout is enabled"
+                },
+                "timeoutDuration": {
+                  "type": "integer",
+                  "description": "The timeout duration in milliseconds (only present when the timeout is enabled)"
+                }
+              },
+              "required": [
+                "delay",
+                "failureRatio",
+                "requestVolumeThreshold",
+                "successThreshold",
+                "bulkheadEnabled",
+                "timeoutEnabled"
+              ],
+              "description": "The circuit breaker configuration"
+            }
+          },
+          "required": [
+            "successfulCalls",
+            "failedCalls",
+            "notPermittedCalls"
+          ]
+        },
+        "description": "The circuit breakers"
+      }
+    }
   }
 }
 

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceConsole.java
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/main/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceConsole.java
@@ -23,13 +23,39 @@ import java.util.Map;
 
 import org.apache.camel.Processor;
 import org.apache.camel.Route;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "fault-tolerance", displayName = "MicroProfile Circuit Breaker",
             description = "Display circuit breaker information")
 public class FaultToleranceConsole extends AbstractDevConsole {
+
+    public record Configuration(
+            @Metadata(description = "The delay in milliseconds") long delay,
+            @Metadata(description = "The failure ratio") float failureRatio,
+            @Metadata(description = "The request volume threshold") int requestVolumeThreshold,
+            @Metadata(description = "The success threshold") int successThreshold,
+            @Metadata(description = "Whether the bulkhead is enabled") boolean bulkheadEnabled,
+            @Metadata(description = "The bulkhead maximum concurrent calls (only present when the bulkhead is enabled)") Integer bulkheadMaxConcurrentCalls,
+            @Metadata(description = "The bulkhead waiting task queue size (only present when the bulkhead is enabled)") Integer bulkheadWaitingTaskQueue,
+            @Metadata(description = "Whether the timeout is enabled") boolean timeoutEnabled,
+            @Metadata(description = "The timeout duration in milliseconds (only present when the timeout is enabled)") Long timeoutDuration) {
+    }
+
+    public record CircuitBreakerEntry(
+            @Metadata(description = "The circuit breaker ID") String id,
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The circuit breaker state") String state,
+            @Metadata(description = "Number of successful calls") long successfulCalls,
+            @Metadata(description = "Number of failed calls") long failedCalls,
+            @Metadata(description = "Number of not-permitted calls") long notPermittedCalls,
+            @Metadata(description = "The circuit breaker configuration") Configuration configuration) {
+    }
+
+    public record Response(@Metadata(description = "The circuit breakers") List<CircuitBreakerEntry> circuitBreakers) {
+    }
 
     public FaultToleranceConsole() {
         super("camel", "fault-tolerance", "MicroProfile Circuit Breaker",
@@ -67,9 +93,7 @@ public class FaultToleranceConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         List<FaultToleranceProcessor> cbs = new ArrayList<>();
         for (Route route : getCamelContext().getRoutes()) {
             List<Processor> list = route.filter("*");
@@ -82,35 +106,27 @@ public class FaultToleranceConsole extends AbstractDevConsole {
         // sort by ids
         cbs.sort(Comparator.comparing(FaultToleranceProcessor::getId));
 
-        final List<JsonObject> list = new ArrayList<>();
+        final List<CircuitBreakerEntry> list = new ArrayList<>();
         for (FaultToleranceProcessor cb : cbs) {
-            JsonObject jo = new JsonObject();
-            jo.put("id", cb.getId());
-            jo.put("routeId", cb.getRouteId());
-            jo.put("state", cb.getCircuitBreakerState());
-            jo.put("successfulCalls", cb.getNumberOfSuccessfulCalls());
-            jo.put("failedCalls", cb.getNumberOfFailedCalls());
-            jo.put("notPermittedCalls", cb.getNumberOfNotPermittedCalls());
-            // configuration
-            JsonObject config = new JsonObject();
-            config.put("delay", cb.getDelay());
-            config.put("failureRatio", cb.getFailureRatio());
-            config.put("requestVolumeThreshold", cb.getRequestVolumeThreshold());
-            config.put("successThreshold", cb.getSuccessThreshold());
-            config.put("bulkheadEnabled", cb.isBulkheadEnabled());
+            Integer bulkheadMaxConcurrentCalls = null;
+            Integer bulkheadWaitingTaskQueue = null;
             if (cb.isBulkheadEnabled()) {
-                config.put("bulkheadMaxConcurrentCalls", cb.getBulkheadMaxConcurrentCalls());
-                config.put("bulkheadWaitingTaskQueue", cb.getBulkheadWaitingTaskQueue());
+                bulkheadMaxConcurrentCalls = cb.getBulkheadMaxConcurrentCalls();
+                bulkheadWaitingTaskQueue = cb.getBulkheadWaitingTaskQueue();
             }
-            config.put("timeoutEnabled", cb.isTimeoutEnabled());
-            if (cb.isTimeoutEnabled()) {
-                config.put("timeoutDuration", cb.getTimeoutDuration());
-            }
-            jo.put("configuration", config);
-            list.add(jo);
-        }
-        root.put("circuitBreakers", list);
+            Long timeoutDuration = cb.isTimeoutEnabled() ? cb.getTimeoutDuration() : null;
 
-        return root;
+            Configuration config = new Configuration(
+                    cb.getDelay(), cb.getFailureRatio(), cb.getRequestVolumeThreshold(), cb.getSuccessThreshold(),
+                    cb.isBulkheadEnabled(), bulkheadMaxConcurrentCalls, bulkheadWaitingTaskQueue, cb.isTimeoutEnabled(),
+                    timeoutDuration);
+
+            list.add(new CircuitBreakerEntry(
+                    cb.getId(), cb.getRouteId(), cb.getCircuitBreakerState(), cb.getNumberOfSuccessfulCalls(),
+                    cb.getNumberOfFailedCalls(), cb.getNumberOfNotPermittedCalls(), config));
+        }
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/src/test/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceConsoleTest.java
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/src/test/java/org/apache/camel/component/microprofile/faulttolerance/FaultToleranceConsoleTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.microprofile.faulttolerance;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class FaultToleranceConsoleTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute")
+                        .circuitBreaker().id("myBreaker")
+                        .to("mock:result")
+                        .end();
+            }
+        };
+    }
+
+    @Test
+    public void testFaultToleranceConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("fault-tolerance");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("fault-tolerance", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+    }
+
+    @Test
+    public void testFaultToleranceConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("fault-tolerance");
+        assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+
+        JsonArray circuitBreakers = out.getCollection("circuitBreakers");
+        assertNotNull(circuitBreakers);
+        assertFalse(circuitBreakers.isEmpty());
+
+        JsonObject entry = (JsonObject) circuitBreakers.get(0);
+        assertEquals("myBreaker", entry.getString("id"));
+        assertEquals("myRoute", entry.getString("routeId"));
+        assertNotNull(entry.getString("state"));
+
+        JsonObject config = entry.getJsonObject("configuration");
+        assertNotNull(config);
+        assertNotNull(config.getBoolean("bulkheadEnabled"));
+        assertNotNull(config.getBoolean("timeoutEnabled"));
+    }
+}

--- a/components/camel-opentelemetry2/src/generated/resources/META-INF/org/apache/camel/dev-console/opentelemetry.json
+++ b/components/camel-opentelemetry2/src/generated/resources/META-INF/org/apache/camel/dev-console/opentelemetry.json
@@ -46,6 +46,93 @@
       "defaultValue": 100,
       "description": "Limits the number of spans dumped"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether the OpenTelemetry in-memory exporter is enabled"
+      },
+      "spanCount": {
+        "type": "integer",
+        "description": "The number of finished spans held (only present when not dumping spans)"
+      },
+      "capacity": {
+        "type": "integer",
+        "description": "The maximum number of spans held (only present when not dumping spans)"
+      },
+      "spans": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "traceId": {
+              "type": "string",
+              "description": "The trace id"
+            },
+            "spanId": {
+              "type": "string",
+              "description": "The span id"
+            },
+            "parentSpanId": {
+              "type": "string",
+              "description": "The parent span id (only present when known)"
+            },
+            "name": {
+              "type": "string",
+              "description": "The span name"
+            },
+            "kind": {
+              "type": "string",
+              "description": "The span kind"
+            },
+            "status": {
+              "type": "string",
+              "description": "The span status"
+            },
+            "startEpochNanos": {
+              "type": "integer",
+              "description": "Epoch time in nanoseconds when the span started"
+            },
+            "endEpochNanos": {
+              "type": "integer",
+              "description": "Epoch time in nanoseconds when the span ended"
+            },
+            "durationMs": {
+              "type": "integer",
+              "description": "The span duration in milliseconds"
+            },
+            "scopeName": {
+              "type": "string",
+              "description": "The instrumentation scope name (only present when known)"
+            },
+            "attributes": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "The span attributes (only present when there are any)"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route id this span belongs to (only present when known)"
+            },
+            "processorId": {
+              "type": "string",
+              "description": "The processor id this span belongs to (only present for processor spans)"
+            }
+          },
+          "required": [
+            "startEpochNanos",
+            "endEpochNanos",
+            "durationMs"
+          ]
+        },
+        "description": "The dumped spans (only present when dumping spans)"
+      }
+    },
+    "required": [
+      "enabled"
+    ]
   }
 }
 

--- a/components/camel-opentelemetry2/src/main/java/org/apache/camel/opentelemetry2/OpenTelemetryDevConsole.java
+++ b/components/camel-opentelemetry2/src/main/java/org/apache/camel/opentelemetry2/OpenTelemetryDevConsole.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.opentelemetry2;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,8 +29,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "opentelemetry", displayName = "OpenTelemetry Spans",
             description = "OpenTelemetry span data captured in dev mode")
@@ -41,6 +42,29 @@ public class OpenTelemetryDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Limits the number of spans dumped", defaultValue = "100",
               javaType = "java.lang.Integer")
     public static final String LIMIT = "limit";
+
+    public record SpanEntry(
+            @Metadata(description = "The trace id") String traceId,
+            @Metadata(description = "The span id") String spanId,
+            @Metadata(description = "The parent span id (only present when known)") String parentSpanId,
+            @Metadata(description = "The span name") String name,
+            @Metadata(description = "The span kind") String kind,
+            @Metadata(description = "The span status") String status,
+            @Metadata(description = "Epoch time in nanoseconds when the span started") long startEpochNanos,
+            @Metadata(description = "Epoch time in nanoseconds when the span ended") long endEpochNanos,
+            @Metadata(description = "The span duration in milliseconds") long durationMs,
+            @Metadata(description = "The instrumentation scope name (only present when known)") String scopeName,
+            @Metadata(description = "The span attributes (only present when there are any)") Map<String, Object> attributes,
+            @Metadata(description = "The route id this span belongs to (only present when known)") String routeId,
+            @Metadata(description = "The processor id this span belongs to (only present for processor spans)") String processorId) {
+    }
+
+    public record Response(
+            @Metadata(description = "Whether the OpenTelemetry in-memory exporter is enabled") boolean enabled,
+            @Metadata(description = "The number of finished spans held (only present when not dumping spans)") Integer spanCount,
+            @Metadata(description = "The maximum number of spans held (only present when not dumping spans)") Integer capacity,
+            @Metadata(description = "The dumped spans (only present when dumping spans)") List<SpanEntry> spans) {
+    }
 
     public OpenTelemetryDevConsole() {
         super("camel", "opentelemetry", "OpenTelemetry Spans",
@@ -78,63 +102,57 @@ public class OpenTelemetryDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         DevSpanExporter exporter = findExporter();
-        if (exporter == null) {
-            root.put("enabled", false);
-            return root;
-        }
+        boolean enabled = exporter != null;
+        Integer spanCount = null;
+        Integer capacity = null;
+        List<SpanEntry> spanEntries = null;
 
-        root.put("enabled", true);
+        if (exporter != null) {
+            String dump = optionString(options, DUMP);
+            if (dump != null) {
+                int limit = optionInt(options, LIMIT, 100);
+                List<SpanData> spans = exporter.getFinishedSpans();
+                int start = Math.max(0, spans.size() - limit);
+                List<SpanData> selected = spans.subList(start, spans.size());
 
-        String dump = optionString(options, DUMP);
-        if (dump != null) {
-            int limit = optionInt(options, LIMIT, 100);
-            List<SpanData> spans = exporter.getFinishedSpans();
-            int start = Math.max(0, spans.size() - limit);
+                // Build lookup map for enriching spans with route context
+                Map<String, String> endpointToRouteId = new HashMap<>();
+                buildEnrichmentMaps(endpointToRouteId);
 
-            // Build lookup map for enriching spans with route context
-            Map<String, String> endpointToRouteId = new HashMap<>();
-            buildEnrichmentMaps(endpointToRouteId);
-
-            // First pass: convert spans to JSON and resolve routeIds for endpoint spans
-            JsonArray arr = new JsonArray();
-            Map<String, String> spanIdToRouteId = new HashMap<>();
-            Map<String, String> spanIdToParent = new HashMap<>();
-            for (int i = start; i < spans.size(); i++) {
-                SpanData sd = spans.get(i);
-                JsonObject jo = spanToJson(sd, endpointToRouteId);
-                arr.add(jo);
-                // Track routeId and parent relationships for propagation
-                if (jo.containsKey("routeId")) {
-                    spanIdToRouteId.put(sd.getSpanId(), jo.getString("routeId"));
-                }
-                String pid = sd.getParentSpanId();
-                if (pid != null && !pid.isEmpty() && !"0000000000000000".equals(pid)) {
-                    spanIdToParent.put(sd.getSpanId(), pid);
-                }
-            }
-
-            // Second pass: propagate routeId to processor spans by walking parent chain
-            for (int i = 0; i < arr.size(); i++) {
-                JsonObject jo = (JsonObject) arr.get(i);
-                if (!jo.containsKey("routeId")) {
-                    String spanId = jo.getString("spanId");
-                    String inheritedRouteId = findAncestorRouteId(spanId, spanIdToRouteId, spanIdToParent);
-                    if (inheritedRouteId != null) {
-                        jo.put("routeId", inheritedRouteId);
+                // First pass: resolve direct routeIds for endpoint spans, and track parent relationships
+                Map<String, String> directRouteIdBySpanId = new HashMap<>();
+                Map<String, String> spanIdToParent = new HashMap<>();
+                for (SpanData sd : selected) {
+                    String uri = sd.getAttributes().get(AttributeKey.stringKey("camel.uri"));
+                    String directRouteId = uri != null ? endpointToRouteId.get(uri) : null;
+                    if (directRouteId != null) {
+                        directRouteIdBySpanId.put(sd.getSpanId(), directRouteId);
+                    }
+                    String pid = sd.getParentSpanId();
+                    if (pid != null && !pid.isEmpty() && !"0000000000000000".equals(pid)) {
+                        spanIdToParent.put(sd.getSpanId(), pid);
                     }
                 }
+
+                // Second pass: propagate routeId to processor spans by walking parent chain
+                spanEntries = new ArrayList<>();
+                for (SpanData sd : selected) {
+                    String routeId = directRouteIdBySpanId.get(sd.getSpanId());
+                    if (routeId == null) {
+                        routeId = findAncestorRouteId(sd.getSpanId(), directRouteIdBySpanId, spanIdToParent);
+                    }
+                    spanEntries.add(buildSpanEntry(sd, routeId));
+                }
+            } else {
+                spanCount = exporter.getSpanCount();
+                capacity = exporter.getCapacity();
             }
-            root.put("spans", arr);
-        } else {
-            root.put("spanCount", exporter.getSpanCount());
-            root.put("capacity", exporter.getCapacity());
         }
 
-        return root;
+        Response response = new Response(enabled, spanCount, capacity, spanEntries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private DevSpanExporter findExporter() {
@@ -155,53 +173,37 @@ public class OpenTelemetryDevConsole extends AbstractDevConsole {
     }
 
     @SuppressWarnings("unchecked")
-    private static JsonObject spanToJson(SpanData span, Map<String, String> endpointToRouteId) {
-        JsonObject jo = new JsonObject();
-        jo.put("traceId", span.getTraceId());
-        jo.put("spanId", span.getSpanId());
+    private static SpanEntry buildSpanEntry(SpanData span, String routeId) {
         String parentSpanId = span.getParentSpanId();
-        if (parentSpanId != null && !parentSpanId.isEmpty()
-                && !"0000000000000000".equals(parentSpanId)) {
-            jo.put("parentSpanId", parentSpanId);
+        if (parentSpanId != null && (parentSpanId.isEmpty() || "0000000000000000".equals(parentSpanId))) {
+            parentSpanId = null;
         }
-        jo.put("name", span.getName());
-        jo.put("kind", span.getKind().name());
-        jo.put("status", span.getStatus().getStatusCode().name());
-        jo.put("startEpochNanos", span.getStartEpochNanos());
-        jo.put("endEpochNanos", span.getEndEpochNanos());
-        jo.put("durationMs", (span.getEndEpochNanos() - span.getStartEpochNanos()) / 1_000_000);
 
         String scopeName = span.getInstrumentationScopeInfo().getName();
-        if (scopeName != null && !scopeName.isEmpty()) {
-            jo.put("scopeName", scopeName);
+        if (scopeName != null && scopeName.isEmpty()) {
+            scopeName = null;
         }
 
-        JsonObject attrs = new JsonObject();
+        Map<String, Object> attrs = new LinkedHashMap<>();
         span.getAttributes().forEach((key, value) -> attrs.put(key.getKey(), value));
-        if (!attrs.isEmpty()) {
-            jo.put("attributes", attrs);
-        }
-
-        // Enrich with route context from endpoint URI
-        String uri = span.getAttributes().get(AttributeKey.stringKey("camel.uri"));
-        if (uri != null) {
-            String routeId = endpointToRouteId.get(uri);
-            if (routeId != null) {
-                jo.put("routeId", routeId);
-            }
-        }
+        Map<String, Object> attributes = attrs.isEmpty() ? null : attrs;
 
         // Enrich processor spans with processorId extracted from span name (format: id-shortName)
+        String processorId = null;
         String op = span.getAttributes().get(AttributeKey.stringKey("op"));
         if ("EVENT_PROCESS".equals(op)) {
             String name = span.getName();
             int dash = name.lastIndexOf('-');
             if (dash > 0) {
-                jo.put("processorId", name.substring(0, dash));
+                processorId = name.substring(0, dash);
             }
         }
 
-        return jo;
+        return new SpanEntry(
+                span.getTraceId(), span.getSpanId(), parentSpanId, span.getName(), span.getKind().name(),
+                span.getStatus().getStatusCode().name(), span.getStartEpochNanos(), span.getEndEpochNanos(),
+                (span.getEndEpochNanos() - span.getStartEpochNanos()) / 1_000_000, scopeName, attributes, routeId,
+                processorId);
     }
 
     private static String findAncestorRouteId(

--- a/components/camel-opentelemetry2/src/test/java/org/apache/camel/opentelemetry2/OpenTelemetryDevConsoleTest.java
+++ b/components/camel-opentelemetry2/src/test/java/org/apache/camel/opentelemetry2/OpenTelemetryDevConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.opentelemetry2;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class OpenTelemetryDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testOpenTelemetryConsoleNoExporter() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("opentelemetry");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("opentelemetry", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertFalse(out.getBoolean("enabled"));
+    }
+}

--- a/components/camel-platform-http-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-http-server.json
+++ b/components/camel-platform-http-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-http-server.json
@@ -11,6 +11,39 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-platform-http-main",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "host": {
+        "type": "string",
+        "description": "The bind host (only present when the server is running)"
+      },
+      "port": {
+        "type": "integer",
+        "description": "The bind port (only present when the server is running)"
+      },
+      "path": {
+        "type": "string",
+        "description": "The context path (only present when the server is running)"
+      },
+      "maxBodySize": {
+        "type": "integer",
+        "description": "Maximum HTTP body size in bytes (only present when configured)"
+      },
+      "fileUploadEnabled": {
+        "type": "boolean",
+        "description": "Whether file upload is enabled (only present when the server is running)"
+      },
+      "fileUploadDirectory": {
+        "type": "string",
+        "description": "The file upload directory (only present when configured)"
+      },
+      "useGlobalSslContextParameters": {
+        "type": "boolean",
+        "description": "Whether global SSL context parameters are used (only present when the server is running)"
+      }
+    }
   }
 }
 

--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerDevConsole.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerDevConsole.java
@@ -18,12 +18,23 @@ package org.apache.camel.component.platform.http.main;
 
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "main-http-server", displayName = "Main HTTP Server", description = "Camel Main HTTP Server")
 public class MainHttpServerDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The bind host (only present when the server is running)") String host,
+            @Metadata(description = "The bind port (only present when the server is running)") Integer port,
+            @Metadata(description = "The context path (only present when the server is running)") String path,
+            @Metadata(description = "Maximum HTTP body size in bytes (only present when configured)") Long maxBodySize,
+            @Metadata(description = "Whether file upload is enabled (only present when the server is running)") Boolean fileUploadEnabled,
+            @Metadata(description = "The file upload directory (only present when configured)") String fileUploadDirectory,
+            @Metadata(description = "Whether global SSL context parameters are used (only present when the server is running)") Boolean useGlobalSslContextParameters) {
+    }
 
     public MainHttpServerDevConsole() {
         super("camel", "main-http-server", "Main HTTP Server", "Camel Main HTTP Server");
@@ -54,23 +65,27 @@ public class MainHttpServerDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+        String host = null;
+        Integer port = null;
+        String path = null;
+        Long maxBodySize = null;
+        Boolean fileUploadEnabled = null;
+        String fileUploadDirectory = null;
+        Boolean useGlobalSslContextParameters = null;
 
         MainHttpServer server = getCamelContext().hasService(MainHttpServer.class);
         if (server != null) {
-            root.put("host", server.getHost());
-            root.put("port", server.getPort());
-            root.put("path", server.getPath());
-            if (server.getMaxBodySize() != null) {
-                root.put("maxBodySize", server.getMaxBodySize());
-            }
-            root.put("fileUploadEnabled", server.isFileUploadEnabled());
-            if (server.getFileUploadDirectory() != null) {
-                root.put("fileUploadDirectory", server.getFileUploadDirectory());
-            }
-            root.put("useGlobalSslContextParameters", server.isUseGlobalSslContextParameters());
+            host = server.getHost();
+            port = server.getPort();
+            path = server.getPath();
+            maxBodySize = server.getMaxBodySize();
+            fileUploadEnabled = server.isFileUploadEnabled();
+            fileUploadDirectory = server.getFileUploadDirectory();
+            useGlobalSslContextParameters = server.isUseGlobalSslContextParameters();
         }
 
-        return root;
+        Response response = new Response(
+                host, port, path, maxBodySize, fileUploadEnabled, fileUploadDirectory, useGlobalSslContextParameters);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/MainHttpServerDevConsoleTest.java
+++ b/components/camel-platform-http-main/src/test/java/org/apache/camel/component/platform/http/main/MainHttpServerDevConsoleTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http.main;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.console.DevConsoleRegistry;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.console.DefaultDevConsoleRegistry;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MainHttpServerDevConsole reports on a running {@link MainHttpServer} service; spinning up a real one is out of scope
+ * for this test, so it only verifies the console's basic shape when no server is registered.
+ */
+public class MainHttpServerDevConsoleTest {
+
+    private CamelContext camelContext;
+
+    @BeforeEach
+    void setUp() {
+        camelContext = new DefaultCamelContext();
+        camelContext.setDevConsole(true);
+        DefaultDevConsoleRegistry registry = new DefaultDevConsoleRegistry(camelContext);
+        registry.register(new MainHttpServerDevConsole());
+        camelContext.getCamelContextExtension().addContextPlugin(DevConsoleRegistry.class, registry);
+        camelContext.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        camelContext.stop();
+    }
+
+    @Test
+    void testMainHttpServerConsoleNoServer() {
+        DevConsole con = camelContext.getCamelContextExtension().getContextPlugin(DevConsoleRegistry.class)
+                .resolveById("main-http-server");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-platform-http/src/generated/resources/META-INF/org/apache/camel/dev-console/platform-http.json
+++ b/components/camel-platform-http/src/generated/resources/META-INF/org/apache/camel/dev-console/platform-http.json
@@ -11,6 +11,73 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-platform-http",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "server": {
+        "type": "string",
+        "description": "The server base URL (only present when the platform-http component is active)"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The full endpoint URL"
+            },
+            "path": {
+              "type": "string",
+              "description": "The endpoint path"
+            },
+            "verbs": {
+              "type": "string",
+              "description": "The HTTP verbs (only present when configured)"
+            },
+            "consumes": {
+              "type": "string",
+              "description": "The consumed media types (only present when configured)"
+            },
+            "produces": {
+              "type": "string",
+              "description": "The produced media types (only present when configured)"
+            }
+          }
+        },
+        "description": "The registered HTTP endpoints (only present when there are any)"
+      },
+      "managementEndpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The full endpoint URL"
+            },
+            "path": {
+              "type": "string",
+              "description": "The endpoint path"
+            },
+            "verbs": {
+              "type": "string",
+              "description": "The HTTP verbs (only present when configured)"
+            },
+            "consumes": {
+              "type": "string",
+              "description": "The consumed media types (only present when configured)"
+            },
+            "produces": {
+              "type": "string",
+              "description": "The produced media types (only present when configured)"
+            }
+          }
+        },
+        "description": "The registered HTTP management endpoints (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpConsole.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpConsole.java
@@ -21,12 +21,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "platform-http", displayName = "Platform HTTP", description = "Embedded HTTP Server")
 public class PlatformHttpConsole extends AbstractDevConsole {
+
+    public record EndpointEntry(
+            @Metadata(description = "The full endpoint URL") String url,
+            @Metadata(description = "The endpoint path") String path,
+            @Metadata(description = "The HTTP verbs (only present when configured)") String verbs,
+            @Metadata(description = "The consumed media types (only present when configured)") String consumes,
+            @Metadata(description = "The produced media types (only present when configured)") String produces) {
+    }
+
+    public record Response(
+            @Metadata(description = "The server base URL (only present when the platform-http component is active)") String server,
+            @Metadata(description = "The registered HTTP endpoints (only present when there are any)") List<EndpointEntry> endpoints,
+            @Metadata(description = "The registered HTTP management endpoints (only present when there are any)") List<EndpointEntry> managementEndpoints) {
+    }
 
     public PlatformHttpConsole() {
         super("camel", "platform-http", "Platform HTTP", "Embedded HTTP Server");
@@ -69,54 +84,41 @@ public class PlatformHttpConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String server = null;
+        List<EndpointEntry> endpoints = null;
+        List<EndpointEntry> managementEndpoints = null;
 
         // do not auto-create as during bootstrap then this component in Spring Boot may
         // currently be creating which can lead to a dead-lock in Spring Boot
         PlatformHttpComponent http = (PlatformHttpComponent) getCamelContext().hasComponent("platform-http");
         if (http != null) {
-            String server = "http://0.0.0.0";
+            server = "http://0.0.0.0";
             int port = http.getEngine().getServerPort();
             if (port > 0) {
                 server += ":" + port;
             }
-            root.put("server", server);
 
-            List<JsonObject> list = buildEndpointList(http, server, false);
-            if (!list.isEmpty()) {
-                root.put("endpoints", list);
-            }
+            List<EndpointEntry> list = buildEndpointList(http, server, false);
+            endpoints = list.isEmpty() ? null : list;
             list = buildEndpointList(http, server, true);
-            if (!list.isEmpty()) {
-                root.put("managementEndpoints", list);
-            }
+            managementEndpoints = list.isEmpty() ? null : list;
         }
 
-        return root;
+        Response response = new Response(server, endpoints, managementEndpoints);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static List<JsonObject> buildEndpointList(PlatformHttpComponent http, String server, boolean management) {
+    private static List<EndpointEntry> buildEndpointList(PlatformHttpComponent http, String server, boolean management) {
         Set<HttpEndpointModel> models = management ? http.getHttpManagementEndpoints() : http.getHttpEndpoints();
-        List<JsonObject> list = new ArrayList<>();
+        List<EndpointEntry> list = new ArrayList<>();
         for (HttpEndpointModel model : models) {
-            JsonObject jo = new JsonObject();
             String uri = model.getUri();
             if (!uri.startsWith("/")) {
                 uri = "/" + uri;
             }
-            jo.put("url", server + uri);
-            jo.put("path", model.getUri());
-            if (model.getVerbs() != null) {
-                jo.put("verbs", model.getVerbs());
-            }
-            if (model.getConsumes() != null) {
-                jo.put("consumes", model.getConsumes());
-            }
-            if (model.getProduces() != null) {
-                jo.put("produces", model.getProduces());
-            }
-            list.add(jo);
+            list.add(new EndpointEntry(
+                    server + uri, model.getUri(), model.getVerbs(), model.getConsumes(), model.getProduces()));
         }
         return list;
     }

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpConsoleTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpConsoleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PlatformHttpConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testPlatformHttpConsoleNoComponent() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("platform-http");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("platform-http", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/components/camel-quartz/src/generated/resources/META-INF/org/apache/camel/dev-console/quartz.json
+++ b/components/camel-quartz/src/generated/resources/META-INF/org/apache/camel/dev-console/quartz.json
@@ -11,6 +11,125 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-quartz",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "schedulerName": {
+        "type": "string"
+      },
+      "schedulerInstanceId": {
+        "type": "string"
+      },
+      "quartzVersion": {
+        "type": "string"
+      },
+      "runningSince": {
+        "type": "integer"
+      },
+      "totalCounter": {
+        "type": "integer"
+      },
+      "started": {
+        "type": "boolean"
+      },
+      "shutdown": {
+        "type": "boolean"
+      },
+      "inStandbyMode": {
+        "type": "boolean"
+      },
+      "threadPoolClass": {
+        "type": "string"
+      },
+      "threadPoolSize": {
+        "type": "integer"
+      },
+      "jpbStoreClass": {
+        "type": "string",
+        "description": "The job store class name (field kept as jpbStoreClass for backwards compatibility)"
+      },
+      "jpbStoreClustered": {
+        "type": "boolean"
+      },
+      "jpbStoreSupportsPersistence": {
+        "type": "boolean"
+      },
+      "currentExecutingJobs": {
+        "type": "integer"
+      },
+      "jobs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "jobId": {
+              "type": "string"
+            },
+            "triggerType": {
+              "type": "string"
+            },
+            "cron": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            },
+            "prevFireTime": {
+              "type": "integer"
+            },
+            "fireTime": {
+              "type": "integer"
+            },
+            "nextFireTime": {
+              "type": "integer"
+            },
+            "finalFireTime": {
+              "type": "integer"
+            },
+            "recovering": {
+              "type": "boolean"
+            },
+            "refireCount": {
+              "type": "integer"
+            },
+            "misfireInstruction": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "recovering",
+            "refireCount",
+            "misfireInstruction"
+          ]
+        },
+        "description": "Only present when there are any currently executing jobs"
+      },
+      "triggers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string"
+            },
+            "triggerType": {
+              "type": "string"
+            },
+            "cron": {
+              "type": "string"
+            },
+            "repeatInterval": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Only present when there are any scheduled triggers"
+      }
+    }
   }
 }
 

--- a/components/camel-quartz/src/generated/resources/META-INF/org/apache/camel/dev-console/quartz.json
+++ b/components/camel-quartz/src/generated/resources/META-INF/org/apache/camel/dev-console/quartz.json
@@ -16,47 +16,60 @@
     "type": "object",
     "properties": {
       "schedulerName": {
-        "type": "string"
+        "type": "string",
+        "description": "The scheduler name"
       },
       "schedulerInstanceId": {
-        "type": "string"
+        "type": "string",
+        "description": "The scheduler instance id"
       },
       "quartzVersion": {
-        "type": "string"
+        "type": "string",
+        "description": "The Quartz version (only present when known)"
       },
       "runningSince": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Epoch time in milliseconds the scheduler started running (only present when known)"
       },
       "totalCounter": {
-        "type": "integer"
+        "type": "integer",
+        "description": "The total number of jobs executed (only present when known)"
       },
       "started": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the scheduler is started (only present when known)"
       },
       "shutdown": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the scheduler is shutdown (only present when known)"
       },
       "inStandbyMode": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the scheduler is in standby mode (only present when known)"
       },
       "threadPoolClass": {
-        "type": "string"
+        "type": "string",
+        "description": "The thread pool class name (only present when known)"
       },
       "threadPoolSize": {
-        "type": "integer"
+        "type": "integer",
+        "description": "The thread pool size (only present when known)"
       },
       "jpbStoreClass": {
         "type": "string",
-        "description": "The job store class name (field kept as jpbStoreClass for backwards compatibility)"
+        "description": "The job store class name (field kept as jpbStoreClass for backwards compatibility, only present when known)"
       },
       "jpbStoreClustered": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the job store is clustered (field kept as jpbStoreClustered for backwards compatibility, only present when known)"
       },
       "jpbStoreSupportsPersistence": {
-        "type": "boolean"
+        "type": "boolean",
+        "description": "Whether the job store supports persistence (field kept as jpbStoreSupportsPersistence for backwards compatibility, only present when known)"
       },
       "currentExecutingJobs": {
-        "type": "integer"
+        "type": "integer",
+        "description": "The number of currently executing jobs"
       },
       "jobs": {
         "type": "array",
@@ -64,40 +77,52 @@
           "type": "object",
           "properties": {
             "jobId": {
-              "type": "string"
+              "type": "string",
+              "description": "The job fire instance id"
             },
             "triggerType": {
-              "type": "string"
+              "type": "string",
+              "description": "The trigger type: cron or simple"
             },
             "cron": {
-              "type": "string"
+              "type": "string",
+              "description": "The cron expression (only present for a cron trigger)"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id (only present when known)"
             },
             "uri": {
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint URI (only present when a cron expression is set)"
             },
             "prevFireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the previous fire time (only present when known)"
             },
             "fireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the fire time (only present when known)"
             },
             "nextFireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the next fire time (only present when known)"
             },
             "finalFireTime": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the final fire time (only present when known)"
             },
             "recovering": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether the job is recovering"
             },
             "refireCount": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of times the job has been refired"
             },
             "misfireInstruction": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The trigger's misfire instruction"
             }
           },
           "required": [
@@ -114,16 +139,20 @@
           "type": "object",
           "properties": {
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id (only present when known)"
             },
             "triggerType": {
-              "type": "string"
+              "type": "string",
+              "description": "The trigger type: cron or simple (only present when known)"
             },
             "cron": {
-              "type": "string"
+              "type": "string",
+              "description": "The cron expression (only present when known)"
             },
             "repeatInterval": {
-              "type": "string"
+              "type": "string",
+              "description": "The simple trigger repeat interval (only present when known)"
             }
           }
         },

--- a/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzConsole.java
+++ b/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzConsole.java
@@ -38,20 +38,42 @@ import org.quartz.impl.matchers.GroupMatcher;
 public class QuartzConsole extends AbstractDevConsole {
 
     public record JobEntry(
-            String jobId, String triggerType, String cron, String routeId, String uri, Long prevFireTime,
-            Long fireTime, Long nextFireTime, Long finalFireTime, boolean recovering, int refireCount,
-            int misfireInstruction) {
+            @Metadata(description = "The job fire instance id") String jobId,
+            @Metadata(description = "The trigger type: cron or simple") String triggerType,
+            @Metadata(description = "The cron expression (only present for a cron trigger)") String cron,
+            @Metadata(description = "The route id (only present when known)") String routeId,
+            @Metadata(description = "The endpoint URI (only present when a cron expression is set)") String uri,
+            @Metadata(description = "Epoch time in milliseconds of the previous fire time (only present when known)") Long prevFireTime,
+            @Metadata(description = "Epoch time in milliseconds of the fire time (only present when known)") Long fireTime,
+            @Metadata(description = "Epoch time in milliseconds of the next fire time (only present when known)") Long nextFireTime,
+            @Metadata(description = "Epoch time in milliseconds of the final fire time (only present when known)") Long finalFireTime,
+            @Metadata(description = "Whether the job is recovering") boolean recovering,
+            @Metadata(description = "The number of times the job has been refired") int refireCount,
+            @Metadata(description = "The trigger's misfire instruction") int misfireInstruction) {
     }
 
-    public record TriggerEntry(String routeId, String triggerType, String cron, String repeatInterval) {
+    public record TriggerEntry(
+            @Metadata(description = "The route id (only present when known)") String routeId,
+            @Metadata(description = "The trigger type: cron or simple (only present when known)") String triggerType,
+            @Metadata(description = "The cron expression (only present when known)") String cron,
+            @Metadata(description = "The simple trigger repeat interval (only present when known)") String repeatInterval) {
     }
 
     public record Response(
-            String schedulerName, String schedulerInstanceId, String quartzVersion, Long runningSince,
-            Integer totalCounter, Boolean started, Boolean shutdown, Boolean inStandbyMode, String threadPoolClass,
-            Integer threadPoolSize,
-            @Metadata(description = "The job store class name (field kept as jpbStoreClass for backwards compatibility)") String jpbStoreClass,
-            Boolean jpbStoreClustered, Boolean jpbStoreSupportsPersistence, Integer currentExecutingJobs,
+            @Metadata(description = "The scheduler name") String schedulerName,
+            @Metadata(description = "The scheduler instance id") String schedulerInstanceId,
+            @Metadata(description = "The Quartz version (only present when known)") String quartzVersion,
+            @Metadata(description = "Epoch time in milliseconds the scheduler started running (only present when known)") Long runningSince,
+            @Metadata(description = "The total number of jobs executed (only present when known)") Integer totalCounter,
+            @Metadata(description = "Whether the scheduler is started (only present when known)") Boolean started,
+            @Metadata(description = "Whether the scheduler is shutdown (only present when known)") Boolean shutdown,
+            @Metadata(description = "Whether the scheduler is in standby mode (only present when known)") Boolean inStandbyMode,
+            @Metadata(description = "The thread pool class name (only present when known)") String threadPoolClass,
+            @Metadata(description = "The thread pool size (only present when known)") Integer threadPoolSize,
+            @Metadata(description = "The job store class name (field kept as jpbStoreClass for backwards compatibility, only present when known)") String jpbStoreClass,
+            @Metadata(description = "Whether the job store is clustered (field kept as jpbStoreClustered for backwards compatibility, only present when known)") Boolean jpbStoreClustered,
+            @Metadata(description = "Whether the job store supports persistence (field kept as jpbStoreSupportsPersistence for backwards compatibility, only present when known)") Boolean jpbStoreSupportsPersistence,
+            @Metadata(description = "The number of currently executing jobs") Integer currentExecutingJobs,
             @Metadata(description = "Only present when there are any currently executing jobs") List<JobEntry> jobs,
             @Metadata(description = "Only present when there are any scheduled triggers") List<TriggerEntry> triggers) {
     }

--- a/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzConsole.java
+++ b/components/camel-quartz/src/main/java/org/apache/camel/component/quartz/QuartzConsole.java
@@ -17,15 +17,16 @@
 package org.apache.camel.component.quartz;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
@@ -35,6 +36,25 @@ import org.quartz.impl.matchers.GroupMatcher;
 
 @DevConsole(name = "quartz", description = "Quartz Scheduler")
 public class QuartzConsole extends AbstractDevConsole {
+
+    public record JobEntry(
+            String jobId, String triggerType, String cron, String routeId, String uri, Long prevFireTime,
+            Long fireTime, Long nextFireTime, Long finalFireTime, boolean recovering, int refireCount,
+            int misfireInstruction) {
+    }
+
+    public record TriggerEntry(String routeId, String triggerType, String cron, String repeatInterval) {
+    }
+
+    public record Response(
+            String schedulerName, String schedulerInstanceId, String quartzVersion, Long runningSince,
+            Integer totalCounter, Boolean started, Boolean shutdown, Boolean inStandbyMode, String threadPoolClass,
+            Integer threadPoolSize,
+            @Metadata(description = "The job store class name (field kept as jpbStoreClass for backwards compatibility)") String jpbStoreClass,
+            Boolean jpbStoreClustered, Boolean jpbStoreSupportsPersistence, Integer currentExecutingJobs,
+            @Metadata(description = "Only present when there are any currently executing jobs") List<JobEntry> jobs,
+            @Metadata(description = "Only present when there are any scheduled triggers") List<TriggerEntry> triggers) {
+    }
 
     public QuartzConsole() {
         super("camel", "quartz", "Quartz", "Quartz Scheduler");
@@ -127,111 +147,99 @@ public class QuartzConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+        String schedulerName = null;
+        String schedulerInstanceId = null;
+        String quartzVersion = null;
+        Long runningSince = null;
+        Integer totalCounter = null;
+        Boolean started = null;
+        Boolean shutdown = null;
+        Boolean inStandbyMode = null;
+        String threadPoolClass = null;
+        Integer threadPoolSize = null;
+        String jpbStoreClass = null;
+        Boolean jpbStoreClustered = null;
+        Boolean jpbStoreSupportsPersistence = null;
+        Integer currentExecutingJobs = null;
+        List<JobEntry> jobs = null;
+        List<TriggerEntry> triggers = null;
 
         QuartzComponent quartz = getCamelContext().getComponent("quartz", QuartzComponent.class);
         if (quartz != null) {
             Scheduler scheduler = quartz.getScheduler();
             try {
-                root.put("schedulerName", scheduler.getSchedulerName());
-                root.put("schedulerInstanceId", scheduler.getSchedulerInstanceId());
+                schedulerName = scheduler.getSchedulerName();
+                schedulerInstanceId = scheduler.getSchedulerInstanceId();
                 SchedulerMetaData meta = scheduler.getMetaData();
                 if (meta != null) {
-                    root.put("quartzVersion", meta.getVersion());
-                    root.put("runningSince", meta.getRunningSince().getTime());
-                    root.put("totalCounter", meta.getNumberOfJobsExecuted());
-                    root.put("started", meta.isStarted());
-                    root.put("shutdown", meta.isShutdown());
-                    root.put("inStandbyMode", meta.isInStandbyMode());
-                    root.put("threadPoolClass", meta.getThreadPoolClass().getName());
-                    root.put("threadPoolSize", meta.getThreadPoolSize());
-                    root.put("jpbStoreClass", meta.getJobStoreClass().getName());
-                    root.put("jpbStoreClustered", meta.isJobStoreClustered());
-                    root.put("jpbStoreSupportsPersistence", meta.isJobStoreSupportsPersistence());
+                    quartzVersion = meta.getVersion();
+                    runningSince = meta.getRunningSince().getTime();
+                    totalCounter = meta.getNumberOfJobsExecuted();
+                    started = meta.isStarted();
+                    shutdown = meta.isShutdown();
+                    inStandbyMode = meta.isInStandbyMode();
+                    threadPoolClass = meta.getThreadPoolClass().getName();
+                    threadPoolSize = meta.getThreadPoolSize();
+                    jpbStoreClass = meta.getJobStoreClass().getName();
+                    jpbStoreClustered = meta.isJobStoreClustered();
+                    jpbStoreSupportsPersistence = meta.isJobStoreSupportsPersistence();
                 }
 
-                List<JobExecutionContext> jobs = scheduler.getCurrentlyExecutingJobs();
-                root.put("currentExecutingJobs", jobs.size());
-                if (!jobs.isEmpty()) {
-                    JsonArray arr = new JsonArray();
-                    root.put("jobs", arr);
-                    for (JobExecutionContext job : jobs) {
-                        JsonObject jo = new JsonObject();
-                        jo.put("jobId", job.getFireInstanceId());
-
+                List<JobExecutionContext> executingJobs = scheduler.getCurrentlyExecutingJobs();
+                currentExecutingJobs = executingJobs.size();
+                if (!executingJobs.isEmpty()) {
+                    List<JobEntry> arr = new ArrayList<>();
+                    for (JobExecutionContext job : executingJobs) {
                         String type = (String) job.getJobDetail().getJobDataMap().get(QuartzConstants.QUARTZ_TRIGGER_TYPE);
-                        jo.put("triggerType", type);
                         String cron = (String) job.getJobDetail().getJobDataMap()
                                 .get(QuartzConstants.QUARTZ_TRIGGER_CRON_EXPRESSION);
-                        if (cron != null) {
-                            jo.put("cron", cron);
-                        }
                         String routeId = (String) job.getJobDetail().getJobDataMap().get("routeId");
-                        if (routeId != null) {
-                            jo.put("routeId", routeId);
-                        }
-                        String uri = (String) job.getJobDetail().getJobDataMap().get(QuartzConstants.QUARTZ_ENDPOINT_URI);
+                        String uri = null;
                         if (cron != null) {
-                            jo.put("uri", uri);
+                            uri = (String) job.getJobDetail().getJobDataMap().get(QuartzConstants.QUARTZ_ENDPOINT_URI);
                         }
-                        Date d = job.getTrigger().getPreviousFireTime();
-                        if (d != null) {
-                            jo.put("prevFireTime", d.getTime());
-                        }
-                        d = job.getFireTime();
-                        if (d != null) {
-                            jo.put("fireTime", d.getTime());
-                        }
-                        d = job.getTrigger().getNextFireTime();
-                        if (d != null) {
-                            jo.put("nextFireTime", d.getTime());
-                        }
-                        d = job.getTrigger().getFinalFireTime();
-                        if (d != null) {
-                            jo.put("finalFireTime", d.getTime());
-                        }
-                        jo.put("recovering", job.isRecovering());
-                        jo.put("refireCount", job.getRefireCount());
-                        jo.put("misfireInstruction", job.getTrigger().getMisfireInstruction());
-                        arr.add(jo);
+                        Date prevFireTimeD = job.getTrigger().getPreviousFireTime();
+                        Date fireTimeD = job.getFireTime();
+                        Date nextFireTimeD = job.getTrigger().getNextFireTime();
+                        Date finalFireTimeD = job.getTrigger().getFinalFireTime();
+
+                        arr.add(new JobEntry(
+                                job.getFireInstanceId(), type, cron, routeId, uri,
+                                prevFireTimeD != null ? prevFireTimeD.getTime() : null,
+                                fireTimeD != null ? fireTimeD.getTime() : null,
+                                nextFireTimeD != null ? nextFireTimeD.getTime() : null,
+                                finalFireTimeD != null ? finalFireTimeD.getTime() : null, job.isRecovering(),
+                                job.getRefireCount(), job.getTrigger().getMisfireInstruction()));
                     }
+                    jobs = arr;
                 }
 
                 // all scheduled triggers (for TUI consumer schedule display)
                 Set<JobKey> jobKeys = scheduler.getJobKeys(GroupMatcher.anyGroup());
                 if (!jobKeys.isEmpty()) {
-                    JsonArray arr = new JsonArray();
-                    root.put("triggers", arr);
+                    List<TriggerEntry> arr = new ArrayList<>();
                     for (JobKey jobKey : jobKeys) {
                         JobDetail job = scheduler.getJobDetail(jobKey);
                         if (job != null) {
-                            JsonObject jo = new JsonObject();
                             String routeId = (String) job.getJobDataMap().get("routeId");
-                            if (routeId != null) {
-                                jo.put("routeId", routeId);
-                            }
                             String type = (String) job.getJobDataMap().get(QuartzConstants.QUARTZ_TRIGGER_TYPE);
-                            if (type != null) {
-                                jo.put("triggerType", type);
-                            }
                             String cron = (String) job.getJobDataMap().get(QuartzConstants.QUARTZ_TRIGGER_CRON_EXPRESSION);
-                            if (cron != null) {
-                                jo.put("cron", cron);
-                            }
                             String interval
                                     = (String) job.getJobDataMap().get(QuartzConstants.QUARTZ_TRIGGER_SIMPLE_REPEAT_INTERVAL);
-                            if (interval != null) {
-                                jo.put("repeatInterval", interval);
-                            }
-                            arr.add(jo);
+                            arr.add(new TriggerEntry(routeId, type, cron, interval));
                         }
                     }
+                    triggers = arr;
                 }
             } catch (Exception e) {
                 // ignore
             }
         }
 
-        return root;
+        Response response = new Response(
+                schedulerName, schedulerInstanceId, quartzVersion, runningSince, totalCounter, started, shutdown,
+                inStandbyMode, threadPoolClass, threadPoolSize, jpbStoreClass, jpbStoreClustered,
+                jpbStoreSupportsPersistence, currentExecutingJobs, jobs, triggers);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzConsoleTest.java
+++ b/components/camel-quartz/src/test/java/org/apache/camel/component/quartz/QuartzConsoleTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.quartz;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class QuartzConsoleTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("quartz://myGroup/myTimerName?cron=0/2+*+*+*+*+?").routeId("myRoute")
+                        .to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testQuartzConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("quartz");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("quartz", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+    }
+
+    @Test
+    public void testQuartzConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("quartz");
+        assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertNotNull(out.getString("schedulerName"));
+
+        JsonArray triggers = out.getCollection("triggers");
+        assertNotNull(triggers);
+        assertFalse(triggers.isEmpty());
+
+        JsonObject trigger = (JsonObject) triggers.get(0);
+        assertEquals("cron", trigger.getString("triggerType"));
+    }
+}

--- a/components/camel-resilience4j/src/generated/resources/META-INF/org/apache/camel/dev-console/resilience4j.json
+++ b/components/camel-resilience4j/src/generated/resources/META-INF/org/apache/camel/dev-console/resilience4j.json
@@ -21,73 +21,91 @@
           "type": "object",
           "properties": {
             "id": {
-              "type": "string"
+              "type": "string",
+              "description": "The circuit breaker id"
             },
             "routeId": {
-              "type": "string"
+              "type": "string",
+              "description": "The route id"
             },
             "state": {
-              "type": "string"
+              "type": "string",
+              "description": "The circuit breaker state"
             },
             "bufferedCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of buffered calls"
             },
             "successfulCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of successful calls"
             },
             "failedCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of failed calls"
             },
             "notPermittedCalls": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of not permitted calls"
             },
             "failureRate": {
-              "type": "number"
+              "type": "number",
+              "description": "The failure rate in percentage"
             },
             "configuration": {
               "type": "object",
               "properties": {
                 "failureRateThreshold": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "The failure rate threshold in percentage"
                 },
                 "slowCallRateThreshold": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "The slow call rate threshold in percentage"
                 },
                 "minimumNumberOfCalls": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The minimum number of calls before the failure rate is calculated"
                 },
                 "permittedNumberOfCallsInHalfOpenState": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The number of permitted calls when the circuit breaker is half open"
                 },
                 "slidingWindowSize": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The sliding window size"
                 },
                 "slidingWindowType": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "The sliding window type"
                 },
                 "waitDurationInOpenState": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "The wait duration in the open state, in milliseconds"
                 },
                 "automaticTransitionFromOpenToHalfOpen": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the circuit breaker automatically transitions from open to half-open"
                 },
                 "bulkheadEnabled": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the bulkhead is enabled"
                 },
                 "bulkheadMaxConcurrentCalls": {
                   "type": "integer",
-                  "description": "Only present when bulkheadEnabled is true"
+                  "description": "The maximum concurrent calls allowed by the bulkhead (only present when bulkheadEnabled is true)"
                 },
                 "bulkheadMaxWaitDuration": {
                   "type": "integer",
-                  "description": "Only present when bulkheadEnabled is true"
+                  "description": "The maximum wait duration for the bulkhead in milliseconds (only present when bulkheadEnabled is true)"
                 },
                 "timeoutEnabled": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the timeout is enabled"
                 },
                 "timeoutDuration": {
                   "type": "integer",
-                  "description": "Only present when timeoutEnabled is true"
+                  "description": "The timeout duration in milliseconds (only present when timeoutEnabled is true)"
                 }
               },
               "required": [
@@ -100,7 +118,8 @@
                 "automaticTransitionFromOpenToHalfOpen",
                 "bulkheadEnabled",
                 "timeoutEnabled"
-              ]
+              ],
+              "description": "The circuit breaker configuration"
             }
           },
           "required": [

--- a/components/camel-resilience4j/src/generated/resources/META-INF/org/apache/camel/dev-console/resilience4j.json
+++ b/components/camel-resilience4j/src/generated/resources/META-INF/org/apache/camel/dev-console/resilience4j.json
@@ -11,6 +11,109 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-resilience4j",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "circuitBreakers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "routeId": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "bufferedCalls": {
+              "type": "integer"
+            },
+            "successfulCalls": {
+              "type": "integer"
+            },
+            "failedCalls": {
+              "type": "integer"
+            },
+            "notPermittedCalls": {
+              "type": "integer"
+            },
+            "failureRate": {
+              "type": "number"
+            },
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "failureRateThreshold": {
+                  "type": "number"
+                },
+                "slowCallRateThreshold": {
+                  "type": "number"
+                },
+                "minimumNumberOfCalls": {
+                  "type": "integer"
+                },
+                "permittedNumberOfCallsInHalfOpenState": {
+                  "type": "integer"
+                },
+                "slidingWindowSize": {
+                  "type": "integer"
+                },
+                "slidingWindowType": {
+                  "type": "string"
+                },
+                "waitDurationInOpenState": {
+                  "type": "integer"
+                },
+                "automaticTransitionFromOpenToHalfOpen": {
+                  "type": "boolean"
+                },
+                "bulkheadEnabled": {
+                  "type": "boolean"
+                },
+                "bulkheadMaxConcurrentCalls": {
+                  "type": "integer",
+                  "description": "Only present when bulkheadEnabled is true"
+                },
+                "bulkheadMaxWaitDuration": {
+                  "type": "integer",
+                  "description": "Only present when bulkheadEnabled is true"
+                },
+                "timeoutEnabled": {
+                  "type": "boolean"
+                },
+                "timeoutDuration": {
+                  "type": "integer",
+                  "description": "Only present when timeoutEnabled is true"
+                }
+              },
+              "required": [
+                "failureRateThreshold",
+                "slowCallRateThreshold",
+                "minimumNumberOfCalls",
+                "permittedNumberOfCallsInHalfOpenState",
+                "slidingWindowSize",
+                "waitDurationInOpenState",
+                "automaticTransitionFromOpenToHalfOpen",
+                "bulkheadEnabled",
+                "timeoutEnabled"
+              ]
+            }
+          },
+          "required": [
+            "bufferedCalls",
+            "successfulCalls",
+            "failedCalls",
+            "notPermittedCalls",
+            "failureRate"
+          ]
+        },
+        "description": "The circuit breakers"
+      }
+    }
   }
 }
 

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceConsole.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceConsole.java
@@ -33,18 +33,31 @@ import org.apache.camel.util.json.JsonRecordSupport;
 public class ResilienceConsole extends AbstractDevConsole {
 
     public record Configuration(
-            float failureRateThreshold, float slowCallRateThreshold, int minimumNumberOfCalls,
-            int permittedNumberOfCallsInHalfOpenState, int slidingWindowSize, String slidingWindowType,
-            long waitDurationInOpenState, boolean automaticTransitionFromOpenToHalfOpen, boolean bulkheadEnabled,
-            @Metadata(description = "Only present when bulkheadEnabled is true") Integer bulkheadMaxConcurrentCalls,
-            @Metadata(description = "Only present when bulkheadEnabled is true") Long bulkheadMaxWaitDuration,
-            boolean timeoutEnabled,
-            @Metadata(description = "Only present when timeoutEnabled is true") Long timeoutDuration) {
+            @Metadata(description = "The failure rate threshold in percentage") float failureRateThreshold,
+            @Metadata(description = "The slow call rate threshold in percentage") float slowCallRateThreshold,
+            @Metadata(description = "The minimum number of calls before the failure rate is calculated") int minimumNumberOfCalls,
+            @Metadata(description = "The number of permitted calls when the circuit breaker is half open") int permittedNumberOfCallsInHalfOpenState,
+            @Metadata(description = "The sliding window size") int slidingWindowSize,
+            @Metadata(description = "The sliding window type") String slidingWindowType,
+            @Metadata(description = "The wait duration in the open state, in milliseconds") long waitDurationInOpenState,
+            @Metadata(description = "Whether the circuit breaker automatically transitions from open to half-open") boolean automaticTransitionFromOpenToHalfOpen,
+            @Metadata(description = "Whether the bulkhead is enabled") boolean bulkheadEnabled,
+            @Metadata(description = "The maximum concurrent calls allowed by the bulkhead (only present when bulkheadEnabled is true)") Integer bulkheadMaxConcurrentCalls,
+            @Metadata(description = "The maximum wait duration for the bulkhead in milliseconds (only present when bulkheadEnabled is true)") Long bulkheadMaxWaitDuration,
+            @Metadata(description = "Whether the timeout is enabled") boolean timeoutEnabled,
+            @Metadata(description = "The timeout duration in milliseconds (only present when timeoutEnabled is true)") Long timeoutDuration) {
     }
 
     public record CircuitBreakerEntry(
-            String id, String routeId, String state, int bufferedCalls, int successfulCalls, int failedCalls,
-            long notPermittedCalls, float failureRate, Configuration configuration) {
+            @Metadata(description = "The circuit breaker id") String id,
+            @Metadata(description = "The route id") String routeId,
+            @Metadata(description = "The circuit breaker state") String state,
+            @Metadata(description = "The number of buffered calls") int bufferedCalls,
+            @Metadata(description = "The number of successful calls") int successfulCalls,
+            @Metadata(description = "The number of failed calls") int failedCalls,
+            @Metadata(description = "The number of not permitted calls") long notPermittedCalls,
+            @Metadata(description = "The failure rate in percentage") float failureRate,
+            @Metadata(description = "The circuit breaker configuration") Configuration configuration) {
     }
 
     public record Response(@Metadata(description = "The circuit breakers") List<CircuitBreakerEntry> circuitBreakers) {

--- a/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceConsole.java
+++ b/components/camel-resilience4j/src/main/java/org/apache/camel/component/resilience4j/ResilienceConsole.java
@@ -23,13 +23,32 @@ import java.util.Map;
 
 import org.apache.camel.Processor;
 import org.apache.camel.Route;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "resilience4j", displayName = "Resilience Circuit Breaker",
             description = "Display circuit breaker information")
 public class ResilienceConsole extends AbstractDevConsole {
+
+    public record Configuration(
+            float failureRateThreshold, float slowCallRateThreshold, int minimumNumberOfCalls,
+            int permittedNumberOfCallsInHalfOpenState, int slidingWindowSize, String slidingWindowType,
+            long waitDurationInOpenState, boolean automaticTransitionFromOpenToHalfOpen, boolean bulkheadEnabled,
+            @Metadata(description = "Only present when bulkheadEnabled is true") Integer bulkheadMaxConcurrentCalls,
+            @Metadata(description = "Only present when bulkheadEnabled is true") Long bulkheadMaxWaitDuration,
+            boolean timeoutEnabled,
+            @Metadata(description = "Only present when timeoutEnabled is true") Long timeoutDuration) {
+    }
+
+    public record CircuitBreakerEntry(
+            String id, String routeId, String state, int bufferedCalls, int successfulCalls, int failedCalls,
+            long notPermittedCalls, float failureRate, Configuration configuration) {
+    }
+
+    public record Response(@Metadata(description = "The circuit breakers") List<CircuitBreakerEntry> circuitBreakers) {
+    }
 
     public ResilienceConsole() {
         super("camel", "resilience4j", "Resilience Circuit Breaker", "Display circuit breaker information");
@@ -73,9 +92,7 @@ public class ResilienceConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         List<ResilienceProcessor> cbs = new ArrayList<>();
         for (Route route : getCamelContext().getRoutes()) {
             List<Processor> list = route.filter("*");
@@ -88,43 +105,25 @@ public class ResilienceConsole extends AbstractDevConsole {
         // sort by ids
         cbs.sort(Comparator.comparing(ResilienceProcessor::getId));
 
-        final List<JsonObject> list = new ArrayList<>();
+        final List<CircuitBreakerEntry> list = new ArrayList<>();
         for (ResilienceProcessor cb : cbs) {
-            JsonObject jo = new JsonObject();
-            jo.put("id", cb.getId());
-            jo.put("routeId", cb.getRouteId());
-            jo.put("state", cb.getCircuitBreakerState());
-            jo.put("bufferedCalls", cb.getNumberOfBufferedCalls());
-            jo.put("successfulCalls", cb.getNumberOfSuccessfulCalls());
-            jo.put("failedCalls", cb.getNumberOfFailedCalls());
-            jo.put("notPermittedCalls", cb.getNumberOfNotPermittedCalls());
-            jo.put("failureRate", cb.getFailureRate());
-            // configuration
-            JsonObject config = new JsonObject();
-            config.put("failureRateThreshold", cb.getCircuitBreakerFailureRateThreshold());
-            config.put("slowCallRateThreshold", cb.getCircuitBreakerSlowCallRateThreshold());
-            config.put("minimumNumberOfCalls", cb.getCircuitBreakerMinimumNumberOfCalls());
-            config.put("permittedNumberOfCallsInHalfOpenState",
-                    cb.getCircuitBreakerPermittedNumberOfCallsInHalfOpenState());
-            config.put("slidingWindowSize", cb.getCircuitBreakerSlidingWindowSize());
-            config.put("slidingWindowType", cb.getCircuitBreakerSlidingWindowType());
-            config.put("waitDurationInOpenState", cb.getCircuitBreakerWaitDurationInOpenState());
-            config.put("automaticTransitionFromOpenToHalfOpen",
-                    cb.isCircuitBreakerTransitionFromOpenToHalfOpenEnabled());
-            config.put("bulkheadEnabled", cb.isBulkheadEnabled());
-            if (cb.isBulkheadEnabled()) {
-                config.put("bulkheadMaxConcurrentCalls", cb.getBulkheadMaxConcurrentCalls());
-                config.put("bulkheadMaxWaitDuration", cb.getBulkheadMaxWaitDuration());
-            }
-            config.put("timeoutEnabled", cb.isTimeoutEnabled());
-            if (cb.isTimeoutEnabled()) {
-                config.put("timeoutDuration", cb.getTimeoutDuration());
-            }
-            jo.put("configuration", config);
-            list.add(jo);
-        }
-        root.put("circuitBreakers", list);
+            Configuration config = new Configuration(
+                    cb.getCircuitBreakerFailureRateThreshold(), cb.getCircuitBreakerSlowCallRateThreshold(),
+                    cb.getCircuitBreakerMinimumNumberOfCalls(), cb.getCircuitBreakerPermittedNumberOfCallsInHalfOpenState(),
+                    cb.getCircuitBreakerSlidingWindowSize(), cb.getCircuitBreakerSlidingWindowType(),
+                    cb.getCircuitBreakerWaitDurationInOpenState(),
+                    cb.isCircuitBreakerTransitionFromOpenToHalfOpenEnabled(), cb.isBulkheadEnabled(),
+                    cb.isBulkheadEnabled() ? cb.getBulkheadMaxConcurrentCalls() : null,
+                    cb.isBulkheadEnabled() ? cb.getBulkheadMaxWaitDuration() : null, cb.isTimeoutEnabled(),
+                    cb.isTimeoutEnabled() ? cb.getTimeoutDuration() : null);
 
-        return root;
+            list.add(new CircuitBreakerEntry(
+                    cb.getId(), cb.getRouteId(), cb.getCircuitBreakerState(), cb.getNumberOfBufferedCalls(),
+                    cb.getNumberOfSuccessfulCalls(), cb.getNumberOfFailedCalls(), cb.getNumberOfNotPermittedCalls(),
+                    cb.getFailureRate(), config));
+        }
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceConsoleTest.java
+++ b/components/camel-resilience4j/src/test/java/org/apache/camel/component/resilience4j/ResilienceConsoleTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.resilience4j;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ResilienceConsoleTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute")
+                        .circuitBreaker().id("myBreaker")
+                        .to("mock:result")
+                        .end();
+            }
+        };
+    }
+
+    @Test
+    public void testResilienceConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("resilience4j");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("resilience4j", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+    }
+
+    @Test
+    public void testResilienceConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("resilience4j");
+        assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+
+        JsonArray circuitBreakers = out.getCollection("circuitBreakers");
+        assertNotNull(circuitBreakers);
+        assertFalse(circuitBreakers.isEmpty());
+
+        JsonObject entry = (JsonObject) circuitBreakers.get(0);
+        assertEquals("myBreaker", entry.getString("id"));
+        assertEquals("myRoute", entry.getString("routeId"));
+        assertNotNull(entry.getString("state"));
+
+        JsonObject config = entry.getJsonObject("configuration");
+        assertNotNull(config);
+        assertNotNull(config.getBoolean("bulkheadEnabled"));
+        assertNotNull(config.getBoolean("timeoutEnabled"));
+    }
+}

--- a/components/camel-stub/src/generated/resources/META-INF/org/apache/camel/dev-console/stub.json
+++ b/components/camel-stub/src/generated/resources/META-INF/org/apache/camel/dev-console/stub.json
@@ -74,6 +74,48 @@
       "secret": false,
       "description": "Limits the number of messages dumped"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "queues": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The queue name"
+            },
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "max": {
+              "type": "integer",
+              "description": "The maximum queue size"
+            },
+            "size": {
+              "type": "integer",
+              "description": "The current queue size"
+            },
+            "messages": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": "The browsed messages (only present when browsing is enabled and there are any)"
+            }
+          },
+          "required": [
+            "max",
+            "size"
+          ]
+        },
+        "description": "The stub queues"
+      }
+    }
   }
 }
 

--- a/components/camel-stub/src/main/java/org/apache/camel/component/stub/StubConsole.java
+++ b/components/camel-stub/src/main/java/org/apache/camel/component/stub/StubConsole.java
@@ -29,11 +29,22 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "stub", description = "Browse messages on stub endpoints")
 public class StubConsole extends AbstractDevConsole {
+
+    public record QueueEntry(
+            @Metadata(description = "The queue name") String name,
+            @Metadata(description = "The endpoint URI") String endpointUri,
+            @Metadata(description = "The maximum queue size") int max,
+            @Metadata(description = "The current queue size") int size,
+            @Metadata(description = "The browsed messages (only present when browsing is enabled and there are any)") List<Map<String, Object>> messages) {
+    }
+
+    public record Response(@Metadata(description = "The stub queues") List<QueueEntry> queues) {
+    }
 
     @Metadata(label = "query", description = "Filters the routes matching by queue name",
               javaType = "java.lang.String")
@@ -114,13 +125,12 @@ public class StubConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String filter = optionString(options, FILTER);
         final int max = optionInt(options, LIMIT, Integer.MAX_VALUE);
         final boolean dump = optionBoolean(options, BROWSE, false);
 
-        JsonObject root = new JsonObject();
-        JsonArray queues = new JsonArray();
+        List<QueueEntry> queues = new ArrayList<>();
 
         List<StubEndpoint> list = getCamelContext().getEndpoints()
                 .stream().filter(e -> e instanceof StubEndpoint)
@@ -138,15 +148,10 @@ public class StubConsole extends AbstractDevConsole {
                 names.add(name);
             }
 
-            JsonObject jo = new JsonObject();
-            jo.put("name", name);
-            jo.put("endpointUri", se.getEndpointUri());
-            jo.put("max", se.getSize());
-            jo.put("size", se.getCurrentQueueSize());
-
             // browse messages
+            List<Map<String, Object>> messages = null;
             if (dump) {
-                List<JsonObject> arr = new ArrayList<>();
+                List<Map<String, Object>> arr = new ArrayList<>();
 
                 Queue<Exchange> q = se.getQueue();
                 List<Exchange> copy = new ArrayList<>(q);
@@ -165,15 +170,13 @@ public class StubConsole extends AbstractDevConsole {
                         // ignore
                     }
                 }
-                if (!arr.isEmpty()) {
-                    jo.put("messages", arr);
-                }
+                messages = arr.isEmpty() ? null : arr;
             }
-            queues.add(jo);
+            queues.add(new QueueEntry(name, se.getEndpointUri(), se.getSize(), se.getCurrentQueueSize(), messages));
         }
 
-        root.put("queues", queues);
-        return root;
+        Response response = new Response(queues);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static boolean accept(String name, String filter) {

--- a/components/camel-vertx/camel-vertx-websocket/src/generated/resources/META-INF/org/apache/camel/dev-console/vertx-websocket.json
+++ b/components/camel-vertx/camel-vertx-websocket/src/generated/resources/META-INF/org/apache/camel/dev-console/vertx-websocket.json
@@ -28,6 +28,73 @@
       "defaultValue": true,
       "description": "Whether to include WebSocket peer connection header details in the output"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "hosts": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "host": {
+              "type": "string",
+              "description": "The host"
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "The websocket path"
+                  },
+                  "peers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The peer connection id"
+                        },
+                        "path": {
+                          "type": "string",
+                          "description": "The websocket path"
+                        },
+                        "rawPath": {
+                          "type": "string",
+                          "description": "The raw websocket path"
+                        },
+                        "hostAddress": {
+                          "type": "string",
+                          "description": "The local host address"
+                        },
+                        "subProtocol": {
+                          "type": "string",
+                          "description": "The negotiated sub protocol (only present when known)"
+                        },
+                        "headers": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "The connection headers (only present when includeHeaders is enabled)"
+                        }
+                      }
+                    },
+                    "description": "The connected peers"
+                  }
+                }
+              },
+              "description": "The websocket paths served on this host"
+            }
+          }
+        },
+        "description": "The Vert.x WebSocket consumer hosts"
+      }
+    }
   }
 }
 

--- a/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketDevConsole.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/main/java/org/apache/camel/component/vertx/websocket/VertxWebsocketDevConsole.java
@@ -28,14 +28,35 @@ import org.apache.camel.Route;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "vertx-websocket", displayName = "Vert.x WebSocket", description = "Vert.x WebSocket consumer details")
 public class VertxWebsocketDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Whether to include WebSocket peer connection header details in the output",
               defaultValue = "true", javaType = "java.lang.Boolean")
     public static final String INCLUDE_HEADERS = "includeHeaders";
+
+    public record PeerEntry(
+            @Metadata(description = "The peer connection id") String id,
+            @Metadata(description = "The websocket path") String path,
+            @Metadata(description = "The raw websocket path") String rawPath,
+            @Metadata(description = "The local host address") String hostAddress,
+            @Metadata(description = "The negotiated sub protocol (only present when known)") String subProtocol,
+            @Metadata(description = "The connection headers (only present when includeHeaders is enabled)") Map<String, String> headers) {
+    }
+
+    public record PathEntry(
+            @Metadata(description = "The websocket path") String path,
+            @Metadata(description = "The connected peers") List<PeerEntry> peers) {
+    }
+
+    public record HostEntry(
+            @Metadata(description = "The host") String host,
+            @Metadata(description = "The websocket paths served on this host") List<PathEntry> paths) {
+    }
+
+    public record Response(@Metadata(description = "The Vert.x WebSocket consumer hosts") List<HostEntry> hosts) {
+    }
 
     public VertxWebsocketDevConsole() {
         super("camel", "vertx-websocket", "Vert.x WebSocket", "Vert.x WebSocket consumer details");
@@ -95,22 +116,16 @@ public class VertxWebsocketDevConsole extends AbstractDevConsole {
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         boolean includeHeaders = optionBoolean(options, INCLUDE_HEADERS, true);
 
-        JsonObject root = new JsonObject();
-        JsonArray hosts = new JsonArray();
+        List<HostEntry> hosts = new ArrayList<>();
 
         Map<VertxWebsocketHostKey, List<VertxWebsocketConsumer>> consumersByHost = getConsumersByHost();
 
         for (Map.Entry<VertxWebsocketHostKey, List<VertxWebsocketConsumer>> hostEntry : consumersByHost.entrySet()) {
             VertxWebsocketHostKey hostKey = hostEntry.getKey();
-            JsonObject host = new JsonObject();
-            host.put("host", hostKey.toString());
 
-            JsonArray paths = new JsonArray();
+            List<PathEntry> paths = new ArrayList<>();
             for (VertxWebsocketConsumer consumer : hostEntry.getValue()) {
                 String path = consumer.getEndpoint().getConfiguration().getWebsocketURI().getPath();
-
-                JsonObject pathJson = new JsonObject();
-                pathJson.put("path", path);
 
                 List<VertxWebsocketPeer> pathPeers = consumer.getEndpoint().getVertxHostRegistry()
                         .values()
@@ -119,41 +134,33 @@ public class VertxWebsocketDevConsole extends AbstractDevConsole {
                         .filter(peer -> peer.getRawPath().equals(path))
                         .toList();
 
-                JsonArray peers = new JsonArray();
+                List<PeerEntry> peers = new ArrayList<>();
                 for (VertxWebsocketPeer peer : pathPeers) {
-                    JsonObject peerJson = new JsonObject();
-                    peerJson.put("id", peer.getConnectionKey());
-                    peerJson.put("path", peer.getPath());
-                    peerJson.put("rawPath", peer.getRawPath());
-
                     ServerWebSocket webSocket = peer.getWebSocket();
                     SocketAddress socketAddress = webSocket.localAddress();
                     String hostAddress = socketAddress == null ? "Unknown" : socketAddress.hostAddress();
 
-                    peerJson.put("hostAddress", hostAddress);
-                    peerJson.put("subProtocol", webSocket.subProtocol());
-
+                    Map<String, String> headers = null;
                     if (includeHeaders) {
-                        JsonObject headers = new JsonObject();
-                        webSocket.headers()
-                                .entries()
-                                .forEach(e -> headers.put(e.getKey(), e.getValue()));
-                        peerJson.put("headers", headers);
+                        headers = new LinkedHashMap<>();
+                        for (Map.Entry<String, String> e : webSocket.headers().entries()) {
+                            headers.put(e.getKey(), e.getValue());
+                        }
                     }
 
-                    peers.add(peerJson);
+                    peers.add(new PeerEntry(
+                            peer.getConnectionKey(), peer.getPath(), peer.getRawPath(), hostAddress,
+                            webSocket.subProtocol(), headers));
                 }
 
-                pathJson.put("peers", peers);
-                paths.add(pathJson);
+                paths.add(new PathEntry(path, peers));
             }
 
-            host.put("paths", paths);
-            hosts.add(host);
+            hosts.add(new HostEntry(hostKey.toString(), paths));
         }
 
-        root.put("hosts", hosts);
-        return root;
+        Response response = new Response(hosts);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     Map<VertxWebsocketHostKey, List<VertxWebsocketConsumer>> getConsumersByHost() {

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketDevConsoleTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketDevConsoleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.vertx.websocket;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VertxWebsocketDevConsoleTest extends CamelTestSupport {
+
+    @Test
+    public void testVertxWebsocketConsoleNoConsumers() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("vertx-websocket");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("vertx-websocket", con.getId());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+
+        JsonArray hosts = out.getCollection("hosts");
+        assertNotNull(hosts);
+        assertTrue(hosts.isEmpty());
+    }
+}

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/activity.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/activity.json
@@ -11,6 +11,90 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "activityEnabled": {
+        "type": "boolean",
+        "description": "Whether activity tracking is enabled"
+      },
+      "activitySize": {
+        "type": "integer",
+        "description": "The maximum number of activity entries retained"
+      },
+      "activity": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uid": {
+              "type": "integer",
+              "description": "Unique ID of the activity entry"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "fromEndpointUri": {
+              "type": "string",
+              "description": "The from endpoint URI (only present when known)"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "Elapsed time in milliseconds"
+            },
+            "failed": {
+              "type": "boolean",
+              "description": "Whether the exchange failed"
+            },
+            "exception": {
+              "type": "string",
+              "description": "The exception message (only present when the exchange failed)"
+            },
+            "endpointSends": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "endpointUri": {
+                    "type": "string",
+                    "description": "The endpoint URI"
+                  },
+                  "remoteEndpoint": {
+                    "type": "boolean",
+                    "description": "Whether the endpoint is remote"
+                  },
+                  "elapsed": {
+                    "type": "integer",
+                    "description": "Elapsed time in milliseconds"
+                  }
+                },
+                "required": [
+                  "remoteEndpoint",
+                  "elapsed"
+                ]
+              },
+              "description": "The endpoints this exchange was sent to (only present when any)"
+            }
+          },
+          "required": [
+            "uid",
+            "elapsed",
+            "failed"
+          ]
+        },
+        "description": "The recent activity entries"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/bean.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/bean.json
@@ -72,6 +72,48 @@
       "defaultValue": true,
       "description": "Whether to include bean properties"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "beans": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The bean name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The bean class type"
+            },
+            "properties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The property name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The property type (only present when the value is not null)"
+                  },
+                  "value": {
+                    "description": "The property value"
+                  }
+                }
+              },
+              "description": "The bean properties (only present when properties were requested and the bean has some)"
+            }
+          }
+        },
+        "description": "The beans, keyed by bean name"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/blocked.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/blocked.json
@@ -11,6 +11,46 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "blocked": {
+        "type": "integer",
+        "description": "Number of blocked exchanges"
+      },
+      "exchanges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "The node ID"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "The wait duration in milliseconds"
+            }
+          },
+          "required": [
+            "duration"
+          ]
+        },
+        "description": "The blocked exchanges (only present when there are any)"
+      }
+    },
+    "required": [
+      "blocked"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/browse.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/browse.json
@@ -116,6 +116,55 @@
       "secret": false,
       "description": "To receive N last messages from the tail"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "browse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "queueSize": {
+              "type": "integer",
+              "description": "Number of messages currently in the queue"
+            },
+            "limit": {
+              "type": "integer",
+              "description": "The maximum number of messages returned (only present when messages were dumped)"
+            },
+            "position": {
+              "type": "integer",
+              "description": "The starting position of the returned messages (only present when messages were dumped)"
+            },
+            "firstTimestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the first returned message (only present when available)"
+            },
+            "lastTimestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last returned message (only present when available)"
+            },
+            "messages": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": "The dumped messages, as opaque JSON objects (only present when messages were dumped and found)"
+            }
+          },
+          "required": [
+            "queueSize"
+          ]
+        },
+        "description": "The browsed endpoints"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/circuit-breaker.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/circuit-breaker.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "circuitBreakers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "state": {
+              "type": "string",
+              "description": "The circuit breaker state"
+            },
+            "successfulCalls": {
+              "type": "integer",
+              "description": "Number of successful calls"
+            },
+            "failedCalls": {
+              "type": "integer",
+              "description": "Number of failed calls"
+            }
+          },
+          "required": [
+            "successfulCalls",
+            "failedCalls"
+          ]
+        },
+        "description": "The circuit breakers"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/consumer.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/consumer.json
@@ -11,6 +11,221 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "consumers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "state": {
+              "type": "string",
+              "description": "The consumer state"
+            },
+            "clazz": {
+              "type": "string",
+              "description": "The consumer service type"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "hosted": {
+              "type": "boolean",
+              "description": "Whether the consumer is a hosted service"
+            },
+            "inflight": {
+              "type": "integer",
+              "description": "Number of inflight exchanges"
+            },
+            "scheduled": {
+              "type": "boolean",
+              "description": "Whether the consumer is scheduled (a scheduled poll consumer or a timer consumer)"
+            },
+            "polling": {
+              "type": "boolean",
+              "description": "Whether currently polling (only present for scheduled poll consumers)"
+            },
+            "firstPollDone": {
+              "type": "boolean",
+              "description": "Whether the first poll has completed (only present for scheduled poll consumers)"
+            },
+            "schedulerStarted": {
+              "type": "boolean",
+              "description": "Whether the scheduler has started (only present for scheduled poll consumers)"
+            },
+            "schedulerClass": {
+              "type": "string",
+              "description": "The scheduler class name (only present for scheduled poll consumers)"
+            },
+            "repeatCount": {
+              "type": "integer",
+              "description": "The repeat count (only present for scheduled poll consumers)"
+            },
+            "fixedDelay": {
+              "type": "boolean",
+              "description": "Whether a fixed delay is used (only present for scheduled poll consumers)"
+            },
+            "initialDelay": {
+              "type": "integer",
+              "description": "The initial delay (only present for scheduled poll consumers)"
+            },
+            "delay": {
+              "type": "integer",
+              "description": "The delay (only present for scheduled poll consumers)"
+            },
+            "timeUnit": {
+              "type": "string",
+              "description": "The time unit of the delay (only present for scheduled poll consumers)"
+            },
+            "greedy": {
+              "type": "boolean",
+              "description": "Whether greedy scheduling is used (only present for scheduled poll consumers)"
+            },
+            "runningLoggingLevel": {
+              "type": "string",
+              "description": "The running logging level (only present for scheduled poll consumers or timer consumers)"
+            },
+            "totalCounter": {
+              "type": "integer",
+              "description": "Total number of polls (only present for scheduled poll consumers or timer consumers)"
+            },
+            "errorCounter": {
+              "type": "integer",
+              "description": "Number of failed polls (only present for scheduled poll consumers)"
+            },
+            "successCounter": {
+              "type": "integer",
+              "description": "Number of successful polls (only present for scheduled poll consumers)"
+            },
+            "backoffCounter": {
+              "type": "integer",
+              "description": "The backoff counter (only present for scheduled poll consumers)"
+            },
+            "backoffMultiplier": {
+              "type": "integer",
+              "description": "The backoff multiplier (only present for scheduled poll consumers)"
+            },
+            "backoffErrorThreshold": {
+              "type": "integer",
+              "description": "The backoff error threshold (only present for scheduled poll consumers)"
+            },
+            "backoffIdleThreshold": {
+              "type": "integer",
+              "description": "The backoff idle threshold (only present for scheduled poll consumers)"
+            },
+            "timerName": {
+              "type": "string",
+              "description": "The timer name (only present for camel-timer consumers)"
+            },
+            "fixedRate": {
+              "type": "boolean",
+              "description": "Whether a fixed rate is used (only present for camel-timer consumers)"
+            },
+            "period": {
+              "type": "integer",
+              "description": "The period (only present for camel-timer consumers)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the route has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics for the route"
+            }
+          },
+          "required": [
+            "remote",
+            "hosted",
+            "inflight",
+            "scheduled"
+          ]
+        },
+        "description": "The consumers"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/context.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/context.json
@@ -11,6 +11,207 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The CamelContext name"
+      },
+      "description": {
+        "type": "string",
+        "description": "The CamelContext description (only present when configured)"
+      },
+      "profile": {
+        "type": "string",
+        "description": "The active profile (only present when configured)"
+      },
+      "version": {
+        "type": "string",
+        "description": "The Camel version"
+      },
+      "state": {
+        "type": "string",
+        "description": "The CamelContext state"
+      },
+      "phase": {
+        "type": "integer",
+        "description": "The CamelContext lifecycle phase"
+      },
+      "startTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the CamelContext was started (only present once started)"
+      },
+      "uptime": {
+        "type": "integer",
+        "description": "Uptime in milliseconds"
+      },
+      "devMode": {
+        "type": "boolean",
+        "description": "Whether dev mode (live reload) is active"
+      },
+      "statistics": {
+        "type": "object",
+        "properties": {
+          "routesTotal": {
+            "type": "integer",
+            "description": "Total number of routes"
+          },
+          "routesStarted": {
+            "type": "integer",
+            "description": "Number of started routes"
+          },
+          "load01": {
+            "type": "string",
+            "description": "1 minute load average (only present when available)"
+          },
+          "load05": {
+            "type": "string",
+            "description": "5 minute load average (only present when available)"
+          },
+          "load15": {
+            "type": "string",
+            "description": "15 minute load average (only present when available)"
+          },
+          "exchangesThroughput": {
+            "type": "string",
+            "description": "Messages per second throughput (only present when available)"
+          },
+          "idleSince": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds since the context has been idle"
+          },
+          "exchangesTotal": {
+            "type": "integer",
+            "description": "Total number of exchanges"
+          },
+          "exchangesFailed": {
+            "type": "integer",
+            "description": "Number of failed exchanges"
+          },
+          "exchangesInflight": {
+            "type": "integer",
+            "description": "Number of inflight exchanges"
+          },
+          "remoteExchangesTotal": {
+            "type": "integer",
+            "description": "Total number of remote exchanges"
+          },
+          "remoteExchangesFailed": {
+            "type": "integer",
+            "description": "Number of failed remote exchanges"
+          },
+          "remoteExchangesInflight": {
+            "type": "integer",
+            "description": "Number of inflight remote exchanges"
+          },
+          "meanProcessingTime": {
+            "type": "integer",
+            "description": "Mean processing time in milliseconds"
+          },
+          "maxProcessingTime": {
+            "type": "integer",
+            "description": "Max processing time in milliseconds"
+          },
+          "minProcessingTime": {
+            "type": "integer",
+            "description": "Min processing time in milliseconds"
+          },
+          "p50ProcessingTime": {
+            "type": "integer",
+            "description": "50th percentile processing time in milliseconds (only present when available)"
+          },
+          "p95ProcessingTime": {
+            "type": "integer",
+            "description": "95th percentile processing time in milliseconds (only present when available)"
+          },
+          "p99ProcessingTime": {
+            "type": "integer",
+            "description": "99th percentile processing time in milliseconds (only present when available)"
+          },
+          "lastProcessingTime": {
+            "type": "integer",
+            "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+          },
+          "deltaProcessingTime": {
+            "type": "integer",
+            "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+          },
+          "lastCreatedExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+          },
+          "lastCompletedExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+          },
+          "lastFailureHandledExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+          },
+          "lastFailedExchangeTimestamp": {
+            "type": "integer",
+            "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+          },
+          "reload": {
+            "type": "object",
+            "properties": {
+              "reloaded": {
+                "type": "integer",
+                "description": "Number of successful reloads"
+              },
+              "failed": {
+                "type": "integer",
+                "description": "Number of failed reloads"
+              },
+              "lastError": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "The error message"
+                  },
+                  "stackTrace": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "The error stack trace, one entry per line"
+                  }
+                },
+                "description": "The last reload error (only present when a reload has failed)"
+              }
+            },
+            "required": [
+              "reloaded",
+              "failed"
+            ],
+            "description": "Reload statistics"
+          }
+        },
+        "required": [
+          "routesTotal",
+          "routesStarted",
+          "idleSince",
+          "exchangesTotal",
+          "exchangesFailed",
+          "exchangesInflight",
+          "remoteExchangesTotal",
+          "remoteExchangesFailed",
+          "remoteExchangesInflight",
+          "meanProcessingTime",
+          "maxProcessingTime",
+          "minProcessingTime"
+        ],
+        "description": "Runtime statistics (only present when management is enabled)"
+      }
+    },
+    "required": [
+      "phase",
+      "uptime",
+      "devMode"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/datasource.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/datasource.json
@@ -11,6 +11,68 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "dataSources": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The registry bean name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The DataSource implementation class"
+            },
+            "poolType": {
+              "type": "string",
+              "description": "The detected connection pool type: HikariCP, Agroal, or Unknown"
+            },
+            "poolName": {
+              "type": "string",
+              "description": "The pool name (HikariCP only)"
+            },
+            "maxPoolSize": {
+              "type": "integer",
+              "description": "The maximum pool size (only present once the pool is initialized)"
+            },
+            "active": {
+              "type": "integer",
+              "description": "Number of active connections (only present once the pool is initialized)"
+            },
+            "idle": {
+              "type": "integer",
+              "description": "Number of idle connections (only present once the pool is initialized)"
+            },
+            "total": {
+              "type": "integer",
+              "description": "Total number of connections (only present once the pool is initialized)"
+            },
+            "waiting": {
+              "type": "integer",
+              "description": "Number of threads awaiting a connection (HikariCP only)"
+            },
+            "maxUsed": {
+              "type": "integer",
+              "description": "Maximum number of connections used at once (Agroal only)"
+            },
+            "leakDetection": {
+              "type": "integer",
+              "description": "Number of leak detections (Agroal only)"
+            },
+            "created": {
+              "type": "integer",
+              "description": "Number of connections created (Agroal only)"
+            }
+          }
+        },
+        "description": "The DataSources"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/debug.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/debug.json
@@ -85,6 +85,87 @@
       "secret": false,
       "description": "The position to step to"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "version": {
+        "type": "string",
+        "description": "The Camel version (only present when a backlog debugger is available)"
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether the debugger is enabled (only present when a backlog debugger is available)"
+      },
+      "standby": {
+        "type": "boolean",
+        "description": "Whether the debugger is in standby mode (only present when a backlog debugger is available)"
+      },
+      "suspendedMode": {
+        "type": "boolean",
+        "description": "Whether suspended mode is active (only present when a backlog debugger is available)"
+      },
+      "fallbackTimeout": {
+        "type": "integer",
+        "description": "Fallback timeout in seconds (only present when a backlog debugger is available)"
+      },
+      "loggingLevel": {
+        "type": "string",
+        "description": "The logging level (only present when a backlog debugger is available)"
+      },
+      "includeExchangeProperties": {
+        "type": "boolean",
+        "description": "Whether exchange properties are included (only present when a backlog debugger is available)"
+      },
+      "includeFiles": {
+        "type": "boolean",
+        "description": "Whether file-based message bodies are included (only present when a backlog debugger is available)"
+      },
+      "includeStreams": {
+        "type": "boolean",
+        "description": "Whether streaming message bodies are included (only present when a backlog debugger is available)"
+      },
+      "maxChars": {
+        "type": "integer",
+        "description": "Maximum size of the message body to include (only present when a backlog debugger is available)"
+      },
+      "debugCounter": {
+        "type": "integer",
+        "description": "Total number of times a breakpoint has been hit (only present when a backlog debugger is available)"
+      },
+      "singleStepMode": {
+        "type": "boolean",
+        "description": "Whether single-step mode is active (only present when a backlog debugger is available)"
+      },
+      "breakpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "nodeId": {
+              "type": "string",
+              "description": "The breakpoint node ID"
+            },
+            "suspended": {
+              "type": "boolean",
+              "description": "Whether the breakpoint is currently suspended"
+            }
+          },
+          "required": [
+            "suspended"
+          ]
+        },
+        "description": "The configured breakpoints (only present when there are any)"
+      },
+      "suspended": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The suspended breakpoint messages, as opaque JSON objects enriched with source code and message history (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/endpoint.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/endpoint.json
@@ -11,6 +11,94 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "size": {
+        "type": "integer",
+        "description": "Total number of endpoints"
+      },
+      "staticSize": {
+        "type": "integer",
+        "description": "Number of endpoints in the static registry"
+      },
+      "dynamicSize": {
+        "type": "integer",
+        "description": "Number of endpoints in the dynamic registry"
+      },
+      "maximumCacheSize": {
+        "type": "integer",
+        "description": "Maximum number of entries to store in the dynamic registry"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "stub": {
+              "type": "boolean",
+              "description": "Whether the endpoint is a stub endpoint"
+            },
+            "direction": {
+              "type": "string",
+              "description": "Whether the endpoint is used as input or output (in or out) (only present when runtime endpoint registry statistics are available)"
+            },
+            "hits": {
+              "type": "integer",
+              "description": "Usage of the endpoint (only present when runtime endpoint registry statistics are available)"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when runtime endpoint registry statistics are available and the endpoint is associated with a route)"
+            },
+            "minBodySize": {
+              "type": "integer",
+              "description": "Minimum message body size in bytes (only present when available)"
+            },
+            "maxBodySize": {
+              "type": "integer",
+              "description": "Maximum message body size in bytes (only present when available)"
+            },
+            "meanBodySize": {
+              "type": "integer",
+              "description": "Mean message body size in bytes (only present when available)"
+            },
+            "minHeadersSize": {
+              "type": "integer",
+              "description": "Minimum message headers size in bytes (only present when available)"
+            },
+            "maxHeadersSize": {
+              "type": "integer",
+              "description": "Maximum message headers size in bytes (only present when available)"
+            },
+            "meanHeadersSize": {
+              "type": "integer",
+              "description": "Mean message headers size in bytes (only present when available)"
+            }
+          },
+          "required": [
+            "remote",
+            "stub"
+          ]
+        },
+        "description": "The endpoints"
+      }
+    },
+    "required": [
+      "size",
+      "staticSize",
+      "dynamicSize",
+      "maximumCacheSize"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/errors.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/errors.json
@@ -98,6 +98,40 @@
       "defaultValue": false,
       "description": "Whether to include stack traces"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether the error registry is enabled"
+      },
+      "size": {
+        "type": "integer",
+        "description": "Number of captured errors"
+      },
+      "maximumEntries": {
+        "type": "integer",
+        "description": "The maximum number of entries retained"
+      },
+      "timeToLive": {
+        "type": "string",
+        "description": "The time to live for entries"
+      },
+      "errors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The captured errors; shape depends on the underlying message implementation"
+      }
+    },
+    "required": [
+      "enabled",
+      "size",
+      "maximumEntries"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/eval-language.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/eval-language.json
@@ -99,6 +99,24 @@
       "secret": false,
       "description": "Optional exchange variables"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "The evaluation status, success or failed (only present when a template was given)"
+      },
+      "result": {
+        "type": "string",
+        "description": "The evaluation result (only present on success)"
+      },
+      "exception": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The exception, as an opaque JSON object (only present on failure)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/event.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/event.json
@@ -11,6 +11,86 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "events": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The event type"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID (only present for exchange events)"
+            },
+            "message": {
+              "type": "string",
+              "description": "The event's string representation"
+            }
+          }
+        },
+        "description": "The most recent Camel events (only present when there are any)"
+      },
+      "routeEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The event type"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID (only present for exchange events)"
+            },
+            "message": {
+              "type": "string",
+              "description": "The event's string representation"
+            }
+          }
+        },
+        "description": "The most recent route events (only present when there are any)"
+      },
+      "exchangeEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The event type"
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds (only present when known)"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID (only present for exchange events)"
+            },
+            "message": {
+              "type": "string",
+              "description": "The event's string representation"
+            }
+          }
+        },
+        "description": "The most recent exchange events (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/gc.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/gc.json
@@ -11,6 +11,40 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "garbageCollectors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The garbage collector name"
+            },
+            "collectionCount": {
+              "type": "integer",
+              "description": "Number of collections"
+            },
+            "collectionTime": {
+              "type": "integer",
+              "description": "Total collection time in milliseconds"
+            },
+            "memoryPoolNames": {
+              "type": "string",
+              "description": "Comma separated list of memory pool names managed by this collector"
+            }
+          },
+          "required": [
+            "collectionCount",
+            "collectionTime"
+          ]
+        },
+        "description": "The garbage collectors"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/health.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/health.json
@@ -95,7 +95,9 @@
             },
             "details": {
               "type": "object",
-              "additionalProperties": true,
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "Additional health check specific details (only present when available)"
             }
           },

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/health.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/health.json
@@ -33,6 +33,87 @@
       "defaultValue": "default",
       "description": "Exposure level for health check details"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "up": {
+        "type": "boolean",
+        "description": "Whether the overall health status is up"
+      },
+      "ready": {
+        "type": "boolean",
+        "description": "Whether the readiness checks are up"
+      },
+      "live": {
+        "type": "boolean",
+        "description": "Whether the liveness checks are up"
+      },
+      "checks": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The health check ID"
+            },
+            "group": {
+              "type": "string",
+              "description": "The health check group"
+            },
+            "up": {
+              "type": "boolean",
+              "description": "Whether the health check is up"
+            },
+            "state": {
+              "type": "string",
+              "description": "The health check state"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether the health check is enabled"
+            },
+            "readiness": {
+              "type": "boolean",
+              "description": "Whether the health check is a readiness check"
+            },
+            "liveness": {
+              "type": "boolean",
+              "description": "Whether the health check is a liveness check"
+            },
+            "message": {
+              "type": "string",
+              "description": "The failure message (only present when not up)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The failure stack trace, one entry per line (only present when not up and an error is available)"
+            },
+            "details": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Additional health check specific details (only present when available)"
+            }
+          },
+          "required": [
+            "up",
+            "enabled",
+            "readiness",
+            "liveness"
+          ]
+        },
+        "description": "The individual health checks"
+      }
+    },
+    "required": [
+      "up",
+      "ready",
+      "live"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-dump.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-dump.json
@@ -42,6 +42,23 @@
       "secret": false,
       "description": "File name for the heap dump (without .hprof extension)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string",
+        "description": "The absolute path of the written heap dump file (only present on success)"
+      },
+      "size": {
+        "type": "integer",
+        "description": "The size in bytes of the written heap dump file (only present on success)"
+      },
+      "error": {
+        "type": "string",
+        "description": "The error message (only present on failure)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-histogram.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/heap-histogram.json
@@ -28,6 +28,53 @@
       "defaultValue": 100,
       "description": "Limits the number of classes displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "classes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "num": {
+              "type": "integer",
+              "description": "The class number"
+            },
+            "instances": {
+              "type": "integer",
+              "description": "Number of instances"
+            },
+            "bytes": {
+              "type": "integer",
+              "description": "Number of bytes used"
+            },
+            "className": {
+              "type": "string",
+              "description": "The class name"
+            }
+          },
+          "required": [
+            "num",
+            "instances",
+            "bytes"
+          ]
+        },
+        "description": "The classes in the histogram"
+      },
+      "totalInstances": {
+        "type": "integer",
+        "description": "Total number of instances"
+      },
+      "totalBytes": {
+        "type": "integer",
+        "description": "Total number of bytes"
+      }
+    },
+    "required": [
+      "totalInstances",
+      "totalBytes"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/inflight.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/inflight.json
@@ -41,6 +41,65 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "inflight": {
+        "type": "integer",
+        "description": "Number of inflight exchanges"
+      },
+      "inflightBrowseEnabled": {
+        "type": "boolean",
+        "description": "Whether browsing inflight exchanges is enabled"
+      },
+      "exchanges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "fromRouteId": {
+              "type": "string",
+              "description": "The route ID where the exchange originated from"
+            },
+            "fromRemoteEndpoint": {
+              "type": "boolean",
+              "description": "Whether the exchange originated from a remote endpoint"
+            },
+            "atRouteId": {
+              "type": "string",
+              "description": "The route ID where the exchange currently is"
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "The node ID where the exchange currently is"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "Elapsed time in milliseconds since the exchange started"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "Duration in milliseconds the exchange has been at the current node"
+            }
+          },
+          "required": [
+            "fromRemoteEndpoint",
+            "elapsed",
+            "duration"
+          ]
+        },
+        "description": "The inflight exchanges (only present when browsing is enabled)"
+      }
+    },
+    "required": [
+      "inflight",
+      "inflightBrowseEnabled"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/internal-tasks.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/internal-tasks.json
@@ -11,6 +11,69 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "tasks": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The task name"
+            },
+            "status": {
+              "type": "string",
+              "description": "The task status"
+            },
+            "attempting": {
+              "type": "boolean",
+              "description": "Whether the task is currently attempting"
+            },
+            "attempts": {
+              "type": "integer",
+              "description": "The current number of iterations"
+            },
+            "delay": {
+              "type": "integer",
+              "description": "The current computed delay"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "The current elapsed time"
+            },
+            "firstTime": {
+              "type": "integer",
+              "description": "The time the first attempt was performed"
+            },
+            "lastTime": {
+              "type": "integer",
+              "description": "The time the last attempt was performed"
+            },
+            "nextTime": {
+              "type": "integer",
+              "description": "The time the next attempt will be made"
+            },
+            "error": {
+              "type": "string",
+              "description": "The failure message (only present when known)"
+            }
+          },
+          "required": [
+            "attempting",
+            "attempts",
+            "delay",
+            "elapsed",
+            "firstTime",
+            "lastTime",
+            "nextTime"
+          ]
+        },
+        "description": "The internal tasks"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/java-security.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/java-security.json
@@ -11,6 +11,53 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "securityProviders": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The provider name"
+            },
+            "version": {
+              "type": "string",
+              "description": "The provider version"
+            },
+            "info": {
+              "type": "string",
+              "description": "The provider info (only present when known)"
+            },
+            "services": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The service type"
+                  },
+                  "algorithm": {
+                    "type": "string",
+                    "description": "The algorithm"
+                  },
+                  "className": {
+                    "type": "string",
+                    "description": "The implementation class name"
+                  }
+                }
+              },
+              "description": "The services offered by this provider (only present when any)"
+            }
+          }
+        },
+        "description": "The security providers (only present when any are registered)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr-memory-leak.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jfr-memory-leak.json
@@ -95,6 +95,294 @@
       "defaultValue": false,
       "description": "Whether to include stack traces in the output"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "The console status: recording, completed, compared, idle, or error"
+      },
+      "error": {
+        "type": "string",
+        "description": "An error message (only present when status is error)"
+      },
+      "note": {
+        "type": "string",
+        "description": "An informational note (only present for an idle query)"
+      },
+      "startTime": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the recording started (only present while recording)"
+      },
+      "durationSeconds": {
+        "type": "integer",
+        "description": "The requested recording duration in seconds (only present when set)"
+      },
+      "elapsedMs": {
+        "type": "integer",
+        "description": "Elapsed time in milliseconds since the recording started (only present while recording)"
+      },
+      "remainingMs": {
+        "type": "integer",
+        "description": "Remaining time in milliseconds until auto-stop (only present when a duration was requested)"
+      },
+      "hasCachedResults": {
+        "type": "boolean",
+        "description": "Whether cached results are available (only present for a status query)"
+      },
+      "hasComparisonData": {
+        "type": "boolean",
+        "description": "Whether a previous recording is available for comparison (only present for a status query)"
+      },
+      "sampleCount": {
+        "type": "integer",
+        "description": "The number of aggregated samples (only present when results are available)"
+      },
+      "recordingDurationMs": {
+        "type": "integer",
+        "description": "The recording duration in milliseconds (only present when results are available)"
+      },
+      "recordingEndTime": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds the recording ended (only present when results are available)"
+      },
+      "rawSampleCount": {
+        "type": "integer",
+        "description": "The number of raw samples before aggregation (only present when results are available)"
+      },
+      "gcCount": {
+        "type": "integer",
+        "description": "The number of garbage collections observed (only present when results are available)"
+      },
+      "samples": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "allocationClass": {
+              "type": "string",
+              "description": "The allocated class name (only present when known)"
+            },
+            "allocationSize": {
+              "type": "integer",
+              "description": "The allocation size in bytes (only present when known)"
+            },
+            "lastKnownHeapUsage": {
+              "type": "integer",
+              "description": "The last known heap usage in bytes (only present when known)"
+            },
+            "arrayElements": {
+              "type": "integer",
+              "description": "The number of array elements (only present for arrays)"
+            },
+            "objectAge": {
+              "type": "integer",
+              "description": "The object age in milliseconds (only present when known)"
+            },
+            "allocationTime": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds when the object was allocated"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "description": "The fully qualified method name"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "The line number"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The allocation stack trace (only present when requested)"
+            },
+            "referenceChain": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type name (only present when known)"
+                  },
+                  "field": {
+                    "type": "string",
+                    "description": "The field name (only present when known)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A description of the link (only present when known)"
+                  }
+                }
+              },
+              "description": "The reference chain back to the GC root (only present when there is one)"
+            },
+            "count": {
+              "type": "integer",
+              "description": "The number of samples aggregated into this entry"
+            },
+            "sampledSize": {
+              "type": "integer",
+              "description": "The total sampled size in bytes across the aggregated samples"
+            }
+          },
+          "required": [
+            "allocationTime",
+            "count",
+            "sampledSize"
+          ]
+        },
+        "description": "The aggregated samples (only present when results are available)"
+      },
+      "baseline": {
+        "type": "object",
+        "properties": {
+          "recordingDurationMs": {
+            "type": "integer",
+            "description": "The recording duration in milliseconds"
+          },
+          "sampleCount": {
+            "type": "integer",
+            "description": "The number of aggregated samples"
+          },
+          "gcCount": {
+            "type": "integer",
+            "description": "The number of garbage collections observed"
+          }
+        },
+        "required": [
+          "recordingDurationMs",
+          "sampleCount",
+          "gcCount"
+        ],
+        "description": "The baseline recording info (only present for a comparison)"
+      },
+      "current": {
+        "type": "object",
+        "properties": {
+          "recordingDurationMs": {
+            "type": "integer",
+            "description": "The recording duration in milliseconds"
+          },
+          "sampleCount": {
+            "type": "integer",
+            "description": "The number of aggregated samples"
+          },
+          "gcCount": {
+            "type": "integer",
+            "description": "The number of garbage collections observed"
+          }
+        },
+        "required": [
+          "recordingDurationMs",
+          "sampleCount",
+          "gcCount"
+        ],
+        "description": "The current recording info (only present for a comparison)"
+      },
+      "durationRatio": {
+        "type": "number",
+        "description": "The ratio of the current to the baseline recording duration (only present for a comparison)"
+      },
+      "comparisons": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "allocationClass": {
+              "type": "string",
+              "description": "The allocated class name"
+            },
+            "baselineSampledSize": {
+              "type": "integer",
+              "description": "The baseline sampled size in bytes"
+            },
+            "baselineCount": {
+              "type": "integer",
+              "description": "The baseline sample count"
+            },
+            "currentSampledSize": {
+              "type": "integer",
+              "description": "The current sampled size in bytes"
+            },
+            "currentCount": {
+              "type": "integer",
+              "description": "The current sample count"
+            },
+            "growthRatio": {
+              "type": "number",
+              "description": "The growth ratio between baseline and current sampled size"
+            },
+            "trend": {
+              "type": "string",
+              "description": "The trend: new, gone, growing, suspicious, shrinking, or stable"
+            },
+            "lowConfidence": {
+              "type": "boolean",
+              "description": "Whether the comparison has low statistical confidence"
+            },
+            "referenceChain": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type name (only present when known)"
+                  },
+                  "field": {
+                    "type": "string",
+                    "description": "The field name (only present when known)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A description of the link (only present when known)"
+                  }
+                }
+              },
+              "description": "The reference chain back to the GC root (only present when there is one)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "description": "The fully qualified method name"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "The line number"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The allocation stack trace (only present when requested)"
+            }
+          },
+          "required": [
+            "baselineSampledSize",
+            "baselineCount",
+            "currentSampledSize",
+            "currentCount",
+            "growthRatio",
+            "lowConfidence"
+          ]
+        },
+        "description": "The per-class comparisons, sorted by growth ratio descending (only present for a comparison)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jvm.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jvm.json
@@ -11,6 +11,49 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "vmName": {
+        "type": "string",
+        "description": "The JVM name"
+      },
+      "vmVersion": {
+        "type": "string",
+        "description": "The JVM version"
+      },
+      "vmVendor": {
+        "type": "string",
+        "description": "The JVM vendor"
+      },
+      "vmUptime": {
+        "type": "string",
+        "description": "The JVM uptime"
+      },
+      "pid": {
+        "type": "integer",
+        "description": "The process ID"
+      },
+      "inputArguments": {
+        "type": "string",
+        "description": "The JVM input arguments (only present when any are set)"
+      },
+      "bootClasspath": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The boot classpath entries (only present when supported)"
+      },
+      "classpath": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The classpath entries"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/log.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/log.json
@@ -11,6 +11,18 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "levels": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "The logger names mapped to their log level (only present when available)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/memory.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/memory.json
@@ -11,6 +11,67 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "heapMemoryInit": {
+        "type": "string",
+        "description": "Heap memory initial size"
+      },
+      "heapMemoryMax": {
+        "type": "string",
+        "description": "Heap memory max size"
+      },
+      "heapMemoryUsed": {
+        "type": "string",
+        "description": "Heap memory used"
+      },
+      "heapMemoryCommitted": {
+        "type": "string",
+        "description": "Heap memory committed"
+      },
+      "nonHeapMemoryInit": {
+        "type": "string",
+        "description": "Non-heap memory initial size"
+      },
+      "nonHeapMemoryMax": {
+        "type": "string",
+        "description": "Non-heap memory max size"
+      },
+      "nonHeapMemoryUsed": {
+        "type": "string",
+        "description": "Non-heap memory used"
+      },
+      "nonHeapMemoryCommitted": {
+        "type": "string",
+        "description": "Non-heap memory committed"
+      },
+      "oldGenUsed": {
+        "type": "string",
+        "description": "Old generation memory pool used (only present when such a pool exists)"
+      },
+      "oldGenCommitted": {
+        "type": "string",
+        "description": "Old generation memory pool committed (only present when such a pool exists)"
+      },
+      "oldGenMax": {
+        "type": "string",
+        "description": "Old generation memory pool max (only present when such a pool exists)"
+      },
+      "metaspaceUsed": {
+        "type": "string",
+        "description": "Metaspace memory pool used (only present when such a pool exists)"
+      },
+      "metaspaceCommitted": {
+        "type": "string",
+        "description": "Metaspace memory pool committed (only present when such a pool exists)"
+      },
+      "metaspaceMax": {
+        "type": "string",
+        "description": "Metaspace memory pool max (only present when such a pool exists)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/message-history.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/message-history.json
@@ -28,6 +28,23 @@
       "defaultValue": 5,
       "description": "Number of source code lines around the location to include"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The CamelContext name (only present when a backlog tracer is available)"
+      },
+      "traces": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The latest completed message trace entries, as opaque JSON objects (only present when a backlog tracer is available)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor-detail.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor-detail.json
@@ -27,6 +27,92 @@
       "secret": false,
       "description": "The route id to get processor details for (use * for all routes)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routeId": {
+        "type": "string",
+        "description": "The route ID (only present when a specific route was requested)"
+      },
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The processor ID"
+            },
+            "type": {
+              "type": "string",
+              "description": "The processor type (the XML element name, or 'from' for the route input)"
+            },
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI (only present for the route input entry)"
+            },
+            "line": {
+              "type": "integer",
+              "description": "The source line number (only present when known)"
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The processor's configured options, as attribute\/child-element name to string value"
+            }
+          }
+        },
+        "description": "The route's processors (only present when a specific route was requested)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "processors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The processor ID"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The processor type (the XML element name, or 'from' for the route input)"
+                  },
+                  "endpointUri": {
+                    "type": "string",
+                    "description": "The endpoint URI (only present for the route input entry)"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number (only present when known)"
+                  },
+                  "options": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "The processor's configured options, as attribute\/child-element name to string value"
+                  }
+                }
+              },
+              "description": "The route's processors, starting with the route input"
+            }
+          }
+        },
+        "description": "The route details for all routes (only present when routeId is * or omitted)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/processor.json
@@ -61,6 +61,175 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "id": {
+              "type": "string",
+              "description": "The processor ID"
+            },
+            "nodePrefixId": {
+              "type": "string",
+              "description": "The node prefix ID (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The processor description (only present when configured)"
+            },
+            "note": {
+              "type": "string",
+              "description": "The processor note (only present when configured)"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location, optionally with a line number suffix (only present when known)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The processor state"
+            },
+            "disabled": {
+              "type": "boolean",
+              "description": "Whether the processor is disabled (only present when known)"
+            },
+            "stepId": {
+              "type": "string",
+              "description": "The step ID (only present when known)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number (only present when known)"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  },
+                  "match": {
+                    "type": "boolean",
+                    "description": "Whether this is the matched line (only present when true)"
+                  }
+                }
+              },
+              "description": "A snippet of source code around the processor (only present when known)"
+            },
+            "processor": {
+              "type": "string",
+              "description": "The processor name"
+            },
+            "level": {
+              "type": "integer",
+              "description": "The processor level in the route tree"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The destination URI, for processors that send to a destination (only present when applicable)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the processor has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          },
+          "required": [
+            "level"
+          ]
+        },
+        "description": "The processors (only present when no action was requested)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/producer.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/producer.json
@@ -11,6 +11,52 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "producers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "state": {
+              "type": "string",
+              "description": "The producer state"
+            },
+            "clazz": {
+              "type": "string",
+              "description": "The producer service type"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "singleton": {
+              "type": "boolean",
+              "description": "Whether the producer is a singleton"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "stepId": {
+              "type": "string",
+              "description": "The step ID (only present when known)"
+            }
+          },
+          "required": [
+            "remote",
+            "singleton"
+          ]
+        },
+        "description": "The producers"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/properties.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/properties.json
@@ -11,6 +11,55 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "locations": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The locations properties are loaded from"
+      },
+      "properties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "The property key"
+            },
+            "value": {
+              "type": "string",
+              "description": "The property value (masked when sensitive)"
+            },
+            "originalValue": {
+              "type": "string",
+              "description": "The original unresolved value (only present when resolved via a properties function)"
+            },
+            "defaultValue": {
+              "type": "string",
+              "description": "The default value (only present when one was used)"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source that provided the value (only present when known)"
+            },
+            "location": {
+              "type": "string",
+              "description": "The location the value was loaded from (only present when known)"
+            },
+            "internal": {
+              "type": "boolean",
+              "description": "Whether the location is an internal Camel location (only present when location is known)"
+            }
+          }
+        },
+        "description": "The loaded properties (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/receive.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/receive.json
@@ -63,6 +63,70 @@
       "secret": false,
       "description": "Endpoint for where to receive messages (can also refer to a route id, endpoint pattern)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "messages": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The dumped received messages, as opaque JSON objects (only present when dumping)"
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether receiving is enabled (only present when not dumping)"
+      },
+      "total": {
+        "type": "integer",
+        "description": "Total number of messages received so far (only present when not dumping)"
+      },
+      "firstTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the first message in the last dump (only present when not dumping)"
+      },
+      "lastTimestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds of the last message in the last dump (only present when not dumping)"
+      },
+      "url": {
+        "type": "string",
+        "description": "The endpoint URI that receiving was started for (only present on success)"
+      },
+      "error": {
+        "type": "string",
+        "description": "The error message (only present on failure to start receiving)"
+      },
+      "stackTrace": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The error stack trace, one entry per line (only present on failure to start receiving)"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            }
+          },
+          "required": [
+            "remote"
+          ]
+        },
+        "description": "The active consumer endpoints (only present when not dumping and there are any)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/reload.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/reload.json
@@ -43,6 +43,57 @@
       "defaultValue": false,
       "description": "Option to wait for reloading to complete"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "reloadStrategies": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "description": "The reload strategy class name"
+            },
+            "reloaded": {
+              "type": "integer",
+              "description": "Number of successful reloads"
+            },
+            "failed": {
+              "type": "integer",
+              "description": "Number of failed reloads"
+            },
+            "lastError": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "description": "The error message"
+                },
+                "stackTrace": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The error stack trace, one entry per line"
+                }
+              },
+              "description": "The last reload error (only present when a reload has failed)"
+            }
+          },
+          "required": [
+            "reloaded",
+            "failed"
+          ]
+        },
+        "description": "The reload strategies (only present when not triggering a reload and at least one reload strategy is active)"
+      },
+      "status": {
+        "type": "string",
+        "description": "The reload status, reloading\/success\/failed (only present when triggering a reload)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest-spec.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest-spec.json
@@ -27,6 +27,32 @@
       "secret": false,
       "description": "Filters specifications matching the given URI pattern"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "specs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "specificationUri": {
+              "type": "string",
+              "description": "The OpenAPI specification URI"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "content": {
+              "type": "string",
+              "description": "The specification content (only present when it could be loaded)"
+            }
+          }
+        },
+        "description": "The OpenAPI specifications"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/rest.json
@@ -11,6 +11,80 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "rests": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The absolute URL to the REST service"
+            },
+            "method": {
+              "type": "string",
+              "description": "The HTTP method"
+            },
+            "contractFirst": {
+              "type": "boolean",
+              "description": "Whether the REST service is contract-first"
+            },
+            "specification": {
+              "type": "boolean",
+              "description": "Whether this is the API contract specification (i.e. api-doc)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The REST service state"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "operationId": {
+              "type": "string",
+              "description": "The OpenAPI operation ID (only present for contract-first routes)"
+            },
+            "specificationUri": {
+              "type": "string",
+              "description": "The OpenAPI specification URI (only present for contract-first routes)"
+            },
+            "consumes": {
+              "type": "string",
+              "description": "The accepted media types (only present when known)"
+            },
+            "produces": {
+              "type": "string",
+              "description": "The returned media types (only present when known)"
+            },
+            "inType": {
+              "type": "string",
+              "description": "The input binding class name (only present when known)"
+            },
+            "outType": {
+              "type": "string",
+              "description": "The output binding class name (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The REST service description (only present when configured)"
+            },
+            "hits": {
+              "type": "integer",
+              "description": "Usage of the REST service (only present when greater than zero)"
+            }
+          },
+          "required": [
+            "contractFirst",
+            "specification"
+          ]
+        },
+        "description": "The REST services (only present when a REST registry is available)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-controller.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-controller.json
@@ -43,6 +43,126 @@
       "defaultValue": true,
       "description": "Whether to include stack traces"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "controller": {
+        "type": "string",
+        "description": "The route controller implementation: SupervisingRouteController or DefaultRouteController"
+      },
+      "startingRoutes": {
+        "type": "boolean",
+        "description": "Whether routes are still starting (supervising controller only)"
+      },
+      "unhealthyRoutes": {
+        "type": "boolean",
+        "description": "Whether any route is unhealthy (supervising controller only)"
+      },
+      "totalRoutes": {
+        "type": "integer",
+        "description": "Total number of routes"
+      },
+      "startedRoutes": {
+        "type": "integer",
+        "description": "Number of started routes (supervising controller only)"
+      },
+      "restartingRoutes": {
+        "type": "integer",
+        "description": "Number of restarting routes (supervising controller only)"
+      },
+      "exhaustedRoutes": {
+        "type": "integer",
+        "description": "Number of exhausted routes (supervising controller only)"
+      },
+      "initialDelay": {
+        "type": "integer",
+        "description": "Initial delay in milliseconds before restarting (supervising controller only)"
+      },
+      "backoffDelay": {
+        "type": "integer",
+        "description": "Backoff delay in milliseconds (supervising controller only)"
+      },
+      "backoffMaxDelay": {
+        "type": "integer",
+        "description": "Maximum backoff delay in milliseconds (supervising controller only)"
+      },
+      "backoffMaxElapsedTime": {
+        "type": "integer",
+        "description": "Maximum elapsed time in milliseconds before giving up (supervising controller only)"
+      },
+      "backoffMaxAttempts": {
+        "type": "integer",
+        "description": "Maximum number of restart attempts (supervising controller only)"
+      },
+      "threadPoolSize": {
+        "type": "integer",
+        "description": "The size of the restart thread pool (supervising controller only)"
+      },
+      "unhealthyOnRestarting": {
+        "type": "boolean",
+        "description": "Whether a restarting route is considered unhealthy (supervising controller only)"
+      },
+      "unhealthyOnExhausted": {
+        "type": "boolean",
+        "description": "Whether an exhausted route is considered unhealthy (supervising controller only)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "status": {
+              "type": "string",
+              "description": "The route status"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The route endpoint URI (sanitized)"
+            },
+            "attempts": {
+              "type": "integer",
+              "description": "Number of restart attempts (supervising controller only)"
+            },
+            "lastAttempt": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last restart attempt (supervising controller only)"
+            },
+            "nextAttempt": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the next restart attempt (supervising controller only)"
+            },
+            "elapsed": {
+              "type": "integer",
+              "description": "Elapsed time in milliseconds of the current restart attempt (supervising controller only)"
+            },
+            "supervising": {
+              "type": "string",
+              "description": "The supervising status (supervising controller only)"
+            },
+            "error": {
+              "type": "string",
+              "description": "The restart error message (only present when the route is failing)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The restart error stack trace, one entry per line (only present when the route is failing and stack traces are requested)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    },
+    "required": [
+      "totalRoutes"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-dump.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-dump.json
@@ -75,6 +75,56 @@
       "defaultValue": false,
       "description": "Whether to expand URIs into separated key\/value parameters"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "format": {
+              "type": "string",
+              "description": "The dump format, xml\/yaml\/java (only present when the dump succeeded)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number, or -1 when not known"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The dumped route source code (only present when the dump succeeded)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-group.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-group.json
@@ -59,6 +59,145 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routeGroups": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "group": {
+              "type": "string",
+              "description": "The route group ID"
+            },
+            "size": {
+              "type": "integer",
+              "description": "Number of routes in this group"
+            },
+            "state": {
+              "type": "string",
+              "description": "The route group state"
+            },
+            "uptime": {
+              "type": "string",
+              "description": "Route uptime, human readable text"
+            },
+            "routeIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The route IDs within this group"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "coverage": {
+                  "type": "string",
+                  "description": "Route coverage (only present when computable)"
+                },
+                "load01": {
+                  "type": "string",
+                  "description": "1 minute load average (only present when available)"
+                },
+                "load05": {
+                  "type": "string",
+                  "description": "5 minute load average (only present when available)"
+                },
+                "load15": {
+                  "type": "string",
+                  "description": "15 minute load average (only present when available)"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the route group has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          },
+          "required": [
+            "size"
+          ]
+        },
+        "description": "The route groups (only present when no action was requested)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-structure.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-structure.json
@@ -71,6 +71,90 @@
       "defaultValue": false,
       "description": "Whether to include metrics such as number of messages processed (from JMX)"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "line": {
+              "type": "integer",
+              "description": "The source line number (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The route description (only present when configured)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number, or a sequential counter when not known"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The processor type"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "The processor ID"
+                  },
+                  "level": {
+                    "type": "integer",
+                    "description": "The nesting level"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description (only present when known)"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The code representation of this processor"
+                  },
+                  "uri": {
+                    "type": "string",
+                    "description": "The endpoint URI (only present when this processor references an endpoint)"
+                  },
+                  "remote": {
+                    "type": "boolean",
+                    "description": "Whether the endpoint is remote (only present when true)"
+                  },
+                  "statistics": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Runtime statistics for this route or processor, as an opaque JSON object (only present when metrics were requested)"
+                  }
+                },
+                "required": [
+                  "line",
+                  "level"
+                ]
+              },
+              "description": "The route's structure, one entry per processor (only present when the dump succeeded)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-topology.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route-topology.json
@@ -58,6 +58,118 @@
       "defaultValue": false,
       "description": "Whether to include route structure data in the response"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "description": {
+              "type": "string",
+              "description": "The route description (only present when configured)"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "fromScheme": {
+              "type": "string",
+              "description": "The route's endpoint scheme"
+            },
+            "nodeType": {
+              "type": "string",
+              "description": "The node type"
+            },
+            "exchangesTotal": {
+              "type": "integer",
+              "description": "Total number of exchanges (only present when metrics were requested and available)"
+            },
+            "exchangesFailed": {
+              "type": "integer",
+              "description": "Number of failed exchanges (only present when metrics were requested and available)"
+            }
+          }
+        },
+        "description": "The topology nodes (only present when a route topology dumper is available)"
+      },
+      "edges": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "fromRouteId": {
+              "type": "string",
+              "description": "The source route ID"
+            },
+            "toRouteId": {
+              "type": "string",
+              "description": "The target route ID"
+            },
+            "endpoint": {
+              "type": "string",
+              "description": "The endpoint URI connecting the two routes"
+            },
+            "connectionType": {
+              "type": "string",
+              "description": "The connection type"
+            }
+          }
+        },
+        "description": "The connections between nodes (only present when a route topology dumper is available)"
+      },
+      "externalEndpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The endpoint ID"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "scheme": {
+              "type": "string",
+              "description": "The endpoint scheme"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction (in or out)"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "exchangesTotal": {
+              "type": "integer",
+              "description": "Total number of exchanges (only present when metrics were requested and available)"
+            },
+            "exchangesFailed": {
+              "type": "integer",
+              "description": "Number of failed exchanges (only present when metrics were requested and available)"
+            }
+          }
+        },
+        "description": "External systems the routes connect to (only present when requested and there are any)"
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "Route structure data, as opaque JSON objects (only present when requested)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/route.json
@@ -76,6 +76,369 @@
       "defaultValue": false,
       "description": "Whether to include processors"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "group": {
+              "type": "string",
+              "description": "The route group (only present when known)"
+            },
+            "nodePrefixId": {
+              "type": "string",
+              "description": "The node prefix ID (only present when known)"
+            },
+            "description": {
+              "type": "string",
+              "description": "The route description (only present when configured)"
+            },
+            "note": {
+              "type": "string",
+              "description": "The route note (only present when configured)"
+            },
+            "createdByKamelet": {
+              "type": "boolean",
+              "description": "Whether the route was created by a Kamelet"
+            },
+            "createdByRouteTemplate": {
+              "type": "boolean",
+              "description": "Whether the route was created by a route template"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "remote": {
+              "type": "boolean",
+              "description": "Whether the endpoint is remote"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The route state"
+            },
+            "supportsSuspension": {
+              "type": "boolean",
+              "description": "Whether the route supports suspension"
+            },
+            "uptime": {
+              "type": "string",
+              "description": "Route uptime, human readable text"
+            },
+            "lastError": {
+              "type": "object",
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "description": "The error phase"
+                },
+                "timestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds when the error happened"
+                },
+                "message": {
+                  "type": "string",
+                  "description": "The error message (only present when known)"
+                },
+                "stackTrace": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The error stack trace, one entry per line (only present when known)"
+                }
+              },
+              "required": [
+                "timestamp"
+              ],
+              "description": "The last lifecycle error (only present when one has occurred)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "coverage": {
+                  "type": "string",
+                  "description": "Route coverage (only present when computable)"
+                },
+                "load01": {
+                  "type": "string",
+                  "description": "1 minute load average (only present when available)"
+                },
+                "load05": {
+                  "type": "string",
+                  "description": "5 minute load average (only present when available)"
+                },
+                "load15": {
+                  "type": "string",
+                  "description": "15 minute load average (only present when available)"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "idleSince": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds since the route has been idle"
+                },
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                },
+                "lastCreatedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                },
+                "lastCompletedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                },
+                "lastFailureHandledExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                },
+                "lastFailedExchangeTimestamp": {
+                  "type": "integer",
+                  "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                }
+              },
+              "required": [
+                "idleSince",
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            },
+            "processors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "routeId": {
+                    "type": "string",
+                    "description": "The route ID"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "The processor ID"
+                  },
+                  "nodePrefixId": {
+                    "type": "string",
+                    "description": "The node prefix ID (only present when known)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The processor description (only present when configured)"
+                  },
+                  "note": {
+                    "type": "string",
+                    "description": "The processor note (only present when configured)"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "The source location, optionally with a line number suffix (only present when known)"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The processor state"
+                  },
+                  "disabled": {
+                    "type": "boolean",
+                    "description": "Whether the processor is disabled (only present when known)"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "The step ID (only present when known)"
+                  },
+                  "code": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "line": {
+                          "type": "integer",
+                          "description": "The source line number (only present when known)"
+                        },
+                        "code": {
+                          "type": "string",
+                          "description": "The source code line"
+                        },
+                        "match": {
+                          "type": "boolean",
+                          "description": "Whether this is the matched line (only present when true)"
+                        }
+                      }
+                    },
+                    "description": "A snippet of source code around the processor (only present when known)"
+                  },
+                  "processor": {
+                    "type": "string",
+                    "description": "The processor name"
+                  },
+                  "level": {
+                    "type": "integer",
+                    "description": "The processor level in the route tree"
+                  },
+                  "uri": {
+                    "type": "string",
+                    "description": "The destination URI, for processors that send to a destination (only present when applicable)"
+                  },
+                  "statistics": {
+                    "type": "object",
+                    "properties": {
+                      "idleSince": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds since the processor has been idle"
+                      },
+                      "exchangesTotal": {
+                        "type": "integer",
+                        "description": "Total number of exchanges"
+                      },
+                      "exchangesFailed": {
+                        "type": "integer",
+                        "description": "Number of failed exchanges"
+                      },
+                      "exchangesInflight": {
+                        "type": "integer",
+                        "description": "Number of inflight exchanges"
+                      },
+                      "exchangesThroughput": {
+                        "type": "string",
+                        "description": "Messages per second throughput (only present when available)"
+                      },
+                      "meanProcessingTime": {
+                        "type": "integer",
+                        "description": "Mean processing time in milliseconds"
+                      },
+                      "maxProcessingTime": {
+                        "type": "integer",
+                        "description": "Max processing time in milliseconds"
+                      },
+                      "minProcessingTime": {
+                        "type": "integer",
+                        "description": "Min processing time in milliseconds"
+                      },
+                      "p50ProcessingTime": {
+                        "type": "integer",
+                        "description": "50th percentile processing time in milliseconds (only present when available)"
+                      },
+                      "p95ProcessingTime": {
+                        "type": "integer",
+                        "description": "95th percentile processing time in milliseconds (only present when available)"
+                      },
+                      "p99ProcessingTime": {
+                        "type": "integer",
+                        "description": "99th percentile processing time in milliseconds (only present when available)"
+                      },
+                      "lastProcessingTime": {
+                        "type": "integer",
+                        "description": "Processing time in milliseconds of the last exchange (only present once an exchange has completed)"
+                      },
+                      "deltaProcessingTime": {
+                        "type": "integer",
+                        "description": "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)"
+                      },
+                      "lastCreatedExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)"
+                      },
+                      "lastCompletedExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)"
+                      },
+                      "lastFailureHandledExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)"
+                      },
+                      "lastFailedExchangeTimestamp": {
+                        "type": "integer",
+                        "description": "Epoch time in milliseconds the last exchange failed (only present once one has occurred)"
+                      }
+                    },
+                    "required": [
+                      "idleSince",
+                      "exchangesTotal",
+                      "exchangesFailed",
+                      "exchangesInflight",
+                      "meanProcessingTime",
+                      "maxProcessingTime",
+                      "minProcessingTime"
+                    ],
+                    "description": "Runtime statistics"
+                  }
+                },
+                "required": [
+                  "level"
+                ]
+              },
+              "description": "The route's processors (only present when requested)"
+            }
+          },
+          "required": [
+            "createdByKamelet",
+            "createdByRouteTemplate",
+            "remote",
+            "supportsSuspension"
+          ]
+        },
+        "description": "The routes (only present when no action was requested)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/send.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/send.json
@@ -103,6 +103,45 @@
       "defaultValue": 20000,
       "description": "Timeout when using poll mode"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "timestamp": {
+        "type": "integer",
+        "description": "Epoch time in milliseconds when the send was performed"
+      },
+      "status": {
+        "type": "string",
+        "description": "The send status, success\/error\/timeout"
+      },
+      "elapsed": {
+        "type": "integer",
+        "description": "Elapsed time in milliseconds"
+      },
+      "endpoint": {
+        "type": "string",
+        "description": "The endpoint URI (only present when known)"
+      },
+      "exception": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The exception, as an opaque JSON object (only present on error)"
+      },
+      "exchangeId": {
+        "type": "string",
+        "description": "The exchange ID (only present when a response message is available)"
+      },
+      "message": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The response message, as an opaque JSON object (only present when a response message is available)"
+      }
+    },
+    "required": [
+      "timestamp",
+      "elapsed"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/service.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/service.json
@@ -11,6 +11,63 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "services": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "component": {
+              "type": "string",
+              "description": "The Camel component"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction (in or out)"
+            },
+            "hosted": {
+              "type": "boolean",
+              "description": "Whether the service is hosted in this Camel application"
+            },
+            "protocol": {
+              "type": "string",
+              "description": "The protocol the service is using (only present when known)"
+            },
+            "serviceUrl": {
+              "type": "string",
+              "description": "The remote address of the service (only present when known)"
+            },
+            "endpointUri": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "hits": {
+              "type": "integer",
+              "description": "Usage of the endpoint service"
+            },
+            "metadata": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Additional metadata relevant to the service (only present when available)"
+            }
+          },
+          "required": [
+            "hosted",
+            "hits"
+          ]
+        },
+        "description": "The services"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/simple-language.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/simple-language.json
@@ -11,6 +11,37 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "coreSize": {
+        "type": "integer",
+        "description": "Number of core simple functions"
+      },
+      "customSize": {
+        "type": "integer",
+        "description": "Number of custom simple functions"
+      },
+      "coreFunctions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The core function names (only present when there are any)"
+      },
+      "customFunctions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The custom function names (only present when there are any)"
+      }
+    },
+    "required": [
+      "coreSize",
+      "customSize"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source.json
@@ -41,6 +41,56 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The line number"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  },
+                  "match": {
+                    "type": "boolean",
+                    "description": "Whether this is the matched line (only present when true)"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "The source code around the route (only present when resolvable)"
+            }
+          }
+        },
+        "description": "The routes"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-query.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-query.json
@@ -132,6 +132,90 @@
       "secret": false,
       "description": "Table name for update-row action"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "The execution status, success or error"
+      },
+      "message": {
+        "type": "string",
+        "description": "The error message (only present on error)"
+      },
+      "datasource": {
+        "type": "string",
+        "description": "The resolved DataSource bean name (only present once resolved)"
+      },
+      "availableDataSources": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The available DataSource bean names (only present when multiple exist and none was specified)"
+      },
+      "elapsed": {
+        "type": "integer",
+        "description": "Elapsed time in milliseconds (only present once a query attempt was made)"
+      },
+      "columns": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The column name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The column SQL type name"
+            },
+            "primaryKey": {
+              "type": "boolean",
+              "description": "Whether the column is part of the primary key (only present when the query targets a single, editable table)"
+            }
+          }
+        },
+        "description": "The result set columns (only present for queries returning a result set)"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The result set rows, one opaque JSON object per row (only present for queries returning a result set)"
+      },
+      "rowCount": {
+        "type": "integer",
+        "description": "Number of rows returned (only present for queries returning a result set)"
+      },
+      "truncated": {
+        "type": "boolean",
+        "description": "Whether the result set was truncated by maxRows (only present for queries returning a result set)"
+      },
+      "updateCount": {
+        "type": "integer",
+        "description": "Number of rows affected (only present for queries\/updates not returning a result set)"
+      },
+      "tableName": {
+        "type": "string",
+        "description": "The single table the result set maps to (only present when the result is a single, editable table)"
+      },
+      "primaryKeys": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The primary key column names (only present when the result is a single, editable table)"
+      },
+      "editable": {
+        "type": "boolean",
+        "description": "Whether the result set rows can be edited (only present when true)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-trace.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/sql-trace.json
@@ -11,6 +11,126 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "statements": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds when the statement was executed"
+            },
+            "exchangeId": {
+              "type": "string",
+              "description": "The exchange ID"
+            },
+            "routeId": {
+              "type": "string",
+              "description": "The route ID (only present when known)"
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "The processor node ID (only present when known)"
+            },
+            "location": {
+              "type": "string",
+              "description": "The source location of the processor (only present when known)"
+            },
+            "endpoint": {
+              "type": "string",
+              "description": "The endpoint URI"
+            },
+            "query": {
+              "type": "string",
+              "description": "The SQL query (or the endpoint URI when the query could not be determined)"
+            },
+            "category": {
+              "type": "string",
+              "description": "The SQL statement category"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "Duration in milliseconds"
+            },
+            "failed": {
+              "type": "boolean",
+              "description": "Whether the exchange failed"
+            },
+            "rowCount": {
+              "type": "integer",
+              "description": "Number of rows returned (only present when known)"
+            },
+            "updateCount": {
+              "type": "integer",
+              "description": "Number of rows updated (only present when known)"
+            }
+          },
+          "required": [
+            "timestamp",
+            "duration",
+            "failed"
+          ]
+        },
+        "description": "The traced SQL statements, most recent first (only present when statements have been traced)"
+      },
+      "summary": {
+        "type": "object",
+        "properties": {
+          "totalQueries": {
+            "type": "integer",
+            "description": "Total number of queries"
+          },
+          "avgTime": {
+            "type": "integer",
+            "description": "Average duration in milliseconds"
+          },
+          "slowestTime": {
+            "type": "integer",
+            "description": "Slowest duration in milliseconds"
+          },
+          "slowCount": {
+            "type": "integer",
+            "description": "Number of queries considered slow (duration >= 100 ms)"
+          },
+          "failedCount": {
+            "type": "integer",
+            "description": "Number of failed queries"
+          },
+          "selectCount": {
+            "type": "integer",
+            "description": "Number of SELECT statements"
+          },
+          "insertCount": {
+            "type": "integer",
+            "description": "Number of INSERT statements"
+          },
+          "updateCount": {
+            "type": "integer",
+            "description": "Number of UPDATE statements"
+          },
+          "deleteCount": {
+            "type": "integer",
+            "description": "Number of DELETE statements"
+          }
+        },
+        "required": [
+          "totalQueries",
+          "avgTime",
+          "slowestTime",
+          "slowCount",
+          "failedCount",
+          "selectCount",
+          "insertCount",
+          "updateCount",
+          "deleteCount"
+        ],
+        "description": "Summary statistics across the traced statements (only present when statements have been traced)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/startup-recorder.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/startup-recorder.json
@@ -11,6 +11,59 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "The id of the step"
+            },
+            "parentId": {
+              "type": "integer",
+              "description": "The id of the parent step"
+            },
+            "level": {
+              "type": "integer",
+              "description": "The step level (sub step of previous steps)"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the step (only present when known)"
+            },
+            "type": {
+              "type": "string",
+              "description": "The source class type of the step"
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of the step"
+            },
+            "beginTime": {
+              "type": "integer",
+              "description": "The begin time (epoch milliseconds)"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "The duration the step took, in milliseconds"
+            }
+          },
+          "required": [
+            "id",
+            "parentId",
+            "level",
+            "beginTime",
+            "duration"
+          ]
+        },
+        "description": "The startup steps (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/system-properties.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/system-properties.json
@@ -11,6 +11,19 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "systemProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The system properties, one single-entry map per property"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/system-properties.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/system-properties.json
@@ -19,7 +19,9 @@
         "type": "array",
         "items": {
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "description": "The system properties, one single-entry map per property"
       }

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/thread.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/thread.json
@@ -28,6 +28,82 @@
       "defaultValue": false,
       "description": "Whether to include thread stack traces"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "threadCount": {
+        "type": "integer",
+        "description": "Number of threads"
+      },
+      "daemonThreadCount": {
+        "type": "integer",
+        "description": "Number of daemon threads"
+      },
+      "totalStartedThreadCount": {
+        "type": "integer",
+        "description": "Total number of threads started since JVM start"
+      },
+      "peakThreadCount": {
+        "type": "integer",
+        "description": "Peak number of threads"
+      },
+      "threads": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "The thread ID"
+            },
+            "name": {
+              "type": "string",
+              "description": "The thread name"
+            },
+            "state": {
+              "type": "string",
+              "description": "The thread state"
+            },
+            "blockedCount": {
+              "type": "integer",
+              "description": "Number of times the thread has been blocked"
+            },
+            "blockedTime": {
+              "type": "integer",
+              "description": "Total time in milliseconds the thread has been blocked"
+            },
+            "waitedCount": {
+              "type": "integer",
+              "description": "Number of times the thread has waited"
+            },
+            "waitedTime": {
+              "type": "integer",
+              "description": "Total time in milliseconds the thread has waited"
+            },
+            "lockName": {
+              "type": "string",
+              "description": "The name of the lock the thread is waiting on (only present when applicable)"
+            },
+            "stackTrace": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The thread stack trace, one entry per line (only present when requested via the stackTrace option)"
+            }
+          },
+          "required": [
+            "id",
+            "blockedCount",
+            "blockedTime",
+            "waitedCount",
+            "waitedTime"
+          ]
+        },
+        "description": "The threads"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/top.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/top.json
@@ -41,6 +41,223 @@
       "secret": false,
       "description": "Limits the number of entries displayed"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "from": {
+              "type": "string",
+              "description": "The route's endpoint URI"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source location (only present when known)"
+            },
+            "state": {
+              "type": "string",
+              "description": "The route state"
+            },
+            "uptime": {
+              "type": "string",
+              "description": "Route uptime, human readable text"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange"
+                },
+                "totalProcessingTime": {
+                  "type": "integer",
+                  "description": "Total accumulated processing time in milliseconds"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                }
+              },
+              "required": [
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime",
+                "lastProcessingTime",
+                "deltaProcessingTime",
+                "totalProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          }
+        },
+        "description": "The top routes (only present when no processor path was requested)"
+      },
+      "processors": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "routeId": {
+              "type": "string",
+              "description": "The route ID"
+            },
+            "processorId": {
+              "type": "string",
+              "description": "The processor ID"
+            },
+            "location": {
+              "type": "string",
+              "description": "The source location, optionally with a line number suffix (only present when known)"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "line": {
+                    "type": "integer",
+                    "description": "The source line number"
+                  },
+                  "match": {
+                    "type": "boolean",
+                    "description": "Whether this is the matched line (only present when true)"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The source code line"
+                  }
+                },
+                "required": [
+                  "line"
+                ]
+              },
+              "description": "A snippet of source code around the processor (only present when known)"
+            },
+            "statistics": {
+              "type": "object",
+              "properties": {
+                "exchangesTotal": {
+                  "type": "integer",
+                  "description": "Total number of exchanges"
+                },
+                "exchangesFailed": {
+                  "type": "integer",
+                  "description": "Number of failed exchanges"
+                },
+                "exchangesInflight": {
+                  "type": "integer",
+                  "description": "Number of inflight exchanges"
+                },
+                "meanProcessingTime": {
+                  "type": "integer",
+                  "description": "Mean processing time in milliseconds"
+                },
+                "maxProcessingTime": {
+                  "type": "integer",
+                  "description": "Max processing time in milliseconds"
+                },
+                "minProcessingTime": {
+                  "type": "integer",
+                  "description": "Min processing time in milliseconds"
+                },
+                "lastProcessingTime": {
+                  "type": "integer",
+                  "description": "Processing time in milliseconds of the last exchange"
+                },
+                "deltaProcessingTime": {
+                  "type": "integer",
+                  "description": "Difference in processing time in milliseconds since the previous exchange"
+                },
+                "totalProcessingTime": {
+                  "type": "integer",
+                  "description": "Total accumulated processing time in milliseconds"
+                },
+                "exchangesThroughput": {
+                  "type": "string",
+                  "description": "Messages per second throughput (only present when available)"
+                },
+                "p50ProcessingTime": {
+                  "type": "integer",
+                  "description": "50th percentile processing time in milliseconds (only present when available)"
+                },
+                "p95ProcessingTime": {
+                  "type": "integer",
+                  "description": "95th percentile processing time in milliseconds (only present when available)"
+                },
+                "p99ProcessingTime": {
+                  "type": "integer",
+                  "description": "99th percentile processing time in milliseconds (only present when available)"
+                }
+              },
+              "required": [
+                "exchangesTotal",
+                "exchangesFailed",
+                "exchangesInflight",
+                "meanProcessingTime",
+                "maxProcessingTime",
+                "minProcessingTime",
+                "lastProcessingTime",
+                "deltaProcessingTime",
+                "totalProcessingTime"
+              ],
+              "description": "Runtime statistics"
+            }
+          }
+        },
+        "description": "The top processors of a route (only present when a processor path was requested)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/trace.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/trace.json
@@ -49,6 +49,83 @@
       "secret": false,
       "description": "Whether to enable or disable tracing"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Whether tracing is enabled (only present when a backlog tracer is available)"
+      },
+      "traces": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": "The traced messages, as opaque JSON objects (only present when dumping)"
+      },
+      "standby": {
+        "type": "boolean",
+        "description": "Whether the tracer is in standby mode (only present when not dumping)"
+      },
+      "counter": {
+        "type": "integer",
+        "description": "Total number of traced messages (only present when not dumping)"
+      },
+      "backlogSize": {
+        "type": "integer",
+        "description": "The current backlog size (only present when not dumping)"
+      },
+      "queueSize": {
+        "type": "integer",
+        "description": "The current queue size (only present when not dumping)"
+      },
+      "removeOnDump": {
+        "type": "boolean",
+        "description": "Whether messages are removed from the backlog when dumped (only present when not dumping)"
+      },
+      "traceFilter": {
+        "type": "string",
+        "description": "The trace filter (only present when configured)"
+      },
+      "tracePattern": {
+        "type": "string",
+        "description": "The trace pattern (only present when configured)"
+      },
+      "traceRests": {
+        "type": "boolean",
+        "description": "Whether rests are traced (only present when not dumping)"
+      },
+      "traceTemplates": {
+        "type": "boolean",
+        "description": "Whether route templates\/Kamelets are traced (only present when not dumping)"
+      },
+      "bodyMaxChars": {
+        "type": "integer",
+        "description": "Maximum size of the message body to include (only present when not dumping)"
+      },
+      "bodyIncludeFiles": {
+        "type": "boolean",
+        "description": "Whether file-based message bodies are included (only present when not dumping)"
+      },
+      "bodyIncludeStreams": {
+        "type": "boolean",
+        "description": "Whether streaming message bodies are included (only present when not dumping)"
+      },
+      "includeExchangeProperties": {
+        "type": "boolean",
+        "description": "Whether exchange properties are included (only present when not dumping)"
+      },
+      "includeExchangeVariables": {
+        "type": "boolean",
+        "description": "Whether exchange variables are included (only present when not dumping)"
+      },
+      "includeException": {
+        "type": "boolean",
+        "description": "Whether exceptions are included (only present when not dumping)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/transformers.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/transformers.json
@@ -11,6 +11,54 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "size": {
+        "type": "integer",
+        "description": "Total number of transformers"
+      },
+      "dynamicSize": {
+        "type": "integer",
+        "description": "Number of transformers in the dynamic registry"
+      },
+      "staticSize": {
+        "type": "integer",
+        "description": "Number of transformers in the static registry"
+      },
+      "maximumCacheSize": {
+        "type": "integer",
+        "description": "Maximum number of entries to store in the dynamic registry"
+      },
+      "transformers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The transformer name"
+            },
+            "from": {
+              "type": "string",
+              "description": "The from data type (only present when not any-type)"
+            },
+            "to": {
+              "type": "string",
+              "description": "The to data type (only present when not any-type)"
+            }
+          }
+        },
+        "description": "The transformers (only present when there are any)"
+      }
+    },
+    "required": [
+      "size",
+      "dynamicSize",
+      "staticSize",
+      "maximumCacheSize"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/type-converters.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/type-converters.json
@@ -11,6 +11,80 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "size": {
+        "type": "integer",
+        "description": "Number of registered type converters"
+      },
+      "exists": {
+        "type": "string",
+        "description": "Whether a type converter must exist or not"
+      },
+      "existsLoggingLevel": {
+        "type": "string",
+        "description": "Logging level used when a type converter does not exist"
+      },
+      "statistics": {
+        "type": "object",
+        "properties": {
+          "attemptCounter": {
+            "type": "integer",
+            "description": "Number of attempted conversions"
+          },
+          "hitCounter": {
+            "type": "integer",
+            "description": "Number of successful conversions (cache hit)"
+          },
+          "missCounter": {
+            "type": "integer",
+            "description": "Number of cache misses"
+          },
+          "failedCounter": {
+            "type": "integer",
+            "description": "Number of failed conversions"
+          },
+          "noopCounter": {
+            "type": "integer",
+            "description": "Number of noop conversions"
+          }
+        },
+        "required": [
+          "attemptCounter",
+          "hitCounter",
+          "missCounter",
+          "failedCounter",
+          "noopCounter"
+        ],
+        "description": "Type converter usage statistics (only present when statistics are enabled)"
+      },
+      "converters": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "The source type"
+            },
+            "to": {
+              "type": "string",
+              "description": "The target type"
+            },
+            "converterClass": {
+              "type": "string",
+              "description": "The type converter implementation class"
+            }
+          }
+        },
+        "description": "The registered type converters"
+      }
+    },
+    "required": [
+      "size"
+    ]
   }
 }
 

--- a/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/variables.json
+++ b/core/camel-console/src/generated/resources/META-INF/org/apache/camel/dev-console/variables.json
@@ -11,6 +11,44 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "repositories": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The variable repository id"
+            },
+            "variables": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "The variable name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The variable value type (only present when the value is known)"
+                  },
+                  "value": {
+                    "description": "The variable value (only present when known)"
+                  }
+                }
+              },
+              "description": "The variables in this repository"
+            }
+          }
+        },
+        "description": "The variable repositories (only present when there are any with variables)"
+      }
+    }
   }
 }
 

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ActivityDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ActivityDevConsole.java
@@ -16,18 +16,43 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.BacklogTracer;
 import org.apache.camel.spi.BacklogTracerActivityMessage;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "activity", displayName = "Camel Activity", description = "Recent completed exchange activity")
 public class ActivityDevConsole extends AbstractDevConsole {
+
+    public record EndpointSend(
+            @Metadata(description = "The endpoint URI") String endpointUri,
+            @Metadata(description = "Whether the endpoint is remote") boolean remoteEndpoint,
+            @Metadata(description = "Elapsed time in milliseconds") long elapsed) {
+    }
+
+    public record ActivityEntry(
+            @Metadata(description = "Unique ID of the activity entry") long uid,
+            @Metadata(description = "The exchange ID") String exchangeId,
+            @Metadata(description = "The route ID (only present when known)") String routeId,
+            @Metadata(description = "The from endpoint URI (only present when known)") String fromEndpointUri,
+            @Metadata(description = "Epoch time in milliseconds (only present when known)") Long timestamp,
+            @Metadata(description = "Elapsed time in milliseconds") long elapsed,
+            @Metadata(description = "Whether the exchange failed") boolean failed,
+            @Metadata(description = "The exception message (only present when the exchange failed)") String exception,
+            @Metadata(description = "The endpoints this exchange was sent to (only present when any)") List<EndpointSend> endpointSends) {
+    }
+
+    public record Response(
+            @Metadata(description = "Whether activity tracking is enabled") Boolean activityEnabled,
+            @Metadata(description = "The maximum number of activity entries retained") Integer activitySize,
+            @Metadata(description = "The recent activity entries") List<ActivityEntry> activity) {
+    }
 
     public ActivityDevConsole() {
         super("camel", "activity", "Camel Activity", "Recent completed exchange activity");
@@ -60,51 +85,32 @@ public class ActivityDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         BacklogTracer tracer = getCamelContext().getCamelContextExtension().getContextPlugin(BacklogTracer.class);
-        if (tracer != null) {
-            root.put("activityEnabled", tracer.isActivityEnabled());
-            root.put("activitySize", tracer.getActivitySize());
 
-            JsonArray arr = new JsonArray();
-            root.put("activity", arr);
+        Response response;
+        if (tracer != null) {
+            List<ActivityEntry> activity = new ArrayList<>();
             for (BacklogTracerActivityMessage event : tracer.getActivity()) {
-                JsonObject jo = new JsonObject();
-                jo.put("uid", event.getUid());
-                jo.put("exchangeId", event.getExchangeId());
-                if (event.getRouteId() != null) {
-                    jo.put("routeId", event.getRouteId());
-                }
-                if (event.getFromEndpointUri() != null) {
-                    jo.put("fromEndpointUri", event.getFromEndpointUri());
-                }
-                if (event.getTimestamp() > 0) {
-                    jo.put("timestamp", event.getTimestamp());
-                }
-                jo.put("elapsed", event.getElapsed());
-                jo.put("failed", event.isFailed());
-                if (event.getExceptionMessage() != null) {
-                    jo.put("exception", event.getExceptionMessage());
-                }
-                List<BacklogTracerActivityMessage.EndpointSend> sends = event.getEndpointSends();
-                if (sends != null && !sends.isEmpty()) {
-                    JsonArray sa = new JsonArray();
-                    for (BacklogTracerActivityMessage.EndpointSend send : sends) {
-                        JsonObject so = new JsonObject();
-                        so.put("endpointUri", send.getEndpointUri());
-                        so.put("remoteEndpoint", send.isRemoteEndpoint());
-                        so.put("elapsed", send.getElapsed());
-                        sa.add(so);
+                List<EndpointSend> sends = null;
+                List<BacklogTracerActivityMessage.EndpointSend> eventSends = event.getEndpointSends();
+                if (eventSends != null && !eventSends.isEmpty()) {
+                    sends = new ArrayList<>();
+                    for (BacklogTracerActivityMessage.EndpointSend send : eventSends) {
+                        sends.add(new EndpointSend(send.getEndpointUri(), send.isRemoteEndpoint(), send.getElapsed()));
                     }
-                    jo.put("endpointSends", sa);
                 }
-                arr.add(jo);
+                Long timestamp = event.getTimestamp() > 0 ? event.getTimestamp() : null;
+                activity.add(new ActivityEntry(
+                        event.getUid(), event.getExchangeId(), event.getRouteId(), event.getFromEndpointUri(), timestamp,
+                        event.getElapsed(), event.isFailed(), event.getExceptionMessage(), sends));
             }
+            response = new Response(tracer.isActivityEnabled(), tracer.getActivitySize(), activity);
+        } else {
+            response = new Response(null, null, null);
         }
 
-        return root;
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/BeanDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/BeanDevConsole.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
@@ -26,12 +29,26 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "bean", description = "Displays Java beans from the registry")
 public class BeanDevConsole extends AbstractDevConsole {
+
+    public record PropertyEntry(
+            @Metadata(description = "The property name") String name,
+            @Metadata(description = "The property type (only present when the value is not null)") String type,
+            @Metadata(description = "The property value") Object value) {
+    }
+
+    public record BeanEntry(
+            @Metadata(description = "The bean name") String name,
+            @Metadata(description = "The bean class type") String type,
+            @Metadata(description = "The bean properties (only present when properties were requested and the bean has some)") List<PropertyEntry> properties) {
+    }
+
+    public record Response(@Metadata(description = "The beans, keyed by bean name") Map<String, BeanEntry> beans) {
+    }
 
     public BeanDevConsole() {
         super("camel", "bean", "Bean", "Displays Java beans from the registry");
@@ -102,22 +119,21 @@ public class BeanDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String filter = optionString(options, FILTER);
         boolean properties = optionBoolean(options, PROPERTIES, true);
         boolean nulls = optionBoolean(options, NULLS, true);
         boolean internal = optionBoolean(options, INTERNAL, true);
 
-        JsonObject root = new JsonObject();
-        JsonObject jo = new JsonObject();
-        root.put("beans", jo);
+        Map<String, BeanEntry> beans = new LinkedHashMap<>();
 
         BeanIntrospection bi = PluginHelper.getBeanIntrospection(getCamelContext());
         try {
-            Map<String, Object> beans = getCamelContext().getRegistry().findByTypeWithName(Object.class);
-            Stream<String> keys = beans.keySet().stream().filter(r -> accept(r, filter)).sorted(String::compareToIgnoreCase);
+            Map<String, Object> registryBeans = getCamelContext().getRegistry().findByTypeWithName(Object.class);
+            Stream<String> keys
+                    = registryBeans.keySet().stream().filter(r -> accept(r, filter)).sorted(String::compareToIgnoreCase);
             keys.forEach(k -> {
-                Object bean = beans.get(k);
+                Object bean = registryBeans.get(k);
                 if (bean != null) {
                     boolean include = internal || !bean.getClass().getName().startsWith("org.apache.camel.");
                     if (include) {
@@ -129,14 +145,13 @@ public class BeanDevConsole extends AbstractDevConsole {
                                 // ignore
                             }
                         }
-                        JsonObject jb = new JsonObject();
-                        jb.put("name", k);
-                        jb.put("type", bean.getClass().getName());
-                        jo.put(k, jb);
 
+                        List<PropertyEntry> props = null;
                         if (!values.isEmpty()) {
-                            JsonArray arr = new JsonArray();
-                            values.forEach((pk, pv) -> {
+                            props = new ArrayList<>();
+                            for (Map.Entry<String, Object> entry : values.entrySet()) {
+                                String pk = entry.getKey();
+                                Object pv = entry.getValue();
                                 Object value = pv;
                                 String type = pv != null ? pv.getClass().getName() : null;
                                 if (type != null) {
@@ -149,19 +164,14 @@ public class BeanDevConsole extends AbstractDevConsole {
                                         value = pv;
                                     }
                                 }
-                                JsonObject jp = new JsonObject();
-                                jp.put("name", pk);
-                                if (type != null) {
-                                    jp.put("type", type);
-                                }
-                                jp.put("value", value);
                                 boolean accept = value != null || nulls;
                                 if (accept) {
-                                    arr.add(jp);
+                                    props.add(new PropertyEntry(pk, type, value));
                                 }
-                            });
-                            jb.put("properties", arr);
+                            }
                         }
+
+                        beans.put(k, new BeanEntry(k, bean.getClass().getName(), props));
                     }
                 }
             });
@@ -169,7 +179,7 @@ public class BeanDevConsole extends AbstractDevConsole {
             // ignore
         }
 
-        return root;
+        return JsonRecordSupport.toJsonObject(new Response(beans));
     }
 
     private static boolean accept(String name, String filter) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/BlockedConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/BlockedConsole.java
@@ -16,18 +16,32 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.AsyncProcessorAwaitManager;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "blocked", displayName = "Blocked Exchanges", description = "Display blocked exchanges")
 public class BlockedConsole extends AbstractDevConsole {
+
+    public record Entry(
+            @Metadata(description = "The exchange ID") String exchangeId,
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The node ID") String nodeId,
+            @Metadata(description = "The wait duration in milliseconds") long duration) {
+    }
+
+    public record Response(
+            @Metadata(description = "Number of blocked exchanges") int blocked,
+            @Metadata(description = "The blocked exchanges (only present when there are any)") List<Entry> exchanges) {
+    }
 
     public BlockedConsole() {
         super("camel", "blocked", "Blocked Exchanges", "Display blocked exchanges");
@@ -49,25 +63,17 @@ public class BlockedConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         AsyncProcessorAwaitManager am = PluginHelper.getAsyncProcessorAwaitManager(getCamelContext());
-        root.put("blocked", am.size());
 
-        final JsonArray list = new JsonArray();
+        List<Entry> entries = new ArrayList<>();
         for (AsyncProcessorAwaitManager.AwaitThread at : am.browse()) {
-            JsonObject props = new JsonObject();
-            props.put("exchangeId", at.getExchange().getExchangeId());
-            props.put("routeId", at.getRouteId());
-            props.put("nodeId", at.getNodeId());
-            props.put("duration", at.getWaitDuration());
-            list.add(props);
+            entries.add(new Entry(
+                    at.getExchange().getExchangeId(), at.getRouteId(), at.getNodeId(), at.getWaitDuration()));
         }
-        if (!list.isEmpty()) {
-            root.put("exchanges", list);
-        }
-        return root;
+
+        Response response = new Response(am.size(), entries.isEmpty() ? null : entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/BrowseDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/BrowseDevConsole.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -30,11 +31,23 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "browse", description = "Browse pending messages on Camel components")
 public class BrowseDevConsole extends AbstractDevConsole {
+
+    public record BrowseEntry(
+            @Metadata(description = "The endpoint URI") String endpointUri,
+            @Metadata(description = "Number of messages currently in the queue") int queueSize,
+            @Metadata(description = "The maximum number of messages returned (only present when messages were dumped)") Integer limit,
+            @Metadata(description = "The starting position of the returned messages (only present when messages were dumped)") Integer position,
+            @Metadata(description = "Epoch time in milliseconds of the first returned message (only present when available)") Long firstTimestamp,
+            @Metadata(description = "Epoch time in milliseconds of the last returned message (only present when available)") Long lastTimestamp,
+            @Metadata(description = "The dumped messages, as opaque JSON objects (only present when messages were dumped and found)") List<Map<String, Object>> messages) {
+    }
+
+    public record Response(@Metadata(description = "The browsed endpoints") List<BrowseEntry> browse) {
+    }
 
     public BrowseDevConsole() {
         super("camel", "browse", "Browse", "Browse pending messages on Camel components");
@@ -141,9 +154,8 @@ public class BrowseDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<BrowseEntry> arr = new ArrayList<>();
 
         String filter = optionString(options, FILTER);
         final int pos = optionInt(options, TAIL, 0);
@@ -167,54 +179,42 @@ public class BrowseDevConsole extends AbstractDevConsole {
                         list = list.subList(begin, list.size());
                     }
                     if (list != null) {
-                        JsonObject jo = new JsonObject();
-                        jo.put("endpointUri", endpoint.getEndpointUri());
-                        jo.put("queueSize", queueSize);
-                        jo.put("limit", max);
-                        jo.put("position", begin);
+                        Long firstTimestamp = null;
+                        Long lastTimestamp = null;
                         if (!list.isEmpty()) {
                             long ts = list.get(0).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L, long.class);
                             if (ts > 0) {
-                                jo.put("firstTimestamp", ts);
+                                firstTimestamp = ts;
                             }
                             if (list.size() > 1) {
                                 ts = list.get(list.size() - 1).getMessage().getHeader(Exchange.MESSAGE_TIMESTAMP, 0L,
                                         long.class);
                                 if (ts > 0) {
-                                    jo.put("lastTimestamp", ts);
+                                    lastTimestamp = ts;
                                 }
                             }
                         }
-                        arr.add(jo);
-                        JsonArray arr2 = new JsonArray();
+                        List<Map<String, Object>> messages = new ArrayList<>();
                         for (Exchange e : list) {
-                            arr2.add(MessageHelper.dumpAsJSonObject(e.getMessage(), false, false, includeBody, true, true, true,
-                                    maxChars));
+                            messages.add(MessageHelper.dumpAsJSonObject(e.getMessage(), false, false, includeBody, true, true,
+                                    true, maxChars));
                         }
-                        if (!arr2.isEmpty()) {
-                            jo.put("messages", arr2);
-                        }
+                        arr.add(new BrowseEntry(
+                                endpoint.getEndpointUri(), queueSize, max, begin, firstTimestamp, lastTimestamp,
+                                messages.isEmpty() ? null : messages));
                     }
                 } else {
                     BrowsableEndpoint.BrowseStatus status = be.getBrowseStatus(Integer.MAX_VALUE);
-                    JsonObject jo = new JsonObject();
-                    jo.put("endpointUri", endpoint.getEndpointUri());
-                    jo.put("queueSize", status.size());
-                    if (status.firstTimestamp() > 0) {
-                        jo.put("firstTimestamp", status.firstTimestamp());
-                    }
-                    if (status.lastTimestamp() > 0) {
-                        jo.put("lastTimestamp", status.lastTimestamp());
-                    }
-                    arr.add(jo);
+                    Long firstTimestamp = status.firstTimestamp() > 0 ? status.firstTimestamp() : null;
+                    Long lastTimestamp = status.lastTimestamp() > 0 ? status.lastTimestamp() : null;
+                    arr.add(new BrowseEntry(
+                            endpoint.getEndpointUri(), status.size(), null, null, firstTimestamp, lastTimestamp, null));
                 }
             }
         }
-        if (!arr.isEmpty()) {
-            root.put("browse", arr);
-        }
 
-        return root;
+        Response response = new Response(arr.isEmpty() ? null : arr);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/CircuitBreakerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/CircuitBreakerDevConsole.java
@@ -16,19 +16,31 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Route;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.RoutePolicy;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.throttling.ThrottlingExceptionRoutePolicy;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "circuit-breaker", description = "Display circuit breaker information")
 public class CircuitBreakerDevConsole extends AbstractDevConsole {
+
+    public record Entry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The circuit breaker state") String state,
+            @Metadata(description = "Number of successful calls") int successfulCalls,
+            @Metadata(description = "Number of failed calls") int failedCalls) {
+    }
+
+    public record Response(@Metadata(description = "The circuit breakers") List<Entry> circuitBreakers) {
+    }
 
     public CircuitBreakerDevConsole() {
         super("camel", "circuit-breaker", "Circuit Breaker", "Display circuit breaker information");
@@ -57,23 +69,16 @@ public class CircuitBreakerDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
-        final JsonArray list = new JsonArray();
+        List<Entry> entries = new ArrayList<>();
         for (Route route : getCamelContext().getRoutes()) {
             for (RoutePolicy rp : route.getRoutePolicyList()) {
                 if (rp instanceof ThrottlingExceptionRoutePolicy cb) {
-                    JsonObject jo = new JsonObject();
-                    jo.put("routeId", route.getRouteId());
-                    jo.put("state", cb.getStateAsString());
-                    jo.put("successfulCalls", cb.getSuccess());
-                    jo.put("failedCalls", cb.getFailures());
-                    list.add(jo);
+                    entries.add(new Entry(route.getRouteId(), cb.getStateAsString(), cb.getSuccess(), cb.getFailures()));
                 }
             }
         }
-        root.put("circuitBreakers", list);
 
-        return root;
+        Response response = new Response(entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsumerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ConsumerDevConsole.java
@@ -17,7 +17,9 @@
 package org.apache.camel.impl.console;
 
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import javax.management.MBeanServer;
@@ -28,13 +30,68 @@ import org.apache.camel.api.management.ManagedCamelContext;
 import org.apache.camel.api.management.mbean.ManagedConsumerMBean;
 import org.apache.camel.api.management.mbean.ManagedRouteMBean;
 import org.apache.camel.api.management.mbean.ManagedSchedulePollConsumerMBean;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "consumer", displayName = "Consumers", description = "Display information about Camel consumers")
 public class ConsumerDevConsole extends AbstractDevConsole {
+
+    public record Statistics(
+            @Metadata(description = "Epoch time in milliseconds since the route has been idle") long idleSince,
+            @Metadata(description = "Total number of exchanges") long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges") long exchangesFailed,
+            @Metadata(description = "Number of inflight exchanges") long exchangesInflight,
+            @Metadata(description = "Mean processing time in milliseconds") long meanProcessingTime,
+            @Metadata(description = "Max processing time in milliseconds") long maxProcessingTime,
+            @Metadata(description = "Min processing time in milliseconds") long minProcessingTime,
+            @Metadata(description = "50th percentile processing time in milliseconds (only present when available)") Long p50ProcessingTime,
+            @Metadata(description = "95th percentile processing time in milliseconds (only present when available)") Long p95ProcessingTime,
+            @Metadata(description = "99th percentile processing time in milliseconds (only present when available)") Long p99ProcessingTime,
+            @Metadata(description = "Processing time in milliseconds of the last exchange (only present once an exchange has completed)") Long lastProcessingTime,
+            @Metadata(description = "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)") Long deltaProcessingTime,
+            @Metadata(description = "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)") Long lastCreatedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)") Long lastCompletedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)") Long lastFailureHandledExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failed (only present once one has occurred)") Long lastFailedExchangeTimestamp) {
+    }
+
+    public record ConsumerEntry(
+            @Metadata(description = "The route ID") String id,
+            @Metadata(description = "The endpoint URI") String uri,
+            @Metadata(description = "The consumer state") String state,
+            @Metadata(description = "The consumer service type") String clazz,
+            @Metadata(description = "Whether the endpoint is remote") boolean remote,
+            @Metadata(description = "Whether the consumer is a hosted service") boolean hosted,
+            @Metadata(description = "Number of inflight exchanges") int inflight,
+            @Metadata(description = "Whether the consumer is scheduled (a scheduled poll consumer or a timer consumer)") boolean scheduled,
+            @Metadata(description = "Whether currently polling (only present for scheduled poll consumers)") Boolean polling,
+            @Metadata(description = "Whether the first poll has completed (only present for scheduled poll consumers)") Boolean firstPollDone,
+            @Metadata(description = "Whether the scheduler has started (only present for scheduled poll consumers)") Boolean schedulerStarted,
+            @Metadata(description = "The scheduler class name (only present for scheduled poll consumers)") String schedulerClass,
+            @Metadata(description = "The repeat count (only present for scheduled poll consumers)") Long repeatCount,
+            @Metadata(description = "Whether a fixed delay is used (only present for scheduled poll consumers)") Boolean fixedDelay,
+            @Metadata(description = "The initial delay (only present for scheduled poll consumers)") Long initialDelay,
+            @Metadata(description = "The delay (only present for scheduled poll consumers)") Long delay,
+            @Metadata(description = "The time unit of the delay (only present for scheduled poll consumers)") String timeUnit,
+            @Metadata(description = "Whether greedy scheduling is used (only present for scheduled poll consumers)") Boolean greedy,
+            @Metadata(description = "The running logging level (only present for scheduled poll consumers or timer consumers)") String runningLoggingLevel,
+            @Metadata(description = "Total number of polls (only present for scheduled poll consumers or timer consumers)") Long totalCounter,
+            @Metadata(description = "Number of failed polls (only present for scheduled poll consumers)") Long errorCounter,
+            @Metadata(description = "Number of successful polls (only present for scheduled poll consumers)") Long successCounter,
+            @Metadata(description = "The backoff counter (only present for scheduled poll consumers)") Long backoffCounter,
+            @Metadata(description = "The backoff multiplier (only present for scheduled poll consumers)") Long backoffMultiplier,
+            @Metadata(description = "The backoff error threshold (only present for scheduled poll consumers)") Long backoffErrorThreshold,
+            @Metadata(description = "The backoff idle threshold (only present for scheduled poll consumers)") Long backoffIdleThreshold,
+            @Metadata(description = "The timer name (only present for camel-timer consumers)") String timerName,
+            @Metadata(description = "Whether a fixed rate is used (only present for camel-timer consumers)") Boolean fixedRate,
+            @Metadata(description = "The period (only present for camel-timer consumers)") Long period,
+            @Metadata(description = "Runtime statistics for the route") Statistics statistics) {
+    }
+
+    public record Response(@Metadata(description = "The consumers") List<ConsumerEntry> consumers) {
+    }
 
     public ConsumerDevConsole() {
         super("camel", "consumer", "Consumers", "Display information about Camel consumers");
@@ -129,10 +186,8 @@ public class ConsumerDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
-        root.put("consumers", list);
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        final List<ConsumerEntry> list = new ArrayList<>();
 
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
         if (mcc != null) {
@@ -141,43 +196,57 @@ public class ConsumerDevConsole extends AbstractDevConsole {
                 ManagedRouteMBean mr = mcc.getManagedRoute(id);
                 ManagedConsumerMBean mc = mcc.getManagedConsumer(id);
                 if (mr != null && mc != null) {
-                    JsonObject jo = new JsonObject();
-                    Integer inflight = mc.getInflightExchanges();
-                    if (inflight == null) {
-                        inflight = 0;
-                    }
+                    Integer inflightObj = mc.getInflightExchanges();
+                    int inflight = inflightObj != null ? inflightObj : 0;
 
-                    jo.put("id", id);
-                    jo.put("uri", mc.getEndpointUri());
-                    jo.put("state", mc.getState());
-                    jo.put("class", mc.getServiceType());
-                    jo.put("remote", mc.isRemoteEndpoint());
-                    jo.put("hosted", mc.isHostedService());
-                    jo.put("inflight", inflight);
-                    jo.put("scheduled", false);
+                    boolean scheduled = false;
+                    Boolean polling = null;
+                    Boolean firstPollDone = null;
+                    Boolean schedulerStarted = null;
+                    String schedulerClass = null;
+                    Long repeatCount = null;
+                    Boolean fixedDelay = null;
+                    Long initialDelay = null;
+                    Long delay = null;
+                    String timeUnit = null;
+                    Boolean greedy = null;
+                    String runningLoggingLevel = null;
+                    Long totalCounter = null;
+                    Long errorCounter = null;
+                    Long successCounter = null;
+                    Long backoffCounter = null;
+                    Long backoffMultiplier = null;
+                    Long backoffErrorThreshold = null;
+                    Long backoffIdleThreshold = null;
+                    String timerName = null;
+                    Boolean fixedRate = null;
+                    Long period = null;
+
+                    // NOTE: this checks mcc (the ManagedCamelContext), not mc (the consumer) - so this branch is
+                    // effectively dead code, but that pre-existing behavior is preserved as-is here
                     if (mcc instanceof ManagedSchedulePollConsumerMBean mpc) {
-                        jo.put("scheduled", true);
-                        jo.put("polling", mpc.isPolling());
-                        jo.put("firstPollDone", mpc.isFirstPollDone());
-                        jo.put("schedulerStarted", mpc.isSchedulerStarted());
-                        jo.put("schedulerClass", mpc.getSchedulerClassName());
-                        jo.put("repeatCount", mpc.getRepeatCount());
-                        jo.put("fixedDelay", mpc.isUseFixedDelay());
-                        jo.put("initialDelay", mpc.getInitialDelay());
-                        jo.put("delay", mpc.getDelay());
-                        jo.put("timeUnit", mpc.getTimeUnit());
-                        jo.put("greedy", mpc.isGreedy());
-                        jo.put("runningLoggingLevel", mpc.getRunningLoggingLevel());
-                        jo.put("totalCounter", mpc.getCounter());
-                        jo.put("errorCounter", mpc.getErrorCounter());
-                        jo.put("successCounter", mpc.getSuccessCounter());
-                        jo.put("backoffCounter", mpc.getBackoffCounter());
-                        jo.put("backoffMultiplier", mpc.getBackoffMultiplier());
-                        jo.put("backoffErrorThreshold", mpc.getBackoffErrorThreshold());
-                        jo.put("backoffIdleThreshold", mpc.getBackoffIdleThreshold());
+                        scheduled = true;
+                        polling = mpc.isPolling();
+                        firstPollDone = mpc.isFirstPollDone();
+                        schedulerStarted = mpc.isSchedulerStarted();
+                        schedulerClass = mpc.getSchedulerClassName();
+                        repeatCount = mpc.getRepeatCount();
+                        fixedDelay = mpc.isUseFixedDelay();
+                        initialDelay = mpc.getInitialDelay();
+                        delay = mpc.getDelay();
+                        timeUnit = mpc.getTimeUnit();
+                        greedy = mpc.isGreedy();
+                        runningLoggingLevel = mpc.getRunningLoggingLevel();
+                        totalCounter = mpc.getCounter();
+                        errorCounter = mpc.getErrorCounter();
+                        successCounter = mpc.getSuccessCounter();
+                        backoffCounter = (long) mpc.getBackoffCounter();
+                        backoffMultiplier = (long) mpc.getBackoffMultiplier();
+                        backoffErrorThreshold = (long) mpc.getBackoffErrorThreshold();
+                        backoffIdleThreshold = (long) mpc.getBackoffIdleThreshold();
                     }
                     if ("TimerConsumer".equals(mc.getServiceType())) {
-                        jo.put("scheduled", true);
+                        scheduled = true;
                         // need to use JMX to gather details for camel-timer consumer
                         try {
                             MBeanServer ms = ManagementFactory.getPlatformMBeanServer();
@@ -185,80 +254,68 @@ public class ConsumerDevConsole extends AbstractDevConsole {
                                     .getObjectNameForConsumer(getCamelContext(),
                                             route.getConsumer());
                             if (ms.isRegistered(on)) {
-                                String timerName = (String) ms.getAttribute(on, "TimerName");
-                                Long counter = (Long) ms.getAttribute(on, "Counter");
-                                Boolean polling = (Boolean) ms.getAttribute(on, "Polling");
-                                Boolean fixedRate = (Boolean) ms.getAttribute(on, "FixedRate");
-                                Long delay = (Long) ms.getAttribute(on, "Delay");
-                                Long period = (Long) ms.getAttribute(on, "Period");
-                                Long repeatCount = (Long) ms.getAttribute(on, "RepeatCount");
-                                String runLoggingLevel = (String) ms.getAttribute(on, "RunLoggingLevel");
-
-                                jo.put("timerName", timerName);
-                                jo.put("polling", polling);
-                                jo.put("fixedRate", fixedRate);
-                                if (delay != null) {
-                                    jo.put("delay", delay);
-                                }
-                                if (period != null) {
-                                    jo.put("period", period);
-                                }
-                                if (repeatCount != null) {
-                                    jo.put("repeatCount", repeatCount);
-                                }
-                                jo.put("runningLoggingLevel", runLoggingLevel);
-                                jo.put("totalCounter", counter);
+                                timerName = (String) ms.getAttribute(on, "TimerName");
+                                totalCounter = (Long) ms.getAttribute(on, "Counter");
+                                polling = (Boolean) ms.getAttribute(on, "Polling");
+                                fixedRate = (Boolean) ms.getAttribute(on, "FixedRate");
+                                delay = (Long) ms.getAttribute(on, "Delay");
+                                period = (Long) ms.getAttribute(on, "Period");
+                                repeatCount = (Long) ms.getAttribute(on, "RepeatCount");
+                                runningLoggingLevel = (String) ms.getAttribute(on, "RunLoggingLevel");
                             }
                         } catch (Exception e) {
                             // ignore
                         }
                     }
-                    final JsonObject stats = toJsonObject(mr);
-                    jo.put("statistics", stats);
 
-                    list.add(jo);
+                    Statistics stats = toStatistics(mr);
+
+                    list.add(new ConsumerEntry(
+                            id, mc.getEndpointUri(), mc.getState(), mc.getServiceType(), mc.isRemoteEndpoint(),
+                            mc.isHostedService(), inflight, scheduled, polling, firstPollDone, schedulerStarted,
+                            schedulerClass, repeatCount, fixedDelay, initialDelay, delay, timeUnit, greedy,
+                            runningLoggingLevel, totalCounter, errorCounter, successCounter, backoffCounter,
+                            backoffMultiplier, backoffErrorThreshold, backoffIdleThreshold, timerName, fixedRate,
+                            period, stats));
                 }
             }
         }
 
-        return root;
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static JsonObject toJsonObject(ManagedRouteMBean mr) {
-        JsonObject stats = new JsonObject();
-        stats.put("idleSince", mr.getIdleSince());
-        stats.put("exchangesTotal", mr.getExchangesTotal());
-        stats.put("exchangesFailed", mr.getExchangesFailed());
-        stats.put("exchangesInflight", mr.getExchangesInflight());
-        stats.put("meanProcessingTime", mr.getMeanProcessingTime());
-        stats.put("maxProcessingTime", mr.getMaxProcessingTime());
-        stats.put("minProcessingTime", mr.getMinProcessingTime());
+    private static Statistics toStatistics(ManagedRouteMBean mr) {
+        Long p50 = null;
+        Long p95 = null;
+        Long p99 = null;
         if (mr.getProcessingTimeP50() >= 0) {
-            stats.put("p50ProcessingTime", mr.getProcessingTimeP50());
-            stats.put("p95ProcessingTime", mr.getProcessingTimeP95());
-            stats.put("p99ProcessingTime", mr.getProcessingTimeP99());
+            p50 = mr.getProcessingTimeP50();
+            p95 = mr.getProcessingTimeP95();
+            p99 = mr.getProcessingTimeP99();
         }
+
+        Long lastProcessingTime = null;
+        Long deltaProcessingTime = null;
         if (mr.getExchangesTotal() > 0) {
-            stats.put("lastProcessingTime", mr.getLastProcessingTime());
-            stats.put("deltaProcessingTime", mr.getDeltaProcessingTime());
+            lastProcessingTime = mr.getLastProcessingTime();
+            deltaProcessingTime = mr.getDeltaProcessingTime();
         }
-        Date last = mr.getLastExchangeCreatedTimestamp();
-        if (last != null) {
-            stats.put("lastCreatedExchangeTimestamp", last.getTime());
-        }
-        last = mr.getLastExchangeCompletedTimestamp();
-        if (last != null) {
-            stats.put("lastCompletedExchangeTimestamp", last.getTime());
-        }
-        last = mr.getLastExchangeFailureHandledTimestamp();
-        if (last != null) {
-            stats.put("lastFailureHandledExchangeTimestamp", last.getTime());
-        }
-        last = mr.getLastExchangeFailureTimestamp();
-        if (last != null) {
-            stats.put("lastFailedExchangeTimestamp", last.getTime());
-        }
-        return stats;
+
+        Long lastCreated = timestampOf(mr.getLastExchangeCreatedTimestamp());
+        Long lastCompleted = timestampOf(mr.getLastExchangeCompletedTimestamp());
+        Long lastFailureHandled = timestampOf(mr.getLastExchangeFailureHandledTimestamp());
+        Long lastFailed = timestampOf(mr.getLastExchangeFailureTimestamp());
+
+        return new Statistics(
+                mr.getIdleSince(), mr.getExchangesTotal(), mr.getExchangesFailed(), mr.getExchangesInflight(),
+                mr.getMeanProcessingTime(), mr.getMaxProcessingTime(), mr.getMinProcessingTime(),
+                p50, p95, p99, lastProcessingTime, deltaProcessingTime,
+                lastCreated, lastCompleted, lastFailureHandled, lastFailed);
+    }
+
+    private static Long timestampOf(Date date) {
+        return date != null ? date.getTime() : null;
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ContextDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ContextDevConsole.java
@@ -16,8 +16,9 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +27,7 @@ import org.apache.camel.ContextEvents;
 import org.apache.camel.api.management.ManagedCamelContext;
 import org.apache.camel.api.management.mbean.ManagedCamelContextMBean;
 import org.apache.camel.clock.Clock;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.ReloadStrategy;
 import org.apache.camel.spi.ResourceReloadStrategy;
 import org.apache.camel.spi.annotations.DevConsole;
@@ -33,11 +35,63 @@ import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.support.ExceptionHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "context", displayName = "CamelContext", description = "Overall information about the CamelContext")
 public class ContextDevConsole extends AbstractDevConsole {
+
+    public record LastError(
+            @Metadata(description = "The error message") String message,
+            @Metadata(description = "The error stack trace, one entry per line") List<String> stackTrace) {
+    }
+
+    public record Reload(
+            @Metadata(description = "Number of successful reloads") int reloaded,
+            @Metadata(description = "Number of failed reloads") int failed,
+            @Metadata(description = "The last reload error (only present when a reload has failed)") LastError lastError) {
+    }
+
+    public record Statistics(
+            @Metadata(description = "Total number of routes") int routesTotal,
+            @Metadata(description = "Number of started routes") int routesStarted,
+            @Metadata(description = "1 minute load average (only present when available)") String load01,
+            @Metadata(description = "5 minute load average (only present when available)") String load05,
+            @Metadata(description = "15 minute load average (only present when available)") String load15,
+            @Metadata(description = "Messages per second throughput (only present when available)") String exchangesThroughput,
+            @Metadata(description = "Epoch time in milliseconds since the context has been idle") long idleSince,
+            @Metadata(description = "Total number of exchanges") long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges") long exchangesFailed,
+            @Metadata(description = "Number of inflight exchanges") long exchangesInflight,
+            @Metadata(description = "Total number of remote exchanges") long remoteExchangesTotal,
+            @Metadata(description = "Number of failed remote exchanges") long remoteExchangesFailed,
+            @Metadata(description = "Number of inflight remote exchanges") long remoteExchangesInflight,
+            @Metadata(description = "Mean processing time in milliseconds") long meanProcessingTime,
+            @Metadata(description = "Max processing time in milliseconds") long maxProcessingTime,
+            @Metadata(description = "Min processing time in milliseconds") long minProcessingTime,
+            @Metadata(description = "50th percentile processing time in milliseconds (only present when available)") Long p50ProcessingTime,
+            @Metadata(description = "95th percentile processing time in milliseconds (only present when available)") Long p95ProcessingTime,
+            @Metadata(description = "99th percentile processing time in milliseconds (only present when available)") Long p99ProcessingTime,
+            @Metadata(description = "Processing time in milliseconds of the last exchange (only present once an exchange has completed)") Long lastProcessingTime,
+            @Metadata(description = "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)") Long deltaProcessingTime,
+            @Metadata(description = "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)") Long lastCreatedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)") Long lastCompletedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)") Long lastFailureHandledExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failed (only present once one has occurred)") Long lastFailedExchangeTimestamp,
+            @Metadata(description = "Reload statistics") Reload reload) {
+    }
+
+    public record Response(
+            @Metadata(description = "The CamelContext name") String name,
+            @Metadata(description = "The CamelContext description (only present when configured)") String description,
+            @Metadata(description = "The active profile (only present when configured)") String profile,
+            @Metadata(description = "The Camel version") String version,
+            @Metadata(description = "The CamelContext state") String state,
+            @Metadata(description = "The CamelContext lifecycle phase") int phase,
+            @Metadata(description = "Epoch time in milliseconds the CamelContext was started (only present once started)") Long startTimestamp,
+            @Metadata(description = "Uptime in milliseconds") long uptime,
+            @Metadata(description = "Whether dev mode (live reload) is active") boolean devMode,
+            @Metadata(description = "Runtime statistics (only present when management is enabled)") Statistics statistics) {
+    }
 
     public ContextDevConsole() {
         super("camel", "context", "CamelContext", "Overall information about the CamelContext");
@@ -134,115 +188,91 @@ public class ContextDevConsole extends AbstractDevConsole {
         return sb.toString();
     }
 
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        root.put("name", getCamelContext().getName());
-        if (getCamelContext().getDescription() != null) {
-            root.put("description", getCamelContext().getDescription());
-        }
-        if (getCamelContext().getCamelContextExtension().getProfile() != null) {
-            root.put("profile", getCamelContext().getCamelContextExtension().getProfile());
-        }
-        root.put("version", getCamelContext().getVersion());
-        root.put("state", getCamelContext().getStatus().name());
-        root.put("phase", getCamelContext().getCamelContextExtension().getStatusPhase());
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String description = getCamelContext().getDescription();
+        String profile = getCamelContext().getCamelContextExtension().getProfile();
         long uptimeMillis = getCamelContext().getUptime().toMillis();
         Clock startClock = getCamelContext().getClock().get(ContextEvents.START);
-        if (startClock != null) {
-            root.put("startTimestamp", startClock.getCreated());
-        }
-        root.put("uptime", uptimeMillis);
-        root.put("devMode", getCamelContext().hasService(ResourceReloadStrategy.class) != null);
+        Long startTimestamp = startClock != null ? startClock.getCreated() : null;
+        int phase = getCamelContext().getCamelContextExtension().getStatusPhase();
+        boolean devMode = getCamelContext().hasService(ResourceReloadStrategy.class) != null;
 
+        Statistics stats = null;
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
         if (mcc != null) {
             ManagedCamelContextMBean mb = mcc.getManagedCamelContext();
             if (mb != null) {
-                JsonObject stats = new JsonObject();
-
-                int total = mb.getTotalRoutes();
-                int started = mb.getStartedRoutes();
-                stats.put("routesTotal", total);
-                stats.put("routesStarted", started);
-
-                String load1 = getLoad1(mb);
-                String load5 = getLoad5(mb);
-                String load15 = getLoad15(mb);
-                if (!load1.isEmpty() || !load5.isEmpty() || !load15.isEmpty()) {
-                    stats.put("load01", load1);
-                    stats.put("load05", load5);
-                    stats.put("load15", load15);
-                }
-                String thp = getThroughput(mb);
-                if (!thp.isEmpty()) {
-                    stats.put("exchangesThroughput", thp);
-                }
-                stats.put("idleSince", mb.getIdleSince());
-                stats.put("exchangesTotal", mb.getExchangesTotal());
-                stats.put("exchangesFailed", mb.getExchangesFailed());
-                stats.put("exchangesInflight", mb.getExchangesInflight());
-                stats.put("remoteExchangesTotal", mb.getRemoteExchangesTotal());
-                stats.put("remoteExchangesFailed", mb.getRemoteExchangesFailed());
-                stats.put("remoteExchangesInflight", mb.getRemoteExchangesInflight());
-                stats.put("meanProcessingTime", mb.getMeanProcessingTime());
-                stats.put("maxProcessingTime", mb.getMaxProcessingTime());
-                stats.put("minProcessingTime", mb.getMinProcessingTime());
-                if (mb.getProcessingTimeP50() >= 0) {
-                    stats.put("p50ProcessingTime", mb.getProcessingTimeP50());
-                    stats.put("p95ProcessingTime", mb.getProcessingTimeP95());
-                    stats.put("p99ProcessingTime", mb.getProcessingTimeP99());
-                }
-                if (mb.getExchangesTotal() > 0) {
-                    stats.put("lastProcessingTime", mb.getLastProcessingTime());
-                    stats.put("deltaProcessingTime", mb.getDeltaProcessingTime());
-                }
-                Date last = mb.getLastExchangeCreatedTimestamp();
-                if (last != null) {
-                    stats.put("lastCreatedExchangeTimestamp", last.getTime());
-                }
-                last = mb.getLastExchangeCompletedTimestamp();
-                if (last != null) {
-                    stats.put("lastCompletedExchangeTimestamp", last.getTime());
-                }
-                last = mb.getLastExchangeFailureHandledTimestamp();
-                if (last != null) {
-                    stats.put("lastFailureHandledExchangeTimestamp", last.getTime());
-                }
-                last = mb.getLastExchangeFailureTimestamp();
-                if (last != null) {
-                    stats.put("lastFailedExchangeTimestamp", last.getTime());
-                }
-                // reload stats
-                int reloaded = 0;
-                int reloadedFailed = 0;
-                Exception reloadCause = null;
-                Set<ReloadStrategy> rs = getCamelContext().hasServices(ReloadStrategy.class);
-                for (ReloadStrategy r : rs) {
-                    reloaded += r.getReloadCounter();
-                    reloadedFailed += r.getFailedCounter();
-                    if (reloadCause == null) {
-                        reloadCause = r.getLastError();
-                    }
-                }
-                JsonObject ro = new JsonObject();
-                ro.put("reloaded", reloaded);
-                ro.put("failed", reloadedFailed);
-                if (reloadCause != null) {
-                    JsonObject eo = new JsonObject();
-                    eo.put("message", reloadCause.getMessage());
-                    JsonArray arr2 = new JsonArray();
-                    final String trace = ExceptionHelper.stackTraceToString(reloadCause);
-                    eo.put("stackTrace", arr2);
-                    Collections.addAll(arr2, trace.split("\n"));
-                    ro.put("lastError", eo);
-                }
-                stats.put("reload", ro);
-
-                root.put("statistics", stats);
+                stats = buildStatistics(mb);
             }
         }
 
-        return root;
+        Response response = new Response(
+                getCamelContext().getName(), description, profile, getCamelContext().getVersion(),
+                getCamelContext().getStatus().name(), phase, startTimestamp, uptimeMillis, devMode, stats);
+        return JsonRecordSupport.toJsonObject(response);
+    }
+
+    private Statistics buildStatistics(ManagedCamelContextMBean mb) {
+        String load1 = getLoad1(mb);
+        String load5 = getLoad5(mb);
+        String load15 = getLoad15(mb);
+        boolean hasLoad = !load1.isEmpty() || !load5.isEmpty() || !load15.isEmpty();
+
+        String thp = getThroughput(mb);
+
+        Long p50 = null;
+        Long p95 = null;
+        Long p99 = null;
+        if (mb.getProcessingTimeP50() >= 0) {
+            p50 = mb.getProcessingTimeP50();
+            p95 = mb.getProcessingTimeP95();
+            p99 = mb.getProcessingTimeP99();
+        }
+
+        Long lastProcessingTime = null;
+        Long deltaProcessingTime = null;
+        if (mb.getExchangesTotal() > 0) {
+            lastProcessingTime = mb.getLastProcessingTime();
+            deltaProcessingTime = mb.getDeltaProcessingTime();
+        }
+
+        Long lastCreated = timestampOf(mb.getLastExchangeCreatedTimestamp());
+        Long lastCompleted = timestampOf(mb.getLastExchangeCompletedTimestamp());
+        Long lastFailureHandled = timestampOf(mb.getLastExchangeFailureHandledTimestamp());
+        Long lastFailed = timestampOf(mb.getLastExchangeFailureTimestamp());
+
+        // reload stats
+        int reloaded = 0;
+        int reloadedFailed = 0;
+        Exception reloadCause = null;
+        Set<ReloadStrategy> rs = getCamelContext().hasServices(ReloadStrategy.class);
+        for (ReloadStrategy r : rs) {
+            reloaded += r.getReloadCounter();
+            reloadedFailed += r.getFailedCounter();
+            if (reloadCause == null) {
+                reloadCause = r.getLastError();
+            }
+        }
+        LastError lastError = null;
+        if (reloadCause != null) {
+            final String trace = ExceptionHelper.stackTraceToString(reloadCause);
+            lastError = new LastError(reloadCause.getMessage(), Arrays.asList(trace.split("\n")));
+        }
+        Reload reload = new Reload(reloaded, reloadedFailed, lastError);
+
+        return new Statistics(
+                mb.getTotalRoutes(), mb.getStartedRoutes(),
+                hasLoad ? load1 : null, hasLoad ? load5 : null, hasLoad ? load15 : null,
+                thp.isEmpty() ? null : thp,
+                mb.getIdleSince(), mb.getExchangesTotal(), mb.getExchangesFailed(), mb.getExchangesInflight(),
+                mb.getRemoteExchangesTotal(), mb.getRemoteExchangesFailed(), mb.getRemoteExchangesInflight(),
+                mb.getMeanProcessingTime(), mb.getMaxProcessingTime(), mb.getMinProcessingTime(),
+                p50, p95, p99, lastProcessingTime, deltaProcessingTime,
+                lastCreated, lastCompleted, lastFailureHandled, lastFailed, reload);
+    }
+
+    private static Long timestampOf(Date date) {
+        return date != null ? date.getTime() : null;
     }
 
     private String getLoad1(ManagedCamelContextMBean mb) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/DataSourceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/DataSourceDevConsole.java
@@ -17,15 +17,17 @@
 package org.apache.camel.impl.console;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
 
 import org.apache.camel.spi.Configurer;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "datasource", displayName = "DataSource", description = "Displays DataSource connection pool metrics")
 @Configurer(extended = true)
@@ -33,6 +35,24 @@ public class DataSourceDevConsole extends AbstractDevConsole {
 
     private static final String HIKARI_CLASS = "com.zaxxer.hikari.HikariDataSource";
     private static final String AGROAL_CLASS = "io.agroal.api.AgroalDataSource";
+
+    public record Entry(
+            @Metadata(description = "The registry bean name") String name,
+            @Metadata(description = "The DataSource implementation class") String type,
+            @Metadata(description = "The detected connection pool type: HikariCP, Agroal, or Unknown") String poolType,
+            @Metadata(description = "The pool name (HikariCP only)") String poolName,
+            @Metadata(description = "The maximum pool size (only present once the pool is initialized)") Long maxPoolSize,
+            @Metadata(description = "Number of active connections (only present once the pool is initialized)") Long active,
+            @Metadata(description = "Number of idle connections (only present once the pool is initialized)") Long idle,
+            @Metadata(description = "Total number of connections (only present once the pool is initialized)") Long total,
+            @Metadata(description = "Number of threads awaiting a connection (HikariCP only)") Long waiting,
+            @Metadata(description = "Maximum number of connections used at once (Agroal only)") Long maxUsed,
+            @Metadata(description = "Number of leak detections (Agroal only)") Long leakDetection,
+            @Metadata(description = "Number of connections created (Agroal only)") Long created) {
+    }
+
+    public record Response(@Metadata(description = "The DataSources") List<Entry> dataSources) {
+    }
 
     public DataSourceDevConsole() {
         super("camel", "datasource", "DataSource", "Displays DataSource connection pool metrics");
@@ -69,9 +89,8 @@ public class DataSourceDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<Entry> entries = new ArrayList<>();
 
         Map<String, DataSource> dataSources
                 = getCamelContext().getRegistry().findByTypeWithName(DataSource.class);
@@ -80,22 +99,21 @@ public class DataSourceDevConsole extends AbstractDevConsole {
             DataSource ds = entry.getValue();
             String poolType = detectPoolType(ds);
 
-            JsonObject jo = new JsonObject();
-            jo.put("name", entry.getKey());
-            jo.put("type", ds.getClass().getName());
-            jo.put("poolType", poolType);
-
+            Entry e;
             if ("HikariCP".equals(poolType)) {
-                collectHikariMetrics(jo, ds);
+                e = collectHikariMetrics(entry.getKey(), ds, poolType);
             } else if ("Agroal".equals(poolType)) {
-                collectAgroalMetrics(jo, ds);
+                e = collectAgroalMetrics(entry.getKey(), ds, poolType);
+            } else {
+                e = new Entry(
+                        entry.getKey(), ds.getClass().getName(), poolType, null, null, null, null, null, null, null,
+                        null, null);
             }
-
-            arr.add(jo);
+            entries.add(e);
         }
 
-        root.put("dataSources", arr);
-        return root;
+        Response response = new Response(entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static String detectPoolType(DataSource ds) {
@@ -110,23 +128,26 @@ public class DataSourceDevConsole extends AbstractDevConsole {
 
     // ---- HikariCP ----
 
-    private void collectHikariMetrics(JsonObject jo, DataSource ds) {
-        Object poolName = invokeMethod(ds, "getPoolName");
-        if (poolName != null) {
-            jo.put("poolName", String.valueOf(poolName));
-        }
-        Object maxPoolSize = invokeMethod(ds, "getMaximumPoolSize");
-        if (maxPoolSize instanceof Number n) {
-            jo.put("maxPoolSize", n.intValue());
-        }
+    private Entry collectHikariMetrics(String name, DataSource ds, String poolType) {
+        Object poolNameObj = invokeMethod(ds, "getPoolName");
+        String poolName = poolNameObj != null ? String.valueOf(poolNameObj) : null;
+        Long maxPoolSize = asLong(invokeMethod(ds, "getMaximumPoolSize"));
 
+        Long active = null;
+        Long idle = null;
+        Long total = null;
+        Long waiting = null;
         Object mxBean = invokeMethod(ds, "getHikariPoolMXBean");
         if (mxBean != null) {
-            putInt(jo, "active", invokeMethod(mxBean, "getActiveConnections"));
-            putInt(jo, "idle", invokeMethod(mxBean, "getIdleConnections"));
-            putInt(jo, "total", invokeMethod(mxBean, "getTotalConnections"));
-            putInt(jo, "waiting", invokeMethod(mxBean, "getThreadsAwaitingConnection"));
+            active = asLong(invokeMethod(mxBean, "getActiveConnections"));
+            idle = asLong(invokeMethod(mxBean, "getIdleConnections"));
+            total = asLong(invokeMethod(mxBean, "getTotalConnections"));
+            waiting = asLong(invokeMethod(mxBean, "getThreadsAwaitingConnection"));
         }
+
+        return new Entry(
+                name, ds.getClass().getName(), poolType, poolName, maxPoolSize, active, idle, total, waiting, null, null,
+                null);
     }
 
     private void appendHikariText(StringBuilder sb, DataSource ds) {
@@ -152,34 +173,37 @@ public class DataSourceDevConsole extends AbstractDevConsole {
 
     // ---- Agroal ----
 
-    private void collectAgroalMetrics(JsonObject jo, DataSource ds) {
+    private Entry collectAgroalMetrics(String name, DataSource ds, String poolType) {
+        Long active = null;
+        Long idle = null;
+        Long maxUsed = null;
+        Long leakDetection = null;
+        Long created = null;
         Object metrics = invokeMethod(ds, "getMetrics");
         if (metrics != null) {
-            putLong(jo, "active", invokeMethod(metrics, "activeCount"));
-            putLong(jo, "idle", invokeMethod(metrics, "availableCount"));
-            putLong(jo, "maxUsed", invokeMethod(metrics, "maxUsedCount"));
-            putLong(jo, "leakDetection", invokeMethod(metrics, "leakDetectionCount"));
-            putLong(jo, "created", invokeMethod(metrics, "creationCount"));
+            active = asLong(invokeMethod(metrics, "activeCount"));
+            idle = asLong(invokeMethod(metrics, "availableCount"));
+            maxUsed = asLong(invokeMethod(metrics, "maxUsedCount"));
+            leakDetection = asLong(invokeMethod(metrics, "leakDetectionCount"));
+            created = asLong(invokeMethod(metrics, "creationCount"));
         }
 
         // max pool size via configuration chain
+        Long maxPoolSize = null;
         Object config = invokeMethod(ds, "getConfiguration");
         if (config != null) {
             Object poolConfig = invokeMethod(config, "connectionPoolConfiguration");
             if (poolConfig != null) {
-                Object maxSize = invokeMethod(poolConfig, "maxSize");
-                if (maxSize instanceof Number n) {
-                    jo.put("maxPoolSize", n.intValue());
-                }
+                maxPoolSize = asLong(invokeMethod(poolConfig, "maxSize"));
             }
         }
 
         // compute total from active + idle
-        Object active = jo.get("active");
-        Object idle = jo.get("idle");
-        if (active instanceof Number a && idle instanceof Number i) {
-            jo.put("total", a.longValue() + i.longValue());
-        }
+        Long total = active != null && idle != null ? active + idle : null;
+
+        return new Entry(
+                name, ds.getClass().getName(), poolType, null, maxPoolSize, active, idle, total, null, maxUsed,
+                leakDetection, created);
     }
 
     private void appendAgroalText(StringBuilder sb, DataSource ds) {
@@ -211,15 +235,7 @@ public class DataSourceDevConsole extends AbstractDevConsole {
         }
     }
 
-    private static void putInt(JsonObject jo, String key, Object value) {
-        if (value instanceof Number n) {
-            jo.put(key, n.intValue());
-        }
-    }
-
-    private static void putLong(JsonObject jo, String key, Object value) {
-        if (value instanceof Number n) {
-            jo.put(key, n.longValue());
-        }
+    private static Long asLong(Object value) {
+        return value instanceof Number n ? n.longValue() : null;
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/DebugDevConsole.java
@@ -39,10 +39,33 @@ import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "debug", description = "Camel route debugger", readOnly = false)
 public class DebugDevConsole extends AbstractDevConsole {
+
+    public record BreakpointEntry(
+            @Metadata(description = "The breakpoint node ID") String nodeId,
+            @Metadata(description = "Whether the breakpoint is currently suspended") boolean suspended) {
+    }
+
+    public record Response(
+            @Metadata(description = "The Camel version (only present when a backlog debugger is available)") String version,
+            @Metadata(description = "Whether the debugger is enabled (only present when a backlog debugger is available)") Boolean enabled,
+            @Metadata(description = "Whether the debugger is in standby mode (only present when a backlog debugger is available)") Boolean standby,
+            @Metadata(description = "Whether suspended mode is active (only present when a backlog debugger is available)") Boolean suspendedMode,
+            @Metadata(description = "Fallback timeout in seconds (only present when a backlog debugger is available)") Long fallbackTimeout,
+            @Metadata(description = "The logging level (only present when a backlog debugger is available)") String loggingLevel,
+            @Metadata(description = "Whether exchange properties are included (only present when a backlog debugger is available)") Boolean includeExchangeProperties,
+            @Metadata(description = "Whether file-based message bodies are included (only present when a backlog debugger is available)") Boolean includeFiles,
+            @Metadata(description = "Whether streaming message bodies are included (only present when a backlog debugger is available)") Boolean includeStreams,
+            @Metadata(description = "Maximum size of the message body to include (only present when a backlog debugger is available)") Integer maxChars,
+            @Metadata(description = "Total number of times a breakpoint has been hit (only present when a backlog debugger is available)") Long debugCounter,
+            @Metadata(description = "Whether single-step mode is active (only present when a backlog debugger is available)") Boolean singleStepMode,
+            @Metadata(description = "The configured breakpoints (only present when there are any)") List<BreakpointEntry> breakpoints,
+            @Metadata(description = "The suspended breakpoint messages, as opaque JSON objects enriched with source code and message history (only present when there are any)") List<Map<String, Object>> suspended) {
+    }
 
     @Metadata(label = "query", description = "Action command to execute on the debugger", javaType = "java.lang.String")
     public static final String COMMAND = "command";
@@ -209,8 +232,6 @@ public class DebugDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
         String command = optionString(options, COMMAND);
         String breakpoint = optionString(options, BREAKPOINT);
         int codeLimit = optionInt(options, CODE_LIMIT, 5);
@@ -219,42 +240,53 @@ public class DebugDevConsole extends AbstractDevConsole {
 
         if (ObjectHelper.isNotEmpty(command)) {
             doCommand(command, breakpoint, num);
-            return root;
+            Response empty = new Response(
+                    null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            return JsonRecordSupport.toJsonObject(empty);
         }
+
+        String version = null;
+        Boolean enabled = null;
+        Boolean standby = null;
+        Boolean suspendedMode = null;
+        Long fallbackTimeout = null;
+        String loggingLevel = null;
+        Boolean includeExchangeProperties = null;
+        Boolean includeFiles = null;
+        Boolean includeStreams = null;
+        Integer maxChars = null;
+        Long debugCounter = null;
+        Boolean singleStepMode = null;
+        List<BreakpointEntry> breakpoints = null;
+        List<Map<String, Object>> suspended = null;
 
         BacklogDebugger backlog = getCamelContext().hasService(BacklogDebugger.class);
         if (backlog != null) {
-            root.put("version", getCamelContext().getVersion());
-            root.put("enabled", backlog.isEnabled());
-            root.put("standby", backlog.isStandby());
-            root.put("suspendedMode", backlog.isSuspendMode());
-            root.put("fallbackTimeout", backlog.getFallbackTimeout());
-            root.put("loggingLevel", backlog.getLoggingLevel());
-            root.put("includeExchangeProperties", backlog.isIncludeExchangeProperties());
-            root.put("includeFiles", backlog.isBodyIncludeFiles());
-            root.put("includeStreams", backlog.isBodyIncludeStreams());
-            root.put("maxChars", backlog.getBodyMaxChars());
-            root.put("debugCounter", backlog.getDebugCounter());
-            root.put("singleStepMode", backlog.isSingleStepMode());
+            version = getCamelContext().getVersion();
+            enabled = backlog.isEnabled();
+            standby = backlog.isStandby();
+            suspendedMode = backlog.isSuspendMode();
+            fallbackTimeout = backlog.getFallbackTimeout();
+            loggingLevel = backlog.getLoggingLevel();
+            includeExchangeProperties = backlog.isIncludeExchangeProperties();
+            includeFiles = backlog.isBodyIncludeFiles();
+            includeStreams = backlog.isBodyIncludeStreams();
+            maxChars = backlog.getBodyMaxChars();
+            debugCounter = backlog.getDebugCounter();
+            singleStepMode = backlog.isSingleStepMode();
 
-            JsonArray arr = new JsonArray();
+            List<BreakpointEntry> bps = new ArrayList<>();
             for (String n : backlog.getBreakpoints()) {
-                JsonObject jo = new JsonObject();
-                jo.put("nodeId", n);
-                boolean suspended = backlog.getSuspendedBreakpointNodeIds().contains(n);
-                jo.put("suspended", suspended);
-                arr.add(jo);
+                boolean sus = backlog.getSuspendedBreakpointNodeIds().contains(n);
+                bps.add(new BreakpointEntry(n, sus));
             }
-            if (!arr.isEmpty()) {
-                root.put("breakpoints", arr);
-            }
+            breakpoints = bps.isEmpty() ? null : bps;
 
-            arr = new JsonArray();
+            List<Map<String, Object>> susp = new ArrayList<>();
             for (String n : backlog.getSuspendedBreakpointNodeIds()) {
                 BacklogTracerEventMessage t = backlog.getSuspendedBreakpointMessage(n);
                 if (t != null) {
                     JsonObject to = (JsonObject) t.asJSon();
-                    arr.add(to);
 
                     // enrich with source code +/- lines around location
                     int limit = codeLimit;
@@ -275,14 +307,16 @@ public class DebugDevConsole extends AbstractDevConsole {
                             to.put("history", steps);
                         }
                     }
+                    susp.add(to);
                 }
             }
-            if (!arr.isEmpty()) {
-                root.put("suspended", arr);
-            }
+            suspended = susp.isEmpty() ? null : susp;
         }
 
-        return root;
+        Response response = new Response(
+                version, enabled, standby, suspendedMode, fallbackTimeout, loggingLevel, includeExchangeProperties,
+                includeFiles, includeStreams, maxChars, debugCounter, singleStepMode, breakpoints, suspended);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private List<JsonObject> enrichHistory(BacklogDebugger backlog, String id) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EndpointDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EndpointDevConsole.java
@@ -16,20 +16,44 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.spi.EndpointRegistry;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.RuntimeEndpointRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "endpoint", displayName = "Endpoints", description = "Endpoint Registry information")
 public class EndpointDevConsole extends AbstractDevConsole {
+
+    public record EndpointEntry(
+            @Metadata(description = "The endpoint URI") String uri,
+            @Metadata(description = "Whether the endpoint is remote") boolean remote,
+            @Metadata(description = "Whether the endpoint is a stub endpoint") boolean stub,
+            @Metadata(description = "Whether the endpoint is used as input or output (in or out) (only present when runtime endpoint registry statistics are available)") String direction,
+            @Metadata(description = "Usage of the endpoint (only present when runtime endpoint registry statistics are available)") Long hits,
+            @Metadata(description = "The route ID (only present when runtime endpoint registry statistics are available and the endpoint is associated with a route)") String routeId,
+            @Metadata(description = "Minimum message body size in bytes (only present when available)") Long minBodySize,
+            @Metadata(description = "Maximum message body size in bytes (only present when available)") Long maxBodySize,
+            @Metadata(description = "Mean message body size in bytes (only present when available)") Long meanBodySize,
+            @Metadata(description = "Minimum message headers size in bytes (only present when available)") Long minHeadersSize,
+            @Metadata(description = "Maximum message headers size in bytes (only present when available)") Long maxHeadersSize,
+            @Metadata(description = "Mean message headers size in bytes (only present when available)") Long meanHeadersSize) {
+    }
+
+    public record Response(
+            @Metadata(description = "Total number of endpoints") int size,
+            @Metadata(description = "Number of endpoints in the static registry") int staticSize,
+            @Metadata(description = "Number of endpoints in the dynamic registry") int dynamicSize,
+            @Metadata(description = "Maximum number of entries to store in the dynamic registry") int maximumCacheSize,
+            @Metadata(description = "The endpoints") List<EndpointEntry> endpoints) {
+    }
 
     public EndpointDevConsole() {
         super("camel", "endpoint", "Endpoints", "Endpoint Registry information");
@@ -85,9 +109,7 @@ public class EndpointDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         // runtime registry is optional but if enabled we have additional statistics to use in output
         List<RuntimeEndpointRegistry.Statistic> stats = null;
         RuntimeEndpointRegistry runtimeReg = getCamelContext().getRuntimeEndpointRegistry();
@@ -95,13 +117,8 @@ public class EndpointDevConsole extends AbstractDevConsole {
             stats = runtimeReg.getEndpointStatistics();
         }
         EndpointRegistry reg = getCamelContext().getEndpointRegistry();
-        root.put("size", reg.size());
-        root.put("staticSize", reg.staticSize());
-        root.put("dynamicSize", reg.dynamicSize());
-        root.put("maximumCacheSize", reg.getMaximumCacheSize());
 
-        final JsonArray list = new JsonArray();
-        root.put("endpoints", list);
+        final List<EndpointEntry> list = new ArrayList<>();
         Collection<Endpoint> col = reg.getReadOnlyValues();
         for (Endpoint e : col) {
             // NOTE: StubComponent is not available at compilation time.
@@ -111,35 +128,34 @@ public class EndpointDevConsole extends AbstractDevConsole {
             if (!endpointStats.isEmpty()) {
                 // emit one entry per direction so both in and out hits are captured
                 for (RuntimeEndpointRegistry.Statistic st : endpointStats) {
-                    JsonObject jo = new JsonObject();
-                    jo.put("uri", e.getEndpointUri());
-                    jo.put("remote", remote);
-                    jo.put("stub", stub);
-                    jo.put("direction", st.getDirection());
-                    jo.put("hits", st.getHits());
-                    jo.put("routeId", st.getRouteId());
+                    Long minBodySize = null;
+                    Long maxBodySize = null;
+                    Long meanBodySize = null;
                     if (st.getMinBodySize() >= 0) {
-                        jo.put("minBodySize", st.getMinBodySize());
-                        jo.put("maxBodySize", st.getMaxBodySize());
-                        jo.put("meanBodySize", st.getMeanBodySize());
+                        minBodySize = st.getMinBodySize();
+                        maxBodySize = st.getMaxBodySize();
+                        meanBodySize = st.getMeanBodySize();
                     }
+                    Long minHeadersSize = null;
+                    Long maxHeadersSize = null;
+                    Long meanHeadersSize = null;
                     if (st.getMinHeadersSize() >= 0) {
-                        jo.put("minHeadersSize", st.getMinHeadersSize());
-                        jo.put("maxHeadersSize", st.getMaxHeadersSize());
-                        jo.put("meanHeadersSize", st.getMeanHeadersSize());
+                        minHeadersSize = st.getMinHeadersSize();
+                        maxHeadersSize = st.getMaxHeadersSize();
+                        meanHeadersSize = st.getMeanHeadersSize();
                     }
-                    list.add(jo);
+                    list.add(new EndpointEntry(
+                            e.getEndpointUri(), remote, stub, st.getDirection(), st.getHits(), st.getRouteId(),
+                            minBodySize, maxBodySize, meanBodySize, minHeadersSize, maxHeadersSize, meanHeadersSize));
                 }
             } else {
-                JsonObject jo = new JsonObject();
-                jo.put("uri", e.getEndpointUri());
-                jo.put("remote", remote);
-                jo.put("stub", stub);
-                list.add(jo);
+                list.add(new EndpointEntry(
+                        e.getEndpointUri(), remote, stub, null, null, null, null, null, null, null, null, null));
             }
         }
 
-        return root;
+        Response response = new Response(reg.size(), reg.staticSize(), reg.dynamicSize(), reg.getMaximumCacheSize(), list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static List<RuntimeEndpointRegistry.Statistic> findStats(

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ErrorRegistryConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ErrorRegistryConsole.java
@@ -27,11 +27,19 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "errors", displayName = "Error Registry", description = "Display captured routing errors")
 public class ErrorRegistryConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "Whether the error registry is enabled") boolean enabled,
+            @Metadata(description = "Number of captured errors") int size,
+            @Metadata(description = "The maximum number of entries retained") int maximumEntries,
+            @Metadata(description = "The time to live for entries") String timeToLive,
+            @Metadata(description = "The captured errors; shape depends on the underlying message implementation") List<Map<String, Object>> errors) {
+    }
 
     @Metadata(label = "query", description = "Filter by route id", javaType = "java.lang.String")
     public static final String ROUTE_ID = "routeId";
@@ -97,20 +105,13 @@ public class ErrorRegistryConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         boolean includeStackTrace = optionBoolean(options, STACK_TRACE, false);
 
-        JsonObject root = new JsonObject();
-
         ErrorRegistry registry = getCamelContext().getErrorRegistry();
-        root.put("enabled", registry.isEnabled());
-        root.put("size", registry.size());
-        root.put("maximumEntries", registry.getMaximumEntries());
-        root.put("timeToLive", registry.getTimeToLive().toString());
-
         List<BacklogErrorEventMessage> entries = fetchAndFilter(registry, options);
 
-        final JsonArray list = new JsonArray();
+        List<Map<String, Object>> errors = new ArrayList<>();
         for (BacklogErrorEventMessage entry : entries) {
             JsonObject jo = (JsonObject) entry.asJSon();
             if (!includeStackTrace) {
@@ -120,11 +121,13 @@ public class ErrorRegistryConsole extends AbstractDevConsole {
                     exObj.remove("stackTrace");
                 }
             }
-            list.add(jo);
+            errors.add(jo);
         }
-        root.put("errors", list);
 
-        return root;
+        Response response = new Response(
+                registry.isEnabled(), registry.size(), registry.getMaximumEntries(), registry.getTimeToLive().toString(),
+                errors);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private List<BacklogErrorEventMessage> fetchAndFilter(ErrorRegistry registry, Map<String, Object> options) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EvalLanguageDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EvalLanguageDevConsole.java
@@ -26,11 +26,17 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.MessageHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "eval-language", displayName = "Evaluate Language", description = "Evaluate Language and display result",
             readOnly = false)
 public class EvalLanguageDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The evaluation status, success or failed (only present when a template was given)") String status,
+            @Metadata(description = "The evaluation result (only present on success)") String result,
+            @Metadata(description = "The exception, as an opaque JSON object (only present on failure)") Map<String, Object> exception) {
+    }
 
     @Metadata(label = "query", description = "The language to use", javaType = "java.lang.String", defaultValue = "simple")
     public static final String LANGUAGE = "language";
@@ -94,13 +100,16 @@ public class EvalLanguageDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String language = optionString(options, LANGUAGE);
         if (language == null) {
             language = "simple";
         }
+
+        String status = null;
+        String result = null;
+        Map<String, Object> exception = null;
+
         String template = optionString(options, TEMPLATE);
         if (template != null) {
             Exchange dummy = new DefaultExchange(getCamelContext());
@@ -130,15 +139,15 @@ public class EvalLanguageDevConsole extends AbstractDevConsole {
             }
 
             if (cause != null) {
-                root.put("status", "failed");
-                root.put("exception",
-                        MessageHelper.dumpExceptionAsJSonObject(cause).getMap("exception"));
+                status = "failed";
+                exception = MessageHelper.dumpExceptionAsJSonObject(cause).getMap("exception");
             } else {
-                root.put("status", "success");
-                root.put("result", out);
+                status = "success";
+                result = out;
             }
         }
 
-        return root;
+        Response response = new Response(status, result, exception);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/EventConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/EventConsole.java
@@ -29,11 +29,24 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.EventNotifierSupport;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "event", displayName = "Camel Events", description = "The most recent Camel events")
 @Configurer(extended = true)
 public class EventConsole extends AbstractDevConsole {
+
+    public record EventEntry(
+            @Metadata(description = "The event type") String type,
+            @Metadata(description = "Epoch time in milliseconds (only present when known)") Long timestamp,
+            @Metadata(description = "The exchange ID (only present for exchange events)") String exchangeId,
+            @Metadata(description = "The event's string representation") String message) {
+    }
+
+    public record Response(
+            @Metadata(description = "The most recent Camel events (only present when there are any)") List<EventEntry> events,
+            @Metadata(description = "The most recent route events (only present when there are any)") List<EventEntry> routeEvents,
+            @Metadata(description = "The most recent exchange events (only present when there are any)") List<EventEntry> exchangeEvents) {
+    }
 
     @Metadata(defaultValue = "25",
               description = "Maximum capacity of last number of events to capture (capacity must be between 25 and 1000)")
@@ -95,26 +108,21 @@ public class EventConsole extends AbstractDevConsole {
         return sb.toString();
     }
 
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         int pos = posEvents.get();
-        List<JsonObject> arr = appendJSonEvents(events, pos, capacity);
-        if (!arr.isEmpty()) {
-            root.put("events", arr);
-        }
+        List<EventEntry> arr = appendJSonEvents(events, pos, capacity);
+        List<EventEntry> eventsOut = !arr.isEmpty() ? arr : null;
+
         pos = posRoutes.get();
         arr = appendJSonEvents(routeEvents, pos, capacity);
-        if (!arr.isEmpty()) {
-            root.put("routeEvents", arr);
-        }
+        List<EventEntry> routeEventsOut = !arr.isEmpty() ? arr : null;
+
         pos = posExchanges.get();
         arr = appendJSonEvents(exchangeEvents, pos, capacity);
-        if (!arr.isEmpty()) {
-            root.put("exchangeEvents", arr);
-        }
+        List<EventEntry> exchangeEventsOut = !arr.isEmpty() ? arr : null;
 
-        return root;
+        Response response = new Response(eventsOut, routeEventsOut, exchangeEventsOut);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static String appendTextEvents(CamelEvent[] events, String kind, int cursor, int capacity) {
@@ -144,25 +152,21 @@ public class EventConsole extends AbstractDevConsole {
         return sb.toString();
     }
 
-    private static List<JsonObject> appendJSonEvents(CamelEvent[] events, int cursor, int capacity) {
-        List<JsonObject> arr = new ArrayList<>();
+    private static List<EventEntry> appendJSonEvents(CamelEvent[] events, int cursor, int capacity) {
+        List<EventEntry> arr = new ArrayList<>();
         int pos = 0;
         // cursor is at last event, so move to back
         cursor = ++cursor % capacity;
         CamelEvent event = events[cursor];
         while (pos < capacity) {
             if (event != null) {
-                JsonObject jo = new JsonObject();
-                jo.put("type", event.getType().toString());
-                if (event.getTimestamp() > 0) {
-                    jo.put("timestamp", event.getTimestamp());
-                }
+                Long timestamp = event.getTimestamp() > 0 ? event.getTimestamp() : null;
+                String exchangeId = null;
                 if (event instanceof CamelEvent.ExchangeEvent) {
                     CamelEvent.ExchangeEvent ee = (CamelEvent.ExchangeEvent) event;
-                    jo.put("exchangeId", ee.getExchange().getExchangeId());
+                    exchangeId = ee.getExchange().getExchangeId();
                 }
-                jo.put("message", event.toString());
-                arr.add(jo);
+                arr.add(new EventEntry(event.getType().toString(), timestamp, exchangeId, event.toString()));
             }
             // move to next
             pos++;

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/GarbageCollectorDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/GarbageCollectorDevConsole.java
@@ -18,19 +18,30 @@ package org.apache.camel.impl.console;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.Configurer;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "gc", displayName = "Garbage Collector", description = "Displays Garbage Collector information")
 @Configurer(extended = true)
 public class GarbageCollectorDevConsole extends AbstractDevConsole {
+
+    public record CollectorEntry(
+            @Metadata(description = "The garbage collector name") String name,
+            @Metadata(description = "Number of collections") long collectionCount,
+            @Metadata(description = "Total collection time in milliseconds") long collectionTime,
+            @Metadata(description = "Comma separated list of memory pool names managed by this collector") String memoryPoolNames) {
+    }
+
+    public record Response(@Metadata(description = "The garbage collectors") List<CollectorEntry> garbageCollectors) {
+    }
 
     public GarbageCollectorDevConsole() {
         super("jvm", "gc", "Garbage Collector", "Displays Garbage Collector information");
@@ -51,22 +62,19 @@ public class GarbageCollectorDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
-        root.put("garbageCollectors", arr);
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<CollectorEntry> entries = new ArrayList<>();
 
         List<GarbageCollectorMXBean> gcs = ManagementFactory.getGarbageCollectorMXBeans();
         if (gcs != null && !gcs.isEmpty()) {
             for (GarbageCollectorMXBean gc : gcs) {
-                JsonObject jo = new JsonObject();
-                arr.add(jo);
-                jo.put("name", gc.getName());
-                jo.put("collectionCount", gc.getCollectionCount());
-                jo.put("collectionTime", gc.getCollectionTime());
-                jo.put("memoryPoolNames", String.join(",", Arrays.asList(gc.getMemoryPoolNames())));
+                entries.add(new CollectorEntry(
+                        gc.getName(), gc.getCollectionCount(), gc.getCollectionTime(),
+                        String.join(",", Arrays.asList(gc.getMemoryPoolNames()))));
             }
         }
-        return root;
+
+        Response response = new Response(entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/HealthDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/HealthDevConsole.java
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -27,8 +30,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.ExceptionHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "health", displayName = "Health Check", description = "Health Check Status")
 public class HealthDevConsole extends AbstractDevConsole {
@@ -36,6 +38,26 @@ public class HealthDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Exposure level for health check details",
               defaultValue = "default", javaType = "java.lang.String", enums = "default,oneline,full")
     public static final String EXPOSURE_LEVEL = "exposureLevel";
+
+    public record CheckEntry(
+            @Metadata(description = "The health check ID") String id,
+            @Metadata(description = "The health check group") String group,
+            @Metadata(description = "Whether the health check is up") boolean up,
+            @Metadata(description = "The health check state") String state,
+            @Metadata(description = "Whether the health check is enabled") boolean enabled,
+            @Metadata(description = "Whether the health check is a readiness check") boolean readiness,
+            @Metadata(description = "Whether the health check is a liveness check") boolean liveness,
+            @Metadata(description = "The failure message (only present when not up)") String message,
+            @Metadata(description = "The failure stack trace, one entry per line (only present when not up and an error is available)") List<String> stackTrace,
+            @Metadata(description = "Additional health check specific details (only present when available)") Map<String, String> details) {
+    }
+
+    public record Response(
+            @Metadata(description = "Whether the overall health status is up") boolean up,
+            @Metadata(description = "Whether the readiness checks are up") boolean ready,
+            @Metadata(description = "Whether the liveness checks are up") boolean live,
+            @Metadata(description = "The individual health checks") List<CheckEntry> checks) {
+    }
 
     public HealthDevConsole() {
         super("camel", "health", "Health Check", "Health Check Status");
@@ -79,61 +101,44 @@ public class HealthDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String exposureLevel = optionString(options, EXPOSURE_LEVEL);
         Collection<HealthCheck.Result> readies = HealthCheckHelper.invokeReadiness(getCamelContext(), exposureLevel);
         Collection<HealthCheck.Result> lives = HealthCheckHelper.invokeLiveness(getCamelContext(), exposureLevel);
         boolean ready = HealthCheckHelper.isResultsUp(readies, true);
         boolean live = HealthCheckHelper.isResultsUp(lives, false);
-        root.put("up", ready && live);
-        root.put("ready", ready);
-        root.put("live", live);
 
-        JsonArray arr = new JsonArray();
-        root.put("checks", arr);
-
-        Stream<HealthCheck.Result> checks = Stream.concat(readies.stream(), lives.stream());
-        checks.forEach(res -> {
-            JsonObject jo = new JsonObject();
-            arr.add(jo);
-
+        List<CheckEntry> checks = new ArrayList<>();
+        Stream.concat(readies.stream(), lives.stream()).forEach(res -> {
             boolean ok = res.getState().equals(HealthCheck.State.UP);
-            jo.put("id", res.getCheck().getId());
-            jo.put("group", res.getCheck().getGroup());
-            if (ok) {
-                jo.put("up", true);
-            } else {
-                jo.put("up", false);
-            }
-            jo.put("state", res.getState().toString());
-            jo.put("enabled", res.getCheck().isEnabled());
-            jo.put("readiness", res.getCheck().isReadiness());
-            jo.put("liveness", res.getCheck().isLiveness());
 
+            String message = null;
+            List<String> stackTrace = null;
             if (!ok) {
-                String msg = res.getMessage().orElse("");
-                jo.put("message", msg);
+                message = res.getMessage().orElse("");
 
                 Throwable cause = res.getError().orElse(null);
                 if (cause != null) {
-                    JsonArray arr2 = new JsonArray();
                     final String trace = ExceptionHelper.stackTraceToString(cause);
-                    jo.put("stackTrace", arr2);
-                    Collections.addAll(arr2, trace.split("\n"));
+                    stackTrace = Arrays.asList(trace.split("\n"));
                 }
             }
 
+            Map<String, String> details = null;
             if (!res.getDetails().isEmpty()) {
-                JsonObject details = new JsonObject();
-                res.getDetails().forEach((k, v) -> {
-                    details.put(k, v.toString());
-                });
-                jo.put("details", details);
+                details = new LinkedHashMap<>();
+                for (Map.Entry<String, Object> entry : res.getDetails().entrySet()) {
+                    details.put(entry.getKey(), entry.getValue().toString());
+                }
             }
+
+            checks.add(new CheckEntry(
+                    res.getCheck().getId(), res.getCheck().getGroup(), ok, res.getState().toString(),
+                    res.getCheck().isEnabled(), res.getCheck().isReadiness(), res.getCheck().isLiveness(), message,
+                    stackTrace, details));
         });
 
-        return root;
+        Response response = new Response(ready && live, ready, live, checks);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapDumpDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapDumpDevConsole.java
@@ -30,12 +30,18 @@ import org.apache.camel.spi.Configurer;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "heap-dump", displayName = "Heap Dump",
             description = "Write a heap dump (.hprof) file for deep memory analysis", readOnly = false)
 @Configurer(extended = true)
 public class HeapDumpDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The absolute path of the written heap dump file (only present on success)") String file,
+            @Metadata(description = "The size in bytes of the written heap dump file (only present on success)") Long size,
+            @Metadata(description = "The error message (only present on failure)") String error) {
+    }
 
     private static final DateTimeFormatter TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
 
@@ -53,18 +59,19 @@ public class HeapDumpDevConsole extends AbstractDevConsole {
 
     @Override
     protected String doCallText(Map<String, Object> options) {
-        JsonObject json = doCallJson(options);
-        String error = json.getString("error");
-        if (error != null) {
-            return "Heap dump failed: " + error;
+        Response response = buildResponse(options);
+        if (response.error() != null) {
+            return "Heap dump failed: " + response.error();
         }
-        return "Heap dump written to: " + json.getString("file") + " (" + json.getLong("size") + " bytes)";
+        return "Heap dump written to: " + response.file() + " (" + response.size() + " bytes)";
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        return JsonRecordSupport.toJsonObject(buildResponse(options));
+    }
 
+    private Response buildResponse(Map<String, Object> options) {
         String name = optionString(options, NAME);
         if (name == null || name.isBlank()) {
             name = "heap-dump-" + TIMESTAMP.format(LocalDateTime.now());
@@ -85,12 +92,9 @@ public class HeapDumpDevConsole extends AbstractDevConsole {
                     new String[] { String.class.getName(), boolean.class.getName() });
 
             File file = new File(name);
-            root.put("file", file.getAbsolutePath());
-            root.put("size", file.length());
+            return new Response(file.getAbsolutePath(), file.length(), null);
         } catch (Exception e) {
-            root.put("error", e.getMessage());
+            return new Response(null, null, e.getMessage());
         }
-
-        return root;
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapHistogramDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/HeapHistogramDevConsole.java
@@ -17,6 +17,8 @@
 package org.apache.camel.impl.console;
 
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import javax.management.MBeanServer;
@@ -27,8 +29,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "heap-histogram", displayName = "Heap Histogram", description = "Displays class-level heap memory usage")
 @Configurer(extended = true)
@@ -37,6 +38,19 @@ public class HeapHistogramDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Limits the number of classes displayed",
               defaultValue = "100", javaType = "java.lang.Integer")
     public static final String LIMIT = "limit";
+
+    public record ClassEntry(
+            @Metadata(description = "The class number") int num,
+            @Metadata(description = "Number of instances") long instances,
+            @Metadata(description = "Number of bytes used") long bytes,
+            @Metadata(description = "The class name") String className) {
+    }
+
+    public record Response(
+            @Metadata(description = "The classes in the histogram") List<ClassEntry> classes,
+            @Metadata(description = "Total number of instances") long totalInstances,
+            @Metadata(description = "Total number of bytes") long totalBytes) {
+    }
 
     public HeapHistogramDevConsole() {
         super("jvm", "heap-histogram", "Heap Histogram", "Displays class-level heap memory usage");
@@ -56,19 +70,16 @@ public class HeapHistogramDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String histogram = invokeGcClassHistogram();
+        Response response;
         if (histogram == null) {
-            root.put("classes", new JsonArray());
-            root.put("totalInstances", 0);
-            root.put("totalBytes", 0);
-            return root;
+            response = new Response(new ArrayList<>(), 0, 0);
+        } else {
+            int limit = getLimit(options);
+            response = parseHistogram(histogram, limit);
         }
-
-        int limit = getLimit(options);
-        return parseHistogram(histogram, limit);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private int getLimit(Map<String, Object> options) {
@@ -89,10 +100,8 @@ public class HeapHistogramDevConsole extends AbstractDevConsole {
         }
     }
 
-    private static JsonObject parseHistogram(String histogram, int limit) {
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
-        root.put("classes", arr);
+    private static Response parseHistogram(String histogram, int limit) {
+        List<ClassEntry> arr = new ArrayList<>();
 
         long totalInstances = 0;
         long totalBytes = 0;
@@ -129,19 +138,11 @@ public class HeapHistogramDevConsole extends AbstractDevConsole {
                 continue;
             }
 
-            JsonObject jo = new JsonObject();
-            jo.put("num", num);
-            jo.put("instances", instances);
-            jo.put("bytes", bytes);
-            jo.put("className", StringHelper.readableClassName(className));
-            arr.add(jo);
+            arr.add(new ClassEntry(num, instances, bytes, StringHelper.readableClassName(className)));
             count++;
         }
 
-        root.put("totalInstances", totalInstances);
-        root.put("totalBytes", totalBytes);
-
-        return root;
+        return new Response(arr, totalInstances, totalBytes);
     }
 
     private static long parseLong(String s) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/InflightConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/InflightConsole.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.InflightRepository;
@@ -23,8 +25,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "inflight", displayName = "Inflight Exchanges", description = "Display inflight exchanges")
 public class InflightConsole extends AbstractDevConsole {
@@ -35,6 +36,22 @@ public class InflightConsole extends AbstractDevConsole {
 
     @Metadata(label = "query", description = "Limits the number of entries displayed", javaType = "java.lang.Integer")
     public static final String LIMIT = "limit";
+
+    public record Exchange(
+            @Metadata(description = "The exchange ID") String exchangeId,
+            @Metadata(description = "The route ID where the exchange originated from") String fromRouteId,
+            @Metadata(description = "Whether the exchange originated from a remote endpoint") boolean fromRemoteEndpoint,
+            @Metadata(description = "The route ID where the exchange currently is") String atRouteId,
+            @Metadata(description = "The node ID where the exchange currently is") String nodeId,
+            @Metadata(description = "Elapsed time in milliseconds since the exchange started") long elapsed,
+            @Metadata(description = "Duration in milliseconds the exchange has been at the current node") long duration) {
+    }
+
+    public record Response(
+            @Metadata(description = "Number of inflight exchanges") int inflight,
+            @Metadata(description = "Whether browsing inflight exchanges is enabled") boolean inflightBrowseEnabled,
+            @Metadata(description = "The inflight exchanges (only present when browsing is enabled)") List<Exchange> exchanges) {
+    }
 
     public InflightConsole() {
         super("camel", "inflight", "Inflight Exchanges", "Display inflight exchanges");
@@ -63,31 +80,24 @@ public class InflightConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String filter = optionString(options, FILTER);
         int max = optionInt(options, LIMIT, Integer.MAX_VALUE);
 
-        JsonObject root = new JsonObject();
-
         InflightRepository repo = getCamelContext().getInflightRepository();
-        root.put("inflight", repo.size());
-        root.put("inflightBrowseEnabled", repo.isInflightBrowseEnabled());
-        if (repo.isInflightBrowseEnabled()) {
-            final JsonArray list = new JsonArray();
+        boolean browseEnabled = repo.isInflightBrowseEnabled();
+
+        List<Exchange> exchanges = null;
+        if (browseEnabled) {
+            exchanges = new ArrayList<>();
             for (InflightRepository.InflightExchange ie : repo.browse(filter, max, false)) {
-                JsonObject props = new JsonObject();
-                props.put("exchangeId", ie.getExchange().getExchangeId());
-                props.put("fromRouteId", ie.getFromRouteId());
-                props.put("fromRemoteEndpoint", ie.isFromRemoteEndpoint());
-                props.put("atRouteId", ie.getAtRouteId());
-                props.put("nodeId", ie.getNodeId());
-                props.put("elapsed", ie.getElapsed());
-                props.put("duration", ie.getDuration());
-                list.add(props);
+                exchanges.add(new Exchange(
+                        ie.getExchange().getExchangeId(), ie.getFromRouteId(), ie.isFromRemoteEndpoint(),
+                        ie.getAtRouteId(), ie.getNodeId(), ie.getElapsed(), ie.getDuration()));
             }
-            root.put("exchanges", list);
         }
 
-        return root;
+        Response response = new Response(repo.size(), browseEnabled, exchanges);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JavaSecurityDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JavaSecurityDevConsole.java
@@ -18,18 +18,36 @@ package org.apache.camel.impl.console;
 
 import java.security.Provider;
 import java.security.Security;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.Configurer;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "java-security", description = "Displays Java Security (JSSE) information")
 @Configurer(extended = true)
 public class JavaSecurityDevConsole extends AbstractDevConsole {
+
+    public record ServiceEntry(
+            @Metadata(description = "The service type") String type,
+            @Metadata(description = "The algorithm") String algorithm,
+            @Metadata(description = "The implementation class name") String className) {
+    }
+
+    public record ProviderEntry(
+            @Metadata(description = "The provider name") String name,
+            @Metadata(description = "The provider version") String version,
+            @Metadata(description = "The provider info (only present when known)") String info,
+            @Metadata(description = "The services offered by this provider (only present when any)") List<ServiceEntry> services) {
+    }
+
+    public record Response(
+            @Metadata(description = "The security providers (only present when any are registered)") List<ProviderEntry> securityProviders) {
+    }
 
     public JavaSecurityDevConsole() {
         super("jvm", "java-security", "Java Security", "Displays Java Security (JSSE) information");
@@ -63,39 +81,29 @@ public class JavaSecurityDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<ProviderEntry> providerEntries = null;
 
         Provider[] providers = Security.getProviders();
         if (providers != null && providers.length > 0) {
-            JsonArray arr = new JsonArray();
-            root.put("securityProviders", arr);
+            providerEntries = new ArrayList<>();
             for (Provider p : providers) {
-                JsonObject jo = new JsonObject();
-                arr.add(jo);
-                jo.put("name", p.getName());
-                jo.put("version", p.getVersionStr());
-                if (p.getInfo() != null) {
-                    jo.put("info", p.getInfo());
-                }
                 List<Provider.Service> services = p.getServices().stream()
                         .sorted(JavaSecurityDevConsole::compare)
                         .toList();
+                List<ServiceEntry> serviceEntries = null;
                 if (!services.isEmpty()) {
-                    JsonArray arr2 = new JsonArray();
-                    jo.put("services", arr2);
+                    serviceEntries = new ArrayList<>();
                     for (Provider.Service s : services) {
-                        JsonObject js = new JsonObject();
-                        js.put("type", s.getType());
-                        js.put("algorithm", s.getAlgorithm());
-                        js.put("className", s.getClassName());
-                        arr2.add(js);
+                        serviceEntries.add(new ServiceEntry(s.getType(), s.getAlgorithm(), s.getClassName()));
                     }
                 }
+                providerEntries.add(new ProviderEntry(p.getName(), p.getVersionStr(), p.getInfo(), serviceEntries));
             }
         }
 
-        return root;
+        Response response = new Response(providerEntries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static int compare(Provider.Service o1, Provider.Service o2) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsole.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,8 +43,8 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,13 +83,120 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
     private static final int MAX_STACK_FRAMES = 10;
     private static final int MAX_CHAIN_DEPTH = 20;
 
+    public record StackFrameEntry(
+            @Metadata(description = "The fully qualified method name") String method,
+            @Metadata(description = "The line number") int line) {
+    }
+
+    public record ReferenceLink(
+            @Metadata(description = "The type name (only present when known)") String type,
+            @Metadata(description = "The field name (only present when known)") String field,
+            @Metadata(description = "A description of the link (only present when known)") String description) {
+    }
+
+    public record SampleEntry(
+            @Metadata(description = "The allocated class name (only present when known)") String allocationClass,
+            @Metadata(description = "The allocation size in bytes (only present when known)") Long allocationSize,
+            @Metadata(description = "The last known heap usage in bytes (only present when known)") Long lastKnownHeapUsage,
+            @Metadata(description = "The number of array elements (only present for arrays)") Integer arrayElements,
+            @Metadata(description = "The object age in milliseconds (only present when known)") Long objectAge,
+            @Metadata(description = "Epoch time in milliseconds when the object was allocated") long allocationTime,
+            @Metadata(description = "The allocation stack trace (only present when requested)") List<StackFrameEntry> stackTrace,
+            @Metadata(description = "The reference chain back to the GC root (only present when there is one)") List<ReferenceLink> referenceChain,
+            @Metadata(description = "The number of samples aggregated into this entry") int count,
+            @Metadata(description = "The total sampled size in bytes across the aggregated samples") long sampledSize) {
+    }
+
+    public record ComparisonEntry(
+            @Metadata(description = "The allocated class name") String allocationClass,
+            @Metadata(description = "The baseline sampled size in bytes") long baselineSampledSize,
+            @Metadata(description = "The baseline sample count") int baselineCount,
+            @Metadata(description = "The current sampled size in bytes") long currentSampledSize,
+            @Metadata(description = "The current sample count") int currentCount,
+            @Metadata(description = "The growth ratio between baseline and current sampled size") double growthRatio,
+            @Metadata(description = "The trend: new, gone, growing, suspicious, shrinking, or stable") String trend,
+            @Metadata(description = "Whether the comparison has low statistical confidence") boolean lowConfidence,
+            @Metadata(description = "The reference chain back to the GC root (only present when there is one)") List<ReferenceLink> referenceChain,
+            @Metadata(description = "The allocation stack trace (only present when requested)") List<StackFrameEntry> stackTrace) {
+    }
+
+    public record RecordingInfo(
+            @Metadata(description = "The recording duration in milliseconds") long recordingDurationMs,
+            @Metadata(description = "The number of aggregated samples") int sampleCount,
+            @Metadata(description = "The number of garbage collections observed") int gcCount) {
+    }
+
+    public record Response(
+            @Metadata(description = "The console status: recording, completed, compared, idle, or error") String status,
+            @Metadata(description = "An error message (only present when status is error)") String error,
+            @Metadata(description = "An informational note (only present for an idle query)") String note,
+            @Metadata(description = "Epoch time in milliseconds the recording started (only present while recording)") Long startTime,
+            @Metadata(description = "The requested recording duration in seconds (only present when set)") Integer durationSeconds,
+            @Metadata(description = "Elapsed time in milliseconds since the recording started (only present while recording)") Long elapsedMs,
+            @Metadata(description = "Remaining time in milliseconds until auto-stop (only present when a duration was requested)") Long remainingMs,
+            @Metadata(description = "Whether cached results are available (only present for a status query)") Boolean hasCachedResults,
+            @Metadata(description = "Whether a previous recording is available for comparison (only present for a status query)") Boolean hasComparisonData,
+            @Metadata(description = "The number of aggregated samples (only present when results are available)") Integer sampleCount,
+            @Metadata(description = "The recording duration in milliseconds (only present when results are available)") Long recordingDurationMs,
+            @Metadata(description = "Epoch time in milliseconds the recording ended (only present when results are available)") Long recordingEndTime,
+            @Metadata(description = "The number of raw samples before aggregation (only present when results are available)") Integer rawSampleCount,
+            @Metadata(description = "The number of garbage collections observed (only present when results are available)") Integer gcCount,
+            @Metadata(description = "The aggregated samples (only present when results are available)") List<SampleEntry> samples,
+            @Metadata(description = "The baseline recording info (only present for a comparison)") RecordingInfo baseline,
+            @Metadata(description = "The current recording info (only present for a comparison)") RecordingInfo current,
+            @Metadata(description = "The ratio of the current to the baseline recording duration (only present for a comparison)") Double durationRatio,
+            @Metadata(description = "The per-class comparisons, sorted by growth ratio descending (only present for a comparison)") List<ComparisonEntry> comparisons) {
+    }
+
+    private record RawSample(
+            String allocationClass, Long allocationSize, Long lastKnownHeapUsage, Integer arrayElements,
+            Long objectAge, long allocationTime, List<StackFrameEntry> stackTrace, List<ReferenceLink> referenceChain) {
+    }
+
+    private record ParsedSamples(List<SampleEntry> samples, int sampleCount, int rawSampleCount, int gcCount) {
+    }
+
+    private record RecordingSnapshot(
+            List<SampleEntry> samples, int sampleCount, int rawSampleCount, int gcCount, long recordingDurationMs,
+            long recordingEndTime) {
+    }
+
+    private static final class SampleAccumulator {
+        private final RawSample first;
+        private int count = 1;
+        private long sampledSize;
+        private Long maxObjectAge;
+
+        SampleAccumulator(RawSample first) {
+            this.first = first;
+            this.sampledSize = first.allocationSize() != null ? first.allocationSize() : 0;
+            this.maxObjectAge = first.objectAge();
+        }
+
+        void merge(RawSample sample) {
+            count++;
+            sampledSize += sample.allocationSize() != null ? sample.allocationSize() : 0;
+            Long age = sample.objectAge();
+            if (age != null && (maxObjectAge == null || age > maxObjectAge)) {
+                maxObjectAge = age;
+            }
+        }
+
+        SampleEntry toEntry() {
+            return new SampleEntry(
+                    first.allocationClass(), first.allocationSize(), first.lastKnownHeapUsage(),
+                    first.arrayElements(), maxObjectAge, first.allocationTime(), first.stackTrace(),
+                    first.referenceChain(), count, sampledSize);
+        }
+    }
+
     // Private monitor for GC wait delays so that wait() does not release the
     // 'this' monitor of synchronized methods (which guards recording state).
     private final Object gcWaitMonitor = new Object();
 
     private volatile Recording activeRecording;
-    private volatile JsonObject cachedResults;
-    private volatile JsonObject previousResults;
+    private volatile RecordingSnapshot cachedResults;
+    private volatile RecordingSnapshot previousResults;
     private volatile long recordingStartTime;
     private volatile int requestedDurationSeconds;
     private ScheduledExecutorService scheduler;
@@ -101,30 +209,30 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
 
     @Override
     protected String doCallText(Map<String, Object> options) {
-        JsonObject json = doCallJson(options);
-        return json.toJson();
+        return ((JsonObject) doCallJson(options)).toJson();
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String command = optionString(options, COMMAND);
         if (command == null) {
             command = "status";
         }
 
-        return switch (command) {
+        Response response = switch (command) {
             case "start" -> doStart(options);
             case "stop" -> doStop(options);
             case "status" -> doStatus();
             case "query" -> doQuery(options);
             case "compare" -> doCompare(options);
-            default -> errorJson("Unknown command: " + command);
+            default -> errorResponse("Unknown command: " + command);
         };
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private synchronized JsonObject doStart(Map<String, Object> options) {
+    private synchronized Response doStart(Map<String, Object> options) {
         if (activeRecording != null) {
-            return errorJson("A JFR recording is already active. Stop it first.");
+            return errorResponse("A JFR recording is already active. Stop it first.");
         }
 
         Recording rec = new Recording();
@@ -168,13 +276,7 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
                 }, duration, TimeUnit.SECONDS);
             }
 
-            JsonObject result = new JsonObject();
-            result.put("status", "recording");
-            result.put("startTime", recordingStartTime);
-            if (duration > 0) {
-                result.put("durationSeconds", duration);
-            }
-            return result;
+            return recordingStartedResponse(recordingStartTime, duration > 0 ? duration : null);
         } catch (Exception e) {
             // Clean up state in case the exception occurred after activeRecording was set
             // (e.g. during auto-stop scheduling), so the console does not get stuck
@@ -185,34 +287,37 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             requestedDurationSeconds = 0;
             rec.close();
             LOG.warn("Failed to start JFR recording: {}", e.getMessage(), e);
-            return errorJson("Failed to start JFR recording: " + e.getMessage());
+            return errorResponse("Failed to start JFR recording: " + e.getMessage());
         }
     }
 
-    private JsonObject doStop(Map<String, Object> options) {
+    private Response doStop(Map<String, Object> options) {
         if (activeRecording == null) {
             if (cachedResults != null) {
-                return applyFilters(cachedResults, options);
+                return snapshotResponse("completed", applyFilters(cachedResults, options));
             }
-            return errorJson("No active JFR recording to stop.");
+            return errorResponse("No active JFR recording to stop.");
         }
 
         cancelAutoStop();
         int limit = optionInt(options, LIMIT, DEFAULT_LIMIT);
 
         try {
-            JsonObject result = doStopRecordingAndParse(limit);
-            return applyFilters(result, options);
+            RecordingSnapshot snapshot = doStopRecordingAndParse(limit);
+            return snapshotResponse("completed", applyFilters(snapshot, options));
+        } catch (IOException e) {
+            LOG.warn("Error parsing JFR recording: {}", e.getMessage(), e);
+            return errorResponse("Error parsing JFR recording: " + e.getMessage());
         } catch (Exception e) {
             LOG.warn("Error stopping JFR recording: {}", e.getMessage(), e);
-            return errorJson("Error stopping JFR recording: " + e.getMessage());
+            return errorResponse("Error stopping JFR recording: " + e.getMessage());
         }
     }
 
-    private synchronized JsonObject doStopRecordingAndParse(int limit) {
+    private synchronized RecordingSnapshot doStopRecordingAndParse(int limit) throws IOException {
         Recording rec = activeRecording;
         if (rec == null) {
-            return cachedResults != null ? cachedResults : errorJson("No active recording.");
+            return cachedResults != null ? cachedResults : new RecordingSnapshot(List.of(), 0, 0, 0, 0, 0);
         }
 
         Path tempDir = null;
@@ -238,17 +343,14 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
 
             long endTime = System.currentTimeMillis();
             long durationMs = endTime - recordingStartTime;
-            JsonObject result = parseRecordingFile(tempFile, limit);
-            result.put("status", "completed");
-            result.put("recordingDurationMs", durationMs);
-            result.put("recordingEndTime", endTime);
+            ParsedSamples parsed = parseRecordingFile(tempFile, limit);
+            RecordingSnapshot snapshot = new RecordingSnapshot(
+                    parsed.samples(), parsed.sampleCount(), parsed.rawSampleCount(), parsed.gcCount(), durationMs,
+                    endTime);
 
             previousResults = cachedResults;
-            cachedResults = result;
-            return result;
-        } catch (IOException e) {
-            LOG.warn("Error parsing JFR recording: {}", e.getMessage(), e);
-            return errorJson("Error parsing JFR recording: " + e.getMessage());
+            cachedResults = snapshot;
+            return snapshot;
         } finally {
             rec.close();
             activeRecording = null;
@@ -271,105 +373,80 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
         }
     }
 
-    private JsonObject doStatus() {
-        JsonObject result = new JsonObject();
+    private Response doStatus() {
         if (activeRecording != null) {
-            result.put("status", "recording");
-            result.put("startTime", recordingStartTime);
             long elapsed = System.currentTimeMillis() - recordingStartTime;
-            result.put("elapsedMs", elapsed);
+            Integer durationSeconds = null;
+            Long remainingMs = null;
             if (requestedDurationSeconds > 0) {
-                result.put("durationSeconds", requestedDurationSeconds);
-                long remaining = (requestedDurationSeconds * 1000L) - elapsed;
-                result.put("remainingMs", Math.max(0, remaining));
+                durationSeconds = requestedDurationSeconds;
+                remainingMs = Math.max(0, (requestedDurationSeconds * 1000L) - elapsed);
             }
+            return recordingStatusResponse(recordingStartTime, elapsed, durationSeconds, remainingMs);
         } else if (cachedResults != null) {
-            result.put("status", "completed");
-            result.put("hasCachedResults", true);
-            result.put("hasComparisonData", previousResults != null);
-            result.put("sampleCount", cachedResults.getIntegerOrDefault("sampleCount", 0));
+            return completedStatusResponse(true, previousResults != null, cachedResults.sampleCount());
         } else {
-            result.put("status", "idle");
+            return idleStatusResponse();
         }
-        return result;
     }
 
-    private JsonObject doQuery(Map<String, Object> options) {
+    private Response doQuery(Map<String, Object> options) {
         if (cachedResults != null) {
-            return applyFilters(cachedResults, options);
+            return snapshotResponse("completed", applyFilters(cachedResults, options));
         }
         if (activeRecording != null) {
             return doStatus();
         }
-        JsonObject result = new JsonObject();
-        result.put("status", "idle");
-        result.put("sampleCount", 0);
-        result.put("samples", new JsonArray());
-        result.put("note", "No results available. Start a recording first.");
-        return result;
+        return idleQueryResponse("No results available. Start a recording first.");
     }
 
-    private JsonObject doCompare(Map<String, Object> options) {
+    private Response doCompare(Map<String, Object> options) {
         if (previousResults == null || cachedResults == null) {
-            return errorJson("Need two recordings to compare. Run two recordings first.");
+            return errorResponse("Need two recordings to compare. Run two recordings first.");
         }
 
         long minSize = optionLong(options, MIN_SIZE, 0);
 
-        long baselineDurationMs = previousResults.getLongOrDefault("recordingDurationMs", 1);
-        long currentDurationMs = cachedResults.getLongOrDefault("recordingDurationMs", 1);
+        long baselineDurationMs = previousResults.recordingDurationMs();
+        long currentDurationMs = cachedResults.recordingDurationMs();
         double durationRatio = baselineDurationMs > 0 ? (double) currentDurationMs / baselineDurationMs : 1.0;
 
         // index baseline samples by group key
-        Map<String, JsonObject> baselineMap = new LinkedHashMap<>();
-        JsonArray baselineSamples = (JsonArray) previousResults.get("samples");
-        if (baselineSamples != null) {
-            for (int i = 0; i < baselineSamples.size(); i++) {
-                JsonObject s = (JsonObject) baselineSamples.get(i);
-                baselineMap.put(sampleGroupKey(s), s);
-            }
+        Map<String, SampleEntry> baselineMap = new LinkedHashMap<>();
+        for (SampleEntry s : previousResults.samples()) {
+            baselineMap.put(sampleGroupKey(s.allocationClass(), s.stackTrace()), s);
         }
 
         // index current samples by group key
-        Map<String, JsonObject> currentMap = new LinkedHashMap<>();
-        JsonArray currentSamples = (JsonArray) cachedResults.get("samples");
-        if (currentSamples != null) {
-            for (int i = 0; i < currentSamples.size(); i++) {
-                JsonObject s = (JsonObject) currentSamples.get(i);
-                currentMap.put(sampleGroupKey(s), s);
-            }
+        Map<String, SampleEntry> currentMap = new LinkedHashMap<>();
+        for (SampleEntry s : cachedResults.samples()) {
+            currentMap.put(sampleGroupKey(s.allocationClass(), s.stackTrace()), s);
         }
 
         // collect all keys preserving order (current first, then baseline-only)
-        Map<String, JsonObject> allKeys = new LinkedHashMap<>(currentMap);
+        Map<String, SampleEntry> allKeys = new LinkedHashMap<>(currentMap);
         for (String key : baselineMap.keySet()) {
             allKeys.putIfAbsent(key, baselineMap.get(key));
         }
 
-        JsonArray comparisons = new JsonArray();
+        List<ComparisonEntry> comparisons = new ArrayList<>();
         for (String key : allKeys.keySet()) {
-            JsonObject baseline = baselineMap.get(key);
-            JsonObject current = currentMap.get(key);
+            SampleEntry baseline = baselineMap.get(key);
+            SampleEntry current = currentMap.get(key);
 
-            JsonObject comp = new JsonObject();
-            String className = current != null
-                    ? current.getStringOrDefault("allocationClass", "unknown")
-                    : baseline.getStringOrDefault("allocationClass", "unknown");
-            comp.put("allocationClass", className);
+            String className = current != null ? current.allocationClass() : baseline.allocationClass();
+            if (className == null) {
+                className = "unknown";
+            }
 
-            long baseSize = baseline != null ? baseline.getLongOrDefault("sampledSize", 0) : 0;
-            int baseCount = baseline != null ? baseline.getIntegerOrDefault("count", 0) : 0;
-            long curSize = current != null ? current.getLongOrDefault("sampledSize", 0) : 0;
-            int curCount = current != null ? current.getIntegerOrDefault("count", 0) : 0;
+            long baseSize = baseline != null ? baseline.sampledSize() : 0;
+            int baseCount = baseline != null ? baseline.count() : 0;
+            long curSize = current != null ? current.sampledSize() : 0;
+            int curCount = current != null ? current.count() : 0;
 
             if (minSize > 0 && baseSize < minSize && curSize < minSize) {
                 continue;
             }
-
-            comp.put("baselineSampledSize", baseSize);
-            comp.put("baselineCount", baseCount);
-            comp.put("currentSampledSize", curSize);
-            comp.put("currentCount", curCount);
 
             String trend;
             double growthRatio = 0;
@@ -394,8 +471,7 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
                     trend = "stable";
                 }
             }
-            comp.put("growthRatio", Math.round(growthRatio * 100.0) / 100.0);
-            comp.put("trend", trend);
+            growthRatio = Math.round(growthRatio * 100.0) / 100.0;
 
             // flag low confidence when sample counts are too low or diverge
             // significantly from the expected duration ratio
@@ -411,51 +487,27 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
                     }
                 }
             }
-            comp.put("lowConfidence", lowConfidence);
 
             // carry forward reference chain and stack trace from current (or baseline if gone)
-            JsonObject source = current != null ? current : baseline;
-            if (source.containsKey("referenceChain")) {
-                comp.put("referenceChain", source.get("referenceChain"));
-            }
-            if (source.containsKey("stackTrace")) {
-                comp.put("stackTrace", source.get("stackTrace"));
-            }
+            SampleEntry source = current != null ? current : baseline;
 
-            comparisons.add(comp);
+            comparisons.add(new ComparisonEntry(
+                    className, baseSize, baseCount, curSize, curCount, growthRatio, trend, lowConfidence,
+                    source.referenceChain(), source.stackTrace()));
         }
 
         // sort by growth ratio descending (leaks first)
-        List<Object> sorted = new ArrayList<>(comparisons);
-        sorted.sort((a, b) -> {
-            double ra = ((JsonObject) a).getDoubleOrDefault("growthRatio", 0);
-            double rb = ((JsonObject) b).getDoubleOrDefault("growthRatio", 0);
-            return Double.compare(rb, ra);
-        });
-        JsonArray sortedArr = new JsonArray();
-        sortedArr.addAll(sorted);
+        comparisons.sort(Comparator.comparingDouble(ComparisonEntry::growthRatio).reversed());
 
-        JsonObject result = new JsonObject();
-        result.put("status", "compared");
+        RecordingInfo baselineInfo = new RecordingInfo(
+                baselineDurationMs, previousResults.sampleCount(), previousResults.gcCount());
+        RecordingInfo currentInfo = new RecordingInfo(
+                currentDurationMs, cachedResults.sampleCount(), cachedResults.gcCount());
 
-        JsonObject baselineInfo = new JsonObject();
-        baselineInfo.put("recordingDurationMs", baselineDurationMs);
-        baselineInfo.put("sampleCount", previousResults.getIntegerOrDefault("sampleCount", 0));
-        baselineInfo.put("gcCount", previousResults.getIntegerOrDefault("gcCount", 0));
-        result.put("baseline", baselineInfo);
-
-        JsonObject currentInfo = new JsonObject();
-        currentInfo.put("recordingDurationMs", currentDurationMs);
-        currentInfo.put("sampleCount", cachedResults.getIntegerOrDefault("sampleCount", 0));
-        currentInfo.put("gcCount", cachedResults.getIntegerOrDefault("gcCount", 0));
-        result.put("current", currentInfo);
-
-        result.put("durationRatio", Math.round(durationRatio * 100.0) / 100.0);
-        result.put("comparisons", sortedArr);
-        return result;
+        return compareResponse(baselineInfo, currentInfo, Math.round(durationRatio * 100.0) / 100.0, comparisons);
     }
 
-    private JsonObject applyFilters(JsonObject original, Map<String, Object> options) {
+    private RecordingSnapshot applyFilters(RecordingSnapshot original, Map<String, Object> options) {
         long minSize = optionLong(options, MIN_SIZE, 0);
         boolean includeStacktrace = optionBoolean(options, STACKTRACE, false);
 
@@ -463,36 +515,29 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             return original;
         }
 
-        // work on a copy so the cached results remain unmodified
-        JsonObject result = new JsonObject(original);
-        Object samplesObj = original.get("samples");
-        if (samplesObj instanceof JsonArray origSamples) {
-            JsonArray filtered = new JsonArray();
-            for (int i = 0; i < origSamples.size(); i++) {
-                Object obj = origSamples.get(i);
-                if (obj instanceof JsonObject sample) {
-                    if (minSize > 0 && sample.getLongOrDefault("sampledSize", 0) < minSize) {
-                        continue;
-                    }
-                    if (!includeStacktrace) {
-                        // shallow copy to avoid mutating cached data
-                        JsonObject copy = new JsonObject(sample);
-                        copy.remove("stackTrace");
-                        filtered.add(copy);
-                    } else {
-                        filtered.add(sample);
-                    }
-                }
+        // build a filtered copy so the cached results remain unmodified
+        List<SampleEntry> filtered = new ArrayList<>();
+        for (SampleEntry sample : original.samples()) {
+            if (minSize > 0 && sample.sampledSize() < minSize) {
+                continue;
             }
-            result.put("samples", filtered);
-            result.put("sampleCount", filtered.size());
+            filtered.add(includeStacktrace ? sample : withoutStackTrace(sample));
         }
-        return result;
+        return new RecordingSnapshot(
+                filtered, filtered.size(), original.rawSampleCount(), original.gcCount(),
+                original.recordingDurationMs(), original.recordingEndTime());
     }
 
-    private JsonObject parseRecordingFile(Path file, int limit) throws IOException {
+    private static SampleEntry withoutStackTrace(SampleEntry sample) {
+        return new SampleEntry(
+                sample.allocationClass(), sample.allocationSize(), sample.lastKnownHeapUsage(),
+                sample.arrayElements(), sample.objectAge(), sample.allocationTime(), null, sample.referenceChain(),
+                sample.count(), sample.sampledSize());
+    }
+
+    private ParsedSamples parseRecordingFile(Path file, int limit) throws IOException {
         // parse all raw samples and count GC events
-        List<JsonObject> rawSamples = new ArrayList<>();
+        List<RawSample> rawSamples = new ArrayList<>();
         int gcCount = 0;
         try (RecordingFile rf = new RecordingFile(file)) {
             while (rf.hasMoreEvents()) {
@@ -505,7 +550,7 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
                 if (!"jdk.OldObjectSample".equals(eventName)) {
                     continue;
                 }
-                JsonObject sample = parseOldObjectSampleEvent(event);
+                RawSample sample = parseOldObjectSampleEvent(event);
                 if (sample != null) {
                     rawSamples.add(sample);
                 }
@@ -513,56 +558,38 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
         }
 
         // aggregate by class + stack trace fingerprint
-        Map<String, JsonObject> groups = new LinkedHashMap<>();
-        for (JsonObject sample : rawSamples) {
-            String key = sampleGroupKey(sample);
-            JsonObject existing = groups.get(key);
+        Map<String, SampleAccumulator> groups = new LinkedHashMap<>();
+        for (RawSample sample : rawSamples) {
+            String key = sampleGroupKey(sample.allocationClass(), sample.stackTrace());
+            SampleAccumulator existing = groups.get(key);
             if (existing == null) {
-                sample.put("count", 1);
-                long size = sample.getLongOrDefault("allocationSize", 0);
-                sample.put("sampledSize", size);
-                groups.put(key, sample);
+                groups.put(key, new SampleAccumulator(sample));
             } else {
-                existing.put("count", existing.getIntegerOrDefault("count", 1) + 1);
-                long prevTotal = existing.getLongOrDefault("sampledSize", 0);
-                long curSize = sample.getLongOrDefault("allocationSize", 0);
-                existing.put("sampledSize", prevTotal + curSize);
-                long prevAge = existing.getLongOrDefault("objectAge", 0);
-                long curAge = sample.getLongOrDefault("objectAge", 0);
-                if (curAge > prevAge) {
-                    existing.put("objectAge", curAge);
-                }
+                existing.merge(sample);
             }
         }
 
-        JsonArray samples = new JsonArray();
+        List<SampleEntry> samples = new ArrayList<>();
         int count = 0;
-        for (JsonObject group : groups.values()) {
+        for (SampleAccumulator group : groups.values()) {
             if (limit > 0 && count >= limit) {
                 break;
             }
-            samples.add(group);
+            samples.add(group.toEntry());
             count++;
         }
 
-        JsonObject root = new JsonObject();
-        root.put("samples", samples);
-        root.put("sampleCount", count);
-        root.put("rawSampleCount", rawSamples.size());
-        root.put("gcCount", gcCount);
-        return root;
+        return new ParsedSamples(samples, count, rawSamples.size(), gcCount);
     }
 
-    private static String sampleGroupKey(JsonObject sample) {
+    private static String sampleGroupKey(String allocationClass, List<StackFrameEntry> stackTrace) {
         StringBuilder sb = new StringBuilder();
-        sb.append(sample.getStringOrDefault("allocationClass", ""));
+        sb.append(allocationClass != null ? allocationClass : "");
         // find the first user-code frame (skip JDK internals and Camel framework frames)
         // this gives stable keys across JFR runs since user code frames don't shift
-        JsonArray st = (JsonArray) sample.get("stackTrace");
-        if (st != null) {
-            for (int i = 0; i < st.size(); i++) {
-                JsonObject frame = (JsonObject) st.get(i);
-                String method = frame.getStringOrDefault("method", "");
+        if (stackTrace != null) {
+            for (StackFrameEntry frame : stackTrace) {
+                String method = frame.method() != null ? frame.method() : "";
                 if (isUserFrame(method)) {
                     int lambdaIdx = method.indexOf("$$Lambda");
                     if (lambdaIdx > 0) {
@@ -587,9 +614,7 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
                 && !method.startsWith("org.apache.camel.");
     }
 
-    private JsonObject parseOldObjectSampleEvent(RecordedEvent event) {
-        JsonObject sample = new JsonObject();
-
+    private RawSample parseOldObjectSampleEvent(RecordedEvent event) {
         // extract the OldObject reference (contains the sampled object's class and reference chain)
         RecordedObject objectRef = null;
         if (event.hasField("object")) {
@@ -601,21 +626,22 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
         }
 
         // allocation class — primary source is object.type, fallback to objectClass on event
+        String allocationClass = null;
         if (objectRef != null && objectRef.hasField("type")) {
             try {
                 RecordedClass type = objectRef.getClass("type");
                 if (type != null) {
-                    sample.put("allocationClass", StringHelper.readableClassName(type.getName()));
+                    allocationClass = StringHelper.readableClassName(type.getName());
                 }
             } catch (Exception e) {
                 // ignore
             }
         }
-        if (!sample.containsKey("allocationClass") && event.hasField("objectClass")) {
+        if (allocationClass == null && event.hasField("objectClass")) {
             try {
                 RecordedClass objectClass = event.getClass("objectClass");
                 if (objectClass != null) {
-                    sample.put("allocationClass", StringHelper.readableClassName(objectClass.getName()));
+                    allocationClass = StringHelper.readableClassName(objectClass.getName());
                 }
             } catch (Exception e) {
                 // ignore
@@ -623,115 +649,120 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
         }
 
         // allocation size — try multiple field names across JDK versions
+        Long allocationSize = null;
         if (event.hasField("allocationSize")) {
-            sample.put("allocationSize", event.getLong("allocationSize"));
+            allocationSize = event.getLong("allocationSize");
         } else if (event.hasField("objectSize")) {
-            sample.put("allocationSize", event.getLong("objectSize"));
+            allocationSize = event.getLong("objectSize");
         }
 
         // last known heap usage
+        Long lastKnownHeapUsage = null;
         if (event.hasField("lastKnownHeapUsage")) {
-            sample.put("lastKnownHeapUsage", event.getLong("lastKnownHeapUsage"));
+            lastKnownHeapUsage = event.getLong("lastKnownHeapUsage");
         }
 
         // array elements
+        Integer arrayElements = null;
         if (event.hasField("arrayElements")) {
-            int arrayElements = event.getInt("arrayElements");
-            if (arrayElements > 0) {
-                sample.put("arrayElements", arrayElements);
+            int n = event.getInt("arrayElements");
+            if (n > 0) {
+                arrayElements = n;
             }
         }
 
         // object age
+        Long objectAge = null;
         if (event.hasField("objectAge")) {
             try {
-                sample.put("objectAge", event.getDuration("objectAge").toMillis());
+                objectAge = event.getDuration("objectAge").toMillis();
             } catch (Exception e) {
                 // some JDK versions may not support this field as Duration
             }
         }
 
         // allocation time
-        sample.put("allocationTime", event.getStartTime().toEpochMilli());
+        long allocationTime = event.getStartTime().toEpochMilli();
 
         // stack trace (where the object was allocated)
-        RecordedStackTrace stackTrace = event.getStackTrace();
-        if (stackTrace != null) {
-            JsonArray frames = new JsonArray();
-            for (RecordedFrame frame : stackTrace.getFrames()) {
-                JsonObject f = new JsonObject();
-                f.put("method", frame.getMethod().getType().getName() + "." + frame.getMethod().getName());
-                f.put("line", frame.getLineNumber());
-                frames.add(f);
+        List<StackFrameEntry> stackTrace = null;
+        RecordedStackTrace recordedStackTrace = event.getStackTrace();
+        if (recordedStackTrace != null) {
+            List<StackFrameEntry> frames = new ArrayList<>();
+            for (RecordedFrame frame : recordedStackTrace.getFrames()) {
+                frames.add(new StackFrameEntry(
+                        frame.getMethod().getType().getName() + "." + frame.getMethod().getName(),
+                        frame.getLineNumber()));
                 if (frames.size() >= MAX_STACK_FRAMES) {
                     break;
                 }
             }
-            sample.put("stackTrace", frames);
+            stackTrace = frames;
         }
 
         // reference chain (path from object to GC root)
+        List<ReferenceLink> referenceChain = null;
         if (objectRef != null) {
-            JsonArray chain = extractReferenceChain(objectRef);
+            List<ReferenceLink> chain = extractReferenceChain(objectRef);
             appendGcRoot(event, chain);
             if (!chain.isEmpty()) {
-                sample.put("referenceChain", chain);
+                referenceChain = chain;
             }
         }
 
-        return sample;
+        return new RawSample(
+                allocationClass, allocationSize, lastKnownHeapUsage, arrayElements, objectAge, allocationTime,
+                stackTrace, referenceChain);
     }
 
-    private JsonArray extractReferenceChain(RecordedObject objectRef) {
-        JsonArray chain = new JsonArray();
+    private List<ReferenceLink> extractReferenceChain(RecordedObject objectRef) {
+        List<ReferenceLink> chain = new ArrayList<>();
         try {
             RecordedObject obj = objectRef;
             int depth = 0;
             while (obj != null && depth < MAX_CHAIN_DEPTH) {
-                JsonObject link = new JsonObject();
-
+                String type = null;
                 if (obj.hasField("type")) {
                     try {
-                        RecordedClass type = obj.getClass("type");
-                        if (type != null) {
-                            link.put("type", StringHelper.readableClassName(type.getName()));
+                        RecordedClass recordedClass = obj.getClass("type");
+                        if (recordedClass != null) {
+                            type = StringHelper.readableClassName(recordedClass.getName());
                         }
                     } catch (Exception e) {
                         // ignore
                     }
                 }
 
+                String field = null;
                 if (obj.hasField("field")) {
                     try {
-                        RecordedObject field = obj.getValue("field");
-                        if (field != null && field.hasField("name")) {
-                            link.put("field", field.getString("name"));
+                        RecordedObject fieldObj = obj.getValue("field");
+                        if (fieldObj != null && fieldObj.hasField("name")) {
+                            field = fieldObj.getString("name");
                         }
                     } catch (Exception e) {
                         try {
-                            String fieldName = obj.getString("field");
-                            if (fieldName != null) {
-                                link.put("field", fieldName);
-                            }
+                            field = obj.getString("field");
                         } catch (Exception ex) {
                             // ignore
                         }
                     }
                 }
 
+                String description = null;
                 if (obj.hasField("description")) {
                     try {
                         String desc = obj.getString("description");
                         if (desc != null && !desc.isEmpty()) {
-                            link.put("description", desc);
+                            description = desc;
                         }
                     } catch (Exception e) {
                         // ignore
                     }
                 }
 
-                if (!link.isEmpty()) {
-                    chain.add(link);
+                if (type != null || field != null || description != null) {
+                    chain.add(new ReferenceLink(type, field, description));
                 }
 
                 // walk to next referrer
@@ -752,7 +783,7 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
         return chain;
     }
 
-    private void appendGcRoot(RecordedEvent event, JsonArray chain) {
+    private void appendGcRoot(RecordedEvent event, List<ReferenceLink> chain) {
         if (!event.hasField("root")) {
             return;
         }
@@ -761,32 +792,32 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
             if (root == null) {
                 return;
             }
-            JsonObject link = new JsonObject();
+            String type = null;
             if (root.hasField("type")) {
-                RecordedClass type = root.getClass("type");
-                if (type != null) {
-                    link.put("type", StringHelper.readableClassName(type.getName()));
+                RecordedClass recordedClass = root.getClass("type");
+                if (recordedClass != null) {
+                    type = StringHelper.readableClassName(recordedClass.getName());
                 }
             }
+            String description = null;
             if (root.hasField("description")) {
                 String desc = root.getString("description");
                 if (desc != null && !desc.isEmpty()) {
-                    link.put("description", desc);
+                    description = desc;
                 }
             }
             if (root.hasField("system")) {
                 try {
                     String system = root.getString("system");
                     if (system != null && !system.isEmpty()) {
-                        link.put("description",
-                                link.getStringOrDefault("description", "") + " [GC Root: " + system + "]");
+                        description = (description != null ? description : "") + " [GC Root: " + system + "]";
                     }
                 } catch (Exception e) {
                     // ignore
                 }
             }
-            if (!link.isEmpty()) {
-                chain.add(link);
+            if (type != null || description != null) {
+                chain.add(new ReferenceLink(type, null, description));
             }
         } catch (Exception e) {
             LOG.debug("Error extracting GC root: {}", e.getMessage());
@@ -833,10 +864,55 @@ public class JfrMemoryLeakDevConsole extends AbstractDevConsole {
         }
     }
 
-    private static JsonObject errorJson(String message) {
-        JsonObject result = new JsonObject();
-        result.put("status", "error");
-        result.put("error", message);
-        return result;
+    private static Response errorResponse(String message) {
+        return new Response(
+                "error", message, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null);
+    }
+
+    private static Response idleStatusResponse() {
+        return new Response(
+                "idle", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null);
+    }
+
+    private static Response idleQueryResponse(String note) {
+        return new Response(
+                "idle", null, note, null, null, null, null, null, null, 0, null, null, null, null, List.of(), null,
+                null, null, null);
+    }
+
+    private static Response recordingStartedResponse(long startTime, Integer durationSeconds) {
+        return new Response(
+                "recording", null, null, startTime, durationSeconds, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null);
+    }
+
+    private static Response recordingStatusResponse(
+            long startTime, long elapsedMs, Integer durationSeconds, Long remainingMs) {
+        return new Response(
+                "recording", null, null, startTime, durationSeconds, elapsedMs, remainingMs, null, null, null, null,
+                null, null, null, null, null, null, null, null);
+    }
+
+    private static Response completedStatusResponse(
+            boolean hasCachedResults, boolean hasComparisonData, int sampleCount) {
+        return new Response(
+                "completed", null, null, null, null, null, null, hasCachedResults, hasComparisonData, sampleCount,
+                null, null, null, null, null, null, null, null, null);
+    }
+
+    private static Response snapshotResponse(String status, RecordingSnapshot snapshot) {
+        return new Response(
+                status, null, null, null, null, null, null, null, null, snapshot.sampleCount(),
+                snapshot.recordingDurationMs(), snapshot.recordingEndTime(), snapshot.rawSampleCount(),
+                snapshot.gcCount(), snapshot.samples(), null, null, null, null);
+    }
+
+    private static Response compareResponse(
+            RecordingInfo baseline, RecordingInfo current, double durationRatio, List<ComparisonEntry> comparisons) {
+        return new Response(
+                "compared", null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                baseline, current, durationRatio, comparisons);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/JvmDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/JvmDevConsole.java
@@ -18,6 +18,8 @@ package org.apache.camel.impl.console;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.Configurer;
@@ -25,11 +27,22 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "jvm", displayName = "JVM", description = "Displays JVM information")
 @Configurer(extended = true)
 public class JvmDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The JVM name") String vmName,
+            @Metadata(description = "The JVM version") String vmVersion,
+            @Metadata(description = "The JVM vendor") String vmVendor,
+            @Metadata(description = "The JVM uptime") String vmUptime,
+            @Metadata(description = "The process ID") Long pid,
+            @Metadata(description = "The JVM input arguments (only present when any are set)") String inputArguments,
+            @Metadata(description = "The boot classpath entries (only present when supported)") List<String> bootClasspath,
+            @Metadata(description = "The classpath entries") List<String> classpath) {
+    }
 
     @Metadata(defaultValue = "true", description = "Show classpath information")
     private boolean showClasspath = true;
@@ -76,28 +89,20 @@ public class JvmDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         RuntimeMXBean mb = ManagementFactory.getRuntimeMXBean();
+        Response response;
         if (mb != null) {
-            root.put("vmName", mb.getVmName());
-            root.put("vmVersion", mb.getVmVersion());
-            root.put("vmVendor", mb.getVmVendor());
-            root.put("vmUptime", TimeUtils.printDuration(mb.getUptime()));
-            root.put("pid", mb.getPid());
-            if (!mb.getInputArguments().isEmpty()) {
-                String arg = String.join(" ", mb.getInputArguments());
-                root.put("inputArguments", arg);
-            }
-            if (mb.isBootClassPathSupported()) {
-                String[] cp = mb.getBootClassPath().split("[:|;]");
-                root.put("bootClasspath", cp);
-            }
-            String[] cp = mb.getClassPath().split("[:|;]");
-            root.put("classpath", cp);
+            String inputArguments = !mb.getInputArguments().isEmpty() ? String.join(" ", mb.getInputArguments()) : null;
+            List<String> bootClasspath
+                    = mb.isBootClassPathSupported() ? Arrays.asList(mb.getBootClassPath().split("[:|;]")) : null;
+            List<String> classpath = Arrays.asList(mb.getClassPath().split("[:|;]"));
+            response = new Response(
+                    mb.getVmName(), mb.getVmVersion(), mb.getVmVendor(), TimeUtils.printDuration(mb.getUptime()),
+                    mb.getPid(), inputArguments, bootClasspath, classpath);
+        } else {
+            response = new Response(null, null, null, null, null, null, null, null);
         }
-
-        return root;
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/LogDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/LogDevConsole.java
@@ -24,15 +24,20 @@ import java.util.TreeMap;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "log", description = "Logging framework")
 public class LogDevConsole extends AbstractDevConsole {
 
     // log4j support
     private static final String LOG4J_MBEAN = "org.apache.logging.log4j2";
+
+    public record Response(
+            @Metadata(description = "The logger names mapped to their log level (only present when available)") Map<String, String> levels) {
+    }
 
     public LogDevConsole() {
         super("camel", "log", "Log", "Logging framework");
@@ -53,15 +58,10 @@ public class LogDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         Map<String, String> levels = fetchLoggingLevels();
-        if (!levels.isEmpty()) {
-            JsonObject props = new JsonObject();
-            root.put("levels", props);
-            props.putAll(levels);
-        }
-        return root;
+        Response response = new Response(levels.isEmpty() ? null : levels);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static Map<String, String> fetchLoggingLevels() {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/MemoryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/MemoryDevConsole.java
@@ -24,15 +24,33 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.camel.spi.Configurer;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 import static org.apache.camel.util.UnitUtils.printUnitFromBytesDot;
 
 @DevConsole(name = "memory", displayName = "JVM Memory", description = "Displays JVM memory information")
 @Configurer(extended = true)
 public class MemoryDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "Heap memory initial size") String heapMemoryInit,
+            @Metadata(description = "Heap memory max size") String heapMemoryMax,
+            @Metadata(description = "Heap memory used") String heapMemoryUsed,
+            @Metadata(description = "Heap memory committed") String heapMemoryCommitted,
+            @Metadata(description = "Non-heap memory initial size") String nonHeapMemoryInit,
+            @Metadata(description = "Non-heap memory max size") String nonHeapMemoryMax,
+            @Metadata(description = "Non-heap memory used") String nonHeapMemoryUsed,
+            @Metadata(description = "Non-heap memory committed") String nonHeapMemoryCommitted,
+            @Metadata(description = "Old generation memory pool used (only present when such a pool exists)") String oldGenUsed,
+            @Metadata(description = "Old generation memory pool committed (only present when such a pool exists)") String oldGenCommitted,
+            @Metadata(description = "Old generation memory pool max (only present when such a pool exists)") String oldGenMax,
+            @Metadata(description = "Metaspace memory pool used (only present when such a pool exists)") String metaspaceUsed,
+            @Metadata(description = "Metaspace memory pool committed (only present when such a pool exists)") String metaspaceCommitted,
+            @Metadata(description = "Metaspace memory pool max (only present when such a pool exists)") String metaspaceMax) {
+    }
 
     public MemoryDevConsole() {
         super("jvm", "memory", "JVM Memory", "Displays JVM memory information");
@@ -74,36 +92,54 @@ public class MemoryDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        String heapMemoryInit = null;
+        String heapMemoryMax = null;
+        String heapMemoryUsed = null;
+        String heapMemoryCommitted = null;
+        String nonHeapMemoryInit = null;
+        String nonHeapMemoryMax = null;
+        String nonHeapMemoryUsed = null;
+        String nonHeapMemoryCommitted = null;
 
         MemoryMXBean mb = ManagementFactory.getMemoryMXBean();
         if (mb != null) {
-            root.put("heapMemoryInit", printUnitFromBytesDot(mb.getHeapMemoryUsage().getInit()));
-            root.put("heapMemoryMax", printUnitFromBytesDot(mb.getHeapMemoryUsage().getMax()));
-            root.put("heapMemoryUsed", printUnitFromBytesDot(mb.getHeapMemoryUsage().getUsed()));
-            root.put("heapMemoryCommitted", printUnitFromBytesDot(mb.getHeapMemoryUsage().getCommitted()));
-            root.put("nonHeapMemoryInit", printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getInit()));
-            root.put("nonHeapMemoryMax", printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getMax()));
-            root.put("nonHeapMemoryUsed", printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getUsed()));
-            root.put("nonHeapMemoryCommitted", printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getCommitted()));
+            heapMemoryInit = printUnitFromBytesDot(mb.getHeapMemoryUsage().getInit());
+            heapMemoryMax = printUnitFromBytesDot(mb.getHeapMemoryUsage().getMax());
+            heapMemoryUsed = printUnitFromBytesDot(mb.getHeapMemoryUsage().getUsed());
+            heapMemoryCommitted = printUnitFromBytesDot(mb.getHeapMemoryUsage().getCommitted());
+            nonHeapMemoryInit = printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getInit());
+            nonHeapMemoryMax = printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getMax());
+            nonHeapMemoryUsed = printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getUsed());
+            nonHeapMemoryCommitted = printUnitFromBytesDot(mb.getNonHeapMemoryUsage().getCommitted());
         }
+
+        String oldGenUsed = null;
+        String oldGenCommitted = null;
+        String oldGenMax = null;
+        String metaspaceUsed = null;
+        String metaspaceCommitted = null;
+        String metaspaceMax = null;
 
         for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
             String name = pool.getName().toLowerCase(Locale.ROOT);
             if (pool.getType() == MemoryType.HEAP && (name.contains("old") || name.contains("tenured"))) {
-                root.put("oldGenUsed", printUnitFromBytesDot(pool.getUsage().getUsed()));
-                root.put("oldGenCommitted", printUnitFromBytesDot(pool.getUsage().getCommitted()));
+                oldGenUsed = printUnitFromBytesDot(pool.getUsage().getUsed());
+                oldGenCommitted = printUnitFromBytesDot(pool.getUsage().getCommitted());
                 long max = pool.getUsage().getMax();
-                root.put("oldGenMax", max > 0 ? printUnitFromBytesDot(max) : "-");
+                oldGenMax = max > 0 ? printUnitFromBytesDot(max) : "-";
             } else if (name.contains("metaspace")) {
-                root.put("metaspaceUsed", printUnitFromBytesDot(pool.getUsage().getUsed()));
-                root.put("metaspaceCommitted", printUnitFromBytesDot(pool.getUsage().getCommitted()));
+                metaspaceUsed = printUnitFromBytesDot(pool.getUsage().getUsed());
+                metaspaceCommitted = printUnitFromBytesDot(pool.getUsage().getCommitted());
                 long max = pool.getUsage().getMax();
-                root.put("metaspaceMax", max > 0 ? printUnitFromBytesDot(max) : "-");
+                metaspaceMax = max > 0 ? printUnitFromBytesDot(max) : "-";
             }
         }
 
-        return root;
+        Response response = new Response(
+                heapMemoryInit, heapMemoryMax, heapMemoryUsed, heapMemoryCommitted, nonHeapMemoryInit, nonHeapMemoryMax,
+                nonHeapMemoryUsed, nonHeapMemoryCommitted, oldGenUsed, oldGenCommitted, oldGenMax, metaspaceUsed,
+                metaspaceCommitted, metaspaceMax);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/MessageHistoryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/MessageHistoryDevConsole.java
@@ -17,7 +17,9 @@
 package org.apache.camel.impl.console;
 
 import java.io.LineNumberReader;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Route;
@@ -32,6 +34,7 @@ import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "message-history", displayName = "Message History", description = "History of latest completed exchange")
@@ -41,6 +44,11 @@ public class MessageHistoryDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Number of source code lines around the location to include",
               javaType = "java.lang.Integer", defaultValue = "5")
     public static final String CODE_LIMIT = "codeLimit";
+
+    public record Response(
+            @Metadata(description = "The CamelContext name (only present when a backlog tracer is available)") String name,
+            @Metadata(description = "The latest completed message trace entries, as opaque JSON objects (only present when a backlog tracer is available)") List<Map<String, Object>> traces) {
+    }
 
     public MessageHistoryDevConsole() {
         super("camel", "message-history", "Message History", "History of latest completed exchange");
@@ -61,14 +69,15 @@ public class MessageHistoryDevConsole extends AbstractDevConsole {
         return sb.toString();
     }
 
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         int codeLimit = optionInt(options, CODE_LIMIT, 5);
+
+        String name = null;
+        List<Map<String, Object>> traces = null;
 
         BacklogTracer tracer = getCamelContext().getCamelContextExtension().getContextPlugin(BacklogTracer.class);
         if (tracer != null) {
-            JsonArray arr = new JsonArray();
+            traces = new ArrayList<>();
 
             Collection<BacklogTracerEventMessage> queue = tracer.getLatestMessageHistory();
             for (BacklogTracerEventMessage t : queue) {
@@ -87,13 +96,13 @@ public class MessageHistoryDevConsole extends AbstractDevConsole {
                     }
                 }
 
-                arr.add(to);
+                traces.add(to);
             }
-            root.put("name", getCamelContext().getName());
-            root.put("traces", arr);
+            name = getCamelContext().getName();
         }
 
-        return root;
+        Response response = new Response(name, traces);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private JsonArray enrichSourceCode(String routeId, String location, int lines) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDetailDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDetailDevConsole.java
@@ -17,6 +17,8 @@
 package org.apache.camel.impl.console;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,8 +41,7 @@ import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "processor-detail", description = "Show configured options for all processors in a route")
 public class ProcessorDetailDevConsole extends AbstractDevConsole {
@@ -50,38 +51,53 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
               javaType = "java.lang.String")
     public static final String ROUTE_ID = "routeId";
 
+    public record ProcessorEntry(
+            @Metadata(description = "The processor ID") String id,
+            @Metadata(description = "The processor type (the XML element name, or 'from' for the route input)") String type,
+            @Metadata(description = "The endpoint URI (only present for the route input entry)") String endpointUri,
+            @Metadata(description = "The source line number (only present when known)") Integer line,
+            @Metadata(description = "The processor's configured options, as attribute/child-element name to string value") Map<String, String> options) {
+    }
+
+    public record RouteDetail(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route's processors, starting with the route input") List<ProcessorEntry> processors) {
+    }
+
+    public record Response(
+            @Metadata(description = "The route ID (only present when a specific route was requested)") String routeId,
+            @Metadata(description = "The route's processors (only present when a specific route was requested)") List<ProcessorEntry> processors,
+            @Metadata(description = "The route details for all routes (only present when routeId is * or omitted)") List<RouteDetail> routes) {
+    }
+
     public ProcessorDetailDevConsole() {
         super("camel", "processor-detail", "Processor Detail", "Show configured options for all processors in a route");
     }
 
     @Override
     protected String doCallText(Map<String, Object> options) {
-        JsonObject json = doCallJson(options);
+        Response response = doCallResponse(options);
         StringBuilder sb = new StringBuilder();
 
-        JsonArray routes = (JsonArray) json.get("routes");
-        if (routes != null) {
-            for (Object routeObj : routes) {
-                appendRouteText(sb, (JsonObject) routeObj);
+        if (response.routes() != null) {
+            for (RouteDetail route : response.routes()) {
+                appendRouteText(sb, route.routeId(), route.processors());
             }
         } else {
-            appendRouteText(sb, json);
+            appendRouteText(sb, response.routeId(), response.processors());
         }
         return sb.toString();
     }
 
-    private static void appendRouteText(StringBuilder sb, JsonObject routeJson) {
-        String routeId = routeJson.getString("routeId");
+    private static void appendRouteText(StringBuilder sb, String routeId, List<ProcessorEntry> processors) {
         if (routeId != null) {
             sb.append(String.format("Route: %s%n", routeId));
-            JsonArray processors = (JsonArray) routeJson.get("processors");
             if (processors != null) {
-                for (Object obj : processors) {
-                    JsonObject p = (JsonObject) obj;
-                    sb.append(String.format("  %s (%s)%n", p.getString("id"), p.getString("type")));
-                    JsonObject opts = p.getMap("options");
+                for (ProcessorEntry p : processors) {
+                    sb.append(String.format("  %s (%s)%n", p.id(), p.type()));
+                    Map<String, String> opts = p.options();
                     if (opts != null) {
-                        for (Map.Entry<String, Object> e : opts.entrySet()) {
+                        for (Map.Entry<String, String> e : opts.entrySet()) {
                             sb.append(String.format("    %s = %s%n", e.getKey(), e.getValue()));
                         }
                     }
@@ -91,7 +107,11 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        return JsonRecordSupport.toJsonObject(doCallResponse(options));
+    }
+
+    private Response doCallResponse(Map<String, Object> options) {
         String path = (String) options.get(Exchange.HTTP_PATH);
         String subPath = path != null ? StringHelper.after(path, "/") : null;
         String routeId = optionString(options, ROUTE_ID);
@@ -103,49 +123,40 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
             routeId = "*";
         }
 
-        JsonObject root = new JsonObject();
-
         ManagedCamelContext mcc
                 = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
         if (mcc == null) {
-            return root;
+            return new Response(null, null, null);
         }
 
         if ("*".equals(routeId)) {
             List<ManagedRouteMBean> managedRoutes = mcc.getManagedRoutes();
             if (managedRoutes == null || managedRoutes.isEmpty()) {
-                return root;
+                return new Response(null, null, null);
             }
-            JsonArray routes = new JsonArray();
+            List<RouteDetail> routes = new ArrayList<>();
             for (ManagedRouteMBean mr : managedRoutes) {
-                JsonObject routeJson = buildRouteDetail(mr);
-                if (routeJson != null) {
-                    routes.add(routeJson);
+                RouteDetail routeDetail = buildRouteDetail(mr);
+                if (routeDetail != null) {
+                    routes.add(routeDetail);
                 }
             }
-            root.put("routes", routes);
-            return root;
+            return new Response(null, null, routes);
         }
 
         ManagedRouteMBean mr = mcc.getManagedRoute(routeId);
         if (mr == null) {
-            return root;
+            return new Response(null, null, null);
         }
-        return buildRouteDetail(mr);
+        RouteDetail routeDetail = buildRouteDetail(mr);
+        return new Response(routeDetail.routeId(), routeDetail.processors(), null);
     }
 
-    private static JsonObject buildRouteDetail(ManagedRouteMBean mr) {
+    private static RouteDetail buildRouteDetail(ManagedRouteMBean mr) {
         String routeId = mr.getRouteId();
-        JsonObject root = new JsonObject();
-        root.put("routeId", routeId);
-        JsonArray processors = new JsonArray();
+        List<ProcessorEntry> processors = new ArrayList<>();
 
-        JsonObject fromEntry = new JsonObject();
-        fromEntry.put("id", routeId);
-        fromEntry.put("type", "from");
-        fromEntry.put("endpointUri", mr.getEndpointUri());
-        fromEntry.put("options", new JsonObject());
-        processors.add(fromEntry);
+        Integer fromLine = null;
 
         try {
             String xml = mr.dumpRouteAsXml(false, true, true);
@@ -161,7 +172,7 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
                 // extract source line number for the from entry from the <from> child element
                 NodeList fromNodes = routeElement.getElementsByTagName("from");
                 if (fromNodes.getLength() > 0) {
-                    extractSourceLineNumber((Element) fromNodes.item(0), fromEntry);
+                    fromLine = extractSourceLineNumber((Element) fromNodes.item(0));
                 }
 
                 collectProcessors(routeElement, processors);
@@ -170,11 +181,13 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
             // ignore
         }
 
-        root.put("processors", processors);
-        return root;
+        ProcessorEntry fromEntry = new ProcessorEntry(routeId, "from", mr.getEndpointUri(), fromLine, new LinkedHashMap<>());
+        processors.add(0, fromEntry);
+
+        return new RouteDetail(routeId, processors);
     }
 
-    private static void collectProcessors(Element parent, JsonArray processors) {
+    private static void collectProcessors(Element parent, List<ProcessorEntry> processors) {
         NodeList children = parent.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             Node node = children.item(i);
@@ -194,13 +207,10 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
             if ("from".equals(type)) {
                 continue;
             }
-            JsonObject entry = new JsonObject();
-            entry.put("id", id);
-            entry.put("type", type);
 
-            extractSourceLineNumber(elem, entry);
+            Integer line = extractSourceLineNumber(elem);
 
-            JsonObject opts = new JsonObject();
+            Map<String, String> opts = new LinkedHashMap<>();
             NamedNodeMap attrs = elem.getAttributes();
             for (int j = 0; j < attrs.getLength(); j++) {
                 Attr attr = (Attr) attrs.item(j);
@@ -215,15 +225,14 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
             // <correlationExpression>, <completionPredicate>, etc.)
             collectExpressionChildren(elem, opts);
 
-            entry.put("options", opts);
-            processors.add(entry);
+            processors.add(new ProcessorEntry(id, type, null, line, opts));
 
             // recurse into child elements (nested EIPs like split > to, choice > when > to)
             collectProcessors(elem, processors);
         }
     }
 
-    private static void collectExpressionChildren(Element parent, JsonObject opts) {
+    private static void collectExpressionChildren(Element parent, Map<String, String> opts) {
         NodeList children = parent.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             Node node = children.item(i);
@@ -286,14 +295,15 @@ public class ProcessorDetailDevConsole extends AbstractDevConsole {
         return null;
     }
 
-    private static void extractSourceLineNumber(Element elem, JsonObject entry) {
+    private static Integer extractSourceLineNumber(Element elem) {
         String lineStr = elem.getAttribute("sourceLineNumber");
         if (lineStr != null && !lineStr.isEmpty()) {
             try {
-                entry.put("line", Integer.parseInt(lineStr));
+                return Integer.parseInt(lineStr);
             } catch (NumberFormatException e) {
                 // ignore
             }
         }
+        return null;
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProcessorDevConsole.java
@@ -36,8 +36,8 @@ import org.apache.camel.support.LoggerHelper;
 import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +46,53 @@ import org.slf4j.LoggerFactory;
 public class ProcessorDevConsole extends AbstractDevConsole {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessorDevConsole.class);
+
+    public record CodeLine(
+            @Metadata(description = "The source line number (only present when known)") Integer line,
+            @Metadata(description = "The source code line") String code,
+            @Metadata(description = "Whether this is the matched line (only present when true)") Boolean match) {
+    }
+
+    public record Statistics(
+            @Metadata(description = "Epoch time in milliseconds since the processor has been idle") long idleSince,
+            @Metadata(description = "Total number of exchanges") long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges") long exchangesFailed,
+            @Metadata(description = "Number of inflight exchanges") long exchangesInflight,
+            @Metadata(description = "Messages per second throughput (only present when available)") String exchangesThroughput,
+            @Metadata(description = "Mean processing time in milliseconds") long meanProcessingTime,
+            @Metadata(description = "Max processing time in milliseconds") long maxProcessingTime,
+            @Metadata(description = "Min processing time in milliseconds") long minProcessingTime,
+            @Metadata(description = "50th percentile processing time in milliseconds (only present when available)") Long p50ProcessingTime,
+            @Metadata(description = "95th percentile processing time in milliseconds (only present when available)") Long p95ProcessingTime,
+            @Metadata(description = "99th percentile processing time in milliseconds (only present when available)") Long p99ProcessingTime,
+            @Metadata(description = "Processing time in milliseconds of the last exchange (only present once an exchange has completed)") Long lastProcessingTime,
+            @Metadata(description = "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)") Long deltaProcessingTime,
+            @Metadata(description = "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)") Long lastCreatedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)") Long lastCompletedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)") Long lastFailureHandledExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failed (only present once one has occurred)") Long lastFailedExchangeTimestamp) {
+    }
+
+    public record ProcessorEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The processor ID") String id,
+            @Metadata(description = "The node prefix ID (only present when known)") String nodePrefixId,
+            @Metadata(description = "The processor description (only present when configured)") String description,
+            @Metadata(description = "The processor note (only present when configured)") String note,
+            @Metadata(description = "The source location, optionally with a line number suffix (only present when known)") String source,
+            @Metadata(description = "The processor state") String state,
+            @Metadata(description = "Whether the processor is disabled (only present when known)") Boolean disabled,
+            @Metadata(description = "The step ID (only present when known)") String stepId,
+            @Metadata(description = "A snippet of source code around the processor (only present when known)") List<CodeLine> code,
+            @Metadata(description = "The processor name") String processor,
+            @Metadata(description = "The processor level in the route tree") int level,
+            @Metadata(description = "The destination URI, for processors that send to a destination (only present when applicable)") String uri,
+            @Metadata(description = "Runtime statistics") Statistics statistics) {
+    }
+
+    public record Response(
+            @Metadata(description = "The processors (only present when no action was requested)") List<ProcessorEntry> processors) {
+    }
 
     @Metadata(label = "query",
               description = "Filters the processors matching by processor id, route id, or route group, and source location",
@@ -187,28 +234,27 @@ public class ProcessorDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String action = optionString(options, ACTION);
         String filter = optionString(options, FILTER);
         final int max = optionInt(options, LIMIT, Integer.MAX_VALUE);
         if (action != null) {
             doAction(getCamelContext(), action, filter);
-            return new JsonObject();
+            return JsonRecordSupport.toJsonObject(new Response(null));
         }
 
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
+        List<ProcessorEntry> list = new ArrayList<>();
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
         for (Route r : getCamelContext().getRoutes()) {
             ManagedRouteMBean mrb = mcc.getManagedRoute(r.getRouteId());
-            includeProcessorsJson(mrb, arr, filter, max);
+            includeProcessorsJson(mrb, list, filter, max);
         }
 
-        root.put("processors", arr);
-        return root;
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private void includeProcessorsJson(ManagedRouteMBean mrb, JsonArray arr, String filter, int max) {
+    private void includeProcessorsJson(ManagedRouteMBean mrb, List<ProcessorEntry> list, String filter, int max) {
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
 
         Collection<String> ids;
@@ -230,42 +276,24 @@ public class ProcessorDevConsole extends AbstractDevConsole {
         // sort processors by index
         mps.sort(Comparator.comparingInt(ManagedProcessorMBean::getIndex));
 
-        // include processors into the array
-        includeProcessorsJSon(getCamelContext(), arr, max, mps);
+        // include processors into the list
+        includeProcessorsJSon(getCamelContext(), list, max, mps);
     }
 
     public static void includeProcessorsJSon(
-            CamelContext camelContext, JsonArray arr, int max, List<ManagedProcessorMBean> mps) {
+            CamelContext camelContext, List<ProcessorEntry> list, int max, List<ManagedProcessorMBean> mps) {
         for (int i = 0; i < mps.size(); i++) {
             ManagedProcessorMBean mp = mps.get(i);
-            if (arr.size() > max) {
+            if (list.size() > max) {
                 return;
             }
-            JsonObject jo = new JsonObject();
-            arr.add(jo);
 
-            jo.put("routeId", mp.getRouteId());
-            jo.put("id", mp.getProcessorId());
-            if (mp.getNodePrefixId() != null) {
-                jo.put("nodePrefixId", mp.getNodePrefixId());
-            }
-            if (mp.getDescription() != null) {
-                jo.put("description", mp.getDescription());
-            }
-            if (mp.getNote() != null) {
-                jo.put("note", mp.getNote());
-            }
+            String source = null;
             if (mp.getSourceLocation() != null) {
-                String loc = mp.getSourceLocation();
+                source = mp.getSourceLocation();
                 if (mp.getSourceLineNumber() != null) {
-                    loc += ":" + mp.getSourceLineNumber();
+                    source += ":" + mp.getSourceLineNumber();
                 }
-                jo.put("source", loc);
-            }
-            jo.put("state", mp.getState());
-            jo.put("disabled", mp.getDisabled());
-            if (mp.getStepId() != null) {
-                jo.put("stepId", mp.getStepId());
             }
 
             // calculate end line number
@@ -280,36 +308,25 @@ public class ProcessorDevConsole extends AbstractDevConsole {
                 }
             }
 
-            JsonArray ca = new JsonArray();
+            List<CodeLine> code = new ArrayList<>();
             List<String> lines
                     = ConsoleHelper.loadSourceLines(camelContext, mp.getSourceLocation(), mp.getSourceLineNumber(), end);
             Integer pos = mp.getSourceLineNumber();
             for (String line : lines) {
-                JsonObject c = new JsonObject();
-                c.put("line", pos);
-                c.put("code", Jsoner.escape(line));
-                if (pos != null && pos.equals(mp.getSourceLineNumber())) {
-                    c.put("match", true);
-                }
-                ca.add(c);
+                Boolean match = pos != null && pos.equals(mp.getSourceLineNumber()) ? true : null;
+                code.add(new CodeLine(pos, Jsoner.escape(line), match));
                 if (pos != null) {
                     pos++;
                 }
             }
-            if (!ca.isEmpty()) {
-                jo.put("code", ca);
-            }
-            jo.put("processor", mp.getProcessorName());
-            jo.put("level", mp.getLevel());
 
             // processors which can send to a destination (such as to/toD/poll etc)
             String destination = getDestination(camelContext, mp);
-            if (destination != null) {
-                jo.put("uri", destination);
-            }
 
-            final JsonObject stats = gatherProcessorStats(mp);
-            jo.put("statistics", stats);
+            list.add(new ProcessorEntry(
+                    mp.getRouteId(), mp.getProcessorId(), mp.getNodePrefixId(), mp.getDescription(), mp.getNote(),
+                    source, mp.getState(), mp.getDisabled(), mp.getStepId(), code.isEmpty() ? null : code,
+                    mp.getProcessorName(), mp.getLevel(), destination, buildStatistics(mp)));
         }
     }
 
@@ -328,47 +345,48 @@ public class ProcessorDevConsole extends AbstractDevConsole {
     }
 
     public static JsonObject gatherProcessorStats(ManagedProcessorMBean mp) {
-        JsonObject stats = new JsonObject();
-        stats.put("idleSince", mp.getIdleSince());
-        stats.put("exchangesTotal", mp.getExchangesTotal());
-        stats.put("exchangesFailed", mp.getExchangesFailed());
-        stats.put("exchangesInflight", mp.getExchangesInflight());
+        return JsonRecordSupport.toJsonObject(buildStatistics(mp));
+    }
+
+    private static Statistics buildStatistics(ManagedProcessorMBean mp) {
         String thp = mp.getThroughput();
         if (thp != null) {
             thp = thp.replace(',', '.');
-            if (!thp.isEmpty()) {
-                stats.put("exchangesThroughput", thp);
+            if (thp.isEmpty()) {
+                thp = null;
             }
         }
-        stats.put("meanProcessingTime", mp.getMeanProcessingTime());
-        stats.put("maxProcessingTime", mp.getMaxProcessingTime());
-        stats.put("minProcessingTime", mp.getMinProcessingTime());
+
+        Long p50 = null;
+        Long p95 = null;
+        Long p99 = null;
         if (mp.getProcessingTimeP50() >= 0) {
-            stats.put("p50ProcessingTime", mp.getProcessingTimeP50());
-            stats.put("p95ProcessingTime", mp.getProcessingTimeP95());
-            stats.put("p99ProcessingTime", mp.getProcessingTimeP99());
+            p50 = mp.getProcessingTimeP50();
+            p95 = mp.getProcessingTimeP95();
+            p99 = mp.getProcessingTimeP99();
         }
+
+        Long lastProcessingTime = null;
+        Long deltaProcessingTime = null;
         if (mp.getExchangesTotal() > 0) {
-            stats.put("lastProcessingTime", mp.getLastProcessingTime());
-            stats.put("deltaProcessingTime", mp.getDeltaProcessingTime());
+            lastProcessingTime = mp.getLastProcessingTime();
+            deltaProcessingTime = mp.getDeltaProcessingTime();
         }
-        Date last = mp.getLastExchangeCreatedTimestamp();
-        if (last != null) {
-            stats.put("lastCreatedExchangeTimestamp", last.getTime());
-        }
-        last = mp.getLastExchangeCompletedTimestamp();
-        if (last != null) {
-            stats.put("lastCompletedExchangeTimestamp", last.getTime());
-        }
-        last = mp.getLastExchangeFailureHandledTimestamp();
-        if (last != null) {
-            stats.put("lastFailureHandledExchangeTimestamp", last.getTime());
-        }
-        last = mp.getLastExchangeFailureTimestamp();
-        if (last != null) {
-            stats.put("lastFailedExchangeTimestamp", last.getTime());
-        }
-        return stats;
+
+        Long lastCreated = timestampOf(mp.getLastExchangeCreatedTimestamp());
+        Long lastCompleted = timestampOf(mp.getLastExchangeCompletedTimestamp());
+        Long lastFailureHandled = timestampOf(mp.getLastExchangeFailureHandledTimestamp());
+        Long lastFailed = timestampOf(mp.getLastExchangeFailureTimestamp());
+
+        return new Statistics(
+                mp.getIdleSince(), mp.getExchangesTotal(), mp.getExchangesFailed(), mp.getExchangesInflight(), thp,
+                mp.getMeanProcessingTime(), mp.getMaxProcessingTime(), mp.getMinProcessingTime(),
+                p50, p95, p99, lastProcessingTime, deltaProcessingTime,
+                lastCreated, lastCompleted, lastFailureHandled, lastFailed);
+    }
+
+    private static Long timestampOf(Date date) {
+        return date != null ? date.getTime() : null;
     }
 
     private static boolean accept(ManagedProcessorMBean mrb, String filter) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ProducerDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ProducerDevConsole.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,13 +26,26 @@ import javax.management.ObjectName;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.api.management.mbean.ManagedProducerMBean;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "producer", displayName = "Producers", description = "Display information about Camel producers")
 public class ProducerDevConsole extends AbstractDevConsole {
+
+    public record ProducerEntry(
+            @Metadata(description = "The endpoint URI") String uri,
+            @Metadata(description = "The producer state") String state,
+            @Metadata(description = "The producer service type") String clazz,
+            @Metadata(description = "Whether the endpoint is remote") boolean remote,
+            @Metadata(description = "Whether the producer is a singleton") boolean singleton,
+            @Metadata(description = "The route ID (only present when known)") String routeId,
+            @Metadata(description = "The step ID (only present when known)") String stepId) {
+    }
+
+    public record Response(@Metadata(description = "The producers") List<ProducerEntry> producers) {
+    }
 
     public ProducerDevConsole() {
         super("camel", "producer", "Producers", "Display information about Camel producers");
@@ -77,10 +92,8 @@ public class ProducerDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
-        root.put("producers", list);
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        final List<ProducerEntry> list = new ArrayList<>();
 
         MBeanServer mbeanServer = getCamelContext().getManagementStrategy().getManagementAgent().getMBeanServer();
         if (mbeanServer != null) {
@@ -95,26 +108,18 @@ public class ProducerDevConsole extends AbstractDevConsole {
                 if (set != null && !set.isEmpty()) {
                     for (ObjectName on : set) {
                         ManagedProducerMBean mp = getManagedProducer(getCamelContext(), on);
-                        JsonObject jo = new JsonObject();
-                        jo.put("uri", mp.getEndpointUri());
-                        jo.put("state", mp.getState());
-                        jo.put("class", mp.getServiceType());
-                        jo.put("remote", mp.isRemoteEndpoint());
-                        jo.put("singleton", mp.isSingleton());
-                        if (mp.getRouteId() != null) {
-                            jo.put("routeId", mp.getRouteId());
-                        }
-                        if (mp.getStepId() != null) {
-                            jo.put("stepId", mp.getStepId());
-                        }
-                        list.add(jo);
+                        list.add(new ProducerEntry(
+                                mp.getEndpointUri(), mp.getState(), mp.getServiceType(), mp.isRemoteEndpoint(),
+                                mp.isSingleton(), mp.getRouteId(), mp.getStepId()));
                     }
                 }
             } catch (Exception e) {
                 // ignore
             }
         }
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static ManagedProducerMBean getManagedProducer(CamelContext camelContext, ObjectName on) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/PropertiesDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/PropertiesDevConsole.java
@@ -16,24 +16,41 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PropertiesComponent;
 import org.apache.camel.spi.RuntimePropertiesProvider;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.OrderedLocationProperties;
 import org.apache.camel.util.SensitiveUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 import static org.apache.camel.util.LocationHelper.locationSummary;
 
 @DevConsole(name = "properties", description = "Displays the properties loaded by Camel")
 public class PropertiesDevConsole extends AbstractDevConsole {
+
+    public record PropertyEntry(
+            @Metadata(description = "The property key") String key,
+            @Metadata(description = "The property value (masked when sensitive)") String value,
+            @Metadata(description = "The original unresolved value (only present when resolved via a properties function)") String originalValue,
+            @Metadata(description = "The default value (only present when one was used)") String defaultValue,
+            @Metadata(description = "The source that provided the value (only present when known)") String source,
+            @Metadata(description = "The location the value was loaded from (only present when known)") String location,
+            @Metadata(description = "Whether the location is an internal Camel location (only present when location is known)") Boolean internal) {
+    }
+
+    public record Response(
+            @Metadata(description = "The locations properties are loaded from") List<String> locations,
+            @Metadata(description = "The loaded properties (only present when there are any)") List<PropertyEntry> properties) {
+    }
 
     public PropertiesDevConsole() {
         super("camel", "properties", "Properties", "Displays the properties loaded by Camel");
@@ -90,13 +107,10 @@ public class PropertiesDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         PropertiesComponent pc = getCamelContext().getPropertiesComponent();
-        root.put("locations", pc.getLocations());
 
-        JsonArray arr = new JsonArray();
+        List<PropertyEntry> entries = new ArrayList<>();
 
         // when a runtime provider is present (Spring Boot, Quarkus, etc.) it is the
         // authoritative source — skip pc.loadProperties() to avoid noisy duplicates
@@ -109,11 +123,9 @@ public class PropertiesDevConsole extends AbstractDevConsole {
                 if (runtimeProps != null && !runtimeProps.isEmpty()) {
                     for (RuntimePropertiesProvider.Property prop : runtimeProps) {
                         boolean sensitive = SensitiveUtils.containsSensitive(prop.key());
-                        JsonObject jo = new JsonObject();
-                        jo.put("key", prop.key());
-                        jo.put("value", sensitive ? "xxxxxx" : prop.value());
-                        jo.put("source", prop.source());
-                        arr.add(jo);
+                        entries.add(new PropertyEntry(
+                                prop.key(), sensitive ? "xxxxxx" : String.valueOf(prop.value()), null, null, prop.source(),
+                                null, null));
                     }
                 }
             }
@@ -121,18 +133,15 @@ public class PropertiesDevConsole extends AbstractDevConsole {
             Properties p = pc.loadProperties();
             OrderedLocationProperties olp = p instanceof OrderedLocationProperties o ? o : null;
             for (var entry : p.entrySet()) {
-                arr.add(toPropertyJson(pc, olp, entry));
+                entries.add(toPropertyEntry(pc, olp, entry));
             }
         }
 
-        if (!arr.isEmpty()) {
-            root.put("properties", arr);
-        }
-
-        return root;
+        Response response = new Response(pc.getLocations(), entries.isEmpty() ? null : entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static JsonObject toPropertyJson(
+    private static PropertyEntry toPropertyEntry(
             PropertiesComponent pc, OrderedLocationProperties olp, Map.Entry<Object, Object> entry) {
 
         String k = entry.getKey().toString();
@@ -149,23 +158,10 @@ public class PropertiesDevConsole extends AbstractDevConsole {
             v = m.get().value();
         }
         boolean sensitive = SensitiveUtils.containsSensitive(k);
-        JsonObject jo = new JsonObject();
-        jo.put("key", k);
-        jo.put("value", sensitive ? "xxxxxx" : v);
-        if (originalValue != null) {
-            jo.put("originalValue", sensitive ? "xxxxxx" : originalValue);
-        }
-        if (defaultValue != null) {
-            jo.put("defaultValue", defaultValue);
-        }
-        if (source != null) {
-            jo.put("source", source);
-        }
-        if (loc != null) {
-            jo.put("location", loc);
-            jo.put("internal", isInternal(loc));
-        }
-        return jo;
+        String value = sensitive ? "xxxxxx" : String.valueOf(v);
+        String originalValueOut = originalValue != null ? (sensitive ? "xxxxxx" : originalValue) : null;
+        Boolean internal = loc != null ? isInternal(loc) : null;
+        return new PropertyEntry(k, value, originalValueOut, defaultValue, source, loc, internal);
     }
 
     private static boolean isInternal(String loc) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ReceiveDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ReceiveDevConsole.java
@@ -17,7 +17,7 @@
 package org.apache.camel.impl.console;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -45,12 +45,30 @@ import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "receive", displayName = "Camel Receive", description = "Consume messages from endpoints",
             readOnly = false)
 @Configurer(extended = true)
 public class ReceiveDevConsole extends AbstractDevConsole {
+
+    public record EndpointEntry(
+            @Metadata(description = "The endpoint URI") String uri,
+            @Metadata(description = "Whether the endpoint is remote") boolean remote) {
+    }
+
+    public record Response(
+            @Metadata(description = "The dumped received messages, as opaque JSON objects (only present when dumping)") List<Map<String, Object>> messages,
+            @Metadata(description = "Whether receiving is enabled (only present when not dumping)") Boolean enabled,
+            @Metadata(description = "Total number of messages received so far (only present when not dumping)") Long total,
+            @Metadata(description = "Epoch time in milliseconds of the first message in the last dump (only present when not dumping)") Long firstTimestamp,
+            @Metadata(description = "Epoch time in milliseconds of the last message in the last dump (only present when not dumping)") Long lastTimestamp,
+            @Metadata(description = "The endpoint URI that receiving was started for (only present on success)") String url,
+            @Metadata(description = "The error message (only present on failure to start receiving)") String error,
+            @Metadata(description = "The error stack trace, one entry per line (only present on failure to start receiving)") List<String> stackTrace,
+            @Metadata(description = "The active consumer endpoints (only present when not dumping and there are any)") List<EndpointEntry> endpoints) {
+    }
 
     @Metadata(defaultValue = "100",
               description = "Maximum capacity of last number of messages to capture (capacity must be between 50 and 1000)")
@@ -184,39 +202,41 @@ public class ReceiveDevConsole extends AbstractDevConsole {
         return sb.toString();
     }
 
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String dump = optionString(options, DUMP);
         if ("true".equals(dump)) {
-            JsonArray arr = new JsonArray();
-            arr.addAll(queue);
+            List<Map<String, Object>> messages = new ArrayList<>(queue);
             if (removeOnDump) {
                 queue.clear();
             }
-            root.put("messages", arr);
-            JsonObject jo = (JsonObject) arr.get(0);
-            firstTimestamp = jo.getLongOrDefault("timestamp", 0);
-            jo = (JsonObject) arr.get(arr.size() - 1);
-            lastTimestamp = jo.getLongOrDefault("timestamp", 0);
-            return root;
+            JsonObject first = (JsonObject) messages.get(0);
+            firstTimestamp = first.getLongOrDefault("timestamp", 0);
+            JsonObject last = (JsonObject) messages.get(messages.size() - 1);
+            lastTimestamp = last.getLongOrDefault("timestamp", 0);
+
+            Response response = new Response(messages, null, null, null, null, null, null, null, null);
+            return JsonRecordSupport.toJsonObject(response);
         }
 
-        String enabled = optionString(options, ENABLED);
-        if ("false".equals(enabled)) {
+        String enabledOpt = optionString(options, ENABLED);
+        if ("false".equals(enabledOpt)) {
             // turn off all consumers
             stopConsumers();
             this.enabled.set(false);
-            root.put("enabled", false);
-            return root;
+            Response response = new Response(null, false, null, null, null, null, null, null, null);
+            return JsonRecordSupport.toJsonObject(response);
         }
+
+        String url = null;
+        String error = null;
+        List<String> stackTrace = null;
 
         String pattern = optionString(options, ENDPOINT);
         if (pattern != null) {
             try {
                 Endpoint target = findMatchingEndpoint(getCamelContext(), pattern);
                 if (target != null) {
-                    root.put("url", target.getEndpointUri());
+                    url = target.getEndpointUri();
                     Consumer consumer = createConsumer(target);
                     if (!consumers.contains(consumer)) {
                         consumers.add(consumer);
@@ -225,30 +245,23 @@ public class ReceiveDevConsole extends AbstractDevConsole {
                 }
                 this.enabled.set(true);
             } catch (Exception e) {
-                root.put("error", Jsoner.escape(e.getMessage()));
-                JsonArray arr2 = new JsonArray();
+                error = Jsoner.escape(e.getMessage());
                 final String trace = ExceptionHelper.stackTraceToString(e);
-                root.put("stackTrace", arr2);
-                Collections.addAll(arr2, trace.split("\n"));
+                stackTrace = Arrays.asList(trace.split("\n"));
             }
         }
 
-        root.put("enabled", this.enabled.get());
-        root.put("total", uuid.get());
-        root.put("firstTimestamp", firstTimestamp);
-        root.put("lastTimestamp", lastTimestamp);
+        List<EndpointEntry> endpoints = null;
+        if (!consumers.isEmpty()) {
+            endpoints = new ArrayList<>();
+            for (Consumer c : consumers) {
+                endpoints.add(new EndpointEntry(c.getEndpoint().toString(), c.getEndpoint().isRemote()));
+            }
+        }
 
-        JsonArray arr = new JsonArray();
-        for (Consumer c : consumers) {
-            JsonObject jo = new JsonObject();
-            jo.put("uri", c.getEndpoint().toString());
-            jo.put("remote", c.getEndpoint().isRemote());
-            arr.add(jo);
-        }
-        if (!arr.isEmpty()) {
-            root.put("endpoints", arr);
-        }
-        return root;
+        Response response = new Response(
+                null, this.enabled.get(), uuid.get(), firstTimestamp, lastTimestamp, url, error, stackTrace, endpoints);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private Consumer createConsumer(Endpoint target) throws Exception {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ReloadDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ReloadDevConsole.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -28,11 +30,27 @@ import org.apache.camel.spi.ReloadStrategy;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.ExceptionHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "reload", description = "Console for reloading running Camel", readOnly = false)
 public class ReloadDevConsole extends AbstractDevConsole {
+
+    public record LastError(
+            @Metadata(description = "The error message") String message,
+            @Metadata(description = "The error stack trace, one entry per line") List<String> stackTrace) {
+    }
+
+    public record ReloadEntry(
+            @Metadata(description = "The reload strategy class name") String className,
+            @Metadata(description = "Number of successful reloads") int reloaded,
+            @Metadata(description = "Number of failed reloads") int failed,
+            @Metadata(description = "The last reload error (only present when a reload has failed)") LastError lastError) {
+    }
+
+    public record Response(
+            @Metadata(description = "The reload strategies (only present when not triggering a reload and at least one reload strategy is active)") List<ReloadEntry> reloadStrategies,
+            @Metadata(description = "The reload status, reloading/success/failed (only present when triggering a reload)") String status) {
+    }
 
     @Metadata(label = "query", description = "Option to trigger reloading", javaType = "java.lang.Boolean",
               defaultValue = "false")
@@ -97,12 +115,13 @@ public class ReloadDevConsole extends AbstractDevConsole {
         return sb.toString();
     }
 
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         boolean trigger = optionBoolean(options, RELOAD, false);
         boolean wait = optionBoolean(options, RELOAD_WAIT, false);
-        JsonObject root = new JsonObject();
 
-        JsonArray arr = new JsonArray();
+        List<ReloadEntry> reloadStrategies = null;
+        String status = null;
+
         Set<ReloadStrategy> rs = getCamelContext().hasServices(ReloadStrategy.class);
         boolean failed = false;
         for (ReloadStrategy r : rs) {
@@ -118,39 +137,26 @@ public class ReloadDevConsole extends AbstractDevConsole {
                     }
                 }
             } else {
-                if (root.isEmpty()) {
-                    root.put("reloadStrategies", arr);
+                if (reloadStrategies == null) {
+                    reloadStrategies = new ArrayList<>();
                 }
-                JsonObject jo = new JsonObject();
-                arr.add(jo);
-                jo.put("className", r.getClass().getName());
-                jo.put("reloaded", r.getReloadCounter());
-                jo.put("failed", r.getFailedCounter());
+                LastError lastError = null;
                 Throwable cause = r.getLastError();
                 if (cause != null) {
-                    JsonObject eo = new JsonObject();
-                    eo.put("message", cause.getMessage());
-                    JsonArray arr2 = new JsonArray();
                     final String trace = ExceptionHelper.stackTraceToString(cause);
-                    eo.put("stackTrace", arr2);
-                    Collections.addAll(arr2, trace.split("\n"));
-                    jo.put("lastError", eo);
+                    lastError = new LastError(cause.getMessage(), Arrays.asList(trace.split("\n")));
                 }
+                reloadStrategies.add(new ReloadEntry(
+                        r.getClass().getName(), r.getReloadCounter(), r.getFailedCounter(), lastError));
             }
         }
 
         if (trigger) {
-            if (wait) {
-                if (failed) {
-                    root.put("status", "failed");
-                } else {
-                    root.put("status", "success");
-                }
-            } else {
-                root.put("status", "reloading");
-            }
+            status = wait ? (failed ? "failed" : "success") : "reloading";
         }
-        return root;
+
+        Response response = new Response(reloadStrategies, status);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     protected ExecutorService getOrCreateReloadTask() {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RestDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RestDevConsole.java
@@ -16,17 +16,40 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.RestRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "rest", displayName = "Rest", description = "Rest DSL Registry information")
 public class RestDevConsole extends AbstractDevConsole {
+
+    public record RestEntry(
+            @Metadata(description = "The absolute URL to the REST service") String url,
+            @Metadata(description = "The HTTP method") String method,
+            @Metadata(description = "Whether the REST service is contract-first") boolean contractFirst,
+            @Metadata(description = "Whether this is the API contract specification (i.e. api-doc)") boolean specification,
+            @Metadata(description = "The REST service state") String state,
+            @Metadata(description = "The route ID (only present when known)") String routeId,
+            @Metadata(description = "The OpenAPI operation ID (only present for contract-first routes)") String operationId,
+            @Metadata(description = "The OpenAPI specification URI (only present for contract-first routes)") String specificationUri,
+            @Metadata(description = "The accepted media types (only present when known)") String consumes,
+            @Metadata(description = "The returned media types (only present when known)") String produces,
+            @Metadata(description = "The input binding class name (only present when known)") String inType,
+            @Metadata(description = "The output binding class name (only present when known)") String outType,
+            @Metadata(description = "The REST service description (only present when configured)") String description,
+            @Metadata(description = "Usage of the REST service (only present when greater than zero)") Long hits) {
+    }
+
+    public record Response(
+            @Metadata(description = "The REST services (only present when a REST registry is available)") List<RestEntry> rests) {
+    }
 
     public RestDevConsole() {
         super("camel", "rest", "Rest", "Rest DSL Registry information");
@@ -82,53 +105,23 @@ public class RestDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+        List<RestEntry> rests = null;
 
         RestRegistry rr = PluginHelper.getRestRegistry(getCamelContext());
         if (rr != null) {
-            JsonArray list = new JsonArray();
-            root.put("rests", list);
-
+            rests = new ArrayList<>();
             for (RestRegistry.RestService rs : rr.listAllRestServices()) {
-                JsonObject jo = new JsonObject();
-                jo.put("url", rs.getUrl());
-                jo.put("method", rs.getMethod());
-                jo.put("contractFirst", rs.isContractFirst());
-                jo.put("specification", rs.isSpecification());
-                jo.put("state", rs.getState());
-                if (rs.getRouteId() != null) {
-                    jo.put("routeId", rs.getRouteId());
-                }
-                if (rs.getOperationId() != null) {
-                    jo.put("operationId", rs.getOperationId());
-                }
-                if (rs.getSpecificationUri() != null) {
-                    jo.put("specificationUri", rs.getSpecificationUri());
-                }
-                if (rs.getConsumes() != null) {
-                    jo.put("consumes", rs.getConsumes());
-                }
-                if (rs.getProduces() != null) {
-                    jo.put("produces", rs.getProduces());
-                }
-                if (rs.getInType() != null) {
-                    jo.put("inType", rs.getInType());
-                }
-                if (rs.getOutType() != null) {
-                    jo.put("outType", rs.getOutType());
-                }
-                if (rs.getDescription() != null) {
-                    jo.put("description", rs.getDescription());
-                }
                 long hits = rs.getHits();
-                if (hits > 0) {
-                    jo.put("hits", hits);
-                }
-                list.add(jo);
+                rests.add(new RestEntry(
+                        rs.getUrl(), rs.getMethod(), rs.isContractFirst(), rs.isSpecification(), rs.getState(),
+                        rs.getRouteId(), rs.getOperationId(), rs.getSpecificationUri(), rs.getConsumes(),
+                        rs.getProduces(), rs.getInType(), rs.getOutType(), rs.getDescription(),
+                        hits > 0 ? hits : null));
             }
         }
 
-        return root;
+        Response response = new Response(rests);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RestSpecDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RestSpecDevConsole.java
@@ -17,7 +17,9 @@
 package org.apache.camel.impl.console;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,12 +31,20 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.IOHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "rest-spec", displayName = "Rest Spec",
             description = "OpenAPI specification content for contract-first REST services")
 public class RestSpecDevConsole extends AbstractDevConsole {
+
+    public record SpecificationEntry(
+            @Metadata(description = "The OpenAPI specification URI") String specificationUri,
+            @Metadata(description = "The route ID (only present when known)") String routeId,
+            @Metadata(description = "The specification content (only present when it could be loaded)") String content) {
+    }
+
+    public record Response(@Metadata(description = "The OpenAPI specifications") List<SpecificationEntry> specs) {
+    }
 
     @Metadata(label = "query", description = "Filters specifications matching the given URI pattern",
               javaType = "java.lang.String")
@@ -72,23 +82,14 @@ public class RestSpecDevConsole extends AbstractDevConsole {
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String filter = optionString(options, FILTER);
-        JsonObject root = new JsonObject();
-        JsonArray list = new JsonArray();
-        root.put("specs", list);
+        List<SpecificationEntry> list = new ArrayList<>();
 
         for (SpecEntry entry : collectSpecs(filter)) {
-            JsonObject jo = new JsonObject();
-            jo.put("specificationUri", entry.uri());
-            if (entry.routeId() != null) {
-                jo.put("routeId", entry.routeId());
-            }
-            if (entry.content() != null) {
-                jo.put("content", entry.content());
-            }
-            list.add(jo);
+            list.add(new SpecificationEntry(entry.uri(), entry.routeId(), entry.content()));
         }
 
-        return root;
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private Set<SpecEntry> collectSpecs(String filter) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteControllerConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteControllerConsole.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.impl.console;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -32,8 +34,7 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.backoff.BackOffTimer;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "route-controller", description = "Route controller information")
@@ -45,6 +46,38 @@ public class RouteControllerConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Whether to include error details", javaType = "java.lang.Boolean",
               defaultValue = "true")
     public static final String ERROR = "error";
+
+    public record RouteEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route status") String status,
+            @Metadata(description = "The route endpoint URI (sanitized)") String uri,
+            @Metadata(description = "Number of restart attempts (supervising controller only)") Long attempts,
+            @Metadata(description = "Epoch time in milliseconds of the last restart attempt (supervising controller only)") Long lastAttempt,
+            @Metadata(description = "Epoch time in milliseconds of the next restart attempt (supervising controller only)") Long nextAttempt,
+            @Metadata(description = "Elapsed time in milliseconds of the current restart attempt (supervising controller only)") Long elapsed,
+            @Metadata(description = "The supervising status (supervising controller only)") String supervising,
+            @Metadata(description = "The restart error message (only present when the route is failing)") String error,
+            @Metadata(description = "The restart error stack trace, one entry per line (only present when the route is failing and stack traces are requested)") List<String> stackTrace) {
+    }
+
+    public record Response(
+            @Metadata(description = "The route controller implementation: SupervisingRouteController or DefaultRouteController") String controller,
+            @Metadata(description = "Whether routes are still starting (supervising controller only)") Boolean startingRoutes,
+            @Metadata(description = "Whether any route is unhealthy (supervising controller only)") Boolean unhealthyRoutes,
+            @Metadata(description = "Total number of routes") int totalRoutes,
+            @Metadata(description = "Number of started routes (supervising controller only)") Long startedRoutes,
+            @Metadata(description = "Number of restarting routes (supervising controller only)") Integer restartingRoutes,
+            @Metadata(description = "Number of exhausted routes (supervising controller only)") Integer exhaustedRoutes,
+            @Metadata(description = "Initial delay in milliseconds before restarting (supervising controller only)") Long initialDelay,
+            @Metadata(description = "Backoff delay in milliseconds (supervising controller only)") Long backoffDelay,
+            @Metadata(description = "Maximum backoff delay in milliseconds (supervising controller only)") Long backoffMaxDelay,
+            @Metadata(description = "Maximum elapsed time in milliseconds before giving up (supervising controller only)") Long backoffMaxElapsedTime,
+            @Metadata(description = "Maximum number of restart attempts (supervising controller only)") Long backoffMaxAttempts,
+            @Metadata(description = "The size of the restart thread pool (supervising controller only)") Integer threadPoolSize,
+            @Metadata(description = "Whether a restarting route is considered unhealthy (supervising controller only)") Boolean unhealthyOnRestarting,
+            @Metadata(description = "Whether an exhausted route is considered unhealthy (supervising controller only)") Boolean unhealthyOnExhausted,
+            @Metadata(description = "The routes") List<RouteEntry> routes) {
+    }
 
     public RouteControllerConsole() {
         super("camel", "route-controller", "Route Controller", "Route controller information");
@@ -158,14 +191,12 @@ public class RouteControllerConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         boolean includeError = optionBoolean(options, ERROR, true);
         boolean includeStacktrace = optionBoolean(options, STACKTRACE, true);
 
-        JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
-
         RouteController rc = getCamelContext().getRouteController();
+        Response response;
         if (rc instanceof SupervisingRouteController src) {
             Set<Route> routes = new TreeSet<>(Comparator.comparing(Route::getId));
             routes.addAll(rc.getControlledRoutes());
@@ -174,64 +205,44 @@ public class RouteControllerConsole extends AbstractDevConsole {
             long started = routes.stream().filter(r -> src.getRouteStatus(r.getRouteId()).isStarted())
                     .count();
 
-            root.put("controller", "SupervisingRouteController");
-            root.put("startingRoutes", src.isStartingRoutes());
-            root.put("unhealthyRoutes", src.hasUnhealthyRoutes());
-            root.put("totalRoutes", routes.size());
-            root.put("startedRoutes", started);
-            root.put("restartingRoutes", src.getRestartingRoutes().size());
-            root.put("exhaustedRoutes", src.getExhaustedRoutes().size());
-            root.put("initialDelay", src.getInitialDelay());
-            root.put("backoffDelay", src.getBackOffDelay());
-            root.put("backoffMaxDelay", src.getBackOffMaxDelay());
-            root.put("backoffMaxElapsedTime", src.getBackOffMaxElapsedTime());
-            root.put("backoffMaxAttempts", src.getBackOffMaxAttempts());
-            root.put("threadPoolSize", src.getThreadPoolSize());
-            root.put("unhealthyOnRestarting", src.isUnhealthyOnRestarting());
-            root.put("unhealthyOnExhausted", src.isUnhealthyOnExhausted());
-            root.put("routes", list);
-
+            List<RouteEntry> list = new ArrayList<>();
             for (Route route : routes) {
                 String routeId = route.getRouteId();
                 String status = rc.getRouteStatus(routeId).name();
-                String uri = route.getEndpoint().getEndpointBaseUri();
-                uri = URISupport.sanitizeUri(uri);
+                String uri = URISupport.sanitizeUri(route.getEndpoint().getEndpointBaseUri());
 
                 BackOffTimer.Task state = src.getRestartingRouteState(routeId);
                 String supervising = state != null ? state.getStatus().name() : null;
                 long attempts = state != null ? state.getCurrentAttempts() : 0;
-                long elapsed;
-                long last;
-                long next;
                 // we can only track elapsed/time for active supervised routes
-                elapsed = state != null && BackOffTimer.Task.Status.Active == state.getStatus()
-                        ? state.getCurrentElapsedTime() : 0;
-                last = state != null && BackOffTimer.Task.Status.Active == state.getStatus() ? state.getLastAttemptTime() : 0;
-                next = state != null && BackOffTimer.Task.Status.Active == state.getStatus() ? state.getNextAttemptTime() : 0;
-                JsonObject jo = new JsonObject();
-                list.add(jo);
-                jo.put("routeId", routeId);
-                jo.put("status", status);
-                jo.put("uri", uri);
-                jo.put("attempts", attempts);
-                jo.put("lastAttempt", last);
-                jo.put("nextAttempt", next);
-                jo.put("elapsed", elapsed);
+                boolean active = state != null && BackOffTimer.Task.Status.Active == state.getStatus();
+                long elapsed = active ? state.getCurrentElapsedTime() : 0;
+                long last = active ? state.getLastAttemptTime() : 0;
+                long next = active ? state.getNextAttemptTime() : 0;
+
+                String error = null;
+                List<String> stackTrace = null;
                 if (supervising != null) {
-                    jo.put("supervising", supervising);
                     Throwable cause = src.getRestartException(routeId);
                     if (includeError && cause != null) {
-                        String error = cause.getMessage();
-                        jo.put("error", Jsoner.escape(error));
+                        error = Jsoner.escape(cause.getMessage());
                         if (includeStacktrace) {
-                            JsonArray arr2 = new JsonArray();
                             final String trace = ExceptionHelper.stackTraceToString(cause);
-                            jo.put("stackTrace", arr2);
-                            Collections.addAll(arr2, trace.split("\n"));
+                            stackTrace = Arrays.asList(trace.split("\n"));
                         }
                     }
                 }
+
+                list.add(new RouteEntry(
+                        routeId, status, uri, attempts, last, next, elapsed, supervising, error, stackTrace));
             }
+
+            response = new Response(
+                    "SupervisingRouteController", src.isStartingRoutes(), src.hasUnhealthyRoutes(), routes.size(), started,
+                    src.getRestartingRoutes().size(), src.getExhaustedRoutes().size(), src.getInitialDelay(),
+                    src.getBackOffDelay(), src.getBackOffMaxDelay(), src.getBackOffMaxElapsedTime(),
+                    src.getBackOffMaxAttempts(), src.getThreadPoolSize(), src.isUnhealthyOnRestarting(),
+                    src.isUnhealthyOnExhausted(), list);
         } else {
             Set<Route> routes = new TreeSet<>(Comparator.comparing(Route::getId));
             routes.addAll(rc.getControlledRoutes());
@@ -241,24 +252,20 @@ public class RouteControllerConsole extends AbstractDevConsole {
                 routes.addAll(getCamelContext().getRoutes());
             }
 
-            root.put("controller", "DefaultRouteController");
-            root.put("totalRoutes", routes.size());
-            root.put("routes", list);
+            List<RouteEntry> list = new ArrayList<>();
             for (Route route : routes) {
                 String routeId = route.getRouteId();
                 String status = rc.getRouteStatus(routeId).name();
-                String uri = route.getEndpoint().getEndpointBaseUri();
-                uri = URISupport.sanitizeUri(uri);
-
-                JsonObject jo = new JsonObject();
-                list.add(jo);
-                jo.put("routeId", routeId);
-                jo.put("status", status);
-                jo.put("uri", uri);
+                String uri = URISupport.sanitizeUri(route.getEndpoint().getEndpointBaseUri());
+                list.add(new RouteEntry(routeId, status, uri, null, null, null, null, null, null, null));
             }
+
+            response = new Response(
+                    "DefaultRouteController", null, null, routes.size(), null, null, null, null, null, null, null, null,
+                    null, null, null, list);
         }
 
-        return root;
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
@@ -17,8 +17,8 @@
 package org.apache.camel.impl.console;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +40,6 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.JsonRecordSupport;
 import org.slf4j.Logger;
@@ -50,6 +49,60 @@ import org.slf4j.LoggerFactory;
 public class RouteDevConsole extends AbstractDevConsole {
 
     private static final Logger LOG = LoggerFactory.getLogger(RouteDevConsole.class);
+
+    public record LastError(
+            @Metadata(description = "The error phase") String phase,
+            @Metadata(description = "Epoch time in milliseconds when the error happened") long timestamp,
+            @Metadata(description = "The error message (only present when known)") String message,
+            @Metadata(description = "The error stack trace, one entry per line (only present when known)") List<String> stackTrace) {
+    }
+
+    public record Statistics(
+            @Metadata(description = "Route coverage (only present when computable)") String coverage,
+            @Metadata(description = "1 minute load average (only present when available)") String load01,
+            @Metadata(description = "5 minute load average (only present when available)") String load05,
+            @Metadata(description = "15 minute load average (only present when available)") String load15,
+            @Metadata(description = "Messages per second throughput (only present when available)") String exchangesThroughput,
+            @Metadata(description = "Epoch time in milliseconds since the route has been idle") long idleSince,
+            @Metadata(description = "Total number of exchanges") long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges") long exchangesFailed,
+            @Metadata(description = "Number of inflight exchanges") long exchangesInflight,
+            @Metadata(description = "Mean processing time in milliseconds") long meanProcessingTime,
+            @Metadata(description = "Max processing time in milliseconds") long maxProcessingTime,
+            @Metadata(description = "Min processing time in milliseconds") long minProcessingTime,
+            @Metadata(description = "50th percentile processing time in milliseconds (only present when available)") Long p50ProcessingTime,
+            @Metadata(description = "95th percentile processing time in milliseconds (only present when available)") Long p95ProcessingTime,
+            @Metadata(description = "99th percentile processing time in milliseconds (only present when available)") Long p99ProcessingTime,
+            @Metadata(description = "Processing time in milliseconds of the last exchange (only present once an exchange has completed)") Long lastProcessingTime,
+            @Metadata(description = "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)") Long deltaProcessingTime,
+            @Metadata(description = "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)") Long lastCreatedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)") Long lastCompletedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)") Long lastFailureHandledExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failed (only present once one has occurred)") Long lastFailedExchangeTimestamp) {
+    }
+
+    public record RouteEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route group (only present when known)") String group,
+            @Metadata(description = "The node prefix ID (only present when known)") String nodePrefixId,
+            @Metadata(description = "The route description (only present when configured)") String description,
+            @Metadata(description = "The route note (only present when configured)") String note,
+            @Metadata(description = "Whether the route was created by a Kamelet") boolean createdByKamelet,
+            @Metadata(description = "Whether the route was created by a route template") boolean createdByRouteTemplate,
+            @Metadata(description = "The route's endpoint URI") String from,
+            @Metadata(description = "Whether the endpoint is remote") boolean remote,
+            @Metadata(description = "The source location (only present when known)") String source,
+            @Metadata(description = "The route state") String state,
+            @Metadata(description = "Whether the route supports suspension") boolean supportsSuspension,
+            @Metadata(description = "Route uptime, human readable text") String uptime,
+            @Metadata(description = "The last lifecycle error (only present when one has occurred)") LastError lastError,
+            @Metadata(description = "Runtime statistics") Statistics statistics,
+            @Metadata(description = "The route's processors (only present when requested)") List<ProcessorDevConsole.ProcessorEntry> processors) {
+    }
+
+    public record Response(
+            @Metadata(description = "The routes (only present when no action was requested)") List<RouteEntry> routes) {
+    }
 
     @Metadata(label = "query",
               description = "Filters the routes matching by route id, route uri, or route group, and source location",
@@ -218,81 +271,59 @@ public class RouteDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String action = optionString(options, ACTION);
         String filter = optionString(options, FILTER);
         if (action != null) {
             doAction(getCamelContext(), action, filter);
-            return new JsonObject();
+            return JsonRecordSupport.toJsonObject(new Response(null));
         }
 
         final boolean processors = optionBoolean(options, PROCESSORS, false);
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
+        final List<RouteEntry> list = new ArrayList<>();
         Function<ManagedRouteMBean, Object> task = mrb -> {
-            JsonObject jo = new JsonObject();
-            list.add(jo);
-            jo.put("routeId", mrb.getRouteId());
-            if (mrb.getRouteGroup() != null) {
-                jo.put("group", mrb.getRouteGroup());
-            }
-            if (mrb.getNodePrefixId() != null) {
-                jo.put("nodePrefixId", mrb.getNodePrefixId());
-            }
-            if (mrb.getDescription() != null) {
-                jo.put("description", mrb.getDescription());
-            }
-            if (mrb.getNote() != null) {
-                jo.put("note", mrb.getNote());
-            }
-            jo.put("createdByKamelet", mrb.isCreatedByKamelet());
-            jo.put("createdByRouteTemplate", mrb.isCreatedByRouteTemplate());
-            jo.put("from", mrb.getEndpointUri());
-            jo.put("remote", mrb.isRemoteEndpoint());
-            if (mrb.getSourceLocation() != null) {
-                jo.put("source", mrb.getSourceLocation());
-            }
-            jo.put("state", mrb.getState());
-            Route r = getCamelContext().getRoute(mrb.getRouteId());
-            jo.put("supportsSuspension", r != null && r.supportsSuspension());
-            jo.put("uptime", mrb.getUptime());
+            LastError lastError = null;
             if (mrb.getLastError() != null) {
                 String phase = StringHelper.capitalize(mrb.getLastError().getPhase().name().toLowerCase());
-                JsonObject eo = new JsonObject();
-                eo.put("phase", phase);
-                eo.put("timestamp", mrb.getLastError().getDate().getTime());
+                long timestamp = mrb.getLastError().getDate().getTime();
+                String message = null;
+                List<String> stackTrace = null;
                 Throwable cause = mrb.getLastError().getException();
                 if (cause != null) {
-                    eo.put("message", cause.getMessage());
-                    JsonArray arr2 = new JsonArray();
+                    message = cause.getMessage();
                     final String trace = ExceptionHelper.stackTraceToString(cause);
-                    eo.put("stackTrace", arr2);
-                    Collections.addAll(arr2, trace.split("\n"));
+                    stackTrace = Arrays.asList(trace.split("\n"));
                 }
-                jo.put("lastError", eo);
+                lastError = new LastError(phase, timestamp, message, stackTrace);
             }
-            JsonObject stats = gatherRouteStats(getCamelContext(), mrb);
-            jo.put("statistics", stats);
-            if (processors) {
-                JsonArray arr = new JsonArray();
-                jo.put("processors", arr);
-                includeProcessorsJson(mrb, arr);
-            }
+
+            Statistics stats = buildStatistics(getCamelContext(), mrb);
+
+            List<ProcessorDevConsole.ProcessorEntry> procList = processors ? includeProcessorsJson(mrb) : null;
+
+            Route r = getCamelContext().getRoute(mrb.getRouteId());
+            list.add(new RouteEntry(
+                    mrb.getRouteId(), mrb.getRouteGroup(), mrb.getNodePrefixId(), mrb.getDescription(), mrb.getNote(),
+                    mrb.isCreatedByKamelet(), mrb.isCreatedByRouteTemplate(), mrb.getEndpointUri(),
+                    mrb.isRemoteEndpoint(), mrb.getSourceLocation(), mrb.getState(),
+                    r != null && r.supportsSuspension(), mrb.getUptime(), lastError, stats, procList));
             return null;
         };
         doCall(options, task);
-        root.put("routes", list);
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private void includeProcessorsJson(ManagedRouteMBean mrb, JsonArray arr) {
+    private List<ProcessorDevConsole.ProcessorEntry> includeProcessorsJson(ManagedRouteMBean mrb) {
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
 
+        List<ProcessorDevConsole.ProcessorEntry> entries = new ArrayList<>();
         Collection<String> ids;
         try {
             ids = mrb.processorIds();
         } catch (Exception e) {
-            return;
+            return entries;
         }
 
         List<ManagedProcessorMBean> mps = ids.stream().map(mcc::getManagedProcessor)
@@ -301,11 +332,8 @@ public class RouteDevConsole extends AbstractDevConsole {
                 .sorted(Comparator.comparingInt(ManagedProcessorMBean::getIndex))
                 .toList();
 
-        List<ProcessorDevConsole.ProcessorEntry> entries = new ArrayList<>();
         ProcessorDevConsole.includeProcessorsJSon(getCamelContext(), entries, Integer.MAX_VALUE, mps);
-        for (ProcessorDevConsole.ProcessorEntry entry : entries) {
-            arr.add(JsonRecordSupport.toJsonObject(entry));
-        }
+        return entries;
     }
 
     protected void doCall(Map<String, Object> options, Function<ManagedRouteMBean, Object> task) {
@@ -470,56 +498,51 @@ public class RouteDevConsole extends AbstractDevConsole {
     }
 
     public static JsonObject gatherRouteStats(CamelContext camelContext, ManagedRouteMBean mrb) {
-        JsonObject stats = new JsonObject();
+        return JsonRecordSupport.toJsonObject(buildStatistics(camelContext, mrb));
+    }
+
+    private static Statistics buildStatistics(CamelContext camelContext, ManagedRouteMBean mrb) {
         String coverage = calculateRouteCoverage(camelContext, mrb, false);
-        if (coverage != null) {
-            stats.put("coverage", coverage);
-        }
+
         String load1 = getLoad1(mrb);
         String load5 = getLoad5(mrb);
         String load15 = getLoad15(mrb);
-        if (!load1.isEmpty() || !load5.isEmpty() || !load15.isEmpty()) {
-            stats.put("load01", load1);
-            stats.put("load05", load5);
-            stats.put("load15", load15);
-        }
+        boolean hasLoad = !load1.isEmpty() || !load5.isEmpty() || !load15.isEmpty();
+
         String thp = getThroughput(mrb);
-        if (!thp.isEmpty()) {
-            stats.put("exchangesThroughput", thp);
-        }
-        stats.put("idleSince", mrb.getIdleSince());
-        stats.put("exchangesTotal", mrb.getExchangesTotal());
-        stats.put("exchangesFailed", mrb.getExchangesFailed());
-        stats.put("exchangesInflight", mrb.getExchangesInflight());
-        stats.put("meanProcessingTime", mrb.getMeanProcessingTime());
-        stats.put("maxProcessingTime", mrb.getMaxProcessingTime());
-        stats.put("minProcessingTime", mrb.getMinProcessingTime());
+
+        Long p50 = null;
+        Long p95 = null;
+        Long p99 = null;
         if (mrb.getProcessingTimeP50() >= 0) {
-            stats.put("p50ProcessingTime", mrb.getProcessingTimeP50());
-            stats.put("p95ProcessingTime", mrb.getProcessingTimeP95());
-            stats.put("p99ProcessingTime", mrb.getProcessingTimeP99());
+            p50 = mrb.getProcessingTimeP50();
+            p95 = mrb.getProcessingTimeP95();
+            p99 = mrb.getProcessingTimeP99();
         }
+
+        Long lastProcessingTime = null;
+        Long deltaProcessingTime = null;
         if (mrb.getExchangesTotal() > 0) {
-            stats.put("lastProcessingTime", mrb.getLastProcessingTime());
-            stats.put("deltaProcessingTime", mrb.getDeltaProcessingTime());
+            lastProcessingTime = mrb.getLastProcessingTime();
+            deltaProcessingTime = mrb.getDeltaProcessingTime();
         }
-        Date last = mrb.getLastExchangeCreatedTimestamp();
-        if (last != null) {
-            stats.put("lastCreatedExchangeTimestamp", last.getTime());
-        }
-        last = mrb.getLastExchangeCompletedTimestamp();
-        if (last != null) {
-            stats.put("lastCompletedExchangeTimestamp", last.getTime());
-        }
-        last = mrb.getLastExchangeFailureHandledTimestamp();
-        if (last != null) {
-            stats.put("lastFailureHandledExchangeTimestamp", last.getTime());
-        }
-        last = mrb.getLastExchangeFailureTimestamp();
-        if (last != null) {
-            stats.put("lastFailedExchangeTimestamp", last.getTime());
-        }
-        return stats;
+
+        Long lastCreated = timestampOf(mrb.getLastExchangeCreatedTimestamp());
+        Long lastCompleted = timestampOf(mrb.getLastExchangeCompletedTimestamp());
+        Long lastFailureHandled = timestampOf(mrb.getLastExchangeFailureHandledTimestamp());
+        Long lastFailed = timestampOf(mrb.getLastExchangeFailureTimestamp());
+
+        return new Statistics(
+                coverage, hasLoad ? load1 : null, hasLoad ? load5 : null, hasLoad ? load15 : null,
+                thp.isEmpty() ? null : thp,
+                mrb.getIdleSince(), mrb.getExchangesTotal(), mrb.getExchangesFailed(), mrb.getExchangesInflight(),
+                mrb.getMeanProcessingTime(), mrb.getMaxProcessingTime(), mrb.getMinProcessingTime(),
+                p50, p95, p99, lastProcessingTime, deltaProcessingTime,
+                lastCreated, lastCompleted, lastFailureHandled, lastFailed);
+    }
+
+    private static Long timestampOf(Date date) {
+        return date != null ? date.getTime() : null;
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDevConsole.java
@@ -42,6 +42,7 @@ import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -300,7 +301,11 @@ public class RouteDevConsole extends AbstractDevConsole {
                 .sorted(Comparator.comparingInt(ManagedProcessorMBean::getIndex))
                 .toList();
 
-        ProcessorDevConsole.includeProcessorsJSon(getCamelContext(), arr, Integer.MAX_VALUE, mps);
+        List<ProcessorDevConsole.ProcessorEntry> entries = new ArrayList<>();
+        ProcessorDevConsole.includeProcessorsJSon(getCamelContext(), entries, Integer.MAX_VALUE, mps);
+        for (ProcessorDevConsole.ProcessorEntry entry : entries) {
+            arr.add(JsonRecordSupport.toJsonObject(entry));
+        }
     }
 
     protected void doCall(Map<String, Object> options, Function<ManagedRouteMBean, Object> task) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDumpDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteDumpDevConsole.java
@@ -19,6 +19,7 @@ package org.apache.camel.impl.console;
 import java.io.LineNumberReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -37,12 +38,27 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "route-dump", description = "Dump route in XML, YAML, or Java DSL format")
 public class RouteDumpDevConsole extends AbstractDevConsole {
+
+    public record CodeLine(
+            @Metadata(description = "The source line number, or -1 when not known") int line,
+            @Metadata(description = "The source code line") String code) {
+    }
+
+    public record RouteEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route's endpoint URI") String from,
+            @Metadata(description = "The source location (only present when known)") String source,
+            @Metadata(description = "The dump format, xml/yaml/java (only present when the dump succeeded)") String format,
+            @Metadata(description = "The dumped route source code (only present when the dump succeeded)") List<CodeLine> code) {
+    }
+
+    public record Response(@Metadata(description = "The routes") List<RouteEntry> routes) {
+    }
 
     private static final Pattern XML_SOURCE_LOCATION_PATTERN = Pattern.compile("(\\ssourceLocation=\"(.*?)\")");
     private static final Pattern XML_SOURCE_LINE_PATTERN = Pattern.compile("(\\ssourceLineNumber=\"(.*?)\")");
@@ -105,54 +121,46 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         final boolean uriAsParameters = optionBoolean(options, URI_AS_PARAMETERS, false);
 
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
+        final List<RouteEntry> list = new ArrayList<>();
 
         Function<ManagedRouteMBean, Object> task = mrb -> {
-            JsonObject jo = new JsonObject();
-            list.add(jo);
-
-            jo.put("routeId", mrb.getRouteId());
-            jo.put("from", mrb.getEndpointUri());
-            if (mrb.getSourceLocation() != null) {
-                jo.put("source", mrb.getSourceLocation());
-            }
+            String format = null;
+            List<CodeLine> code = null;
 
             try {
                 String dump = null;
-                String format = optionString(options, FORMAT);
-                if (format == null || "xml".equals(format)) {
-                    jo.put("format", "xml");
+                String requestedFormat = optionString(options, FORMAT);
+                if (requestedFormat == null || "xml".equals(requestedFormat)) {
+                    format = "xml";
                     dump = mrb.dumpRouteAsXml(true, false, true);
-                } else if ("yaml".equals(format)) {
-                    jo.put("format", "yaml");
+                } else if ("yaml".equals(requestedFormat)) {
+                    format = "yaml";
                     dump = mrb.dumpRouteAsYaml(true, uriAsParameters, false, true);
-                } else if ("java".equals(format)) {
-                    jo.put("format", "java");
+                } else if ("java".equals(requestedFormat)) {
+                    format = "java";
                     dump = mrb.dumpRouteAsJava(true, false, true);
                 }
                 if (dump != null) {
-                    JsonArray code;
-                    if (format == null || "xml".equals(format)) {
+                    if (requestedFormat == null || "xml".equals(requestedFormat)) {
                         code = xmlLoadSourceAsJson(new StringReader(dump));
                     } else {
                         code = javaOrYamlLoadSourceAsJson(new StringReader(dump));
-                    }
-                    if (code != null) {
-                        jo.put("code", code);
                     }
                 }
             } catch (Exception e) {
                 // ignore
             }
+
+            list.add(new RouteEntry(mrb.getRouteId(), mrb.getEndpointUri(), mrb.getSourceLocation(), format, code));
             return null;
         };
         doCall(options, task);
-        root.put("routes", list);
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     protected void doCall(Map<String, Object> options, Function<ManagedRouteMBean, Object> task) {
@@ -193,8 +201,8 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
         return o1.getRouteId().compareTo(o2.getRouteId());
     }
 
-    private static JsonArray xmlLoadSourceAsJson(Reader reader) {
-        JsonArray code = new JsonArray();
+    private static List<CodeLine> xmlLoadSourceAsJson(Reader reader) {
+        List<CodeLine> code = new ArrayList<>();
         try {
             LineNumberReader lnr = new LineNumberReader(reader);
             String t;
@@ -212,10 +220,7 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
                         idx = m.group(2);
                         t = m.replaceFirst("");
                     }
-                    JsonObject c = new JsonObject();
-                    c.put("line", idx != null ? Integer.parseInt(idx) : -1);
-                    c.put("code", Jsoner.escape(t));
-                    code.add(c);
+                    code.add(new CodeLine(idx != null ? Integer.parseInt(idx) : -1, Jsoner.escape(t)));
                 }
             } while (t != null);
             IOHelper.close(lnr);
@@ -226,8 +231,8 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
         return code.isEmpty() ? null : code;
     }
 
-    private static JsonArray javaOrYamlLoadSourceAsJson(Reader reader) {
-        JsonArray code = new JsonArray();
+    private static List<CodeLine> javaOrYamlLoadSourceAsJson(Reader reader) {
+        List<CodeLine> code = new ArrayList<>();
         try {
             LineNumberReader lnr = new LineNumberReader(reader);
             String t;
@@ -241,18 +246,15 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
                         String idx = StringHelper.after(t, "sourceLineNumber: ").trim();
                         if (!code.isEmpty()) {
                             // assign line number to previous code line
-                            JsonObject c = (JsonObject) code.get(code.size() - 1);
+                            CodeLine prev = code.get(code.size() - 1);
                             try {
-                                c.put("line", Integer.parseInt(idx));
+                                code.set(code.size() - 1, new CodeLine(Integer.parseInt(idx), prev.code()));
                             } catch (NumberFormatException e) {
                                 // ignore
                             }
                         }
                     } else {
-                        JsonObject c = new JsonObject();
-                        c.put("code", Jsoner.escape(t));
-                        c.put("line", -1);
-                        code.add(c);
+                        code.add(new CodeLine(-1, Jsoner.escape(t)));
                     }
                 }
             } while (t != null);
@@ -263,12 +265,12 @@ public class RouteDumpDevConsole extends AbstractDevConsole {
 
         // merge trailing ; with previous code line (sourceLineNumber comments may have separated them)
         if (code.size() > 1) {
-            JsonObject last = (JsonObject) code.get(code.size() - 1);
-            String lastCode = Jsoner.unescape(last.getString("code")).trim();
+            CodeLine last = code.get(code.size() - 1);
+            String lastCode = Jsoner.unescape(last.code()).trim();
             if (";".equals(lastCode)) {
                 code.remove(code.size() - 1);
-                JsonObject prev = (JsonObject) code.get(code.size() - 1);
-                prev.put("code", prev.getString("code") + ";");
+                CodeLine prev = code.get(code.size() - 1);
+                code.set(code.size() - 1, new CodeLine(prev.line(), prev.code() + ";"));
             }
         }
 

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteGroupDevConsole.java
@@ -38,8 +38,7 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +46,43 @@ import org.slf4j.LoggerFactory;
 public class RouteGroupDevConsole extends AbstractDevConsole {
 
     private static final Logger LOG = LoggerFactory.getLogger(RouteGroupDevConsole.class);
+
+    public record Statistics(
+            @Metadata(description = "Route coverage (only present when computable)") String coverage,
+            @Metadata(description = "1 minute load average (only present when available)") String load01,
+            @Metadata(description = "5 minute load average (only present when available)") String load05,
+            @Metadata(description = "15 minute load average (only present when available)") String load15,
+            @Metadata(description = "Messages per second throughput (only present when available)") String exchangesThroughput,
+            @Metadata(description = "Epoch time in milliseconds since the route group has been idle") long idleSince,
+            @Metadata(description = "Total number of exchanges") long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges") long exchangesFailed,
+            @Metadata(description = "Number of inflight exchanges") long exchangesInflight,
+            @Metadata(description = "Mean processing time in milliseconds") long meanProcessingTime,
+            @Metadata(description = "Max processing time in milliseconds") long maxProcessingTime,
+            @Metadata(description = "Min processing time in milliseconds") long minProcessingTime,
+            @Metadata(description = "50th percentile processing time in milliseconds (only present when available)") Long p50ProcessingTime,
+            @Metadata(description = "95th percentile processing time in milliseconds (only present when available)") Long p95ProcessingTime,
+            @Metadata(description = "99th percentile processing time in milliseconds (only present when available)") Long p99ProcessingTime,
+            @Metadata(description = "Processing time in milliseconds of the last exchange (only present once an exchange has completed)") Long lastProcessingTime,
+            @Metadata(description = "Difference in processing time in milliseconds since the previous exchange (only present once an exchange has completed)") Long deltaProcessingTime,
+            @Metadata(description = "Epoch time in milliseconds the last exchange was created (only present once an exchange has been created)") Long lastCreatedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange completed (only present once an exchange has completed)") Long lastCompletedExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failure was handled (only present once one has occurred)") Long lastFailureHandledExchangeTimestamp,
+            @Metadata(description = "Epoch time in milliseconds the last exchange failed (only present once one has occurred)") Long lastFailedExchangeTimestamp) {
+    }
+
+    public record RouteGroupEntry(
+            @Metadata(description = "The route group ID") String group,
+            @Metadata(description = "Number of routes in this group") int size,
+            @Metadata(description = "The route group state") String state,
+            @Metadata(description = "Route uptime, human readable text") String uptime,
+            @Metadata(description = "The route IDs within this group") List<String> routeIds,
+            @Metadata(description = "Runtime statistics") Statistics statistics) {
+    }
+
+    public record Response(
+            @Metadata(description = "The route groups (only present when no action was requested)") List<RouteGroupEntry> routeGroups) {
+    }
 
     @Metadata(label = "query", description = "Filters the route groups matching by group id", javaType = "java.lang.String")
     public static final String FILTER = "filter";
@@ -138,79 +174,70 @@ public class RouteGroupDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String action = optionString(options, ACTION);
         String filter = optionString(options, FILTER);
         if (action != null) {
             doAction(getCamelContext(), action, filter);
-            return new JsonObject();
+            return JsonRecordSupport.toJsonObject(new Response(null));
         }
 
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
+        final List<RouteGroupEntry> list = new ArrayList<>();
         Function<ManagedRouteGroupMBean, Object> task = mrg -> {
-            JsonObject jo = new JsonObject();
-            list.add(jo);
-            jo.put("group", mrg.getRouteGroup());
-            jo.put("size", mrg.getGroupSize());
-            jo.put("state", mrg.getState());
-            jo.put("uptime", mrg.getUptime());
-            jo.put("routeIds", new JsonArray(Arrays.stream(mrg.getGroupIds()).toList()));
-            JsonObject stats = new JsonObject();
-            String coverage = calculateRouteCoverage(mrg, false);
-            if (coverage != null) {
-                stats.put("coverage", coverage);
-            }
-            String load1 = getLoad1(mrg);
-            String load5 = getLoad5(mrg);
-            String load15 = getLoad15(mrg);
-            if (!load1.isEmpty() || !load5.isEmpty() || !load15.isEmpty()) {
-                stats.put("load01", load1);
-                stats.put("load05", load5);
-                stats.put("load15", load15);
-            }
-            String thp = getThroughput(mrg);
-            if (!thp.isEmpty()) {
-                stats.put("exchangesThroughput", thp);
-            }
-            stats.put("idleSince", mrg.getIdleSince());
-            stats.put("exchangesTotal", mrg.getExchangesTotal());
-            stats.put("exchangesFailed", mrg.getExchangesFailed());
-            stats.put("exchangesInflight", mrg.getExchangesInflight());
-            stats.put("meanProcessingTime", mrg.getMeanProcessingTime());
-            stats.put("maxProcessingTime", mrg.getMaxProcessingTime());
-            stats.put("minProcessingTime", mrg.getMinProcessingTime());
-            if (mrg.getProcessingTimeP50() >= 0) {
-                stats.put("p50ProcessingTime", mrg.getProcessingTimeP50());
-                stats.put("p95ProcessingTime", mrg.getProcessingTimeP95());
-                stats.put("p99ProcessingTime", mrg.getProcessingTimeP99());
-            }
-            if (mrg.getExchangesTotal() > 0) {
-                stats.put("lastProcessingTime", mrg.getLastProcessingTime());
-                stats.put("deltaProcessingTime", mrg.getDeltaProcessingTime());
-            }
-            Date last = mrg.getLastExchangeCreatedTimestamp();
-            if (last != null) {
-                stats.put("lastCreatedExchangeTimestamp", last.getTime());
-            }
-            last = mrg.getLastExchangeCompletedTimestamp();
-            if (last != null) {
-                stats.put("lastCompletedExchangeTimestamp", last.getTime());
-            }
-            last = mrg.getLastExchangeFailureHandledTimestamp();
-            if (last != null) {
-                stats.put("lastFailureHandledExchangeTimestamp", last.getTime());
-            }
-            last = mrg.getLastExchangeFailureTimestamp();
-            if (last != null) {
-                stats.put("lastFailedExchangeTimestamp", last.getTime());
-            }
-            jo.put("statistics", stats);
+            Statistics stats = buildStatistics(mrg);
+            list.add(new RouteGroupEntry(
+                    mrg.getRouteGroup(), mrg.getGroupSize(), mrg.getState(), mrg.getUptime(),
+                    Arrays.asList(mrg.getGroupIds()), stats));
             return null;
         };
         doCall(options, task);
-        root.put("routeGroups", list);
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
+    }
+
+    private Statistics buildStatistics(ManagedRouteGroupMBean mrg) {
+        String coverage = calculateRouteCoverage(mrg, false);
+
+        String load1 = getLoad1(mrg);
+        String load5 = getLoad5(mrg);
+        String load15 = getLoad15(mrg);
+        boolean hasLoad = !load1.isEmpty() || !load5.isEmpty() || !load15.isEmpty();
+
+        String thp = getThroughput(mrg);
+
+        Long p50 = null;
+        Long p95 = null;
+        Long p99 = null;
+        if (mrg.getProcessingTimeP50() >= 0) {
+            p50 = mrg.getProcessingTimeP50();
+            p95 = mrg.getProcessingTimeP95();
+            p99 = mrg.getProcessingTimeP99();
+        }
+
+        Long lastProcessingTime = null;
+        Long deltaProcessingTime = null;
+        if (mrg.getExchangesTotal() > 0) {
+            lastProcessingTime = mrg.getLastProcessingTime();
+            deltaProcessingTime = mrg.getDeltaProcessingTime();
+        }
+
+        Long lastCreated = timestampOf(mrg.getLastExchangeCreatedTimestamp());
+        Long lastCompleted = timestampOf(mrg.getLastExchangeCompletedTimestamp());
+        Long lastFailureHandled = timestampOf(mrg.getLastExchangeFailureHandledTimestamp());
+        Long lastFailed = timestampOf(mrg.getLastExchangeFailureTimestamp());
+
+        return new Statistics(
+                coverage, hasLoad ? load1 : null, hasLoad ? load5 : null, hasLoad ? load15 : null,
+                thp.isEmpty() ? null : thp,
+                mrg.getIdleSince(), mrg.getExchangesTotal(), mrg.getExchangesFailed(), mrg.getExchangesInflight(),
+                mrg.getMeanProcessingTime(), mrg.getMaxProcessingTime(), mrg.getMinProcessingTime(),
+                p50, p95, p99, lastProcessingTime, deltaProcessingTime,
+                lastCreated, lastCompleted, lastFailureHandled, lastFailed);
+    }
+
+    private static Long timestampOf(Date date) {
+        return date != null ? date.getTime() : null;
     }
 
     protected void doCall(Map<String, Object> options, Function<ManagedRouteGroupMBean, Object> task) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteStructureDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteStructureDevConsole.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -35,8 +36,8 @@ import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 import static org.apache.camel.impl.console.ConsoleHelper.extractSourceLocationLineNumber;
@@ -44,6 +45,30 @@ import static org.apache.camel.impl.console.ConsoleHelper.extractSourceLocationN
 
 @DevConsole(name = "route-structure", description = "Dump route structure")
 public class RouteStructureDevConsole extends AbstractDevConsole {
+
+    public record CodeEntry(
+            @Metadata(description = "The source line number, or a sequential counter when not known") int line,
+            @Metadata(description = "The processor type") String type,
+            @Metadata(description = "The processor ID") String id,
+            @Metadata(description = "The nesting level") int level,
+            @Metadata(description = "The description (only present when known)") String description,
+            @Metadata(description = "The code representation of this processor") String code,
+            @Metadata(description = "The endpoint URI (only present when this processor references an endpoint)") String uri,
+            @Metadata(description = "Whether the endpoint is remote (only present when true)") Boolean remote,
+            @Metadata(description = "Runtime statistics for this route or processor, as an opaque JSON object (only present when metrics were requested)") Map<String, Object> statistics) {
+    }
+
+    public record RouteEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route's endpoint URI") String from,
+            @Metadata(description = "The source location (only present when known)") String source,
+            @Metadata(description = "The source line number (only present when known)") Integer line,
+            @Metadata(description = "The route description (only present when configured)") String description,
+            @Metadata(description = "The route's structure, one entry per processor (only present when the dump succeeded)") List<CodeEntry> code) {
+    }
+
+    public record Response(@Metadata(description = "The routes") List<RouteEntry> routes) {
+    }
 
     @Metadata(label = "query", description = "Filters the routes matching by route id, route uri, and source location",
               javaType = "java.lang.String")
@@ -105,45 +130,37 @@ public class RouteStructureDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         final boolean brief = optionBoolean(options, BRIEF, false);
         final boolean metric = optionBoolean(options, METRIC, false);
 
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
+        final List<RouteEntry> list = new ArrayList<>();
 
-        final boolean stats = metric;
         Function<NamedRoute, Object> task = def -> {
-            JsonObject jo = new JsonObject();
-            list.add(jo);
-
-            jo.put("routeId", def.getRouteId());
-            jo.put("from", def.getEndpointUrl());
+            String source = null;
+            Integer line = null;
             if (def.getResource() != null) {
-                jo.put("source", extractSourceLocationNoLineNumber(def.getResource().getLocation()));
-                Integer line = extractSourceLocationLineNumber(def.getResource().getLocation());
-                if (line != null) {
-                    jo.put("line", line);
-                }
-            }
-            if (def.getDescription() != null) {
-                jo.put("description", def.getDescription());
+                source = extractSourceLocationNoLineNumber(def.getResource().getLocation());
+                line = extractSourceLocationLineNumber(def.getResource().getLocation());
             }
 
+            List<CodeEntry> code = null;
             try {
                 ModelToStructureDumper dumper = PluginHelper.getModelToStructureDumper(getCamelContext());
                 List<ModelDumpLine> lines
                         = dumper.dumpStructure(getCamelContext(), def.getRouteId(), brief);
-                JsonArray code = dumpAsJSon(getCamelContext(), lines, stats);
-                jo.put("code", code);
+                code = buildCodeEntries(getCamelContext(), lines, metric);
             } catch (Exception e) {
                 // ignore
             }
+
+            list.add(new RouteEntry(def.getRouteId(), def.getEndpointUrl(), source, line, def.getDescription(), code));
             return null;
         };
         doCall(options, task);
-        root.put("routes", list);
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     protected void doCall(Map<String, Object> options, Function<NamedRoute, Object> task) {
@@ -179,33 +196,21 @@ public class RouteStructureDevConsole extends AbstractDevConsole {
                 || PatternHelper.matchPattern(onlyName, filter);
     }
 
-    private JsonArray dumpAsJSon(CamelContext camelContext, List<ModelDumpLine> lines, boolean metric) {
+    private List<CodeEntry> buildCodeEntries(CamelContext camelContext, List<ModelDumpLine> lines, boolean metric) {
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
 
-        JsonArray code = new JsonArray();
+        List<CodeEntry> code = new ArrayList<>();
         int counter = 0;
         for (var line : lines) {
             counter++;
-            JsonObject c = new JsonObject();
             Integer idx = extractSourceLocationLineNumber(line.location());
             if (idx == null) {
                 idx = counter;
             }
-            c.put("line", idx);
-            c.put("type", line.type());
-            c.put("id", line.id());
-            c.put("level", line.level());
-            if (line.description() != null) {
-                c.put("description", line.description());
-            }
-            c.put("code", Jsoner.escape(line.code()));
-            if (line.uri() != null) {
-                c.put("uri", Jsoner.escape(line.uri()));
-                if (line.remote()) {
-                    c.put("remote", true);
-                }
-            }
+            String uri = line.uri() != null ? Jsoner.escape(line.uri()) : null;
+            Boolean remote = line.uri() != null && line.remote() ? true : null;
 
+            Map<String, Object> statistics = null;
             if (metric && mcc != null) {
                 if (counter <= 2) {
                     ManagedRouteMBean mrb = mcc.getManagedRoute(line.id());
@@ -218,17 +223,19 @@ public class RouteStructureDevConsole extends AbstractDevConsole {
                             stats.remove("load05");
                             stats.remove("load15");
                         }
-                        c.put("statistics", stats);
+                        statistics = stats;
                     }
                 } else {
                     ManagedProcessorMBean mp = mcc.getManagedProcessor(line.id());
                     if (mp != null) {
-                        JsonObject stats = ProcessorDevConsole.gatherProcessorStats(mp);
-                        c.put("statistics", stats);
+                        statistics = ProcessorDevConsole.gatherProcessorStats(mp);
                     }
                 }
             }
-            code.add(c);
+
+            code.add(new CodeEntry(
+                    idx, line.type(), line.id(), line.level(), line.description(), Jsoner.escape(line.code()), uri,
+                    remote, statistics));
         }
         return code;
     }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteTopologyDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/RouteTopologyDevConsole.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.api.management.ManagedCamelContext;
@@ -36,9 +38,44 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.URISupport;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "route-topology", description = "Route topology showing inter-route connections")
 public class RouteTopologyDevConsole extends AbstractDevConsole {
+
+    public record NodeEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route description (only present when configured)") String description,
+            @Metadata(description = "The route's endpoint URI") String from,
+            @Metadata(description = "The route's endpoint scheme") String fromScheme,
+            @Metadata(description = "The node type") String nodeType,
+            @Metadata(description = "Total number of exchanges (only present when metrics were requested and available)") Long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges (only present when metrics were requested and available)") Long exchangesFailed) {
+    }
+
+    public record EdgeEntry(
+            @Metadata(description = "The source route ID") String fromRouteId,
+            @Metadata(description = "The target route ID") String toRouteId,
+            @Metadata(description = "The endpoint URI connecting the two routes") String endpoint,
+            @Metadata(description = "The connection type") String connectionType) {
+    }
+
+    public record ExternalEndpointEntry(
+            @Metadata(description = "The endpoint ID") String id,
+            @Metadata(description = "The endpoint URI") String uri,
+            @Metadata(description = "The endpoint scheme") String scheme,
+            @Metadata(description = "The direction (in or out)") String direction,
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "Total number of exchanges (only present when metrics were requested and available)") Long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges (only present when metrics were requested and available)") Long exchangesFailed) {
+    }
+
+    public record Response(
+            @Metadata(description = "The topology nodes (only present when a route topology dumper is available)") List<NodeEntry> nodes,
+            @Metadata(description = "The connections between nodes (only present when a route topology dumper is available)") List<EdgeEntry> edges,
+            @Metadata(description = "External systems the routes connect to (only present when requested and there are any)") List<ExternalEndpointEntry> externalEndpoints,
+            @Metadata(description = "Route structure data, as opaque JSON objects (only present when requested)") List<Map<String, Object>> routes) {
+    }
 
     @Metadata(label = "query", description = "Whether to include live metrics (message counts) on nodes and edges",
               defaultValue = "false", javaType = "java.lang.Boolean")
@@ -93,11 +130,10 @@ public class RouteTopologyDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         RouteTopologyDumper dumper = PluginHelper.getRouteTopologyDumper(getCamelContext());
         if (dumper == null) {
-            return root;
+            return JsonRecordSupport.toJsonObject(new Response(null, null, null, null));
         }
         TopologyResult result = dumper.dumpTopology(getCamelContext());
 
@@ -107,78 +143,63 @@ public class RouteTopologyDevConsole extends AbstractDevConsole {
                 ? getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class)
                 : null;
 
-        JsonArray nodesArr = new JsonArray();
+        List<NodeEntry> nodes = new ArrayList<>();
         for (TopologyNode node : result.nodes()) {
-            JsonObject jo = new JsonObject();
-            jo.put("routeId", node.routeId());
-            if (node.description() != null) {
-                jo.put("description", node.description());
-            }
-            jo.put("from", node.from());
-            jo.put("fromScheme", node.fromScheme());
-            jo.put("nodeType", node.nodeType());
-
+            Long exchangesTotal = null;
+            Long exchangesFailed = null;
             if (mcc != null) {
                 ManagedRouteMBean mrb = mcc.getManagedRoute(node.routeId());
                 if (mrb != null) {
-                    jo.put("exchangesTotal", mrb.getExchangesTotal());
-                    jo.put("exchangesFailed", mrb.getExchangesFailed());
+                    exchangesTotal = mrb.getExchangesTotal();
+                    exchangesFailed = mrb.getExchangesFailed();
                 }
             }
-
-            nodesArr.add(jo);
+            nodes.add(new NodeEntry(
+                    node.routeId(), node.description(), node.from(), node.fromScheme(), node.nodeType(),
+                    exchangesTotal, exchangesFailed));
         }
-        root.put("nodes", nodesArr);
 
-        JsonArray edgesArr = new JsonArray();
+        List<EdgeEntry> edges = new ArrayList<>();
         for (TopologyEdge edge : result.edges()) {
-            JsonObject jo = new JsonObject();
-            jo.put("fromRouteId", edge.fromRouteId());
-            jo.put("toRouteId", edge.toRouteId());
-            jo.put("endpoint", edge.endpoint());
-            jo.put("connectionType", edge.connectionType());
-            edgesArr.add(jo);
+            edges.add(new EdgeEntry(edge.fromRouteId(), edge.toRouteId(), edge.endpoint(), edge.connectionType()));
         }
-        root.put("edges", edgesArr);
 
+        List<ExternalEndpointEntry> externalEndpoints = null;
         if (external && !result.externalEndpoints().isEmpty()) {
             // Collect per-endpoint metrics for producers (direction=out)
             Map<String, long[]> endpointMetrics = collectEndpointMetrics(mcc, result);
 
-            JsonArray extArr = new JsonArray();
+            externalEndpoints = new ArrayList<>();
             for (TopologyExternalEndpoint ep : result.externalEndpoints()) {
-                JsonObject jo = new JsonObject();
-                jo.put("id", ep.id());
-                jo.put("uri", ep.uri());
-                jo.put("scheme", ep.scheme());
-                jo.put("direction", ep.direction());
-                jo.put("routeId", ep.routeId());
+                Long exchangesTotal = null;
+                Long exchangesFailed = null;
 
                 if (mcc != null) {
                     if ("in".equals(ep.direction())) {
                         // Consumer: use route-level metrics (route has exactly 1 consumer)
                         ManagedRouteMBean mrb = mcc.getManagedRoute(ep.routeId());
                         if (mrb != null) {
-                            jo.put("exchangesTotal", mrb.getExchangesTotal());
-                            jo.put("exchangesFailed", mrb.getExchangesFailed());
+                            exchangesTotal = mrb.getExchangesTotal();
+                            exchangesFailed = mrb.getExchangesFailed();
                         }
                     } else {
                         // Producer: use processor-level metrics
                         String key = ep.routeId() + "|" + ep.uri();
                         long[] stats = endpointMetrics.get(key);
                         if (stats != null) {
-                            jo.put("exchangesTotal", stats[0]);
-                            jo.put("exchangesFailed", stats[1]);
+                            exchangesTotal = stats[0];
+                            exchangesFailed = stats[1];
                         }
                     }
                 }
 
-                extArr.add(jo);
+                externalEndpoints.add(new ExternalEndpointEntry(
+                        ep.id(), ep.uri(), ep.scheme(), ep.direction(), ep.routeId(), exchangesTotal, exchangesFailed));
             }
-            root.put("externalEndpoints", extArr);
         }
 
         // Optionally include route structure data in the same response
+        List<Map<String, Object>> routes = null;
         if (optionBoolean(options, ROUTES, false)) {
             DevConsoleRegistry registry = getCamelContext().getCamelContextExtension()
                     .getContextPlugin(DevConsoleRegistry.class);
@@ -190,13 +211,20 @@ public class RouteTopologyDevConsole extends AbstractDevConsole {
                             org.apache.camel.console.DevConsole.MediaType.JSON,
                             Map.of("filter", "*", "brief", "false", "metric", metricStr));
                     if (structureResult != null) {
-                        root.put("routes", structureResult.get("routes"));
+                        JsonArray routesArr = structureResult.getCollection("routes");
+                        if (routesArr != null) {
+                            routes = new ArrayList<>();
+                            for (Object o : routesArr) {
+                                routes.add((JsonObject) o);
+                            }
+                        }
                     }
                 }
             }
         }
 
-        return root;
+        Response response = new Response(nodes, edges, externalEndpoints, routes);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     /**

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SendDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SendDevConsole.java
@@ -41,11 +41,21 @@ import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "send", displayName = "Camel Send", description = "Send messages to endpoints", readOnly = false)
 @Configurer(extended = true)
 public class SendDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "Epoch time in milliseconds when the send was performed") long timestamp,
+            @Metadata(description = "The send status, success/error/timeout") String status,
+            @Metadata(description = "Elapsed time in milliseconds") long elapsed,
+            @Metadata(description = "The endpoint URI (only present when known)") String endpoint,
+            @Metadata(description = "The exception, as an opaque JSON object (only present on error)") Map<String, Object> exception,
+            @Metadata(description = "The exchange ID (only present when a response message is available)") String exchangeId,
+            @Metadata(description = "The response message, as an opaque JSON object (only present when a response message is available)") Map<String, Object> message) {
+    }
 
     private ProducerTemplate producer;
     private ConsumerTemplate consumer;
@@ -183,8 +193,6 @@ public class SendDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
         StopWatch watch = new StopWatch();
         long timestamp = System.currentTimeMillis();
         String endpoint = optionString(options, ENDPOINT);
@@ -221,27 +229,31 @@ public class SendDevConsole extends AbstractDevConsole {
             status = "timeout";
         }
 
-        root.put("timestamp", timestamp);
-        root.put("status", status);
-        root.put("elapsed", taken);
+        String endpointStr = null;
         if (target != null) {
-            root.put("endpoint", target.toString());
+            endpointStr = target.toString();
         } else if (endpoint != null) {
-            root.put("endpoint", endpoint);
-        }
-        if (cause != null) {
-            // avoid double wrap
-            root.put("exception", MessageHelper.dumpExceptionAsJSonObject(cause).getMap("exception"));
-        }
-        if (out != null && (poll || "InOut".equals(exchangePattern))) {
-            root.put("exchangeId", out.getExchangeId());
-            int maxChars = optionInt(options, BODY_MAX_CHARS, bodyMaxChars);
-            // avoid double wrap
-            root.put("message", MessageHelper.dumpAsJSonObject(out.getMessage(), true, true, true, true, true, true,
-                    maxChars).getMap("message"));
+            endpointStr = endpoint;
         }
 
-        return root;
+        Map<String, Object> exception = null;
+        if (cause != null) {
+            // avoid double wrap
+            exception = MessageHelper.dumpExceptionAsJSonObject(cause).getMap("exception");
+        }
+
+        String exchangeId = null;
+        Map<String, Object> message = null;
+        if (out != null && (poll || "InOut".equals(exchangePattern))) {
+            exchangeId = out.getExchangeId();
+            int maxChars = optionInt(options, BODY_MAX_CHARS, bodyMaxChars);
+            // avoid double wrap
+            message = MessageHelper.dumpAsJSonObject(out.getMessage(), true, true, true, true, true, true, maxChars)
+                    .getMap("message");
+        }
+
+        Response response = new Response(timestamp, status, taken, endpointStr, exception, exchangeId, message);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private Exchange findToTarget(

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ServiceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ServiceDevConsole.java
@@ -16,17 +16,34 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.EndpointServiceRegistry;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.URISupport;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "service", displayName = "Services", description = "Services used for network communication with clients")
 public class ServiceDevConsole extends AbstractDevConsole {
+
+    public record ServiceEntry(
+            @Metadata(description = "The Camel component") String component,
+            @Metadata(description = "The direction (in or out)") String direction,
+            @Metadata(description = "Whether the service is hosted in this Camel application") boolean hosted,
+            @Metadata(description = "The protocol the service is using (only present when known)") String protocol,
+            @Metadata(description = "The remote address of the service (only present when known)") String serviceUrl,
+            @Metadata(description = "The endpoint URI") String endpointUri,
+            @Metadata(description = "The route ID (only present when known)") String routeId,
+            @Metadata(description = "Usage of the endpoint service") long hits,
+            @Metadata(description = "Additional metadata relevant to the service (only present when available)") Map<String, String> metadata) {
+    }
+
+    public record Response(@Metadata(description = "The services") List<ServiceEntry> services) {
+    }
 
     public ServiceDevConsole() {
         super("camel", "service", "Services", "Services used for network communication with clients");
@@ -59,32 +76,17 @@ public class ServiceDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
-        JsonArray list = new JsonArray();
-        root.put("services", list);
+        List<ServiceEntry> list = new ArrayList<>();
 
         EndpointServiceRegistry esr = getCamelContext().getCamelContextExtension().getEndpointServiceRegistry();
         for (EndpointServiceRegistry.EndpointService es : esr.listAllEndpointServices()) {
-            JsonObject jo = new JsonObject();
-            jo.put("component", es.getComponent());
-            jo.put("direction", es.getDirection());
-            jo.put("hosted", es.isHostedService());
-            jo.put("protocol", es.getServiceProtocol());
-            jo.put("serviceUrl", es.getServiceUrl());
-            jo.put("endpointUri", es.getEndpointUri());
-            if (es.getRouteId() != null) {
-                jo.put("routeId", es.getRouteId());
-            }
-            jo.put("hits", es.getHits());
-            var map = es.getServiceMetadata();
-            if (map != null) {
-                jo.put("metadata", map);
-            }
-            list.add(jo);
+            list.add(new ServiceEntry(
+                    es.getComponent(), es.getDirection(), es.isHostedService(), es.getServiceProtocol(),
+                    es.getServiceUrl(), es.getEndpointUri(), es.getRouteId(), es.getHits(), es.getServiceMetadata()));
         }
 
-        return root;
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SimpleLanguageDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SimpleLanguageDevConsole.java
@@ -16,17 +16,26 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.SimpleFunctionRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "simple-language", displayName = "Simple Language", description = "Display simple language details")
 public class SimpleLanguageDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "Number of core simple functions") int coreSize,
+            @Metadata(description = "Number of custom simple functions") int customSize,
+            @Metadata(description = "The core function names (only present when there are any)") List<String> coreFunctions,
+            @Metadata(description = "The custom function names (only present when there are any)") List<String> customFunctions) {
+    }
 
     public SimpleLanguageDevConsole() {
         super("camel", "simple-language", "Simple Language", "Display simple language details");
@@ -52,23 +61,14 @@ public class SimpleLanguageDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         SimpleFunctionRegistry reg = PluginHelper.getSimpleFunctionRegistry(getCamelContext());
-        root.put("coreSize", reg.coreSize());
-        root.put("customSize", reg.customSize());
-        JsonArray arr = new JsonArray();
-        arr.addAll(reg.getCoreFunctionNames());
-        if (!arr.isEmpty()) {
-            root.put("coreFunctions", arr);
-        }
-        arr = new JsonArray();
-        arr.addAll(reg.getCustomFunctionNames());
-        if (!arr.isEmpty()) {
-            root.put("customFunctions", arr);
-        }
 
-        return root;
+        List<String> core = new ArrayList<>(reg.getCoreFunctionNames());
+        List<String> custom = new ArrayList<>(reg.getCustomFunctionNames());
+
+        Response response = new Response(
+                reg.coreSize(), reg.customSize(), core.isEmpty() ? null : core, custom.isEmpty() ? null : custom);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SourceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SourceDevConsole.java
@@ -17,6 +17,7 @@
 package org.apache.camel.impl.console;
 
 import java.io.LineNumberReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -37,6 +38,7 @@ import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "source", description = "Dump route source code")
 public class SourceDevConsole extends AbstractDevConsole {
@@ -48,6 +50,22 @@ public class SourceDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Limits the number of entries displayed",
               javaType = "java.lang.Integer")
     public static final String LIMIT = "limit";
+
+    public record CodeLine(
+            @Metadata(description = "The line number") int line,
+            @Metadata(description = "The source code line") String code,
+            @Metadata(description = "Whether this is the matched line (only present when true)") Boolean match) {
+    }
+
+    public record SourceEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route's endpoint URI") String from,
+            @Metadata(description = "The source location (only present when known)") String source,
+            @Metadata(description = "The source code around the route (only present when resolvable)") List<CodeLine> code) {
+    }
+
+    public record Response(@Metadata(description = "The routes") List<SourceEntry> routes) {
+    }
 
     public SourceDevConsole() {
         super("camel", "source", "Source", "Dump route source code");
@@ -101,30 +119,32 @@ public class SourceDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        final List<SourceEntry> list = new ArrayList<>();
 
         Function<ManagedRouteMBean, Object> task = mrb -> {
-            JsonObject jo = new JsonObject();
-            list.add(jo);
-
-            jo.put("routeId", mrb.getRouteId());
-            jo.put("from", mrb.getEndpointUri());
-            if (mrb.getSourceLocation() != null) {
-                jo.put("source", mrb.getSourceLocation());
-            }
-
             String loc = mrb.getSourceLocation();
             JsonArray code = ConsoleHelper.loadSourceAsJson(getCamelContext(), loc);
-            if (code != null) {
-                jo.put("code", code);
-            }
+            list.add(new SourceEntry(mrb.getRouteId(), mrb.getEndpointUri(), loc, toCodeLines(code)));
             return null;
         };
         doCall(options, task);
-        root.put("routes", list);
-        return root;
+
+        Response response = new Response(list);
+        return JsonRecordSupport.toJsonObject(response);
+    }
+
+    private static List<CodeLine> toCodeLines(JsonArray code) {
+        if (code == null) {
+            return null;
+        }
+        List<CodeLine> lines = new ArrayList<>();
+        for (Object o : code) {
+            JsonObject jo = (JsonObject) o;
+            Boolean match = jo.getBoolean("match");
+            lines.add(new CodeLine(jo.getInteger("line"), jo.getString("code"), match));
+        }
+        return lines;
     }
 
     protected void doCall(Map<String, Object> options, Function<ManagedRouteMBean, Object> task) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlQueryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlQueryDevConsole.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,14 +37,40 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StopWatch;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "sql-query", displayName = "SQL Query", description = "Execute SQL queries on DataSource beans",
             readOnly = false)
 @Configurer(extended = true)
 public class SqlQueryDevConsole extends AbstractDevConsole {
+
+    public record ColumnEntry(
+            @Metadata(description = "The column name") String name,
+            @Metadata(description = "The column SQL type name") String type,
+            @Metadata(description = "Whether the column is part of the primary key (only present when the query targets a single, editable table)") Boolean primaryKey) {
+    }
+
+    public record Response(
+            @Metadata(description = "The execution status, success or error") String status,
+            @Metadata(description = "The error message (only present on error)") String message,
+            @Metadata(description = "The resolved DataSource bean name (only present once resolved)") String datasource,
+            @Metadata(description = "The available DataSource bean names (only present when multiple exist and none was specified)") List<String> availableDataSources,
+            @Metadata(description = "Elapsed time in milliseconds (only present once a query attempt was made)") Long elapsed,
+            @Metadata(description = "The result set columns (only present for queries returning a result set)") List<ColumnEntry> columns,
+            @Metadata(description = "The result set rows, one opaque JSON object per row (only present for queries returning a result set)") List<Map<String, Object>> rows,
+            @Metadata(description = "Number of rows returned (only present for queries returning a result set)") Integer rowCount,
+            @Metadata(description = "Whether the result set was truncated by maxRows (only present for queries returning a result set)") Boolean truncated,
+            @Metadata(description = "Number of rows affected (only present for queries/updates not returning a result set)") Integer updateCount,
+            @Metadata(description = "The single table the result set maps to (only present when the result is a single, editable table)") String tableName,
+            @Metadata(description = "The primary key column names (only present when the result is a single, editable table)") List<String> primaryKeys,
+            @Metadata(description = "Whether the result set rows can be edited (only present when true)") Boolean editable) {
+    }
+
+    private record ResolvedDataSource(
+            DataSource dataSource, String datasourceName, String status, String message, List<String> availableDataSources) {
+    }
 
     @Metadata(label = "query", description = "The SQL query to execute",
               javaType = "java.lang.String")
@@ -204,33 +231,38 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String actionType = optionString(options, ACTION_TYPE);
-        if ("update-row".equals(actionType)) {
-            return doUpdateRow(options);
-        }
-        return doQuery(options);
+        Response response = "update-row".equals(actionType) ? doUpdateRow(options) : doQuery(options);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private JsonObject doQuery(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    private static Response simpleError(String message) {
+        return new Response("error", message, null, null, null, null, null, null, null, null, null, null, null);
+    }
 
+    private static Response dataSourceError(ResolvedDataSource resolved) {
+        return new Response(
+                resolved.status(), resolved.message(), null, resolved.availableDataSources(), null, null, null, null,
+                null, null, null, null, null);
+    }
+
+    private Response doQuery(Map<String, Object> options) {
         String sql = optionString(options, SQL);
         if (sql == null || sql.isBlank()) {
-            root.put("status", "error");
-            root.put("message", "No SQL query provided");
-            return root;
+            return simpleError("No SQL query provided");
         }
 
         String dsName = optionString(options, DATASOURCE);
         int maxRows = optionInt(options, MAX_ROWS, defaultMaxRows);
         int queryTimeout = optionInt(options, QUERY_TIMEOUT, defaultQueryTimeout);
 
-        DataSource ds = resolveDataSource(dsName, root);
-        if (ds == null) {
-            return root;
+        ResolvedDataSource resolved = resolveDataSource(dsName);
+        if (resolved.dataSource() == null) {
+            return dataSourceError(resolved);
         }
-        String resolvedName = root.getString("datasource");
+        DataSource ds = resolved.dataSource();
+        String resolvedName = resolved.datasourceName();
 
         StopWatch watch = new StopWatch();
         try (Connection conn = ds.getConnection();
@@ -242,9 +274,6 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
             boolean hasResultSet = stmt.execute(sql);
             long elapsed = watch.taken();
 
-            root.put("status", "success");
-            root.put("elapsed", elapsed);
-
             if (hasResultSet) {
                 // read all data and metadata from ResultSet first, then close it
                 // before any DatabaseMetaData calls (some drivers only support one
@@ -252,8 +281,9 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
                 String singleTable = null;
                 String catalog = null;
                 String schema = null;
-                JsonArray columns = new JsonArray();
-                JsonArray rows = new JsonArray();
+                List<String> colNames = new ArrayList<>();
+                List<String> colTypes = new ArrayList<>();
+                List<Map<String, Object>> rows = new ArrayList<>();
                 int rowCount = 0;
                 String[] colLabels;
 
@@ -266,6 +296,8 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
                     boolean allSameTable = true;
                     for (int i = 1; i <= colCount; i++) {
                         colLabels[i - 1] = meta.getColumnLabel(i);
+                        colNames.add(colLabels[i - 1]);
+                        colTypes.add(meta.getColumnTypeName(i));
                         String tn = meta.getTableName(i);
                         if (tn == null || tn.isEmpty()) {
                             allSameTable = false;
@@ -281,15 +313,8 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
                         singleTable = null;
                     }
 
-                    for (int i = 1; i <= colCount; i++) {
-                        JsonObject col = new JsonObject();
-                        col.put("name", meta.getColumnLabel(i));
-                        col.put("type", meta.getColumnTypeName(i));
-                        columns.add(col);
-                    }
-
                     while (rs.next()) {
-                        JsonObject row = new JsonObject();
+                        Map<String, Object> row = new LinkedHashMap<>();
                         for (int i = 1; i <= colCount; i++) {
                             Object val = rs.getObject(i);
                             if (val == null) {
@@ -325,53 +350,44 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
                     }
                 }
 
-                // annotate columns with PK info
-                if (singleTable != null && !pkColumns.isEmpty()) {
-                    for (int i = 0; i < columns.size(); i++) {
-                        JsonObject col = (JsonObject) columns.get(i);
-                        col.put("primaryKey", pkColumns.contains(col.getString("name")));
-                    }
-                    root.put("tableName", singleTable);
-                    JsonArray pkArr = new JsonArray();
-                    pkColumns.forEach(pkArr::add);
-                    root.put("primaryKeys", pkArr);
-                    root.put("editable", true);
+                boolean editableTable = singleTable != null && !pkColumns.isEmpty();
+                List<ColumnEntry> columns = new ArrayList<>();
+                for (int i = 0; i < colNames.size(); i++) {
+                    Boolean pk = editableTable ? pkColumns.contains(colNames.get(i)) : null;
+                    columns.add(new ColumnEntry(colNames.get(i), colTypes.get(i), pk));
                 }
 
-                root.put("columns", columns);
-                root.put("rows", rows);
-                root.put("rowCount", rowCount);
-                root.put("truncated", rowCount >= maxRows);
+                String tableName = editableTable ? singleTable : null;
+                List<String> primaryKeys = editableTable ? new ArrayList<>(pkColumns) : null;
+                Boolean editable = editableTable ? true : null;
+
+                return new Response(
+                        "success", null, resolvedName, null, elapsed, columns, rows, rowCount, rowCount >= maxRows,
+                        null, tableName, primaryKeys, editable);
             } else {
                 int updateCount = stmt.getUpdateCount();
-                root.put("updateCount", updateCount);
+                return new Response(
+                        "success", null, resolvedName, null, elapsed, null, null, null, null, updateCount, null, null,
+                        null);
             }
         } catch (Exception e) {
             long elapsed = watch.taken();
-            root.put("status", "error");
-            root.put("elapsed", elapsed);
-            root.put("message", e.getMessage());
+            return new Response(
+                    "error", e.getMessage(), resolvedName, null, elapsed, null, null, null, null, null, null, null,
+                    null);
         }
-
-        return root;
     }
 
-    private JsonObject doUpdateRow(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    private Response doUpdateRow(Map<String, Object> options) {
         String tableName = optionString(options, TABLE);
         if (tableName == null || tableName.isBlank()) {
-            root.put("status", "error");
-            root.put("message", "No table name provided");
-            return root;
+            return simpleError("No table name provided");
         }
 
         String pkJson = optionString(options, PRIMARY_KEY_VALUES);
         String colJson = optionString(options, COLUMN_VALUES);
         if (pkJson == null || colJson == null) {
-            root.put("status", "error");
-            root.put("message", "Missing primaryKeyValues or columnValues");
-            return root;
+            return simpleError("Missing primaryKeyValues or columnValues");
         }
 
         JsonObject pkValues;
@@ -380,22 +396,20 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
             pkValues = (JsonObject) Jsoner.deserialize(pkJson);
             colValues = (JsonObject) Jsoner.deserialize(colJson);
         } catch (Exception e) {
-            root.put("status", "error");
-            root.put("message", "Invalid JSON: " + e.getMessage());
-            return root;
+            return simpleError("Invalid JSON: " + e.getMessage());
         }
 
         if (colValues.isEmpty()) {
-            root.put("status", "error");
-            root.put("message", "No columns to update");
-            return root;
+            return simpleError("No columns to update");
         }
 
         String dsName = optionString(options, DATASOURCE);
-        DataSource ds = resolveDataSource(dsName, root);
-        if (ds == null) {
-            return root;
+        ResolvedDataSource resolved = resolveDataSource(dsName);
+        if (resolved.dataSource() == null) {
+            return dataSourceError(resolved);
         }
+        DataSource ds = resolved.dataSource();
+        String resolvedName = resolved.datasourceName();
 
         // build UPDATE table SET col1=?, col2=? WHERE pk1=? AND pk2=?
         List<String> setCols = new ArrayList<>(colValues.keySet());
@@ -431,48 +445,38 @@ public class SqlQueryDevConsole extends AbstractDevConsole {
 
             int updateCount = ps.executeUpdate();
             long elapsed = watch.taken();
-            root.put("status", "success");
-            root.put("elapsed", elapsed);
-            root.put("updateCount", updateCount);
+            return new Response(
+                    "success", null, resolvedName, null, elapsed, null, null, null, null, updateCount, null, null,
+                    null);
         } catch (Exception e) {
             long elapsed = watch.taken();
-            root.put("status", "error");
-            root.put("elapsed", elapsed);
-            root.put("message", e.getMessage());
+            return new Response(
+                    "error", e.getMessage(), resolvedName, null, elapsed, null, null, null, null, null, null, null,
+                    null);
         }
-
-        return root;
     }
 
-    private DataSource resolveDataSource(String dsName, JsonObject root) {
+    private ResolvedDataSource resolveDataSource(String dsName) {
         if (dsName != null && !dsName.isBlank()) {
             DataSource ds = getCamelContext().getRegistry().lookupByNameAndType(dsName, DataSource.class);
             if (ds == null) {
-                root.put("status", "error");
-                root.put("message", String.format("DataSource '%s' not found in registry", dsName));
-                return null;
+                return new ResolvedDataSource(
+                        null, null, "error", String.format("DataSource '%s' not found in registry", dsName), null);
             }
-            root.put("datasource", dsName);
-            return ds;
+            return new ResolvedDataSource(ds, dsName, null, null, null);
         }
 
         Map<String, DataSource> all = getCamelContext().getRegistry().findByTypeWithName(DataSource.class);
         if (all.isEmpty()) {
-            root.put("status", "error");
-            root.put("message", "No DataSource found in registry");
-            return null;
+            return new ResolvedDataSource(null, null, "error", "No DataSource found in registry", null);
         }
         if (all.size() > 1) {
-            root.put("status", "error");
-            root.put("message", "Multiple DataSources found, specify one: " + String.join(", ", all.keySet()));
-            JsonArray names = new JsonArray();
-            all.keySet().forEach(names::add);
-            root.put("availableDataSources", names);
-            return null;
+            return new ResolvedDataSource(
+                    null, null, "error", "Multiple DataSources found, specify one: " + String.join(", ", all.keySet()),
+                    new ArrayList<>(all.keySet()));
         }
         Map.Entry<String, DataSource> single = all.entrySet().iterator().next();
-        root.put("datasource", single.getKey());
-        return single.getValue();
+        return new ResolvedDataSource(single.getValue(), single.getKey(), null, null, null);
     }
 
     private static void setParameter(PreparedStatement ps, int index, Object value) throws Exception {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlTraceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SqlTraceDevConsole.java
@@ -35,8 +35,7 @@ import org.apache.camel.support.EventNotifierSupport;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "sql-trace", displayName = "SQL Trace", description = "Trace SQL query executions")
 @Configurer(extended = true)
@@ -46,9 +45,41 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
               description = "Maximum capacity of traced SQL statements (capacity must be between 25 and 1000)")
     private int capacity = 200;
 
-    private JsonObject[] events;
+    private StatementEntry[] events;
     private final AtomicInteger pos = new AtomicInteger();
     private final ConsoleEventNotifier listener = new ConsoleEventNotifier();
+
+    public record StatementEntry(
+            @Metadata(description = "Epoch time in milliseconds when the statement was executed") long timestamp,
+            @Metadata(description = "The exchange ID") String exchangeId,
+            @Metadata(description = "The route ID (only present when known)") String routeId,
+            @Metadata(description = "The processor node ID (only present when known)") String nodeId,
+            @Metadata(description = "The source location of the processor (only present when known)") String location,
+            @Metadata(description = "The endpoint URI") String endpoint,
+            @Metadata(description = "The SQL query (or the endpoint URI when the query could not be determined)") String query,
+            @Metadata(description = "The SQL statement category") String category,
+            @Metadata(description = "Duration in milliseconds") long duration,
+            @Metadata(description = "Whether the exchange failed") boolean failed,
+            @Metadata(description = "Number of rows returned (only present when known)") Integer rowCount,
+            @Metadata(description = "Number of rows updated (only present when known)") Integer updateCount) {
+    }
+
+    public record Summary(
+            @Metadata(description = "Total number of queries") long totalQueries,
+            @Metadata(description = "Average duration in milliseconds") long avgTime,
+            @Metadata(description = "Slowest duration in milliseconds") long slowestTime,
+            @Metadata(description = "Number of queries considered slow (duration >= 100 ms)") long slowCount,
+            @Metadata(description = "Number of failed queries") long failedCount,
+            @Metadata(description = "Number of SELECT statements") long selectCount,
+            @Metadata(description = "Number of INSERT statements") long insertCount,
+            @Metadata(description = "Number of UPDATE statements") long updateCount,
+            @Metadata(description = "Number of DELETE statements") long deleteCount) {
+    }
+
+    public record Response(
+            @Metadata(description = "The traced SQL statements, most recent first (only present when statements have been traced)") List<StatementEntry> statements,
+            @Metadata(description = "Summary statistics across the traced statements (only present when statements have been traced)") Summary summary) {
+    }
 
     public SqlTraceDevConsole() {
         super("camel", "sql-trace", "SQL Trace", "Trace SQL query executions");
@@ -67,7 +98,7 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
         if (capacity > 1000 || capacity < 25) {
             throw new IllegalArgumentException("Capacity must be between 25 and 1000");
         }
-        this.events = new JsonObject[capacity];
+        this.events = new StatementEntry[capacity];
     }
 
     @Override
@@ -84,14 +115,10 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
     protected String doCallText(Map<String, Object> options) {
         StringBuilder sb = new StringBuilder();
 
-        List<JsonObject> list = collectEvents();
-        for (JsonObject jo : list) {
+        List<StatementEntry> list = collectEvents();
+        for (StatementEntry e : list) {
             sb.append(String.format("    %s %s %s (%d ms) route:%s%n",
-                    jo.getString("category"),
-                    jo.getString("query"),
-                    jo.getBooleanOrDefault("failed", false) ? "FAILED" : "OK",
-                    jo.getLongOrDefault("duration", 0),
-                    jo.getString("routeId")));
+                    e.category(), e.query(), e.failed() ? "FAILED" : "OK", e.duration(), e.routeId()));
         }
         if (!list.isEmpty()) {
             sb.insert(0, String.format("Last %d SQL Statements:%n", list.size()));
@@ -101,17 +128,14 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<StatementEntry> list = collectEvents();
 
-        List<JsonObject> list = collectEvents();
+        List<StatementEntry> statements = null;
+        Summary summary = null;
         if (!list.isEmpty()) {
-            JsonArray arr = new JsonArray();
-            arr.addAll(list);
-            root.put("statements", arr);
+            statements = list;
 
-            // compute summary
-            JsonObject summary = new JsonObject();
             long total = list.size();
             long totalTime = 0;
             long slowest = 0;
@@ -122,8 +146,8 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
             long updateCount = 0;
             long deleteCount = 0;
 
-            for (JsonObject jo : list) {
-                long duration = jo.getLongOrDefault("duration", 0);
+            for (StatementEntry e : list) {
+                long duration = e.duration();
                 totalTime += duration;
                 if (duration > slowest) {
                     slowest = duration;
@@ -131,11 +155,10 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
                 if (duration >= 100) {
                     slowCount++;
                 }
-                if (jo.getBooleanOrDefault("failed", false)) {
+                if (e.failed()) {
                     failedCount++;
                 }
-                String cat = jo.getStringOrDefault("category", "");
-                switch (cat) {
+                switch (e.category()) {
                     case "SELECT":
                         selectCount++;
                         break;
@@ -153,28 +176,22 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
                 }
             }
 
-            summary.put("totalQueries", total);
-            summary.put("avgTime", total > 0 ? totalTime / total : 0);
-            summary.put("slowestTime", slowest);
-            summary.put("slowCount", slowCount);
-            summary.put("failedCount", failedCount);
-            summary.put("selectCount", selectCount);
-            summary.put("insertCount", insertCount);
-            summary.put("updateCount", updateCount);
-            summary.put("deleteCount", deleteCount);
-            root.put("summary", summary);
+            summary = new Summary(
+                    total, total > 0 ? totalTime / total : 0, slowest, slowCount, failedCount, selectCount,
+                    insertCount, updateCount, deleteCount);
         }
 
-        return root;
+        Response response = new Response(statements, summary);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private List<JsonObject> collectEvents() {
-        List<JsonObject> list = new ArrayList<>();
+    private List<StatementEntry> collectEvents() {
+        List<StatementEntry> list = new ArrayList<>();
         int cursor = pos.get();
         // cursor points to the NEXT write slot, so walk backward from cursor-1
         for (int i = 0; i < capacity; i++) {
             cursor = (cursor - 1 + capacity) % capacity;
-            JsonObject event = events[cursor];
+            StatementEntry event = events[cursor];
             if (event != null) {
                 list.add(event);
             }
@@ -270,47 +287,29 @@ public class SqlTraceDevConsole extends AbstractDevConsole {
                         query = resolveResource(query.substring("resource:".length()));
                     }
 
-                    JsonObject jo = new JsonObject();
-                    jo.put("timestamp", event.getTimestamp());
-                    jo.put("exchangeId", exchange.getExchangeId());
-                    jo.put("routeId", exchange.getFromRouteId());
                     String nodeId = exchange.getExchangeExtension().getHistoryNodeId();
-                    if (nodeId != null) {
-                        jo.put("nodeId", nodeId);
-                    }
-                    String nodeSource = exchange.getExchangeExtension().getHistoryNodeSource();
-                    if (nodeSource != null) {
-                        jo.put("location", nodeSource);
-                    }
-                    jo.put("endpoint", uri);
-                    if (query != null) {
-                        jo.put("query", query);
-                        jo.put("category", detectCategory(query));
-                    } else {
-                        jo.put("query", uri);
-                        jo.put("category", "OTHER");
-                    }
-                    jo.put("duration", ese.getTimeTaken());
-                    jo.put("failed", exchange.isFailed());
+                    String location = exchange.getExchangeExtension().getHistoryNodeSource();
+                    String finalQuery = query != null ? query : uri;
+                    String category = query != null ? detectCategory(query) : "OTHER";
 
                     // row/update counts from sql and jdbc component headers
                     Object rc = exchange.getMessage().getHeader("CamelSqlRowCount");
                     if (rc == null) {
                         rc = exchange.getMessage().getHeader("CamelJdbcRowCount");
                     }
-                    if (rc instanceof Number) {
-                        jo.put("rowCount", ((Number) rc).intValue());
-                    }
+                    Integer rowCount = rc instanceof Number ? ((Number) rc).intValue() : null;
                     Object uc = exchange.getMessage().getHeader("CamelSqlUpdateCount");
                     if (uc == null) {
                         uc = exchange.getMessage().getHeader("CamelJdbcUpdateCount");
                     }
-                    if (uc instanceof Number) {
-                        jo.put("updateCount", ((Number) uc).intValue());
-                    }
+                    Integer updateCount = uc instanceof Number ? ((Number) uc).intValue() : null;
+
+                    StatementEntry entry = new StatementEntry(
+                            event.getTimestamp(), exchange.getExchangeId(), exchange.getFromRouteId(), nodeId, location,
+                            uri, finalQuery, category, ese.getTimeTaken(), exchange.isFailed(), rowCount, updateCount);
 
                     int p = pos.getAndUpdate(operand -> ++operand % capacity);
-                    events[p] = jo;
+                    events[p] = entry;
                 }
             }
         }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/StartupRecorderDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/StartupRecorderDevConsole.java
@@ -16,19 +16,36 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.StartupStep;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.StartupStepRecorder;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "startup-recorder", description = "Starting recording information")
 public class StartupRecorderDevConsole extends AbstractDevConsole {
+
+    public record StepEntry(
+            @Metadata(description = "The id of the step") int id,
+            @Metadata(description = "The id of the parent step") int parentId,
+            @Metadata(description = "The step level (sub step of previous steps)") int level,
+            @Metadata(description = "Name of the step (only present when known)") String name,
+            @Metadata(description = "The source class type of the step") String type,
+            @Metadata(description = "Description of the step") String description,
+            @Metadata(description = "The begin time (epoch milliseconds)") long beginTime,
+            @Metadata(description = "The duration the step took, in milliseconds") long duration) {
+    }
+
+    public record Response(
+            @Metadata(description = "The startup steps (only present when there are any)") List<StepEntry> steps) {
+    }
 
     public StartupRecorderDevConsole() {
         super("camel", "startup-recorder", "Startup Recorder", "Starting recording information");
@@ -51,32 +68,18 @@ public class StartupRecorderDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
+        List<StepEntry> steps = new ArrayList<>();
 
         ExtendedCamelContext ecc = getCamelContext().getCamelContextExtension();
         StartupStepRecorder recorder = ecc.getStartupStepRecorder();
         if (recorder != null) {
-            recorder.steps().forEach(s -> {
-                JsonObject jo = new JsonObject();
-                jo.put("id", s.getId());
-                jo.put("parentId", s.getParentId());
-                jo.put("level", s.getLevel());
-                if (s.getName() != null) {
-                    jo.put("name", s.getName());
-                }
-                jo.put("type", s.getType());
-                jo.put("description", s.getDescription());
-                jo.put("beginTime", s.getBeginTime());
-                jo.put("duration", s.getDuration());
-                arr.add(jo);
-            });
+            recorder.steps().forEach(s -> steps.add(new StepEntry(
+                    s.getId(), s.getParentId(), s.getLevel(), s.getName(), s.getType(), s.getDescription(),
+                    s.getBeginTime(), s.getDuration())));
         }
 
-        if (!arr.isEmpty()) {
-            root.put("steps", arr);
-        }
-        return root;
+        Response response = new Response(steps.isEmpty() ? null : steps);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     protected String logStep(StartupStep step) {

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/SystemPropertiesDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/SystemPropertiesDevConsole.java
@@ -16,20 +16,26 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.camel.spi.Configurer;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "system-properties", description = "Displays Java System Properties")
 @Configurer(extended = true)
 public class SystemPropertiesDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The system properties, one single-entry map per property") List<Map<String, String>> systemProperties) {
+    }
 
     public SystemPropertiesDevConsole() {
         super("jvm", "system-properties", "Java System Properties", "Displays Java System Properties");
@@ -53,21 +59,17 @@ public class SystemPropertiesDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
-        JsonArray arr = new JsonArray();
-        root.put("systemProperties", arr);
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<Map<String, String>> entries = new ArrayList<>();
 
         Properties p = System.getProperties();
         Set<String> keys = new TreeSet<>(p.stringPropertyNames());
         for (String k : keys) {
-            JsonObject jo = new JsonObject();
-            jo.put(k, System.getProperty(k));
-            arr.add(jo);
+            entries.add(Map.of(k, System.getProperty(k)));
         }
 
-        return root;
+        Response response = new Response(entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TaskRegistryDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TaskRegistryDevConsole.java
@@ -16,18 +16,36 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.support.task.Task;
 import org.apache.camel.support.task.TaskManagerRegistry;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "internal-tasks", displayName = "Internal Tasks", description = "Display information about internal tasks")
 public class TaskRegistryDevConsole extends AbstractDevConsole {
+
+    public record TaskEntry(
+            @Metadata(description = "The task name") String name,
+            @Metadata(description = "The task status") String status,
+            @Metadata(description = "Whether the task is currently attempting") boolean attempting,
+            @Metadata(description = "The current number of iterations") int attempts,
+            @Metadata(description = "The current computed delay") long delay,
+            @Metadata(description = "The current elapsed time") long elapsed,
+            @Metadata(description = "The time the first attempt was performed") long firstTime,
+            @Metadata(description = "The time the last attempt was performed") long lastTime,
+            @Metadata(description = "The time the next attempt will be made") long nextTime,
+            @Metadata(description = "The failure message (only present when known)") String error) {
+    }
+
+    public record Response(@Metadata(description = "The internal tasks") List<TaskEntry> tasks) {
+    }
 
     public TaskRegistryDevConsole() {
         super("camel", "internal-tasks", "Internal Tasks", "Display information about internal tasks");
@@ -53,30 +71,20 @@ public class TaskRegistryDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        JsonArray arr = new JsonArray();
-        root.put("tasks", arr);
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<TaskEntry> tasks = new ArrayList<>();
 
         TaskManagerRegistry reg = PluginHelper.getTaskManagerRegistry(getCamelContext().getCamelContextExtension());
         for (Task task : reg.getTasks()) {
-            JsonObject jo = new JsonObject();
-            jo.put("name", task.getName());
-            jo.put("status", task.getStatus().name());
-            jo.put("attempting", task.isAttempting());
-            jo.put("attempts", task.iteration());
-            jo.put("delay", task.getCurrentDelay());
-            jo.put("elapsed", task.getCurrentElapsedTime());
-            jo.put("firstTime", task.getFirstAttemptTime());
-            jo.put("lastTime", task.getLastAttemptTime());
-            jo.put("nextTime", task.getNextAttemptTime());
             String failure = task.getException() != null ? task.getException().getMessage() : "";
-            if (failure != null) {
-                jo.put("error", failure);
-            }
-            arr.add(jo);
+            tasks.add(new TaskEntry(
+                    task.getName(), task.getStatus().name(), task.isAttempting(), task.iteration(),
+                    task.getCurrentDelay(), task.getCurrentElapsedTime(), task.getFirstAttemptTime(),
+                    task.getLastAttemptTime(), task.getNextAttemptTime(), failure));
         }
-        return root;
+
+        Response response = new Response(tasks);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/ThreadDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/ThreadDevConsole.java
@@ -19,15 +19,16 @@ package org.apache.camel.impl.console;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.spi.Configurer;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "thread", description = "Displays JVM Threads information")
 @Configurer(extended = true)
@@ -36,6 +37,26 @@ public class ThreadDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Whether to include thread stack traces",
               defaultValue = "false", javaType = "java.lang.Boolean")
     public static final String STACK_TRACE = "stackTrace";
+
+    public record ThreadEntry(
+            @Metadata(description = "The thread ID") long id,
+            @Metadata(description = "The thread name") String name,
+            @Metadata(description = "The thread state") String state,
+            @Metadata(description = "Number of times the thread has been blocked") long blockedCount,
+            @Metadata(description = "Total time in milliseconds the thread has been blocked") long blockedTime,
+            @Metadata(description = "Number of times the thread has waited") long waitedCount,
+            @Metadata(description = "Total time in milliseconds the thread has waited") long waitedTime,
+            @Metadata(description = "The name of the lock the thread is waiting on (only present when applicable)") String lockName,
+            @Metadata(description = "The thread stack trace, one entry per line (only present when requested via the stackTrace option)") List<String> stackTrace) {
+    }
+
+    public record Response(
+            @Metadata(description = "Number of threads") Integer threadCount,
+            @Metadata(description = "Number of daemon threads") Integer daemonThreadCount,
+            @Metadata(description = "Total number of threads started since JVM start") Long totalStartedThreadCount,
+            @Metadata(description = "Peak number of threads") Integer peakThreadCount,
+            @Metadata(description = "The threads") List<ThreadEntry> threads) {
+    }
 
     public ThreadDevConsole() {
         super("jvm", "thread", "Thread", "Displays JVM Threads information");
@@ -74,54 +95,42 @@ public class ThreadDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         boolean st = optionBoolean(options, STACK_TRACE, false);
         ThreadMXBean tb = ManagementFactory.getThreadMXBean();
+
+        Response response;
         if (tb != null) {
-            root.put("threadCount", tb.getThreadCount());
-            root.put("daemonThreadCount", tb.getDaemonThreadCount());
-            root.put("totalStartedThreadCount", tb.getTotalStartedThreadCount());
-            root.put("peakThreadCount", tb.getPeakThreadCount());
-
-            JsonArray arr = new JsonArray();
-            root.put("threads", arr);
-
+            List<ThreadEntry> threads = new ArrayList<>();
             long[] ids = tb.getAllThreadIds();
             Arrays.sort(ids);
             for (long id : ids) {
                 ThreadInfo ti = st ? tb.getThreadInfo(id, Integer.MAX_VALUE) : tb.getThreadInfo(id);
                 if (ti != null) {
-                    final JsonObject jo = toJsonObject(ti, st);
-                    arr.add(jo);
+                    threads.add(toThreadEntry(ti, st));
                 }
             }
+            response = new Response(
+                    tb.getThreadCount(), tb.getDaemonThreadCount(), tb.getTotalStartedThreadCount(),
+                    tb.getPeakThreadCount(), threads);
+        } else {
+            response = new Response(null, null, null, null, null);
         }
 
-        return root;
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static JsonObject toJsonObject(ThreadInfo ti, boolean st) {
-        JsonObject jo = new JsonObject();
-        jo.put("id", ti.getThreadId());
-        jo.put("name", ti.getThreadName());
-        jo.put("state", ti.getThreadState().name());
-        jo.put("blockedCount", ti.getBlockedCount());
-        jo.put("blockedTime", ti.getBlockedTime());
-        jo.put("waitedCount", ti.getWaitedCount());
-        jo.put("waitedTime", ti.getWaitedTime());
-        if (ti.getLockName() != null) {
-            jo.put("lockName", ti.getLockName());
-        }
+    private static ThreadEntry toThreadEntry(ThreadInfo ti, boolean st) {
+        List<String> stackTrace = null;
         if (st) {
-            JsonArray arr2 = new JsonArray();
-            jo.put("stackTrace", arr2);
+            stackTrace = new ArrayList<>();
             for (StackTraceElement e : ti.getStackTrace()) {
-                arr2.add(e.toString());
+                stackTrace.add(e.toString());
             }
         }
-        return jo;
+        return new ThreadEntry(
+                ti.getThreadId(), ti.getThreadName(), ti.getThreadState().name(), ti.getBlockedCount(), ti.getBlockedTime(),
+                ti.getWaitedCount(), ti.getWaitedTime(), ti.getLockName(), stackTrace);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TopDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TopDevConsole.java
@@ -40,12 +40,55 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "top", displayName = "Top Routes", description = "Display the top routes")
 public class TopDevConsole extends AbstractDevConsole {
+
+    public record Statistics(
+            @Metadata(description = "Total number of exchanges") long exchangesTotal,
+            @Metadata(description = "Number of failed exchanges") long exchangesFailed,
+            @Metadata(description = "Number of inflight exchanges") long exchangesInflight,
+            @Metadata(description = "Mean processing time in milliseconds") long meanProcessingTime,
+            @Metadata(description = "Max processing time in milliseconds") long maxProcessingTime,
+            @Metadata(description = "Min processing time in milliseconds") long minProcessingTime,
+            @Metadata(description = "Processing time in milliseconds of the last exchange") long lastProcessingTime,
+            @Metadata(description = "Difference in processing time in milliseconds since the previous exchange") long deltaProcessingTime,
+            @Metadata(description = "Total accumulated processing time in milliseconds") long totalProcessingTime,
+            @Metadata(description = "Messages per second throughput (only present when available)") String exchangesThroughput,
+            @Metadata(description = "50th percentile processing time in milliseconds (only present when available)") Long p50ProcessingTime,
+            @Metadata(description = "95th percentile processing time in milliseconds (only present when available)") Long p95ProcessingTime,
+            @Metadata(description = "99th percentile processing time in milliseconds (only present when available)") Long p99ProcessingTime) {
+    }
+
+    public record CodeLine(
+            @Metadata(description = "The source line number") int line,
+            @Metadata(description = "Whether this is the matched line (only present when true)") Boolean match,
+            @Metadata(description = "The source code line") String code) {
+    }
+
+    public record RouteEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The route's endpoint URI") String from,
+            @Metadata(description = "The source location (only present when known)") String source,
+            @Metadata(description = "The route state") String state,
+            @Metadata(description = "Route uptime, human readable text") String uptime,
+            @Metadata(description = "Runtime statistics") Statistics statistics) {
+    }
+
+    public record ProcessorEntry(
+            @Metadata(description = "The route ID") String routeId,
+            @Metadata(description = "The processor ID") String processorId,
+            @Metadata(description = "The source location, optionally with a line number suffix (only present when known)") String location,
+            @Metadata(description = "A snippet of source code around the processor (only present when known)") List<CodeLine> code,
+            @Metadata(description = "Runtime statistics") Statistics statistics) {
+    }
+
+    public record Response(
+            @Metadata(description = "The top routes (only present when no processor path was requested)") List<RouteEntry> routes,
+            @Metadata(description = "The top processors of a route (only present when a processor path was requested)") List<ProcessorEntry> processors) {
+    }
 
     @Metadata(label = "query",
               description = "Filters the routes and processors matching by route id, route uri, processor id, and source location",
@@ -167,50 +210,39 @@ public class TopDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String path = optionString(options, Exchange.HTTP_PATH);
         String subPath = path != null ? StringHelper.after(path, "/") : null;
         String filter = optionString(options, FILTER);
         final int max = optionInt(options, LIMIT, Integer.MAX_VALUE);
 
-        final JsonObject root = new JsonObject();
-        final JsonArray list = new JsonArray();
+        List<RouteEntry> routes = null;
+        List<ProcessorEntry> processors = null;
 
         ManagedCamelContext mcc = getCamelContext().getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
         if (mcc != null) {
             if (subPath == null || subPath.isBlank()) {
+                final List<RouteEntry> list = new ArrayList<>();
                 Function<ManagedRouteMBean, Object> task = mrb -> {
-                    JsonObject jo = new JsonObject();
-                    list.add(jo);
-
-                    jo.put("routeId", mrb.getRouteId());
-                    jo.put("from", mrb.getEndpointUri());
-                    if (mrb.getSourceLocation() != null) {
-                        jo.put("source", mrb.getSourceLocation());
-                    }
-                    jo.put("state", mrb.getState());
-                    jo.put("uptime", mrb.getUptime());
-                    final JsonObject stats = getStatsObject(mrb);
-                    jo.put("statistics", stats);
+                    list.add(new RouteEntry(
+                            mrb.getRouteId(), mrb.getEndpointUri(), mrb.getSourceLocation(), mrb.getState(),
+                            mrb.getUptime(), getStatsObject(mrb)));
                     return null;
                 };
                 topRoutes(filter, max, mcc, task);
-                root.put("routes", list);
+                routes = list;
             } else {
+                final List<ProcessorEntry> list = new ArrayList<>();
                 Function<ManagedProcessorMBean, Object> task = mpb -> {
-                    JsonObject jo = new JsonObject();
-                    list.add(jo);
-
-                    jo.put("routeId", mpb.getRouteId());
-                    jo.put("processorId", mpb.getProcessorId());
                     String loc = mpb.getSourceLocation();
-                    JsonArray code = new JsonArray();
+                    List<CodeLine> code = null;
                     if (loc != null && mpb.getSourceLineNumber() != null) {
                         int line = mpb.getSourceLineNumber();
                         try {
                             loc = LoggerHelper.stripSourceLocationLineNumber(loc);
                             Resource resource = PluginHelper.getResourceLoader(getCamelContext()).resolveResource(loc);
                             if (resource != null) {
+                                code = new ArrayList<>();
                                 LineNumberReader reader = new LineNumberReader(resource.getReader());
                                 for (int i = 1; i < line + 3; i++) {
                                     String t = reader.readLine();
@@ -218,63 +250,53 @@ public class TopDevConsole extends AbstractDevConsole {
                                         int low = line - 2;
                                         int high = line + 4;
                                         if (i >= low && i <= high) {
-                                            JsonObject c = new JsonObject();
-                                            c.put("line", i);
-                                            if (line == i) {
-                                                c.put("match", true);
-                                            }
-                                            c.put("code", Jsoner.escape(t));
-                                            code.add(c);
+                                            Boolean match = line == i ? true : null;
+                                            code.add(new CodeLine(i, match, Jsoner.escape(t)));
                                         }
                                     }
                                 }
                                 IOHelper.close(reader);
+                                if (code.isEmpty()) {
+                                    code = null;
+                                }
                             }
                             loc += ":" + mpb.getSourceLineNumber();
                         } catch (Exception e) {
                             // ignore
                         }
                     }
-                    if (loc != null) {
-                        jo.put("location", loc);
-                        if (!code.isEmpty()) {
-                            jo.put("code", code);
-                        }
-                    }
 
-                    final JsonObject stats = getStatsObject(mpb);
-                    jo.put("statistics", stats);
+                    list.add(new ProcessorEntry(
+                            mpb.getRouteId(), mpb.getProcessorId(), loc, code, getStatsObject(mpb)));
                     return null;
                 };
                 topProcessors(filter, subPath, max, mcc, task);
-                root.put("processors", list);
+                processors = list;
             }
         }
 
-        return root;
+        Response response = new Response(routes, processors);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static JsonObject getStatsObject(ManagedPerformanceCounterMBean mbean) {
-        JsonObject stats = new JsonObject();
-        stats.put("exchangesTotal", mbean.getExchangesTotal());
-        stats.put("exchangesFailed", mbean.getExchangesFailed());
-        stats.put("exchangesInflight", mbean.getExchangesInflight());
-        stats.put("meanProcessingTime", mbean.getMeanProcessingTime());
-        stats.put("maxProcessingTime", mbean.getMaxProcessingTime());
-        stats.put("minProcessingTime", mbean.getMinProcessingTime());
-        stats.put("lastProcessingTime", mbean.getLastProcessingTime());
-        stats.put("deltaProcessingTime", mbean.getDeltaProcessingTime());
-        stats.put("totalProcessingTime", mbean.getTotalProcessingTime());
+    private static Statistics getStatsObject(ManagedPerformanceCounterMBean mbean) {
         String thp = mbean.getThroughput();
-        if (thp != null && !thp.isEmpty()) {
-            stats.put("exchangesThroughput", thp);
-        }
+        String throughput = thp != null && !thp.isEmpty() ? thp : null;
+
+        Long p50 = null;
+        Long p95 = null;
+        Long p99 = null;
         if (mbean.getProcessingTimeP50() >= 0) {
-            stats.put("p50ProcessingTime", mbean.getProcessingTimeP50());
-            stats.put("p95ProcessingTime", mbean.getProcessingTimeP95());
-            stats.put("p99ProcessingTime", mbean.getProcessingTimeP99());
+            p50 = mbean.getProcessingTimeP50();
+            p95 = mbean.getProcessingTimeP95();
+            p99 = mbean.getProcessingTimeP99();
         }
-        return stats;
+
+        return new Statistics(
+                mbean.getExchangesTotal(), mbean.getExchangesFailed(), mbean.getExchangesInflight(),
+                mbean.getMeanProcessingTime(), mbean.getMaxProcessingTime(), mbean.getMinProcessingTime(),
+                mbean.getLastProcessingTime(), mbean.getDeltaProcessingTime(), mbean.getTotalProcessingTime(),
+                throughput, p50, p95, p99);
     }
 
     private void topRoutes(

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TraceDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TraceDevConsole.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -26,12 +28,32 @@ import org.apache.camel.spi.Configurer;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "trace", displayName = "Camel Tracing", description = "Trace routed messages", readOnly = false)
 @Configurer(extended = true)
 public class TraceDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "Whether tracing is enabled (only present when a backlog tracer is available)") Boolean enabled,
+            @Metadata(description = "The traced messages, as opaque JSON objects (only present when dumping)") List<Map<String, Object>> traces,
+            @Metadata(description = "Whether the tracer is in standby mode (only present when not dumping)") Boolean standby,
+            @Metadata(description = "Total number of traced messages (only present when not dumping)") Long counter,
+            @Metadata(description = "The current backlog size (only present when not dumping)") Integer backlogSize,
+            @Metadata(description = "The current queue size (only present when not dumping)") Long queueSize,
+            @Metadata(description = "Whether messages are removed from the backlog when dumped (only present when not dumping)") Boolean removeOnDump,
+            @Metadata(description = "The trace filter (only present when configured)") String traceFilter,
+            @Metadata(description = "The trace pattern (only present when configured)") String tracePattern,
+            @Metadata(description = "Whether rests are traced (only present when not dumping)") Boolean traceRests,
+            @Metadata(description = "Whether route templates/Kamelets are traced (only present when not dumping)") Boolean traceTemplates,
+            @Metadata(description = "Maximum size of the message body to include (only present when not dumping)") Integer bodyMaxChars,
+            @Metadata(description = "Whether file-based message bodies are included (only present when not dumping)") Boolean bodyIncludeFiles,
+            @Metadata(description = "Whether streaming message bodies are included (only present when not dumping)") Boolean bodyIncludeStreams,
+            @Metadata(description = "Whether exchange properties are included (only present when not dumping)") Boolean includeExchangeProperties,
+            @Metadata(description = "Whether exchange variables are included (only present when not dumping)") Boolean includeExchangeVariables,
+            @Metadata(description = "Whether exceptions are included (only present when not dumping)") Boolean includeException) {
+    }
 
     @Metadata(defaultValue = "100",
               description = "Maximum capacity of last number of messages to capture (capacity must be between 50 and 1000)")
@@ -125,10 +147,12 @@ public class TraceDevConsole extends AbstractDevConsole {
         queue.add(message);
     }
 
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String enabled = optionString(options, ENABLED);
         String dump = optionString(options, DUMP);
+
+        Response response = new Response(
+                null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
         BacklogTracer tracer = getCamelContext().getCamelContextExtension().getContextPlugin(BacklogTracer.class);
         if (tracer != null) {
@@ -136,43 +160,30 @@ public class TraceDevConsole extends AbstractDevConsole {
                 for (BacklogTracerEventMessage t : tracer.dumpAllTracedMessages()) {
                     addMessage(t);
                 }
-                JsonArray arr = new JsonArray();
-                root.put("enabled", tracer.isEnabled());
-                root.put("traces", arr);
+                List<Map<String, Object>> traces = new ArrayList<>();
                 for (BacklogTracerEventMessage t : queue) {
-                    JsonObject jo = (JsonObject) t.asJSon();
-                    arr.add(jo);
+                    traces.add((JsonObject) t.asJSon());
                 }
+                response = new Response(
+                        tracer.isEnabled(), traces, null, null, null, null, null, null, null, null, null, null, null,
+                        null, null, null, null);
             } else {
                 if ("true".equals(enabled)) {
                     tracer.setEnabled(true);
                 } else if ("false".equals(enabled)) {
                     tracer.setEnabled(false);
                 }
-                root.put("enabled", tracer.isEnabled());
-                root.put("standby", tracer.isStandby());
-                root.put("counter", tracer.getTraceCounter());
-                root.put("backlogSize", tracer.getBacklogSize());
-                root.put("queueSize", tracer.getQueueSize());
-                root.put("removeOnDump", tracer.isRemoveOnDump());
-                if (tracer.getTraceFilter() != null) {
-                    root.put("traceFilter", tracer.getTraceFilter());
-                }
-                if (tracer.getTracePattern() != null) {
-                    root.put("tracePattern", tracer.getTracePattern());
-                }
-                root.put("traceRests", tracer.isTraceRests());
-                root.put("traceTemplates", tracer.isTraceTemplates());
-                root.put("bodyMaxChars", tracer.getBodyMaxChars());
-                root.put("bodyIncludeFiles", tracer.isBodyIncludeFiles());
-                root.put("bodyIncludeStreams", tracer.isBodyIncludeStreams());
-                root.put("includeExchangeProperties", tracer.isIncludeExchangeProperties());
-                root.put("includeExchangeVariables", tracer.isIncludeExchangeVariables());
-                root.put("includeException", tracer.isIncludeException());
+                response = new Response(
+                        tracer.isEnabled(), null, tracer.isStandby(), tracer.getTraceCounter(),
+                        tracer.getBacklogSize(), tracer.getQueueSize(), tracer.isRemoveOnDump(),
+                        tracer.getTraceFilter(), tracer.getTracePattern(), tracer.isTraceRests(),
+                        tracer.isTraceTemplates(), tracer.getBodyMaxChars(), tracer.isBodyIncludeFiles(),
+                        tracer.isBodyIncludeStreams(), tracer.isIncludeExchangeProperties(),
+                        tracer.isIncludeExchangeVariables(), tracer.isIncludeException());
             }
         }
 
-        return root;
+        return JsonRecordSupport.toJsonObject(response);
     }
 
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TransformerConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TransformerConsole.java
@@ -16,17 +16,33 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.Transformer;
 import org.apache.camel.spi.TransformerRegistry;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "transformers", displayName = "Data Type Transformers", description = "Data-type transformer information")
 public class TransformerConsole extends AbstractDevConsole {
+
+    public record TransformerEntry(
+            @Metadata(description = "The transformer name") String name,
+            @Metadata(description = "The from data type (only present when not any-type)") String from,
+            @Metadata(description = "The to data type (only present when not any-type)") String to) {
+    }
+
+    public record Response(
+            @Metadata(description = "Total number of transformers") int size,
+            @Metadata(description = "Number of transformers in the dynamic registry") int dynamicSize,
+            @Metadata(description = "Number of transformers in the static registry") int staticSize,
+            @Metadata(description = "Maximum number of entries to store in the dynamic registry") int maximumCacheSize,
+            @Metadata(description = "The transformers (only present when there are any)") List<TransformerEntry> transformers) {
+    }
 
     public TransformerConsole() {
         super("camel", "transformers", "Data Type Transformers", "Data-type transformer information");
@@ -56,37 +72,24 @@ public class TransformerConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         TransformerRegistry reg = getCamelContext().getTransformerRegistry();
-        root.put("size", reg.size());
-        root.put("dynamicSize", reg.dynamicSize());
-        root.put("staticSize", reg.staticSize());
-        root.put("maximumCacheSize", reg.getMaximumCacheSize());
-        final JsonArray arr = toJsonArray(reg);
-        if (!arr.isEmpty()) {
-            root.put("transformers", arr);
-        }
-        return root;
+        List<TransformerEntry> entries = toEntries(reg);
+
+        Response response = new Response(
+                reg.size(), reg.dynamicSize(), reg.staticSize(), reg.getMaximumCacheSize(),
+                entries.isEmpty() ? null : entries);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static JsonArray toJsonArray(TransformerRegistry reg) {
-        JsonArray arr = new JsonArray();
+    private static List<TransformerEntry> toEntries(TransformerRegistry reg) {
+        List<TransformerEntry> entries = new ArrayList<>();
         for (Map.Entry<?, Transformer> entry : reg.entrySet()) {
             Transformer t = entry.getValue();
             String from = t.getFrom() != null ? t.getFrom().getFullName() : null;
             String to = t.getTo() != null ? t.getTo().getFullName() : null;
-            JsonObject jo = new JsonObject();
-            jo.put("name", t.getName());
-            if (from != null) {
-                jo.put("from", from);
-            }
-            if (to != null) {
-                jo.put("to", to);
-            }
-            arr.add(jo);
+            entries.add(new TransformerEntry(t.getName(), from, to));
         }
-        return arr;
+        return entries;
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/TypeConverterConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/TypeConverterConsole.java
@@ -16,18 +16,44 @@
  */
 package org.apache.camel.impl.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.camel.TypeConverter;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.TypeConverterRegistry;
 import org.apache.camel.spi.TypeConvertible;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "type-converters", description = "Camel Type Converter information")
 public class TypeConverterConsole extends AbstractDevConsole {
+
+    public record Statistics(
+            @Metadata(description = "Number of attempted conversions") long attemptCounter,
+            @Metadata(description = "Number of successful conversions (cache hit)") long hitCounter,
+            @Metadata(description = "Number of cache misses") long missCounter,
+            @Metadata(description = "Number of failed conversions") long failedCounter,
+            @Metadata(description = "Number of noop conversions") long noopCounter) {
+    }
+
+    public record Converter(
+            @Metadata(description = "The source type") String from,
+            @Metadata(description = "The target type") String to,
+            @Metadata(description = "The type converter implementation class") String converterClass) {
+    }
+
+    public record Response(
+            @Metadata(description = "Number of registered type converters") int size,
+            @Metadata(description = "Whether a type converter must exist or not") String exists,
+            @Metadata(description = "Logging level used when a type converter does not exist") String existsLoggingLevel,
+            @Metadata(description = "Type converter usage statistics (only present when statistics are enabled)") Statistics statistics,
+            @Metadata(description = "The registered type converters") List<Converter> converters) {
+    }
 
     public TypeConverterConsole() {
         super("camel", "type-converters", "Type Converters", "Camel Type Converter information");
@@ -53,38 +79,53 @@ public class TypeConverterConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         TypeConverterRegistry reg = getCamelContext().getTypeConverterRegistry();
-        root.put("size", reg.size());
-        root.put("exists", reg.getTypeConverterExists().name());
-        root.put("existsLoggingLevel", reg.getTypeConverterExistsLoggingLevel().name());
 
         final TypeConverterRegistry.Statistics statistics = reg.getStatistics();
-        JsonObject props = new JsonObject();
+        AtomicLong attemptCounter = new AtomicLong();
+        AtomicLong hitCounter = new AtomicLong();
+        AtomicLong missCounter = new AtomicLong();
+        AtomicLong failedCounter = new AtomicLong();
+        AtomicLong noopCounter = new AtomicLong();
+        AtomicBoolean statisticsEnabled = new AtomicBoolean();
 
-        statistics.computeIfEnabled(statistics::getAttemptCounter, v -> props.put("attemptCounter", v));
-        statistics.computeIfEnabled(statistics::getHitCounter, v -> props.put("hitCounter", v));
-        statistics.computeIfEnabled(statistics::getMissCounter, v -> props.put("missCounter", v));
-        statistics.computeIfEnabled(statistics::getFailedCounter, v -> props.put("failedCounter", v));
-        statistics.computeIfEnabled(statistics::getNoopCounter, v -> props.put("noopCounter", v));
+        statistics.computeIfEnabled(statistics::getAttemptCounter, v -> {
+            attemptCounter.set(v);
+            statisticsEnabled.set(true);
+        });
+        statistics.computeIfEnabled(statistics::getHitCounter, v -> {
+            hitCounter.set(v);
+            statisticsEnabled.set(true);
+        });
+        statistics.computeIfEnabled(statistics::getMissCounter, v -> {
+            missCounter.set(v);
+            statisticsEnabled.set(true);
+        });
+        statistics.computeIfEnabled(statistics::getFailedCounter, v -> {
+            failedCounter.set(v);
+            statisticsEnabled.set(true);
+        });
+        statistics.computeIfEnabled(statistics::getNoopCounter, v -> {
+            noopCounter.set(v);
+            statisticsEnabled.set(true);
+        });
 
-        if (!props.isEmpty()) {
-            root.put("statistics", props);
-        }
+        Statistics stats = statisticsEnabled.get()
+                ? new Statistics(
+                        attemptCounter.get(), hitCounter.get(), missCounter.get(), failedCounter.get(), noopCounter.get())
+                : null;
 
-        JsonArray arr = new JsonArray();
+        List<Converter> converters = new ArrayList<>();
         for (Map.Entry<TypeConvertible<?, ?>, TypeConverter> e : reg.listTypeConverters().entrySet()) {
             TypeConvertible<?, ?> tc = e.getKey();
-            JsonObject jo = new JsonObject();
-            jo.put("from", tc.getFrom().getCanonicalName());
-            jo.put("to", tc.getTo().getCanonicalName());
-            jo.put("converterClass", e.getValue().getClass().getName());
-            arr.add(jo);
+            converters.add(new Converter(
+                    tc.getFrom().getCanonicalName(), tc.getTo().getCanonicalName(), e.getValue().getClass().getName()));
         }
-        root.put("converters", arr);
 
-        return root;
+        Response response = new Response(
+                reg.size(), reg.getTypeConverterExists().name(), reg.getTypeConverterExistsLoggingLevel().name(), stats,
+                converters);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/core/camel-console/src/main/java/org/apache/camel/impl/console/VariablesDevConsole.java
+++ b/core/camel-console/src/main/java/org/apache/camel/impl/console/VariablesDevConsole.java
@@ -22,13 +22,29 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.camel.spi.BrowsableVariableRepository;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "variables", description = "Displays variables")
 public class VariablesDevConsole extends AbstractDevConsole {
+
+    public record VariableEntry(
+            @Metadata(description = "The variable name") String key,
+            @Metadata(description = "The variable value type (only present when the value is known)") String type,
+            @Metadata(description = "The variable value (only present when known)") Object value) {
+    }
+
+    public record RepositoryEntry(
+            @Metadata(description = "The variable repository id") String id,
+            @Metadata(description = "The variables in this repository") List<VariableEntry> variables) {
+    }
+
+    public record Response(
+            @Metadata(description = "The variable repositories (only present when there are any with variables)") List<RepositoryEntry> repositories) {
+    }
 
     public VariablesDevConsole() {
         super("camel", "variables", "Variables", "Displays variables");
@@ -55,22 +71,23 @@ public class VariablesDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<RepositoryEntry> repositories = new ArrayList<>();
 
         Set<BrowsableVariableRepository> repos = getCamelContext().getRegistry().findByType(BrowsableVariableRepository.class);
         for (BrowsableVariableRepository repo : repos) {
-            final List<JsonObject> arr = toJsonObjects(repo);
-            if (!arr.isEmpty()) {
-                root.put(repo.getId(), arr);
+            final List<VariableEntry> entries = toEntries(repo);
+            if (!entries.isEmpty()) {
+                repositories.add(new RepositoryEntry(repo.getId(), entries));
             }
         }
 
-        return root;
+        Response response = new Response(repositories.isEmpty() ? null : repositories);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
-    private static List<JsonObject> toJsonObjects(BrowsableVariableRepository repo) {
-        List<JsonObject> arr = new ArrayList<>();
+    private static List<VariableEntry> toEntries(BrowsableVariableRepository repo) {
+        List<VariableEntry> arr = new ArrayList<>();
         for (Map.Entry<String, Object> entry : repo.getVariables().entrySet()) {
             String k = entry.getKey();
             Object v = entry.getValue();
@@ -87,15 +104,7 @@ public class VariablesDevConsole extends AbstractDevConsole {
                 }
             }
 
-            JsonObject e = new JsonObject();
-            e.put("key", k);
-            if (type != null) {
-                e.put("type", type);
-            }
-            if (value != null) {
-                e.put("value", value);
-            }
-            arr.add(e);
+            arr.add(new VariableEntry(k, type, value));
         }
         return arr;
     }

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ActivityDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ActivityDevConsoleTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ActivityDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testActivityConsoleWithoutBacklogTracer() {
+        DevConsole con = assertConsoleExists("activity", "camel");
+
+        JsonObject out = callJson(con);
+        // no BacklogTracer registered by default in a plain test context
+        assertFalse(out.containsKey("activityEnabled"));
+        assertFalse(out.containsKey("activity"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/BlockedConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/BlockedConsoleTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class BlockedConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testBlockedConsoleWithNoBlockedExchanges() {
+        DevConsole con = assertConsoleExists("blocked", "camel");
+
+        JsonObject out = callJson(con);
+        assertEquals(0, out.getInteger("blocked"));
+        assertFalse(out.containsKey("exchanges"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/CircuitBreakerDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/CircuitBreakerDevConsoleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.throttling.ThrottlingExceptionRoutePolicy;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CircuitBreakerDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute")
+                        .routePolicy(new ThrottlingExceptionRoutePolicy())
+                        .to("mock:result");
+                from("direct:other").routeId("otherRoute")
+                        .to("mock:other");
+            }
+        };
+    }
+
+    @Test
+    public void testCircuitBreakerConsole() {
+        DevConsole con = assertConsoleExists("circuit-breaker", "camel");
+
+        JsonObject out = callJson(con);
+        JsonArray entries = out.getJsonArray("circuitBreakers");
+        assertEquals(1, entries.size());
+
+        JsonObject entry = (JsonObject) entries.get(0);
+        assertEquals("myRoute", entry.getString("routeId"));
+        assertTrue(entry.getString("state").length() > 0);
+        assertEquals(0, entry.getInteger("successfulCalls"));
+        assertEquals(0, entry.getInteger("failedCalls"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ConsumerDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ConsumerDevConsoleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * camel-console has no dependency on camel-management, so {@code ManagedCamelContext} is never available here and the
+ * consumer list is always empty - these tests only verify the console's basic shape, not managed bean content.
+ */
+public class ConsumerDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testConsumerConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("consumer");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("consumer", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testConsumerConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("consumer");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray consumers = out.getCollection("consumers");
+        Assertions.assertNotNull(consumers);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ContextDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ContextDevConsoleTest.java
@@ -48,6 +48,18 @@ public class ContextDevConsoleTest extends ContextTestSupport {
         JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
         Assertions.assertNotNull(out);
         Assertions.assertEquals(context.getName(), out.getString("name"));
+        Assertions.assertEquals(context.getVersion(), out.getString("version"));
+        Assertions.assertEquals(context.getStatus().name(), out.getString("state"));
+        Assertions.assertNotNull(out.getLong("uptime"));
+        Assertions.assertNotNull(out.getBoolean("devMode"));
+
+        JsonObject statistics = out.getJsonObject("statistics");
+        if (statistics != null) {
+            JsonObject reload = statistics.getJsonObject("reload");
+            Assertions.assertNotNull(reload);
+            Assertions.assertNotNull(reload.getInteger("reloaded"));
+            Assertions.assertNotNull(reload.getInteger("failed"));
+        }
     }
 
 }

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/DataSourceDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/DataSourceDevConsoleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DataSourceDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testDataSourceConsoleWithNoDataSources() {
+        DevConsole con = assertConsoleExists("datasource", "camel");
+
+        JsonObject out = callJson(con);
+        JsonArray dataSources = out.getJsonArray("dataSources");
+        assertNotNull(dataSources);
+        assertEquals(0, dataSources.size());
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/DebugDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/DebugDevConsoleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DebugDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testDebugConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("debug");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("debug", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testDebugConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("debug");
+        Assertions.assertNotNull(con);
+
+        // no BacklogDebugger service is registered by default, so the response is empty
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+        Assertions.assertTrue(out.isEmpty());
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/EndpointDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/EndpointDevConsoleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EndpointDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testEndpointConsoleText() throws Exception {
+        template.sendBody("direct:start", "Hello");
+
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("endpoint");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("endpoint", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+        assertThat(out).contains("direct://start", "mock://result");
+    }
+
+    @Test
+    public void testEndpointConsoleJson() throws Exception {
+        template.sendBody("direct:start", "Hello");
+
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("endpoint");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        Assertions.assertNotNull(out.getInteger("size"));
+        Assertions.assertNotNull(out.getInteger("staticSize"));
+        Assertions.assertNotNull(out.getInteger("dynamicSize"));
+        Assertions.assertNotNull(out.getInteger("maximumCacheSize"));
+
+        JsonArray endpoints = out.getCollection("endpoints");
+        Assertions.assertNotNull(endpoints);
+        Assertions.assertFalse(endpoints.isEmpty());
+
+        boolean foundStart = endpoints.stream()
+                .map(o -> (JsonObject) o)
+                .anyMatch(jo -> "direct://start".equals(jo.getString("uri")));
+        Assertions.assertTrue(foundStart);
+
+        JsonObject entry = (JsonObject) endpoints.get(0);
+        Assertions.assertNotNull(entry.getBoolean("remote"));
+        Assertions.assertNotNull(entry.getBoolean("stub"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ErrorRegistryConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ErrorRegistryConsoleTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ErrorRegistryConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testErrorRegistryConsole() {
+        DevConsole con = assertConsoleExists("errors", "camel");
+
+        JsonObject out = callJson(con);
+        assertNotNull(out.getBoolean("enabled"));
+        assertNotNull(out.getInteger("size"));
+        assertNotNull(out.getInteger("maximumEntries"));
+        assertNotNull(out.getString("timeToLive"));
+
+        JsonArray errors = out.getJsonArray("errors");
+        assertNotNull(errors);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/EventConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/EventConsoleTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.service.ServiceHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EventConsoleTest extends AbstractDevConsoleTest {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testEventConsole() {
+        DevConsole con = assertConsoleExists("event", "camel");
+        // EventConsole allocates its ring buffers and subscribes to events in doInit()/doStart(),
+        // normally triggered by DevConsoleRegistry.register() - start it explicitly since this
+        // test resolves it directly, then generate an exchange event for it to capture
+        ServiceHelper.startService(con);
+        template.sendBody("direct:start", "hello");
+
+        JsonObject out = callJson(con);
+        JsonArray exchangeEvents = out.getJsonArray("exchangeEvents");
+        assertNotNull(exchangeEvents);
+        assertTrue(exchangeEvents.size() > 0);
+
+        JsonObject first = (JsonObject) exchangeEvents.get(0);
+        assertNotNull(first.getString("type"));
+        assertNotNull(first.getString("exchangeId"));
+        assertNotNull(first.getString("message"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/GarbageCollectorDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/GarbageCollectorDevConsoleTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GarbageCollectorDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testGarbageCollectorConsole() {
+        DevConsole con = assertConsoleExists("gc", "jvm");
+
+        JsonObject out = callJson(con);
+        JsonArray gcs = out.getJsonArray("garbageCollectors");
+        assertNotNull(gcs);
+        assertTrue(gcs.size() > 0);
+
+        JsonObject gc = (JsonObject) gcs.get(0);
+        assertNotNull(gc.getString("name"));
+        assertNotNull(gc.get("collectionCount"));
+        assertNotNull(gc.get("collectionTime"));
+        assertNotNull(gc.getString("memoryPoolNames"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/HealthDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/HealthDevConsoleTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class HealthDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testHealthConsole() {
+        DevConsole con = assertConsoleExists("health", "camel");
+
+        JsonObject out = callJson(con);
+        assertNotNull(out.getBoolean("up"));
+        assertNotNull(out.getBoolean("ready"));
+        assertNotNull(out.getBoolean("live"));
+
+        JsonArray checks = out.getJsonArray("checks");
+        assertNotNull(checks);
+        for (Object check : checks) {
+            JsonObject jo = (JsonObject) check;
+            assertNotNull(jo.getString("id"));
+            assertNotNull(jo.getBoolean("up"));
+            assertNotNull(jo.getString("state"));
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/HeapDumpDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/HeapDumpDevConsoleTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HeapDumpDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testHeapDumpConsole() throws Exception {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("heap-dump");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("jvm", con.getGroup());
+        Assertions.assertEquals("heap-dump", con.getId());
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(HeapDumpDevConsole.NAME, "camel-console-test-heap-dump");
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON, options);
+        Assertions.assertNotNull(out);
+
+        String error = out.getString("error");
+        if (error == null) {
+            String file = out.getString("file");
+            Assertions.assertNotNull(file);
+            Assertions.assertNotNull(out.getLong("size"));
+            new File(file).delete();
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/HeapHistogramDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/HeapHistogramDevConsoleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class HeapHistogramDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testHeapHistogramConsole() {
+        DevConsole con = assertConsoleExists("heap-histogram", "jvm");
+
+        JsonObject out = callJson(con);
+        JsonArray classes = out.getJsonArray("classes");
+        assertNotNull(classes);
+        assertNotNull(out.get("totalInstances"));
+        assertNotNull(out.get("totalBytes"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/InflightConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/InflightConsoleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class InflightConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testBrowseDisabledOmitsExchanges() {
+        DevConsole con = assertConsoleExists("inflight", "camel");
+
+        JsonObject out = callJson(con);
+        assertEquals(0, out.getInteger("inflight"));
+        assertEquals(false, out.getBoolean("inflightBrowseEnabled"));
+        assertFalse(out.containsKey("exchanges"));
+    }
+
+    @Test
+    public void testBrowseEnabledIncludesExchanges() {
+        context.getInflightRepository().setInflightBrowseEnabled(true);
+
+        DevConsole con = assertConsoleExists("inflight", "camel");
+
+        JsonObject out = callJson(con);
+        assertEquals(true, out.getBoolean("inflightBrowseEnabled"));
+        assertTrue(out.containsKey("exchanges"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/JavaSecurityDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/JavaSecurityDevConsoleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavaSecurityDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testJavaSecurityConsole() {
+        DevConsole con = assertConsoleExists("java-security", "jvm");
+
+        JsonObject out = callJson(con);
+        JsonArray providers = out.getJsonArray("securityProviders");
+        assertNotNull(providers);
+        assertTrue(providers.size() > 0);
+
+        JsonObject provider = (JsonObject) providers.get(0);
+        assertNotNull(provider.getString("name"));
+        assertNotNull(provider.getString("version"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/JfrMemoryLeakDevConsoleTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import java.util.Map;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for JfrMemoryLeakDevConsole. The console captures real JFR old-object-sample events, which are inherently
+ * timing/GC-dependent and not reliable to trigger deterministically in a unit test, so these tests focus on the command
+ * lifecycle (start/stop/status/query/compare) and error paths rather than on actual leak data.
+ */
+public class JfrMemoryLeakDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testConsoleNotReadOnly() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak", "jvm");
+        assertFalse(console.isReadOnly());
+    }
+
+    @Test
+    public void testStatusIdleByDefault() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak");
+
+        JsonObject json = callJson(console, Map.of("command", "status"));
+        assertEquals("idle", json.getString("status"));
+        assertNull(json.get("startTime"));
+        assertNull(json.get("sampleCount"));
+    }
+
+    @Test
+    public void testQueryWithNoRecordingYet() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak");
+
+        JsonObject json = callJson(console, Map.of("command", "query"));
+        assertEquals("idle", json.getString("status"));
+        assertEquals(0, json.getInteger("sampleCount"));
+        assertNotNull(json.getCollection("samples"));
+        assertTrue(json.getCollection("samples").isEmpty());
+        assertNotNull(json.getString("note"));
+    }
+
+    @Test
+    public void testCompareWithoutTwoRecordingsReturnsError() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak");
+
+        JsonObject json = callJson(console, Map.of("command", "compare"));
+        assertEquals("error", json.getString("status"));
+        assertNotNull(json.getString("error"));
+    }
+
+    @Test
+    public void testStopWithoutActiveRecordingReturnsError() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak");
+
+        JsonObject json = callJson(console, Map.of("command", "stop"));
+        assertEquals("error", json.getString("status"));
+        assertNotNull(json.getString("error"));
+    }
+
+    @Test
+    public void testUnknownCommandReturnsError() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak");
+
+        JsonObject json = callJson(console, Map.of("command", "bogus"));
+        assertEquals("error", json.getString("status"));
+        assertTrue(json.getString("error").contains("bogus"));
+    }
+
+    @Test
+    public void testStartStatusStopLifecycle() {
+        DevConsole console = assertConsoleExists("jfr-memory-leak");
+        try {
+            JsonObject started = callJson(console, Map.of("command", "start"));
+            assertEquals("recording", started.getString("status"));
+            assertNotNull(started.getLong("startTime"));
+            assertNull(started.get("durationSeconds"));
+
+            JsonObject startedAgain = callJson(console, Map.of("command", "start"));
+            assertEquals("error", startedAgain.getString("status"));
+
+            JsonObject status = callJson(console, Map.of("command", "status"));
+            assertEquals("recording", status.getString("status"));
+            assertNotNull(status.get("elapsedMs"));
+
+            String text = callText(console, Map.of("command", "status"));
+            assertNotNull(text);
+
+            JsonObject stopped = callJson(console, Map.of("command", "stop"));
+            assertEquals("completed", stopped.getString("status"));
+            assertNotNull(stopped.get("sampleCount"));
+            assertNotNull(stopped.get("gcCount"));
+            assertNotNull(stopped.get("recordingDurationMs"));
+            assertNotNull(stopped.get("recordingEndTime"));
+            JsonArray samples = stopped.getCollection("samples");
+            assertNotNull(samples);
+
+            JsonObject afterStopStatus = callJson(console, Map.of("command", "status"));
+            assertEquals("completed", afterStopStatus.getString("status"));
+            assertTrue(afterStopStatus.getBoolean("hasCachedResults"));
+            assertFalse(afterStopStatus.getBoolean("hasComparisonData"));
+
+            // stop again without an active recording should replay the cached (filtered) result
+            JsonObject stoppedAgain = callJson(console, Map.of("command", "stop"));
+            assertEquals("completed", stoppedAgain.getString("status"));
+
+            JsonObject queried = callJson(console, Map.of("command", "query"));
+            assertEquals("completed", queried.getString("status"));
+
+            // a second recording makes comparison data available
+            callJson(console, Map.of("command", "start"));
+            JsonObject secondStop = callJson(console, Map.of("command", "stop"));
+            assertEquals("completed", secondStop.getString("status"));
+
+            JsonObject statusWithComparison = callJson(console, Map.of("command", "status"));
+            assertTrue(statusWithComparison.getBoolean("hasComparisonData"));
+
+            JsonObject compared = callJson(console, Map.of("command", "compare"));
+            assertEquals("compared", compared.getString("status"));
+            assertNotNull(compared.getJsonObject("baseline"));
+            assertNotNull(compared.getJsonObject("current"));
+            assertNotNull(compared.getCollection("comparisons"));
+            assertNotNull(compared.getDouble("durationRatio"));
+        } finally {
+            // ensure no recording is left running across tests
+            callJson(console, Map.of("command", "stop"));
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/JvmDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/JvmDevConsoleTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JvmDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testJvmConsole() {
+        DevConsole con = assertConsoleExists("jvm", "jvm");
+
+        JsonObject out = callJson(con);
+        assertNotNull(out.getString("vmName"));
+        assertNotNull(out.getString("vmVersion"));
+        assertNotNull(out.getString("vmVendor"));
+        assertNotNull(out.getString("vmUptime"));
+        assertNotNull(out.get("pid"));
+
+        JsonArray classpath = out.getJsonArray("classpath");
+        assertNotNull(classpath);
+        assertTrue(classpath.size() > 0);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/LogDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/LogDevConsoleTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LogDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testLogConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("log");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("log", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testLogConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("log");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        // levels is only present when a log4j2 JMX MBean is registered - depends on the log4j
+        // configuration in the test environment, so only verify the shape when present
+        JsonObject levels = out.getJsonObject("levels");
+        if (levels != null) {
+            Assertions.assertFalse(levels.isEmpty());
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/MemoryDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/MemoryDevConsoleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MemoryDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testMemoryConsole() {
+        DevConsole con = assertConsoleExists("memory", "jvm");
+
+        JsonObject out = callJson(con);
+        assertNotNull(out.getString("heapMemoryInit"));
+        assertNotNull(out.getString("heapMemoryMax"));
+        assertNotNull(out.getString("heapMemoryUsed"));
+        assertNotNull(out.getString("heapMemoryCommitted"));
+        assertNotNull(out.getString("nonHeapMemoryInit"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/MessageHistoryDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/MessageHistoryDevConsoleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MessageHistoryDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testMessageHistoryConsoleText() throws Exception {
+        template.sendBody("direct:start", "Hello");
+
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("message-history");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("message-history", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testMessageHistoryConsoleJson() throws Exception {
+        template.sendBody("direct:start", "Hello");
+
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("message-history");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        // traces/name are only present when a backlog tracer is installed on the CamelContext
+        if (out.containsKey("traces")) {
+            Assertions.assertEquals(context.getName(), out.getString("name"));
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ProcessorDetailDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ProcessorDetailDevConsoleTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ProcessorDetailDevConsole is driven by {@code ManagedCamelContext}, which camel-console has no dependency on - so the
+ * response is always empty here. This test only verifies the console's basic shape.
+ */
+public class ProcessorDetailDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testProcessorDetailConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("processor-detail");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("processor-detail", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testProcessorDetailConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("processor-detail");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ProcessorDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ProcessorDevConsoleTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ProcessorDevConsole unconditionally dereferences the ManagedCamelContext context plugin (with no null check, in both
+ * the action and non-action code paths), which is only available when camel-management is on the classpath - that is
+ * not (and should not become) a dependency of this module. So calling the console here would hit that pre-existing,
+ * unrelated gap; this test is limited to verifying the console registers correctly.
+ */
+public class ProcessorDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testProcessorConsoleResolves() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("processor");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("processor", con.getId());
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ProducerDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ProducerDevConsoleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ProducerDevConsole unconditionally dereferences getManagementStrategy().getManagementAgent(), which is only non-null
+ * when JMX management is active - that requires camel-management, which is not (and should not become) a dependency of
+ * this module. So calling the console here would hit that pre-existing, unrelated gap; these tests are limited to
+ * verifying the console registers correctly.
+ */
+public class ProducerDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testProducerConsoleResolves() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("producer");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("producer", con.getId());
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/PropertiesDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/PropertiesDevConsoleTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +51,17 @@ public class PropertiesDevConsoleTest extends AbstractDevConsoleTest {
 
         JsonObject jsonOut = callJson(console);
         assertNotNull(jsonOut.get("locations"));
+
+        JsonArray properties = jsonOut.getJsonArray("properties");
+        assertNotNull(properties);
+        boolean found = false;
+        for (Object o : properties) {
+            JsonObject prop = (JsonObject) o;
+            if ("myProp".equals(prop.getString("key"))) {
+                found = true;
+                assertNotNull(prop.getString("value"));
+            }
+        }
+        assertTrue(found, "myProp should be present in the properties list");
     }
 }

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ReloadDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ReloadDevConsoleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ReloadDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testReloadConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("reload");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("reload", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testReloadConsoleJsonNoStrategy() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("reload");
+        Assertions.assertNotNull(con);
+
+        // no ReloadStrategy is registered by default, so the response is empty
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+        Assertions.assertTrue(out.isEmpty());
+    }
+
+    @Test
+    public void testReloadConsoleTrigger() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("reload");
+        Assertions.assertNotNull(con);
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(ReloadDevConsole.RELOAD, "true");
+
+        // status is reported regardless of whether any ReloadStrategy is registered
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON, options);
+        Assertions.assertNotNull(out);
+        Assertions.assertEquals("reloading", out.getString("status"));
+        Assertions.assertFalse(out.containsKey("reloadStrategies"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/RestDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/RestDevConsoleTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RestDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testRestConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("rest");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("rest", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testRestConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("rest");
+        Assertions.assertNotNull(con);
+
+        // this module has no rest DSL routes, so the "rests" key is only present if a REST registry exists
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/RestSpecDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/RestSpecDevConsoleTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RestSpecDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testRestSpecConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("rest-spec");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("rest-spec", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testRestSpecConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("rest-spec");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray specs = out.getCollection("specs");
+        Assertions.assertNotNull(specs);
+        Assertions.assertTrue(specs.isEmpty());
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteControllerConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteControllerConsoleTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class RouteControllerConsoleTest extends AbstractDevConsoleTest {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testDefaultRouteController() {
+        DevConsole con = assertConsoleExists("route-controller", "camel");
+
+        JsonObject out = callJson(con);
+        assertEquals("DefaultRouteController", out.getString("controller"));
+        assertFalse(out.containsKey("startingRoutes"));
+
+        JsonArray routes = out.getJsonArray("routes");
+        assertNotNull(routes);
+        JsonObject route = (JsonObject) routes.get(0);
+        assertEquals("myRoute", route.getString("routeId"));
+        assertNotNull(route.getString("status"));
+        assertFalse(route.containsKey("supervising"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteDumpDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteDumpDevConsoleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * RouteDumpDevConsole is driven by {@code ManagedCamelContext}, which camel-console has no dependency on - so the route
+ * list is always empty here. This test only verifies the console's basic shape.
+ */
+public class RouteDumpDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testRouteDumpConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-dump");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("route-dump", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testRouteDumpConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-dump");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray routes = out.getCollection("routes");
+        Assertions.assertNotNull(routes);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteGroupDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteGroupDevConsoleTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * RouteGroupDevConsole is driven by {@code ManagedCamelContext}, which camel-console has no dependency on - so the
+ * route group list is always empty here. This test only verifies the console's basic shape.
+ */
+public class RouteGroupDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testRouteGroupConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-group");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("route-group", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testRouteGroupConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-group");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray routeGroups = out.getCollection("routeGroups");
+        Assertions.assertNotNull(routeGroups);
+    }
+
+    @Test
+    public void testRouteGroupConsoleWithAction() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-group");
+        Assertions.assertNotNull(con);
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(RouteGroupDevConsole.ACTION, "start");
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON, options);
+        Assertions.assertNotNull(out);
+        Assertions.assertTrue(out.isEmpty());
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteStructureDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/RouteStructureDevConsoleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RouteStructureDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testRouteStructureConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-structure");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("route-structure", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testRouteStructureConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("route-structure");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray routes = out.getCollection("routes");
+        Assertions.assertNotNull(routes);
+        Assertions.assertFalse(routes.isEmpty());
+
+        JsonObject route = (JsonObject) routes.get(0);
+        Assertions.assertEquals("myRoute", route.getString("routeId"));
+        Assertions.assertNotNull(route.getString("from"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/ServiceDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/ServiceDevConsoleTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ServiceDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testServiceConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("service");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("service", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testServiceConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("service");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray services = out.getCollection("services");
+        Assertions.assertNotNull(services);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/SourceDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/SourceDevConsoleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SourceDevConsole is driven by {@code ManagedCamelContext}, which camel-console has no dependency on - so the route
+ * list is always empty here. This test only verifies the console's basic shape.
+ */
+public class SourceDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testSourceConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("source");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("source", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testSourceConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("source");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray routes = out.getCollection("routes");
+        Assertions.assertNotNull(routes);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/SqlQueryDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/SqlQueryDevConsoleTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SqlQueryDevConsole needs a real javax.sql.DataSource to execute anything; camel-console has no JDBC driver test
+ * dependency, so these tests exercise the option-validation and DataSource-resolution error paths only.
+ */
+public class SqlQueryDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testSqlQueryConsoleNoSql() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sql-query");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("sql-query", con.getId());
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertEquals("error", out.getString("status"));
+        Assertions.assertEquals("No SQL query provided", out.getString("message"));
+    }
+
+    @Test
+    public void testSqlQueryConsoleNoDataSource() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sql-query");
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(SqlQueryDevConsole.SQL, "SELECT 1");
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON, options);
+        Assertions.assertEquals("error", out.getString("status"));
+        Assertions.assertEquals("No DataSource found in registry", out.getString("message"));
+    }
+
+    @Test
+    public void testSqlQueryConsoleUpdateRowNoTable() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sql-query");
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(SqlQueryDevConsole.ACTION_TYPE, "update-row");
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON, options);
+        Assertions.assertEquals("error", out.getString("status"));
+        Assertions.assertEquals("No table name provided", out.getString("message"));
+    }
+
+    @Test
+    public void testSqlQueryConsoleUpdateRowMissingValues() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sql-query");
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(SqlQueryDevConsole.ACTION_TYPE, "update-row");
+        options.put(SqlQueryDevConsole.TABLE, "my_table");
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON, options);
+        Assertions.assertEquals("error", out.getString("status"));
+        Assertions.assertEquals("Missing primaryKeyValues or columnValues", out.getString("message"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/SqlTraceDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/SqlTraceDevConsoleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.support.service.ServiceHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SqlTraceDevConsole only records statements sent to a real sql:/jdbc: endpoint, and camel-console has no dependency on
+ * camel-sql/camel-jdbc - so the ring buffer is always empty here. This test only verifies the console's basic shape.
+ */
+public class SqlTraceDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testSqlTraceConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sql-trace");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("sql-trace", con.getId());
+
+        // events[] is only allocated in doInit(), normally triggered via DevConsoleRegistry.register()
+        ServiceHelper.startService(con);
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+        Assertions.assertEquals("", out);
+    }
+
+    @Test
+    public void testSqlTraceConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("sql-trace");
+        Assertions.assertNotNull(con);
+        ServiceHelper.startService(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+        Assertions.assertFalse(out.containsKey("statements"));
+        Assertions.assertFalse(out.containsKey("summary"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/StartupRecorderDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/StartupRecorderDevConsoleTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StartupRecorderDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testStartupRecorderConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("startup-recorder");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("startup-recorder", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testStartupRecorderConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("startup-recorder");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        // steps is only present when the startup step recorder captured any steps
+        JsonArray steps = out.getCollection("steps");
+        if (steps != null) {
+            JsonObject step = (JsonObject) steps.get(0);
+            Assertions.assertNotNull(step.getString("type"));
+            Assertions.assertNotNull(step.getString("description"));
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/SystemPropertiesDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/SystemPropertiesDevConsoleTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SystemPropertiesDevConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testSystemPropertiesConsole() {
+        DevConsole con = assertConsoleExists("system-properties", "jvm");
+
+        JsonObject out = callJson(con);
+        JsonArray props = out.getJsonArray("systemProperties");
+        assertNotNull(props);
+        assertTrue(props.size() > 0);
+
+        JsonObject first = (JsonObject) props.get(0);
+        assertTrue(first.size() == 1);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/TaskRegistryDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/TaskRegistryDevConsoleTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TaskRegistryDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testInternalTasksConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("internal-tasks");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("internal-tasks", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+        Assertions.assertTrue(out.contains("Tasks:"));
+    }
+
+    @Test
+    public void testInternalTasksConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("internal-tasks");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        JsonArray tasks = out.getCollection("tasks");
+        Assertions.assertNotNull(tasks);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/TopDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/TopDevConsoleTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TopDevConsole is driven by {@code ManagedCamelContext}, which camel-console has no dependency on - so the response is
+ * always empty here. This test only verifies the console's basic shape.
+ */
+public class TopDevConsoleTest extends ContextTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:start").routeId("myRoute").to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testTopConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("top");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("top", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testTopConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("top");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/TraceDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/TraceDevConsoleTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TraceDevConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testTraceConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("trace");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("trace", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+    }
+
+    @Test
+    public void testTraceConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("trace");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+
+        // full status fields are only present when a backlog tracer is installed on the CamelContext
+        if (out.containsKey("enabled")) {
+            Assertions.assertNotNull(out.getBoolean("standby"));
+            Assertions.assertNotNull(out.getLong("counter"));
+        }
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/TransformerConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/TransformerConsoleTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.ContextTestSupport;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TransformerConsoleTest extends ContextTestSupport {
+
+    @Test
+    public void testTransformerConsoleText() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("transformers");
+        Assertions.assertNotNull(con);
+        Assertions.assertEquals("camel", con.getGroup());
+        Assertions.assertEquals("transformers", con.getId());
+
+        String out = (String) con.call(DevConsole.MediaType.TEXT);
+        Assertions.assertNotNull(out);
+        Assertions.assertTrue(out.contains("Size: 0"));
+    }
+
+    @Test
+    public void testTransformerConsoleJson() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("transformers");
+        Assertions.assertNotNull(con);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        Assertions.assertNotNull(out);
+        Assertions.assertEquals(0, out.getInteger("size"));
+        Assertions.assertEquals(0, out.getInteger("dynamicSize"));
+        Assertions.assertEquals(0, out.getInteger("staticSize"));
+        Assertions.assertNotNull(out.getInteger("maximumCacheSize"));
+        Assertions.assertFalse(out.containsKey("transformers"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/TypeConverterConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/TypeConverterConsoleTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.console;
+
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TypeConverterConsoleTest extends AbstractDevConsoleTest {
+
+    @Test
+    public void testTypeConverterConsole() {
+        DevConsole con = assertConsoleExists("type-converters", "camel");
+
+        JsonObject out = callJson(con);
+        assertTrue(out.getInteger("size") > 0);
+        assertNotNull(out.getString("exists"));
+        assertNotNull(out.getString("existsLoggingLevel"));
+
+        JsonArray converters = out.getJsonArray("converters");
+        assertNotNull(converters);
+        assertTrue(converters.size() > 0);
+
+        JsonObject converter = (JsonObject) converters.get(0);
+        assertNotNull(converter.getString("from"));
+        assertNotNull(converter.getString("to"));
+        assertNotNull(converter.getString("converterClass"));
+    }
+}

--- a/core/camel-console/src/test/java/org/apache/camel/impl/console/VariablesDevConsoleTest.java
+++ b/core/camel-console/src/test/java/org/apache/camel/impl/console/VariablesDevConsoleTest.java
@@ -17,10 +17,13 @@
 package org.apache.camel.impl.console;
 
 import org.apache.camel.console.DevConsole;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -46,5 +49,36 @@ public class VariablesDevConsoleTest extends AbstractDevConsoleTest {
 
         JsonObject jsonOut = callJson(console);
         assertFalse(jsonOut.isEmpty());
+
+        JsonArray repositories = jsonOut.getCollection("repositories");
+        assertNotNull(repositories);
+        assertFalse(repositories.isEmpty());
+
+        JsonObject global = null;
+        for (Object o : repositories) {
+            JsonObject repo = (JsonObject) o;
+            if ("global".equals(repo.getString("id"))) {
+                global = repo;
+            }
+        }
+        assertNotNull(global, "global repository should be present");
+
+        JsonArray variables = global.getCollection("variables");
+        assertNotNull(variables);
+
+        boolean foundTestVar = false;
+        boolean foundAnotherVar = false;
+        for (Object o : variables) {
+            JsonObject entry = (JsonObject) o;
+            if ("testVar".equals(entry.getString("key"))) {
+                assertEquals("testValue", entry.getString("value"));
+                foundTestVar = true;
+            } else if ("anotherVar".equals(entry.getString("key"))) {
+                assertEquals(42, entry.getInteger("value"));
+                foundAnotherVar = true;
+            }
+        }
+        assertTrue(foundTestVar, "testVar should be present");
+        assertTrue(foundAnotherVar, "anotherVar should be present");
     }
 }

--- a/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/dev-console/bean-model.json
+++ b/core/camel-core-model/src/generated/resources/META-INF/org/apache/camel/dev-console/bean-model.json
@@ -57,6 +57,92 @@
       "defaultValue": true,
       "description": "Whether to include bean properties"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "beans": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The bean name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The bean type"
+            },
+            "initMethod": {
+              "type": "string",
+              "description": "The init method name (only present when configured)"
+            },
+            "destroyMethod": {
+              "type": "string",
+              "description": "The destroy method name (only present when configured)"
+            },
+            "builderClass": {
+              "type": "string",
+              "description": "The builder class name (only present when configured)"
+            },
+            "builderMethod": {
+              "type": "string",
+              "description": "The builder method name (only present when configured)"
+            },
+            "factoryBean": {
+              "type": "string",
+              "description": "The factory bean name (only present when configured)"
+            },
+            "factoryMethod": {
+              "type": "string",
+              "description": "The factory method name (only present when configured)"
+            },
+            "modelProperties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The property name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The property value type (only present when the value is known)"
+                  },
+                  "value": {
+                    "description": "The property value"
+                  }
+                }
+              },
+              "description": "The bean properties as declared in the DSL model (only present when there are any)"
+            },
+            "properties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The property name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The property value type (only present when the value is known)"
+                  },
+                  "value": {
+                    "description": "The property value"
+                  }
+                }
+              },
+              "description": "The bean properties resolved from the running bean instance (only present when there are any)"
+            }
+          }
+        },
+        "description": "The beans keyed by bean name"
+      }
+    }
   }
 }
 

--- a/core/camel-core-model/src/main/java/org/apache/camel/model/console/BeanModelDevConsole.java
+++ b/core/camel-core-model/src/main/java/org/apache/camel/model/console/BeanModelDevConsole.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.model.console;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -27,8 +30,7 @@ import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.PatternHelper;
 import org.apache.camel.support.PluginHelper;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 import org.apache.camel.util.json.Jsoner;
 
 @DevConsole(name = "bean-model", description = "Displays beans from the DSL model")
@@ -45,6 +47,28 @@ public class BeanModelDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Whether to include null values", defaultValue = "true",
               javaType = "java.lang.Boolean")
     public static final String NULLS = "nulls";
+
+    public record PropertyEntry(
+            @Metadata(description = "The property name") String name,
+            @Metadata(description = "The property value type (only present when the value is known)") String type,
+            @Metadata(description = "The property value") Object value) {
+    }
+
+    public record BeanEntry(
+            @Metadata(description = "The bean name") String name,
+            @Metadata(description = "The bean type") String type,
+            @Metadata(description = "The init method name (only present when configured)") String initMethod,
+            @Metadata(description = "The destroy method name (only present when configured)") String destroyMethod,
+            @Metadata(description = "The builder class name (only present when configured)") String builderClass,
+            @Metadata(description = "The builder method name (only present when configured)") String builderMethod,
+            @Metadata(description = "The factory bean name (only present when configured)") String factoryBean,
+            @Metadata(description = "The factory method name (only present when configured)") String factoryMethod,
+            @Metadata(description = "The bean properties as declared in the DSL model (only present when there are any)") List<PropertyEntry> modelProperties,
+            @Metadata(description = "The bean properties resolved from the running bean instance (only present when there are any)") List<PropertyEntry> properties) {
+    }
+
+    public record Response(@Metadata(description = "The beans keyed by bean name") Map<String, BeanEntry> beans) {
+    }
 
     public BeanModelDevConsole() {
         super("camel", "bean-model", "Bean Model", "Displays beans from the DSL model");
@@ -100,15 +124,12 @@ public class BeanModelDevConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
         String filter = optionString(options, FILTER);
         boolean properties = optionBoolean(options, PROPERTIES, true);
         boolean nulls = optionBoolean(options, NULLS, true);
 
-        JsonObject root = new JsonObject();
-
-        JsonObject jo = new JsonObject();
-        root.put("beans", jo);
+        Map<String, BeanEntry> beans = new LinkedHashMap<>();
 
         BeanIntrospection bi = PluginHelper.getBeanIntrospection(getCamelContext());
         Model model = getCamelContext().getCamelContextExtension().getContextPlugin(Model.class);
@@ -128,48 +149,22 @@ public class BeanModelDevConsole extends AbstractDevConsole {
                         // ignore
                     }
                 }
-                JsonObject jb = new JsonObject();
-                jo.put(b.getName(), jb);
-                jb.put("name", b.getName());
-                jb.put("type", b.getType());
-                if (b.getInitMethod() != null) {
-                    jb.put("initMethod", b.getInitMethod());
-                }
-                if (b.getDestroyMethod() != null) {
-                    jb.put("destroyMethod", b.getDestroyMethod());
-                }
-                if (b.getBuilderClass() != null) {
-                    jb.put("builderClass", b.getBuilderClass());
-                }
-                if (b.getBuilderMethod() != null) {
-                    jb.put("builderMethod", b.getBuilderMethod());
-                }
-                if (b.getFactoryBean() != null) {
-                    jb.put("factoryBean", b.getFactoryBean());
-                }
-                if (b.getFactoryMethod() != null) {
-                    jb.put("factoryMethod", b.getFactoryMethod());
-                }
+
+                List<PropertyEntry> modelProperties = null;
+                List<PropertyEntry> resolvedProperties = null;
                 if (b.getProperties() != null) {
-                    JsonArray arr = new JsonArray();
+                    List<PropertyEntry> arr = new ArrayList<>();
                     b.getProperties().forEach((k, v) -> {
                         Object rv = values.get(k);
                         String type = rv != null ? rv.getClass().getName() : null;
-                        JsonObject jp = new JsonObject();
-                        jp.put("name", k);
-                        if (type != null) {
-                            jp.put("type", type);
-                        }
-                        jp.put("value", v);
                         boolean accept = v != null || nulls;
                         if (accept) {
-                            arr.add(jp);
+                            arr.add(new PropertyEntry(k, type, v));
                         }
                     });
-                    if (!arr.isEmpty()) {
-                        jb.put("modelProperties", arr);
-                    }
-                    JsonArray arr2 = new JsonArray();
+                    modelProperties = arr.isEmpty() ? null : arr;
+
+                    List<PropertyEntry> arr2 = new ArrayList<>();
                     b.getProperties().forEach((k, v) -> {
                         Object rv = values.get(k);
                         Object value = rv;
@@ -184,24 +179,23 @@ public class BeanModelDevConsole extends AbstractDevConsole {
                                 value = rv;
                             }
                         }
-                        JsonObject jp = new JsonObject();
-                        jp.put("name", k);
-                        if (type != null) {
-                            jp.put("type", type);
-                        }
-                        jp.put("value", value);
                         boolean accept = value != null || nulls;
                         if (accept) {
-                            arr2.add(jp);
+                            arr2.add(new PropertyEntry(k, type, value));
                         }
                     });
-                    if (!arr2.isEmpty()) {
-                        jb.put("properties", arr2);
-                    }
+                    resolvedProperties = arr2.isEmpty() ? null : arr2;
                 }
+
+                beans.put(b.getName(), new BeanEntry(
+                        b.getName(), b.getType(), b.getInitMethod(), b.getDestroyMethod(), b.getBuilderClass(),
+                        b.getBuilderMethod(), b.getFactoryBean(), b.getFactoryMethod(), modelProperties,
+                        resolvedProperties));
             }
         }
-        return root;
+
+        Response response = new Response(beans);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static boolean accept(String name, String filter) {

--- a/core/camel-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-configuration.json
+++ b/core/camel-main/src/generated/resources/META-INF/org/apache/camel/dev-console/main-configuration.json
@@ -11,6 +11,45 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-main",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "configurations": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "The configuration key"
+            },
+            "value": {
+              "description": "The configuration value (masked as xxxxxx when sensitive)"
+            },
+            "defaultValue": {
+              "description": "The default value (only present when known)"
+            },
+            "originalValue": {
+              "description": "The original, unresolved value (only present when known and not sensitive)"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source that provided the value (only present when known)"
+            },
+            "location": {
+              "type": "string",
+              "description": "The location the value came from (only present when known)"
+            },
+            "internal": {
+              "type": "boolean",
+              "description": "Whether the location is internal (only present when the location is known)"
+            }
+          }
+        },
+        "description": "The startup configurations (only present when there are any)"
+      }
+    }
   }
 }
 

--- a/core/camel-main/src/main/java/org/apache/camel/main/MainConfigurationDevConsole.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/MainConfigurationDevConsole.java
@@ -16,20 +16,38 @@
  */
 package org.apache.camel.main;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.PropertiesComponent;
+import org.apache.camel.spi.PropertiesResolvedValue;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.OrderedLocationProperties;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 import static org.apache.camel.util.LocationHelper.locationSummary;
 
 @DevConsole(name = "main-configuration", displayName = "Main Configuration",
             description = "Display Camel startup configuration")
 public class MainConfigurationDevConsole extends AbstractDevConsole {
+
+    public record ConfigurationEntry(
+            @Metadata(description = "The configuration key") String key,
+            @Metadata(description = "The configuration value (masked as xxxxxx when sensitive)") Object value,
+            @Metadata(description = "The default value (only present when known)") Object defaultValue,
+            @Metadata(description = "The original, unresolved value (only present when known and not sensitive)") Object originalValue,
+            @Metadata(description = "The source that provided the value (only present when known)") String source,
+            @Metadata(description = "The location the value came from (only present when known)") String location,
+            @Metadata(description = "Whether the location is internal (only present when the location is known)") Boolean internal) {
+    }
+
+    public record Response(
+            @Metadata(description = "The startup configurations (only present when there are any)") List<ConfigurationEntry> configurations) {
+    }
 
     private final OrderedLocationProperties startupConfiguration = new OrderedLocationProperties();
 
@@ -70,9 +88,9 @@ public class MainConfigurationDevConsole extends AbstractDevConsole {
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
         PropertiesComponent pc = getCamelContext().getPropertiesComponent();
 
-        JsonObject root = new JsonObject();
+        List<ConfigurationEntry> configurations = null;
         if (!startupConfiguration.isEmpty()) {
-            JsonArray arr = new JsonArray();
+            configurations = new ArrayList<>();
             for (var entry : startupConfiguration.entrySet()) {
                 String k = entry.getKey().toString();
                 Object v = entry.getValue();
@@ -80,33 +98,28 @@ public class MainConfigurationDevConsole extends AbstractDevConsole {
                 Object defaultValue = startupConfiguration.getDefaultValue(k);
 
                 boolean sensitive = MainHelper.containsSensitive(getCamelContext(), k, v);
-                JsonObject jo = new JsonObject();
-                jo.put("key", k);
-                jo.put("value", sensitive ? "xxxxxx" : v);
-                if (defaultValue != null) {
-                    jo.put("defaultValue", defaultValue);
-                }
-                // enrich if present
-                pc.getResolvedValue(k).ifPresent(r -> {
+                Object value = sensitive ? "xxxxxx" : v;
+
+                Object originalValue = null;
+                String source = null;
+                Optional<PropertiesResolvedValue> resolved = pc.getResolvedValue(k);
+                if (resolved.isPresent()) {
+                    PropertiesResolvedValue r = resolved.get();
                     String ov = r.originalValue();
                     if (ov != null) {
-                        jo.put("originalValue", sensitive ? "xxxxxx" : ov);
+                        originalValue = sensitive ? "xxxxxx" : ov;
                     }
-                    String src = r.source();
-                    if (src != null) {
-                        jo.put("source", src);
-                    }
-                });
-                if (loc != null) {
-                    jo.put("location", loc);
-                    jo.put("internal", isInternal(loc));
+                    source = r.source();
                 }
-                arr.add(jo);
+
+                Boolean internal = loc != null ? isInternal(loc) : null;
+
+                configurations.add(new ConfigurationEntry(k, value, defaultValue, originalValue, source, loc, internal));
             }
-            root.put("configurations", arr);
         }
 
-        return root;
+        Response response = new Response(configurations);
+        return JsonRecordSupport.toJsonObject(response);
     }
 
     private static boolean isInternal(String loc) {

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainConfigurationDevConsoleTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainConfigurationDevConsoleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.PluginHelper;
+import org.apache.camel.util.OrderedLocationProperties;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MainConfigurationDevConsoleTest {
+
+    private CamelContext context;
+
+    @BeforeEach
+    void setUp() {
+        context = new DefaultCamelContext();
+        context.setDevConsole(true);
+        context.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    @Test
+    public void testMainConfigurationConsoleEmpty() {
+        DevConsole con = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("main-configuration");
+        assertNotNull(con);
+        assertEquals("camel", con.getGroup());
+        assertEquals("main-configuration", con.getId());
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    public void testMainConfigurationConsoleWithEntries() {
+        DevConsole resolved = PluginHelper.getDevConsoleResolver(context).resolveDevConsole("main-configuration");
+        assertNotNull(resolved);
+        MainConfigurationDevConsole con = (MainConfigurationDevConsole) resolved;
+
+        OrderedLocationProperties props = new OrderedLocationProperties();
+        props.put("properties", "camel.main.name", "myApp");
+        con.addStartupConfiguration(props);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+
+        JsonArray configurations = out.getCollection("configurations");
+        assertNotNull(configurations);
+        assertFalse(configurations.isEmpty());
+
+        JsonObject entry = (JsonObject) configurations.get(0);
+        assertEquals("camel.main.name", entry.getString("key"));
+        assertEquals("myApp", entry.getString("value"));
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -353,6 +353,35 @@ The affected sites, all of which resolved a header-derived or endpoint-derived v
 Where the value came from the endpoint rather than a header it was already resolved at build time,
 so removing the per-message resolution does not change those routes.
 
+=== camel-console - variables dev console JSON response shape
+
+The `variables` dev console (`/q/dev/variables`) no longer returns a JSON object keyed by each
+variable repository's id. It now returns a fixed shape, so the response has a documented,
+authoritative OpenAPI schema like the other dev consoles (see the `/q/dev/api` OpenAPI document):
+
+Before:
+[source,json]
+----
+{
+  "global": [ { "key": "foo", "type": "java.lang.String", "value": "bar" } ]
+}
+----
+
+After:
+[source,json]
+----
+{
+  "repositories": [
+    { "id": "global", "variables": [ { "key": "foo", "type": "java.lang.String", "value": "bar" } ] }
+  ]
+}
+----
+
+Each repository is now an entry in the `repositories` array carrying its own `id`, rather than the
+id being a dynamic top-level JSON key. Anything that parses this console's raw JSON directly
+(custom tooling, or scripts calling the dev console HTTP endpoint) must be updated to the new
+shape. The `camel get variable` CLI command has already been updated accordingly.
+
 === camel-jbang (TUI)
 
 `camel tui --record` is now rejected when combined with `--web`. The recording configuration applies

--- a/docs/user-manual/modules/ROOT/pages/camel-catalog.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-catalog.adoc
@@ -51,6 +51,7 @@ org
       ├── components (JSON schema)
       ├── dataformats (JSON schema)
       ├── dev-consoles (JSON schema)
+      ├── dev-consoles-openapi.json (OpenAPI 3.0 specification)
       ├── docs (AsciiDoc documentation)
       ├── jbang (JSON schema)
       ├── languages (JSON schema)
@@ -67,6 +68,14 @@ org
 Each directory contains files with the information. Every Camel component is included
 as JSON schema files in the components directory. For example, the Timer component
 is included in the file timer.json.
+
+The `dev-consoles` directory contains JSON schema files describing every
+xref:camel-console.adoc[Dev Console]'s query options and, since Camel 4.23, an authoritative
+response schema generated directly from the console's typed Java `Response` record. The top-level
+`dev-consoles-openapi.json` file aggregates all of this into a single OpenAPI 3.0 specification
+covering every dev console endpoint, so the same contract used internally to serve the live `api`
+dev console is also available standalone for tooling. A `dev-consoles.properties` index file lists
+all available dev console names.
 
 The `docs` directory contains the AsciiDoc documentation pages for all components, EIPs,
 data formats, languages, and other artifacts. A `docs.properties` index file lists all
@@ -111,4 +120,29 @@ String dataFormatDoc = catalog.dataFormatAsciiDoc("jackson2");   // loads jackso
 String languageDoc = catalog.languageAsciiDoc("simple");         // loads simple-language.adoc
 String modelDoc = catalog.modelAsciiDoc("split-eip");            // loads split-eip.adoc
 String otherDoc = catalog.otherAsciiDoc("yaml-dsl");             // loads yaml-dsl.adoc
+----
+
+=== Dev Console information in the Catalog
+
+The catalog also includes the query options and response schema for every
+xref:camel-console.adoc[Dev Console], so tooling can discover what a console accepts and
+what it returns without having to start a running Camel application first.
+
+The Java API provides the following methods for accessing dev console information:
+
+[source,java]
+----
+CamelCatalog catalog = new DefaultCamelCatalog();
+
+// list all available dev console names
+List<String> consoleNames = catalog.findDevConsoleNames();
+
+// look up a single dev console's model, including its query options and response schema
+DevConsoleModel model = catalog.devConsoleModel("circuit-breaker");
+
+// summary of every dev console in JSon
+String summary = catalog.listDevConsolesAsJson();
+
+// the OpenAPI 3.0 specification aggregated across every dev console endpoint
+String openApiSpec = catalog.devConsolesOpenApiSpec();
 ----

--- a/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jbang.json
+++ b/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/jbang.json
@@ -11,6 +11,15 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-jbang-console",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "version": {
+        "type": "string",
+        "description": "The JBang version (only present when known)"
+      }
+    }
   }
 }
 

--- a/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source-dir.json
+++ b/dsl/camel-jbang/camel-jbang-console/src/generated/resources/META-INF/org/apache/camel/dev-console/source-dir.json
@@ -27,6 +27,47 @@
       "secret": false,
       "description": "Whether to show the source in the output"
     }
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "dir": {
+        "type": "string",
+        "description": "The source directory (only present when a reload strategy is active)"
+      },
+      "files": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The file name"
+            },
+            "size": {
+              "type": "integer",
+              "description": "The file size in bytes"
+            },
+            "lastModified": {
+              "type": "integer",
+              "description": "Epoch time in milliseconds of the last modification"
+            },
+            "code": {
+              "type": "array",
+              "items": {
+                
+              },
+              "description": "The source code lines (only present when requested and available)"
+            }
+          },
+          "required": [
+            "size",
+            "lastModified"
+          ]
+        },
+        "description": "The files in the source directory (only present when the directory is not empty)"
+      }
+    }
   }
 }
 

--- a/dsl/camel-jbang/camel-jbang-console/src/main/java/org/apache/camel/jbang/console/JBangDevConsole.java
+++ b/dsl/camel-jbang/camel-jbang-console/src/main/java/org/apache/camel/jbang/console/JBangDevConsole.java
@@ -18,12 +18,17 @@ package org.apache.camel.jbang.console;
 
 import java.util.Map;
 
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "jbang", group = "camel-jbang", displayName = "Camel CLI", description = "Information about Camel CLI")
 public class JBangDevConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The JBang version (only present when known)") String version) {
+    }
 
     public JBangDevConsole() {
         super("camel-jbang", "jbang", "Camel CLI", "Information about Camel CLI");
@@ -43,11 +48,7 @@ public class JBangDevConsole extends AbstractDevConsole {
 
     @Override
     protected Map<String, Object> doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-        String v = VersionHelper.getJBangVersion();
-        if (v != null) {
-            root.put("version", v);
-        }
-        return root;
+        Response response = new Response(VersionHelper.getJBangVersion());
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-console/src/main/java/org/apache/camel/jbang/console/SourceDirDevConsole.java
+++ b/dsl/camel-jbang/camel-jbang-console/src/main/java/org/apache/camel/jbang/console/SourceDirDevConsole.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.StringHelper;
 import org.apache.camel.util.TimeUtils;
 import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "source-dir", group = "camel-jbang", displayName = "Source Directory",
             description = "Information about Camel CLI source files")
@@ -46,6 +47,18 @@ public class SourceDirDevConsole extends AbstractDevConsole {
     @Metadata(label = "query", description = "Whether to show the source in the output",
               javaType = "java.lang.Boolean")
     public static final String SOURCE = "source";
+
+    public record FileEntry(
+            @Metadata(description = "The file name") String name,
+            @Metadata(description = "The file size in bytes") long size,
+            @Metadata(description = "Epoch time in milliseconds of the last modification") long lastModified,
+            @Metadata(description = "The source code lines (only present when requested and available)") List<Object> code) {
+    }
+
+    public record Response(
+            @Metadata(description = "The source directory (only present when a reload strategy is active)") String dir,
+            @Metadata(description = "The files in the source directory (only present when the directory is not empty)") List<FileEntry> files) {
+    }
 
     public SourceDirDevConsole() {
         super("camel-jbang", "source-dir", "Source Directory", "Information about Camel CLI source files");
@@ -124,22 +137,22 @@ public class SourceDirDevConsole extends AbstractDevConsole {
         String subPath = path != null ? StringHelper.after(path, "/") : null;
         boolean source = optionBoolean(options, SOURCE, false);
 
-        JsonObject root = new JsonObject();
+        String dir = null;
+        List<FileEntry> files = null;
 
         RouteOnDemandReloadStrategy reload = getCamelContext().hasService(RouteOnDemandReloadStrategy.class);
         if (reload != null) {
-            root.put("dir", reload.getFolder());
+            dir = reload.getFolder();
             // list files in this directory
-            Path dir = Paths.get(reload.getFolder());
-            if (Files.exists(dir) && Files.isDirectory(dir)) {
-                try (Stream<Path> streams = Files.list(dir)) {
-                    List<Path> files = streams.collect(Collectors.toList());
-                    if (!files.isEmpty()) {
+            Path dirPath = Paths.get(reload.getFolder());
+            if (Files.exists(dirPath) && Files.isDirectory(dirPath)) {
+                try (Stream<Path> streams = Files.list(dirPath)) {
+                    List<Path> paths = streams.collect(Collectors.toList());
+                    if (!paths.isEmpty()) {
                         // sort files by name (ignore case)
-                        files.sort((o1, o2) -> o1.getFileName().toString().compareToIgnoreCase(o2.getFileName().toString()));
-                        JsonArray arr = new JsonArray();
-                        root.put("files", arr);
-                        for (Path f : files) {
+                        paths.sort((o1, o2) -> o1.getFileName().toString().compareToIgnoreCase(o2.getFileName().toString()));
+                        files = new ArrayList<>();
+                        for (Path f : paths) {
                             String fileName = f.getFileName().toString();
                             boolean skip = fileName.startsWith(".") || Files.isHidden(f);
                             if (skip) {
@@ -148,21 +161,19 @@ public class SourceDirDevConsole extends AbstractDevConsole {
                             boolean match = subPath == null || fileName.startsWith(subPath) || fileName.endsWith(subPath)
                                     || PatternHelper.matchPattern(fileName, subPath);
                             if (match) {
-                                JsonObject jo = new JsonObject();
-                                jo.put("name", fileName);
-                                jo.put("size", Files.size(f));
-                                jo.put("lastModified", Files.getLastModifiedTime(f).toMillis());
+                                List<Object> code = null;
                                 if (source) {
                                     try (Reader fileReader = Files.newBufferedReader(f, StandardCharsets.UTF_8)) {
-                                        JsonArray code = ConsoleHelper.loadSourceAsJson(fileReader, null);
-                                        if (code != null) {
-                                            jo.put("code", code);
+                                        JsonArray codeArr = ConsoleHelper.loadSourceAsJson(fileReader, null);
+                                        if (codeArr != null) {
+                                            code = codeArr;
                                         }
                                     } catch (Exception e) {
                                         // ignore
                                     }
                                 }
-                                arr.add(jo);
+                                files.add(new FileEntry(
+                                        fileName, Files.size(f), Files.getLastModifiedTime(f).toMillis(), code));
                             }
                         }
                     }
@@ -171,6 +182,8 @@ public class SourceDirDevConsole extends AbstractDevConsole {
                 }
             }
         }
-        return root;
+
+        Response response = new Response(dir, files);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVariable.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/process/ListVariable.java
@@ -89,17 +89,22 @@ public class ListVariable extends ProcessWatchCommand {
 
                         JsonObject jv = (JsonObject) root.get("variables");
                         if (jv != null) {
-                            for (String id : jv.keySet()) {
-                                JsonArray arr = jv.getCollection(id);
-                                if (arr != null) {
-                                    for (int i = 0; i < arr.size(); i++) {
-                                        row = row.copy();
-                                        JsonObject jo = (JsonObject) arr.get(i);
-                                        row.id = id;
-                                        row.key = jo.getString("key");
-                                        row.type = jo.getString("type");
-                                        row.value = jo.get("value");
-                                        rows.add(row);
+                            JsonArray repositories = jv.getCollection("repositories");
+                            if (repositories != null) {
+                                for (Object r : repositories) {
+                                    JsonObject repo = (JsonObject) r;
+                                    String id = repo.getString("id");
+                                    JsonArray arr = repo.getCollection("variables");
+                                    if (arr != null) {
+                                        for (int i = 0; i < arr.size(); i++) {
+                                            row = row.copy();
+                                            JsonObject jo = (JsonObject) arr.get(i);
+                                            row.id = id;
+                                            row.key = jo.getString("key");
+                                            row.type = jo.getString("type");
+                                            row.value = jo.get("value");
+                                            rows.add(row);
+                                        }
                                     }
                                 }
                             }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/process/ListVariableTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/process/ListVariableTest.java
@@ -116,8 +116,13 @@ class ListVariableTest extends ProcessCommandTestSupport {
     private static JsonObject variablesObj(JsonObject... entries) {
         JsonArray arr = new JsonArray();
         Collections.addAll(arr, entries);
+        JsonObject repo = new JsonObject();
+        repo.put("id", "global");
+        repo.put("variables", arr);
+        JsonArray repositories = new JsonArray();
+        repositories.add(repo);
         JsonObject vars = new JsonObject();
-        vars.put("global", arr);
+        vars.put("repositories", repositories);
         return vars;
     }
 

--- a/dsl/camel-kamelet-main/src/generated/resources/META-INF/org/apache/camel/dev-console/dependency-downloader.json
+++ b/dsl/camel-kamelet-main/src/generated/resources/META-INF/org/apache/camel/dev-console/dependency-downloader.json
@@ -44,22 +44,28 @@
           "type": "object",
           "properties": {
             "groupId": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven group id"
             },
             "artifactId": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven artifact id"
             },
             "version": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven version"
             },
             "repoId": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven repository id the artifact was downloaded from"
             },
             "repoUrl": {
-              "type": "string"
+              "type": "string",
+              "description": "The Maven repository URL the artifact was downloaded from"
             },
             "elapsed": {
-              "type": "integer"
+              "type": "integer",
+              "description": "The download time in milliseconds"
             }
           },
           "required": [

--- a/dsl/camel-kamelet-main/src/generated/resources/META-INF/org/apache/camel/dev-console/dependency-downloader.json
+++ b/dsl/camel-kamelet-main/src/generated/resources/META-INF/org/apache/camel/dev-console/dependency-downloader.json
@@ -11,6 +11,64 @@
     "groupId": "org.apache.camel",
     "artifactId": "camel-kamelet-main",
     "version": "4.23.0-SNAPSHOT"
+  },
+  "response": {
+    "type": "object",
+    "properties": {
+      "dependencies": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The downloaded dependency class-path entries (only present when the application classloader manages downloads)"
+      },
+      "offline": {
+        "type": "boolean",
+        "description": "Whether downloading is disabled (only present when a downloader is active)"
+      },
+      "fresh": {
+        "type": "boolean",
+        "description": "Whether fresh downloads are forced (only present when a downloader is active)"
+      },
+      "verbose": {
+        "type": "boolean",
+        "description": "Whether verbose logging is enabled (only present when a downloader is active)"
+      },
+      "repos": {
+        "type": "string",
+        "description": "The extra Maven repositories (only present when a downloader is active)"
+      },
+      "downloads": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "artifactId": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "repoId": {
+              "type": "string"
+            },
+            "repoUrl": {
+              "type": "string"
+            },
+            "elapsed": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "elapsed"
+          ]
+        },
+        "description": "The downloaded artifacts (only present when a downloader is active)"
+      }
+    }
   }
 }
 

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/console/DependencyDownloaderConsole.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/console/DependencyDownloaderConsole.java
@@ -16,20 +16,31 @@
  */
 package org.apache.camel.main.console;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.main.download.DependencyDownloaderClassLoader;
 import org.apache.camel.main.download.DownloadRecord;
 import org.apache.camel.main.download.MavenDependencyDownloader;
+import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.DevConsole;
 import org.apache.camel.support.console.AbstractDevConsole;
 import org.apache.camel.util.TimeUtils;
-import org.apache.camel.util.json.JsonArray;
-import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonRecordSupport;
 
 @DevConsole(name = "dependency-downloader", group = "camel-jbang", displayName = "Maven Dependency Downloader",
             description = "Displays information about dependencies downloaded at runtime")
 public class DependencyDownloaderConsole extends AbstractDevConsole {
+
+    public record Response(
+            @Metadata(description = "The downloaded dependency class-path entries (only present when the application classloader manages downloads)") List<String> dependencies,
+            @Metadata(description = "Whether downloading is disabled (only present when a downloader is active)") Boolean offline,
+            @Metadata(description = "Whether fresh downloads are forced (only present when a downloader is active)") Boolean fresh,
+            @Metadata(description = "Whether verbose logging is enabled (only present when a downloader is active)") Boolean verbose,
+            @Metadata(description = "The extra Maven repositories (only present when a downloader is active)") String repos,
+            @Metadata(description = "The downloaded artifacts (only present when a downloader is active)") List<DownloadRecord> downloads) {
+    }
 
     public DependencyDownloaderConsole() {
         super("camel-jbang", "dependency-downloader", "Maven Dependency Downloader",
@@ -68,38 +79,32 @@ public class DependencyDownloaderConsole extends AbstractDevConsole {
     }
 
     @Override
-    protected JsonObject doCallJson(Map<String, Object> options) {
-        JsonObject root = new JsonObject();
-
+    protected Map<String, Object> doCallJson(Map<String, Object> options) {
+        List<String> dependencies = null;
         ClassLoader cl = getCamelContext().getApplicationContextClassLoader();
         if (cl instanceof DependencyDownloaderClassLoader) {
             @SuppressWarnings("resource")
             // The resource should not be closed as it belongs to the CamelContext and may be reused.
             DependencyDownloaderClassLoader ddcl = (DependencyDownloaderClassLoader) cl;
-            String[] cp = ddcl.getDownloaded().toArray(new String[0]);
-            root.put("dependencies", cp);
+            dependencies = new ArrayList<>(ddcl.getDownloaded());
         }
+
+        Boolean offline = null;
+        Boolean fresh = null;
+        Boolean verbose = null;
+        String repos = null;
+        List<DownloadRecord> downloads = null;
 
         MavenDependencyDownloader downloader = getCamelContext().hasService(MavenDependencyDownloader.class);
         if (downloader != null) {
-            JsonArray arr = new JsonArray();
-            root.put("offline", !downloader.isDownload());
-            root.put("fresh", downloader.isFresh());
-            root.put("verbose", downloader.isVerbose());
-            root.put("repos", downloader.getRepositories());
-            root.put("downloads", arr);
-            for (DownloadRecord r : downloader.downloadRecords()) {
-                JsonObject jo = new JsonObject();
-                arr.add(jo);
-                jo.put("groupId", r.groupId());
-                jo.put("artifactId", r.artifactId());
-                jo.put("version", r.version());
-                jo.put("elapsed", r.elapsed());
-                jo.put("repoId", r.repoId());
-                jo.put("repoUrl", r.repoUrl());
-            }
+            offline = !downloader.isDownload();
+            fresh = downloader.isFresh();
+            verbose = downloader.isVerbose();
+            repos = downloader.getRepositories();
+            downloads = new ArrayList<>(downloader.downloadRecords());
         }
 
-        return root;
+        Response response = new Response(dependencies, offline, fresh, verbose, repos, downloads);
+        return JsonRecordSupport.toJsonObject(response);
     }
 }

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DownloadRecord.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/download/DownloadRecord.java
@@ -16,15 +16,17 @@
  */
 package org.apache.camel.main.download;
 
+import org.apache.camel.spi.Metadata;
+
 /**
  * Record for details when an artifact was downloaded from a remote Maven repository.
  */
 public record DownloadRecord(
-        String groupId,
-        String artifactId,
-        String version,
-        String repoId,
-        String repoUrl,
-        long elapsed) {
+        @Metadata(description = "The Maven group id") String groupId,
+        @Metadata(description = "The Maven artifact id") String artifactId,
+        @Metadata(description = "The Maven version") String version,
+        @Metadata(description = "The Maven repository id the artifact was downloaded from") String repoId,
+        @Metadata(description = "The Maven repository URL the artifact was downloaded from") String repoUrl,
+        @Metadata(description = "The download time in milliseconds") long elapsed) {
 
 }

--- a/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/console/DependencyDownloaderConsoleTest.java
+++ b/dsl/camel-kamelet-main/src/test/java/org/apache/camel/main/console/DependencyDownloaderConsoleTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main.console;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.console.DevConsoleRegistry;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.console.DefaultDevConsoleRegistry;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DependencyDownloaderConsole reports on a running {@link org.apache.camel.main.download.MavenDependencyDownloader}
+ * service; spinning up a real one is out of scope for this test, so it only verifies the console's basic shape when no
+ * downloader is registered.
+ */
+public class DependencyDownloaderConsoleTest {
+
+    private CamelContext camelContext;
+
+    @BeforeEach
+    void setUp() {
+        camelContext = new DefaultCamelContext();
+        camelContext.setDevConsole(true);
+        DefaultDevConsoleRegistry registry = new DefaultDevConsoleRegistry(camelContext);
+        registry.register(new DependencyDownloaderConsole());
+        camelContext.getCamelContextExtension().addContextPlugin(DevConsoleRegistry.class, registry);
+        camelContext.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        camelContext.stop();
+    }
+
+    @Test
+    void testDependencyDownloaderConsoleNoDownloader() {
+        DevConsole con = camelContext.getCamelContextExtension().getContextPlugin(DevConsoleRegistry.class)
+                .resolveById("dependency-downloader");
+        assertNotNull(con);
+        assertEquals("camel-jbang", con.getGroup());
+
+        String text = (String) con.call(DevConsole.MediaType.TEXT);
+        assertNotNull(text);
+
+        JsonObject out = (JsonObject) con.call(DevConsole.MediaType.JSON);
+        assertNotNull(out);
+        assertTrue(out.isEmpty());
+    }
+}

--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/DevConsoleModel.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/DevConsoleModel.java
@@ -16,10 +16,13 @@
  */
 package org.apache.camel.tooling.model;
 
+import org.apache.camel.util.json.JsonObject;
+
 public class DevConsoleModel extends ArtifactModel<DevConsoleModel.DevConsoleOptionModel> {
 
     protected String group;
     protected boolean readOnly = true;
+    protected JsonObject responseSchema;
 
     public DevConsoleModel() {
     }
@@ -38,6 +41,18 @@ public class DevConsoleModel extends ArtifactModel<DevConsoleModel.DevConsoleOpt
 
     public void setReadOnly(boolean readOnly) {
         this.readOnly = readOnly;
+    }
+
+    /**
+     * The JSON Schema describing this console's response payload, or {@code null} if the console has not declared one
+     * (via a nested {@code Response} record).
+     */
+    public JsonObject getResponseSchema() {
+        return responseSchema;
+    }
+
+    public void setResponseSchema(JsonObject responseSchema) {
+        this.responseSchema = responseSchema;
     }
 
     @Override

--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/DevConsoleOpenApiHelper.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/DevConsoleOpenApiHelper.java
@@ -79,8 +79,12 @@ public final class DevConsoleOpenApiHelper {
         JsonObject responses = new JsonObject();
         JsonObject ok = new JsonObject();
         ok.put("description", model.getTitle() + " output");
+        JsonObject mediaType = new JsonObject();
+        if (model.getResponseSchema() != null) {
+            mediaType.put("schema", model.getResponseSchema());
+        }
         JsonObject responseContent = new JsonObject();
-        responseContent.put("application/json", new JsonObject());
+        responseContent.put("application/json", mediaType);
         ok.put("content", responseContent);
         responses.put("200", ok);
         operation.put("responses", responses);

--- a/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/JsonMapper.java
+++ b/tooling/camel-tooling-model/src/main/java/org/apache/camel/tooling/model/JsonMapper.java
@@ -505,6 +505,7 @@ public final class JsonMapper {
                 model.addOption(option);
             }
         }
+        model.setResponseSchema((JsonObject) obj.get("response"));
         return model;
     }
 
@@ -524,6 +525,9 @@ public final class JsonMapper {
         wrapper.put("console", obj);
         if (!model.getOptions().isEmpty()) {
             wrapper.put("options", asJsonObject(model.getOptions()));
+        }
+        if (model.getResponseSchema() != null) {
+            wrapper.put("response", model.getResponseSchema());
         }
         return wrapper;
     }

--- a/tooling/camel-tooling-model/src/test/java/org/apache/camel/tooling/model/DevConsoleOpenApiHelperTest.java
+++ b/tooling/camel-tooling-model/src/test/java/org/apache/camel/tooling/model/DevConsoleOpenApiHelperTest.java
@@ -101,6 +101,40 @@ class DevConsoleOpenApiHelperTest {
     }
 
     @Test
+    void consoleWithResponseSchemaPopulatesResponseContent() {
+        DevConsoleModel model = new DevConsoleModel();
+        model.setName("circuit-breaker");
+        model.setTitle("Circuit Breaker");
+        model.setDescription("Circuit breaker information");
+        model.setReadOnly(true);
+
+        JsonObject schema = new JsonObject();
+        schema.put("type", "object");
+        model.setResponseSchema(schema);
+
+        JsonObject pathItem = DevConsoleOpenApiHelper.buildPathItem(model);
+        JsonObject content = pathItem.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+                .getJsonObject("content").getJsonObject("application/json");
+
+        assertEquals(schema, content.getJsonObject("schema"));
+    }
+
+    @Test
+    void consoleWithoutResponseSchemaHasEmptyResponseContent() {
+        DevConsoleModel model = new DevConsoleModel();
+        model.setName("context");
+        model.setTitle("CamelContext");
+        model.setDescription("Overall information about the CamelContext");
+        model.setReadOnly(true);
+
+        JsonObject pathItem = DevConsoleOpenApiHelper.buildPathItem(model);
+        JsonObject content = pathItem.getJsonObject("get").getJsonObject("responses").getJsonObject("200")
+                .getJsonObject("content").getJsonObject("application/json");
+
+        assertTrue(content.isEmpty());
+    }
+
+    @Test
     void openApiDocumentContainsOnePathPerConsoleSortedByName() {
         DevConsoleModel context = new DevConsoleModel();
         context.setName("context");

--- a/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/JsonRecordSupport.java
+++ b/tooling/camel-util-json/src/main/java/org/apache/camel/util/json/JsonRecordSupport.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.util.json;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Reflectively converts a Java {@link Record} into a {@link JsonObject}, so a record can be used as the single source
+ * of truth for both a runtime JSON payload and (via reflection over the record's structure) a JSON Schema describing
+ * it.
+ * <p/>
+ * A record component whose value is {@code null} is omitted from the resulting {@link JsonObject}, mirroring the common
+ * "only include a field if present" convention. Supported component value types: primitives, {@link String}, boxed
+ * numbers/{@link Boolean}, {@link Enum} (converted via {@link Enum#name()}), nested {@link Record}s,
+ * {@link Collection}s thereof, and {@link Map}s (converted to a {@link JsonObject}).
+ */
+public final class JsonRecordSupport {
+
+    private JsonRecordSupport() {
+    }
+
+    /**
+     * Converts a record instance into a {@link JsonObject}, one entry per record component.
+     */
+    public static JsonObject toJsonObject(Record record) {
+        JsonObject json = new JsonObject();
+        for (RecordComponent component : record.getClass().getRecordComponents()) {
+            Object value = accessorValue(record, component);
+            Object jsonValue = toJsonValue(value);
+            if (jsonValue != null) {
+                json.put(component.getName(), jsonValue);
+            }
+        }
+        return json;
+    }
+
+    private static Object accessorValue(Record record, RecordComponent component) {
+        try {
+            Method accessor = component.getAccessor();
+            accessor.setAccessible(true);
+            return accessor.invoke(record);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(
+                    "Cannot read record component: " + component.getName() + " on " + record.getClass(), e);
+        }
+    }
+
+    private static Object toJsonValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Record r) {
+            return toJsonObject(r);
+        }
+        if (value instanceof Map<?, ?> map) {
+            JsonObject json = new JsonObject();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object v = toJsonValue(entry.getValue());
+                if (v != null) {
+                    json.put(String.valueOf(entry.getKey()), v);
+                }
+            }
+            return json;
+        }
+        if (value instanceof Collection<?> col) {
+            JsonArray array = new JsonArray();
+            for (Object item : col) {
+                array.add(toJsonValue(item));
+            }
+            return array;
+        }
+        if (value instanceof Enum<?> e) {
+            return e.name();
+        }
+        // String, boxed numbers, Boolean, and anything already JSON-safe pass through as-is
+        return value;
+    }
+}

--- a/tooling/camel-util-json/src/test/java/org/apache/camel/util/json/JsonRecordSupportTest.java
+++ b/tooling/camel-util-json/src/test/java/org/apache/camel/util/json/JsonRecordSupportTest.java
@@ -43,6 +43,14 @@ public class JsonRecordSupportTest {
     record MapRecord(String id, Map<String, String> details) {
     }
 
+    enum Status {
+        ACTIVE,
+        INACTIVE
+    }
+
+    record EnumRecord(String id, Status status) {
+    }
+
     @Test
     void flatRecordConvertsAllFields() {
         JsonObject json = JsonRecordSupport.toJsonObject(new FlatRecord("foo", 3, true));
@@ -90,5 +98,13 @@ public class JsonRecordSupportTest {
         JsonObject detailsJson = json.getJsonObject("details");
         assertEquals("timeout", detailsJson.getString("cause"));
         assertEquals("true", detailsJson.getString("retryable"));
+    }
+
+    @Test
+    void enumFieldConvertsToItsName() {
+        JsonObject json = JsonRecordSupport.toJsonObject(new EnumRecord("check1", Status.ACTIVE));
+
+        assertEquals("check1", json.getString("id"));
+        assertEquals("ACTIVE", json.getString("status"));
     }
 }

--- a/tooling/camel-util-json/src/test/java/org/apache/camel/util/json/JsonRecordSupportTest.java
+++ b/tooling/camel-util-json/src/test/java/org/apache/camel/util/json/JsonRecordSupportTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.util.json;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class JsonRecordSupportTest {
+
+    record FlatRecord(String name, int count, boolean active) {
+    }
+
+    record RowRecord(String id, long value) {
+    }
+
+    record NestedRecord(String label, RowRecord row, List<RowRecord> rows) {
+    }
+
+    record NullableRecord(String required, String optional) {
+    }
+
+    record MapRecord(String id, Map<String, String> details) {
+    }
+
+    @Test
+    void flatRecordConvertsAllFields() {
+        JsonObject json = JsonRecordSupport.toJsonObject(new FlatRecord("foo", 3, true));
+
+        assertEquals("foo", json.getString("name"));
+        assertEquals(3, json.getInteger("count"));
+        assertEquals(true, json.getBoolean("active"));
+    }
+
+    @Test
+    void nestedRecordAndListOfRecordsConvertRecursively() {
+        RowRecord row = new RowRecord("r1", 42L);
+        List<RowRecord> rows = List.of(new RowRecord("r1", 1L), new RowRecord("r2", 2L));
+        NestedRecord nested = new NestedRecord("top", row, rows);
+
+        JsonObject json = JsonRecordSupport.toJsonObject(nested);
+
+        assertEquals("top", json.getString("label"));
+        JsonObject rowJson = json.getJsonObject("row");
+        assertEquals("r1", rowJson.getString("id"));
+        assertEquals(42L, rowJson.getLong("value"));
+
+        JsonArray rowsJson = json.getJsonArray("rows");
+        assertEquals(2, rowsJson.size());
+        assertEquals("r2", ((JsonObject) rowsJson.get(1)).getString("id"));
+    }
+
+    @Test
+    void nullComponentIsOmittedFromOutput() {
+        JsonObject json = JsonRecordSupport.toJsonObject(new NullableRecord("present", null));
+
+        assertEquals("present", json.getString("required"));
+        assertFalse(json.containsKey("optional"));
+        assertNull(json.get("optional"));
+    }
+
+    @Test
+    void mapFieldConvertsToJsonObject() {
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("cause", "timeout");
+        details.put("retryable", "true");
+
+        JsonObject json = JsonRecordSupport.toJsonObject(new MapRecord("check1", details));
+
+        JsonObject detailsJson = json.getJsonObject("details");
+        assertEquals("timeout", detailsJson.getString("cause"));
+        assertEquals("true", detailsJson.getString("retryable"));
+    }
+}

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
@@ -19,9 +19,14 @@ package org.apache.camel.maven.packaging;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 
 import javax.inject.Inject;
@@ -33,6 +38,7 @@ import org.apache.camel.tooling.model.DevConsoleModel.DevConsoleOptionModel;
 import org.apache.camel.tooling.model.JsonMapper;
 import org.apache.camel.tooling.util.PackageHelper;
 import org.apache.camel.tooling.util.Strings;
+import org.apache.camel.util.json.JsonArray;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -84,6 +90,7 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
         private String description;
         private boolean deprecated;
         private boolean readOnly = true;
+        private JsonObject responseSchema;
         private final List<DevConsoleOptionModel> options = new ArrayList<>();
 
         public String getClassName() {
@@ -142,6 +149,14 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             this.readOnly = readOnly;
         }
 
+        public JsonObject getResponseSchema() {
+            return responseSchema;
+        }
+
+        public void setResponseSchema(JsonObject responseSchema) {
+            this.responseSchema = responseSchema;
+        }
+
         public List<DevConsoleOptionModel> getOptions() {
             return options;
         }
@@ -183,6 +198,7 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             boolean skip = "default-registry".equals(model.getName());
             if (!skip) {
                 extractQueryOptions(model);
+                extractResponseSchema(model);
                 models.add(model);
             }
         });
@@ -247,6 +263,9 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
         root.put("console", jo);
         if (!model.getOptions().isEmpty()) {
             root.put("options", JsonMapper.asJsonObject(model.getOptions()));
+        }
+        if (model.getResponseSchema() != null) {
+            root.put("response", model.getResponseSchema());
         }
         return root;
     }
@@ -313,6 +332,94 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             model.getOptions().add(o);
         }
         model.getOptions().sort(Comparator.comparing(BaseOptionModel::getName));
+    }
+
+    private void extractResponseSchema(DevConsoleModel model) {
+        Class<?> clazz;
+        try {
+            clazz = loadClass(model.getClassName());
+        } catch (NoClassDefFoundError e) {
+            getLog().debug("Cannot load class: " + model.getClassName());
+            return;
+        }
+        model.setResponseSchema(buildResponseSchema(clazz));
+    }
+
+    /**
+     * Builds a JSON Schema for the console's response, from its nested {@code Response} record (if any). Returns
+     * {@code null} when the console has no such record, so consoles that have not declared a typed response keep
+     * generating no {@code "response"} key, same as before this schema generation existed.
+     */
+    static JsonObject buildResponseSchema(Class<?> consoleClass) {
+        for (Class<?> nested : consoleClass.getDeclaredClasses()) {
+            if ("Response".equals(nested.getSimpleName()) && nested.isRecord()) {
+                return buildRecordSchema(nested);
+            }
+        }
+        return null;
+    }
+
+    private static JsonObject buildRecordSchema(Class<?> recordClass) {
+        JsonObject schema = new JsonObject();
+        schema.put("type", "object");
+
+        JsonObject properties = new JsonObject();
+        JsonArray required = new JsonArray();
+        for (RecordComponent component : recordClass.getRecordComponents()) {
+            JsonObject propertySchema = buildTypeSchema(component.getGenericType());
+            String description = componentDescription(recordClass, component);
+            if (description != null) {
+                propertySchema.put("description", description);
+            }
+            properties.put(component.getName(), propertySchema);
+            if (component.getType().isPrimitive()) {
+                required.add(component.getName());
+            }
+        }
+        schema.put("properties", properties);
+        if (!required.isEmpty()) {
+            schema.put("required", required);
+        }
+        return schema;
+    }
+
+    private static String componentDescription(Class<?> recordClass, RecordComponent component) {
+        try {
+            Field field = recordClass.getDeclaredField(component.getName());
+            Metadata metadata = field.getAnnotation(Metadata.class);
+            if (metadata != null && !metadata.description().isEmpty()) {
+                return metadata.description();
+            }
+        } catch (NoSuchFieldException e) {
+            // ignore - no annotation available
+        }
+        return null;
+    }
+
+    private static JsonObject buildTypeSchema(Type type) {
+        if (type instanceof ParameterizedType pt) {
+            Class<?> rawType = (Class<?>) pt.getRawType();
+            if (Collection.class.isAssignableFrom(rawType)) {
+                JsonObject schema = new JsonObject();
+                schema.put("type", "array");
+                schema.put("items", buildTypeSchema(pt.getActualTypeArguments()[0]));
+                return schema;
+            }
+            if (Map.class.isAssignableFrom(rawType)) {
+                JsonObject schema = new JsonObject();
+                schema.put("type", "object");
+                schema.put("additionalProperties", true);
+                return schema;
+            }
+        }
+
+        Class<?> clazz = (Class<?>) type;
+        if (clazz.isRecord()) {
+            return buildRecordSchema(clazz);
+        }
+        JsonObject schema = new JsonObject();
+        schema.put("type", javaTypeToType(clazz.getName()));
+        return schema;
     }
 
     private static String javaTypeToType(String javaType) {

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
@@ -415,7 +415,10 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             }
         }
 
-        Class<?> clazz = (Class<?>) type;
+        if (!(type instanceof Class<?> clazz)) {
+            // a TypeVariable, WildcardType or GenericArrayType has no fixed JSON shape to describe
+            return new JsonObject();
+        }
         if (clazz.isRecord()) {
             return buildRecordSchema(clazz);
         }

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojo.java
@@ -408,7 +408,9 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
             if (Map.class.isAssignableFrom(rawType)) {
                 JsonObject schema = new JsonObject();
                 schema.put("type", "object");
-                schema.put("additionalProperties", true);
+                Type valueType = pt.getActualTypeArguments()[1];
+                // Object means "any shape", so a plain true is more honest than a misleading {"type":"object"}
+                schema.put("additionalProperties", valueType == Object.class ? true : buildTypeSchema(valueType));
                 return schema;
             }
         }
@@ -416,6 +418,10 @@ public class GenerateDevConsoleMojo extends AbstractGeneratorMojo {
         Class<?> clazz = (Class<?>) type;
         if (clazz.isRecord()) {
             return buildRecordSchema(clazz);
+        }
+        if (clazz == Object.class) {
+            // no type constraint means "any JSON value", which is more honest than a misleading "type":"object"
+            return new JsonObject();
         }
         JsonObject schema = new JsonObject();
         schema.put("type", javaTypeToType(clazz.getName()));

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/MojoHelper.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/MojoHelper.java
@@ -176,6 +176,8 @@ public final class MojoHelper {
                 return Collections.singletonList(dir.resolve("camel-knative-component"));
             case "camel-yaml-dsl":
                 return Collections.singletonList(dir.resolve("camel-yaml-dsl"));
+            case "camel-jbang":
+                return Collections.singletonList(dir.resolve("camel-jbang-console"));
             default:
                 return Collections.singletonList(dir);
         }

--- a/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareCatalogMojo.java
+++ b/tooling/maven/camel-package-maven-plugin/src/main/java/org/apache/camel/maven/packaging/PrepareCatalogMojo.java
@@ -409,6 +409,8 @@ public class PrepareCatalogMojo extends AbstractMojo {
                                         }
                                         om.setVersion(project.getVersion());
                                     }
+                                }
+                                if (m != null) {
                                     allModels.put(p, m);
                                 }
                             }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojoResponseSchemaTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojoResponseSchemaTest.java
@@ -49,6 +49,13 @@ public class GenerateDevConsoleMojoResponseSchemaTest {
         }
     }
 
+    static class GenericFieldConsole<T> {
+
+        // a type parameter has no resolvable Class, exercising the TypeVariable fallback
+        public record Response<T>(T value) {
+        }
+    }
+
     @Test
     void consoleWithoutResponseRecordReturnsNull() {
         JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(NoResponseConsole.class);
@@ -135,5 +142,14 @@ public class GenerateDevConsoleMojoResponseSchemaTest {
 
         JsonObject anyValue = properties.getJsonObject("anyValue");
         assertTrue(anyValue.isEmpty());
+    }
+
+    @Test
+    void typeVariableFieldBuildsUnconstrainedSchemaInsteadOfThrowing() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(GenericFieldConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject value = properties.getJsonObject("value");
+        assertTrue(value.isEmpty());
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojoResponseSchemaTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojoResponseSchemaTest.java
@@ -43,7 +43,9 @@ public class GenerateDevConsoleMojoResponseSchemaTest {
                 @Metadata(description = "An optional label") String label,
                 Row row,
                 List<Row> rows,
-                Map<String, String> details) {
+                Map<String, String> details,
+                Map<String, Object> opaque,
+                Object anyValue) {
         }
     }
 
@@ -106,13 +108,32 @@ public class GenerateDevConsoleMojoResponseSchemaTest {
     }
 
     @Test
-    void mapFieldBuildsOpenObjectSchema() {
+    void mapWithTypedValueBuildsAdditionalPropertiesSchema() {
         JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
         JsonObject properties = schema.getJsonObject("properties");
 
         JsonObject details = properties.getJsonObject("details");
         assertEquals("object", details.getString("type"));
-        assertEquals(true, details.get("additionalProperties"));
+        assertEquals("string", details.getJsonObject("additionalProperties").getString("type"));
         assertNull(details.get("properties"));
+    }
+
+    @Test
+    void mapWithObjectValueBuildsFullyOpenSchema() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject opaque = properties.getJsonObject("opaque");
+        assertEquals("object", opaque.getString("type"));
+        assertEquals(true, opaque.get("additionalProperties"));
+    }
+
+    @Test
+    void bareObjectFieldBuildsUnconstrainedSchema() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject anyValue = properties.getJsonObject("anyValue");
+        assertTrue(anyValue.isEmpty());
     }
 }

--- a/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojoResponseSchemaTest.java
+++ b/tooling/maven/camel-package-maven-plugin/src/test/java/org/apache/camel/maven/packaging/GenerateDevConsoleMojoResponseSchemaTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.maven.packaging;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.spi.Metadata;
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GenerateDevConsoleMojoResponseSchemaTest {
+
+    static class NoResponseConsole {
+    }
+
+    static class SampleConsole {
+
+        record Row(String id, long value) {
+        }
+
+        public record Response(
+                @Metadata(description = "The size") int size,
+                @Metadata(description = "An optional label") String label,
+                Row row,
+                List<Row> rows,
+                Map<String, String> details) {
+        }
+    }
+
+    @Test
+    void consoleWithoutResponseRecordReturnsNull() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(NoResponseConsole.class);
+        assertEquals(null, schema);
+    }
+
+    @Test
+    void primitiveFieldIsRequiredAndDescribed() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+
+        assertEquals("object", schema.getString("type"));
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject size = properties.getJsonObject("size");
+        assertEquals("integer", size.getString("type"));
+        assertEquals("The size", size.getString("description"));
+
+        var required = schema.getCollection("required");
+        assertTrue(required.contains("size"));
+    }
+
+    @Test
+    void referenceFieldIsNotRequired() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject label = properties.getJsonObject("label");
+        assertEquals("string", label.getString("type"));
+        assertEquals("An optional label", label.getString("description"));
+
+        var required = schema.getCollection("required");
+        assertFalse(required.contains("label"));
+    }
+
+    @Test
+    void nestedRecordBuildsNestedObjectSchema() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject row = properties.getJsonObject("row");
+        assertEquals("object", row.getString("type"));
+        JsonObject rowProperties = row.getJsonObject("properties");
+        assertEquals("string", rowProperties.getJsonObject("id").getString("type"));
+        assertEquals("integer", rowProperties.getJsonObject("value").getString("type"));
+    }
+
+    @Test
+    void listOfRecordBuildsArrayOfObjectSchema() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject rows = properties.getJsonObject("rows");
+        assertEquals("array", rows.getString("type"));
+        JsonObject items = rows.getJsonObject("items");
+        assertEquals("object", items.getString("type"));
+        assertEquals("string", items.getJsonObject("properties").getJsonObject("id").getString("type"));
+    }
+
+    @Test
+    void mapFieldBuildsOpenObjectSchema() {
+        JsonObject schema = GenerateDevConsoleMojo.buildResponseSchema(SampleConsole.class);
+        JsonObject properties = schema.getJsonObject("properties");
+
+        JsonObject details = properties.getJsonObject("details");
+        assertEquals("object", details.getString("type"));
+        assertEquals(true, details.get("additionalProperties"));
+        assertNull(details.get("properties"));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to CAMEL-24564 (#25885). The generated OpenAPI spec declares every dev console's `200`
response as `"content": {"application/json": {}}` — an empty schema, no contract for what actually
comes back. This adds a real response contract, declared **statically in the Java source** so any
future editor (human or AI) touching a console's output naturally sees the contract sitting right
next to it — and makes it **authoritative**: `doCallJson()` actually constructs and returns the
declared record (converted to `JsonObject`), rather than a parallel doc that could silently drift
from the real output.

Rolling out incrementally across `core/camel-console`'s ~54 consoles, in reviewable batches.
**Rollout complete: 53 of 54 consoles migrated.** Only 1 is intentionally left with the empty
placeholder, for a documented structural reason rather than lack of effort:
- `api` — its response *is* a full OpenAPI document dynamically assembled from every registered
  console's model; it's the schema generator, not a fixed shape to describe.

`variables` and `jfr-memory-leak` were both initially left in this category too, but were
reconsidered after the rest of the rollout completed and migrated in follow-up commits:
- `variables` — each variable repository's ID became a dynamic top-level JSON key; redesigned to a
  fixed `Response(List<RepositoryEntry> repositories)` shape (see below) once it became clear the
  dynamic-key problem could be solved by moving the repository id *into* each entry rather than
  using it *as* a key.
- `jfr-memory-leak` — five commands (start/stop/status/query/compare) over mutable cached JFR
  introspection state built via reflection over JDK Flight Recorder events. Initially assessed as
  disproportionately complex, but the mutable-accumulator + unified-superset patterns proven on the
  sibling `jfr` console (`camel-jfr`, migrated earlier in this PR) turned out to apply here too —
  see below.

Two structural patterns emerged for consoles whose output shape varies at runtime:
- **Unified superset with nullable fields** (`route-controller`, `properties`, `browse`,
  `consumer`) — one record with nullable fields for branch-specific data, instead of a `oneOf`.
- **Opaque object** (`errors`, `browse`'s dumped messages) — data owned by another class's own
  JSON serialization, modeled honestly as `additionalProperties: true`/typed rather than guessed.
- **`Map<String, Record>` for one-level-deep dynamic keys** (`bean`'s `beans: {name: {...}}`) —
  distinct from fully dynamic top-level keys (which are skipped), this fits a record field fine.

`consumer` preserves a pre-existing bug as-is (`mcc instanceof ManagedSchedulePollConsumerMBean`,
checking the `ManagedCamelContext` instead of the consumer mbean, making that branch effectively
dead code) — refactoring is about the response contract, not fixing unrelated behavior.

`processor-detail`'s response shape depends on the `routeId` option (a flat `routeId`/`processors`
pair for a specific route, vs a nested `routes` list for `*`/omitted) — modeled as one `Response`
record whose three top-level fields are populated in mutually exclusive combinations, since a
record's top-level fields ARE the JSON's top-level keys with no extra wrapping needed.

`sql-trace`'s ring buffer field changes from `JsonObject[]` to a typed `StatementEntry[]` record
array, since the traced statement data is owned by this console (built by its own event notifier),
not borrowed from another class's JSON serialization — making the record the buffer's storage type
too, not just a response-time conversion, is the more authoritative option.

`route-topology`'s optional `routes` field (route structure data borrowed from the
`route-structure` console's own JSON output) and `route-structure`'s `statistics` field
(borrowed from `RouteDevConsole`/`ProcessorDevConsole`'s stat-gathering helpers, both still
unmigrated) are modeled as opaque `Map<String, Object>` per the existing pattern for data owned by
another class's own JSON serialization.

`ProcessorDevConsole.gatherProcessorStats(mp)`, a public helper reused by `RouteStructureDevConsole`
and `RouteDevConsole` (still unmigrated), keeps its existing `JsonObject`-returning signature —
it now builds the new `Statistics` record internally and converts it, so the computation has a
single source of truth without breaking either caller. Similarly
`ProcessorDevConsole.includeProcessorsJSon(...)` now builds a `List<ProcessorEntry>` instead of a
`JsonArray`; `RouteDevConsole`'s one call site converts the returned entries back to `JsonObject`s
so this shared helper's signature change doesn't leave it broken.

`sql-query`'s query/update-row branches share one `Response` record; result rows stay
`List<Map<String, Object>>` (opaque) since row shape is inherently dynamic SQL result data, but
columns are now a typed `ColumnEntry` list.

## Extending beyond core/camel-console

Once `core/camel-console` was fully rolled out, the same migration was extended to dev consoles
living in other modules (`components/*`, `core/camel-main`, `dsl/camel-jbang-console`,
`dsl/camel-kamelet-main`). No new plumbing was needed for this — the build-time schema generator
(`GenerateDevConsoleMojo`) already runs generically for any module using `@DevConsole`, and
`JsonRecordSupport` resolves transitively via `camel-support`/`camel-core` in every module checked
so far, so no new dependency was added anywhere. **Rollout complete: 28 consoles migrated outside
core/camel-console**, covering every remaining `@DevConsole` in the repository (confirmed via a
full repo-wide grep for `@DevConsole` usages): `jbang` (`camel-jbang-console`), `sftp`
(`camel-ftp`), `hashicorp-secrets` (`camel-hashicorp-vault`), `main-http-server`
(`camel-platform-http-main`), `main-configuration` (`core/camel-main`), `dependency-downloader`
(`camel-kamelet-main`), `aws2-s3` (`camel-aws2-s3`), `groovy` (`camel-groovy`), `fault-tolerance`
(`camel-microprofile-fault-tolerance`), `kubernetes-configmaps` (`camel-kubernetes`), `catalog`
(`camel-catalog-console`), `bean-model` (`camel-core-model`), `azure-secrets`
(`camel-azure-key-vault`), `ibm-secrets` (`camel-ibm-secrets-manager`), `gcp-secrets`
(`camel-google-secret-manager`), `vertx-websocket` (`camel-vertx-websocket`), `stub`
(`camel-stub`), `route-diagram` (`camel-diagram`), `kubernetes-secrets` (`camel-kubernetes`),
`platform-http` (`camel-platform-http`), `resilience4j` (`camel-resilience4j`), `kafka`
(`camel-kafka`), `opentelemetry` (`camel-opentelemetry2`), `micrometer` (`camel-micrometer`),
`source-dir` (`camel-jbang-console`), `aws-secrets` (`camel-aws-secrets-manager`), `quartz`
(`camel-quartz`), `jfr` (`camel-jfr`).

`dependency-downloader` reuses the existing `DownloadRecord` record directly as a nested
`Response` field, rather than redefining an equivalent record.

`kubernetes-configmaps` preserves a pre-existing bug as-is: `ConfigmapsDevConsole` unconditionally
dereferences the Kubernetes vault configuration's secrets list, which NPEs whenever no such
configuration is present — refactoring is about the response contract, not fixing unrelated
behavior, so its test is limited to verifying console registration.

`catalog` (`camel-catalog-console`), `bean-model` (`camel-core-model`), and `stub` (`camel-stub`)
have no `camel-core`/test dependency available (`catalog`/`bean-model` confirmed by an actual
compile failure when a test was attempted; `stub` has no `src/test` directory or test dependency
at all), so no test was added for any of the three — each was verified instead via a clean
compile/install, consistent with the same rationale already applied earlier in this PR to
`camel-jbang-console`.

`azure-secrets`, `ibm-secrets`, and `gcp-secrets` all gate their entire response on an internal
`PropertiesFunction` only being set when a properties function with a specific name (`azure`/`ibm`/
`gcp`) is registered on the properties component — their tests cover the "not registered" empty-
response shape, matching the existing `hashicorp-secrets` test's approach.

`kubernetes-secrets` preserves the same pre-existing bug as its sibling `kubernetes-configmaps`:
unconditionally dereferencing the Kubernetes vault configuration's secrets list, NPE-ing when no
such configuration is present — its test is likewise limited to console registration.

`opentelemetry`'s routeId-propagation logic (a span gets its containing route's id either directly
from its own attributes, or by inheriting from the nearest ancestor span that has one) is
restructured from two passes that mutated `JsonObject`s in place into two passes over immutable
data, since a `record` can't be mutated after construction — output is unchanged.

`source-dir` (`camel-jbang-console`) has no test infrastructure at all, same as its sibling `jbang`
console migrated earlier in this PR, so no test was added for it either.

`aws-secrets` follows the same `PropertiesFunction`-gated shape as `azure-secrets`/`ibm-secrets`/
`gcp-secrets`, tested the same way.

`quartz` preserves two pre-existing quirks exactly as before: the `jpbStoreClass`/
`jpbStoreClustered`/`jpbStoreSupportsPersistence` field name typo, and a bug where a trigger's
`uri` is only populated when `cron` is non-null rather than when `uri` itself is. Its "scheduled
triggers" `routeId` field is also always `null` today, since no producer/endpoint code in this
component ever populates that `JobDataMap` key — the migration surfaces this pre-existing gap
rather than papering over it with a differently-shaped test.

`jfr` is the most involved of this batch (originally 504 lines, five sub-commands: status/enable/
disable/jfc/snapshot), modeled as one `Response` record with nullable fields per command — the
same "unified superset" pattern used for `debug`/`trace`/`processor-detail` earlier in this PR.
Its existing 18-test suite (`CamelJfrDevConsoleTest`, covering every command and several error
paths) continues to pass completely unchanged, which is the strongest signal available that the
refactor preserved behavior exactly. Unlike `jfr-memory-leak` (still permanently out of scope,
see below), `jfr`'s state is a handful of named fields per command rather than deeply dynamic
reflection-built structures, so the record refactor was proportionate here.

While regenerating the catalog for the `jbang` console, found and fixed two compounding,
pre-existing bugs in `PrepareCatalogMojo`/`MojoHelper` that silently dropped every dev console
under `dsl/camel-jbang/*` (e.g. `jbang`, `source-dir`) from the catalog and its OpenAPI aggregate,
regardless of build order: `MojoHelper.getComponentPath()` had no case for the `camel-jbang`
parent folder (its actual dev console lives one level deeper, in
`dsl/camel-jbang/camel-jbang-console` — same pattern as the existing `camel-cxf`/`camel-azure`
cases), and `PrepareCatalogMojo`'s dsl-dir scan only registered discovered models into its lookup
map when they were `OtherModel`, silently excluding every `DevConsoleModel` a step later. Fixed
in a standalone commit, verified by confirming `jbang`/`source-dir`/`dependency-downloader` now
appear in the regenerated catalog (`source-dir` itself was migrated to a typed record later in
this same PR).

With this batch, every dev console in the repository now has an authoritative typed response
record, with the sole exception of the 2 consoles in `core/camel-console` documented above as
permanently out of scope (`api`, `jfr-memory-leak`) for structural reasons unrelated to effort.

## Revisiting `variables`

`variables` was reconsidered after the rest of the rollout completed. Its actual per-entry shape
was already fixed-field (`{key, type, value}`) — the only dynamic part was that each
`BrowsableVariableRepository`'s id became a *top-level JSON key* (`{"global": [...], "route":
[...]}`), which is what didn't fit a record. Moving the id from being a key to being a field
solves this: `Response(List<RepositoryEntry> repositories)` where `RepositoryEntry(String id,
List<VariableEntry> variables)`. This is a genuine, deliberate **wire format change** (not just an
internal refactor) — a repository is no longer addressable as a top-level key, it's an entry in
the `repositories` array instead. Before making the change, checked whether anything actually
depends on the old shape:
- `VariablesDevConsoleTest` only asserted the JSON output was non-empty, not its key structure —
  safe. Strengthened it to assert on the new shape directly.
- The only real consumer in the repo is `dsl/camel-jbang/camel-jbang-core`'s `ListVariable`
  command (`camel get variable`), which read the console's JSON straight out of the CLI-connector
  status file assuming dynamic top-level keys. Updated it (and its test fixture) to read
  `{"repositories":[{"id":...,"variables":[...]}]}` instead.
- `LocalCliConnector` (the CLI-connector) stores this console's JSON into the status file
  *verbatim*, without interpreting its structure — needed no change.
- Nothing in the TUI (`camel-jbang-plugin-tui`) reads this console's output at all — the TUI's
  "variables" references are all about unrelated exchange-variable tracing in message history, not
  this console.

Since `variables` was the only remaining dynamic-top-level-key console in `core/camel-console`
(none of the other 51 migrated consoles had this shape), this closed out the dynamic-key category
entirely.

## Revisiting `jfr-memory-leak`

`jfr-memory-leak` was reconsidered next, once it became the only unmigrated console left. Unlike
`variables`, its shape has no dynamic keys anywhere — every field name (`samples`, `comparisons`,
`referenceChain`, `stackTrace`, `baseline`, `current`, etc.) is static — so this migration needed
**no wire format change at all**, just an internal refactor to build the same JSON through typed
records instead of hand-built `JsonObject`s.

The real complexity wasn't the JSON building (mechanical, same as every other console in this PR)
but that the console caches parsed recording results **as mutable state** across calls
(`cachedResults`/`previousResults`, read by `stop`/`query`/`compare`), and used `JsonObject`'s
copy-constructor and `.remove()` to build filtered views of that cache. This is restructured as:
- A private `RecordingSnapshot` record holds the cached parse result (`samples`, `sampleCount`,
  `rawSampleCount`, `gcCount`, `recordingDurationMs`, `recordingEndTime`) instead of a `JsonObject`.
- `applyFilters` now builds a *new* filtered `RecordingSnapshot` (stream-filter over
  `List<SampleEntry>`) instead of copying and mutating a `JsonObject`.
- The per-class/stack-fingerprint aggregation in `parseRecordingFile` uses a small mutable
  `SampleAccumulator` class during the scan (count, running total size, max object age), then
  converts to immutable `SampleEntry` records at the end — the same accumulate-then-convert pattern
  already used for `DurationStats` in the `camel-jfr` console migrated earlier in this PR.
- The five commands share one large "unified superset" `Response` record (19 nullable fields) via
  small private factory methods (`errorResponse`, `snapshotResponse`, `compareResponse`, etc.) that
  keep each command's construction call readable instead of inlining a 19-argument constructor call
  everywhere.

Before making this change, traced every consumer of this console's JSON to confirm the identical
field names/nullability semantics carry over exactly:
- The TUI's `MemoryLeakTab` (`camel-jbang-plugin-tui`) and the CLI's `CamelMemoryLeak` command
  (`camel-jbang-core`) both read this console's JSON via hardcoded field names, almost entirely
  through `getXxxOrDefault(...)` accessors (safe against a field being absent) or explicit
  `containsKey(...)` guards for a few fields (`durationSeconds`, `note`, `elapsedMs`,
  `remainingMs`). The console never explicitly emits an explicit JSON `null` for any field — every
  field is conditionally `put()` only when applicable — so `JsonRecordSupport`'s "omit null
  components" behavior reproduces the exact same presence/absence semantics these `containsKey`
  guards depend on.
- `LocalCliConnector.doActionJfrMemoryLeakTask` stores this console's `doCallJson()` output
  verbatim into the CLI-connector status file, same as `variables` — no interpretation, no change
  needed.
- The MCP tool (`camel-jbang-mcp`'s `RuntimeTools.camel_runtime_memory_leak`) only inspects the
  `status` field for control flow and returns the rest of the JSON opaquely to the caller — also
  unaffected.

No test existed for this console before (JFR old-object-sample events are inherently
GC-timing-dependent and not reliably triggerable on demand), so a new
`JfrMemoryLeakDevConsoleTest` was added covering the full start/status/stop/query/compare lifecycle
and error paths (double-start, stop-without-recording, compare-without-two-recordings, unknown
command) — everything reliably testable without depending on an actual leak being sampled.

With this, the rollout is complete everywhere except `api`, whose response is the OpenAPI schema
generator itself and is not a fixed shape by design.

**New infrastructure** (none of this existed before):
- `JsonRecordSupport` (new, `tooling/camel-util-json`) — generic reflective `record → JsonObject`
  converter. Null components are omitted, matching every console's existing
  `if (x != null) put(...)` convention.
- `GenerateDevConsoleMojo.buildResponseSchema` (new, `tooling/maven/camel-package-maven-plugin`) —
  generic reflective `record class → JSON Schema` generator, reading `@Metadata(description=...)`
  off record components (works out of the box — `@Metadata`'s `@Target` already includes `FIELD`,
  which record components propagate to). Emits a new `"response"` key into each migrated console's
  generated `dev-console/<id>.json`, sibling to `"options"`. `Map<String,X>` fields now emit a real
  `additionalProperties` schema for `X` instead of a blanket `true`, except when `X` is
  `java.lang.Object` (kept as `true`, genuinely heterogeneous); a bare `Object`-typed field now
  generates an unconstrained (empty) schema instead of a misleading `"type":"object"`.
- `DevConsoleModel` (`camel-tooling-model`) gains a `responseSchema` field, wired through
  `JsonMapper`, consumed by `DevConsoleOpenApiHelper.buildPathItem()` — which now populates the
  OpenAPI response schema instead of the empty placeholder, for **both** the live `api` console and
  the static `dev-consoles-openapi.json` catalog artifact, with zero extra code needed in
  `ApiDevConsole` (it already parses the same catalog schema, from CAMEL-24564).

## Test plan

- [x] `tooling/camel-util-json`: `mvn verify` — `JsonRecordSupportTest` (flat record, nested
      record, `List<record>`, null omission, `Map<String,String>` field) pass.
- [x] `tooling/maven/camel-package-maven-plugin`: `GenerateDevConsoleMojoResponseSchemaTest`
      unit-tests `buildResponseSchema` directly (type mapping, nested object, array-of-object,
      required-vs-optional, typed/opaque `additionalProperties` for maps, unconstrained schema for
      bare `Object`) pass; module builds clean.
- [x] `tooling/camel-tooling-model`: `mvn verify` pass, including `DevConsoleOpenApiHelperTest`
      cases for a model carrying a `responseSchema`.
- [x] `core/camel-console`: `mvn verify` pass. New consoles get new tests; `consumer`/`producer`/
      `processor-detail`/`source`/`route-dump` are JMX-mbean driven and this module has no
      `camel-management` test dependency, so their tests are limited to verifying console
      registration/basic shape (calling `producer` would hit an unrelated, pre-existing NPE gap when
      no management agent is present — not something this migration should fix). Similarly `sql-trace`
      only records statements sent to a real `sql:`/`jdbc:` endpoint, unavailable without
      camel-sql/camel-jdbc, so its test verifies the empty-ring-buffer shape only.
- [x] `catalog/camel-catalog`: `mvn verify` pass. Regenerated `dev-consoles-openapi.json` shows real
      response schemas for all 53 migrated consoles and the empty placeholder for the 1 remaining
      skipped console; `devConsolesOpenApiSpec()` test now checks `api` (permanently skipped,
      GET-only) as the "not yet migrated" example instead of `variables`/`jfr-memory-leak`, since
      both are migrated now. This regeneration also caught up several previously migrated consoles'
      catalog resources that had drifted out of sync with `core/camel-console`.
- [x] `core/camel-console`: `VariablesDevConsoleTest` updated to assert on the new
      `{"repositories":[{"id":...,"variables":[...]}]}` shape directly (repository id, variable
      key/value pairs), not just non-emptiness. New `JfrMemoryLeakDevConsoleTest` (7 tests) covers
      the full start/status/stop/query/compare lifecycle and error paths. Full module `mvn verify`
      re-run clean.
- [x] `dsl/camel-jbang/camel-jbang-core`: `mvn verify` pass. `ListVariableTest`'s status-file
      fixture updated to the new nested shape; full `process` command test package re-run clean.
- [x] `components/camel-ftp`, `components/camel-hashicorp-vault`, `components/camel-platform-http-main`,
      `core/camel-main`, `dsl/camel-kamelet-main`, `components/camel-aws/camel-aws2-s3`,
      `components/camel-groovy`, `components/camel-microprofile/camel-microprofile-fault-tolerance`,
      `components/camel-kubernetes`, `catalog/camel-catalog-console`, `core/camel-core-model`,
      `components/camel-azure/camel-azure-key-vault`, `components/camel-ibm/camel-ibm-secrets-manager`,
      `components/camel-google/camel-google-secret-manager`, `components/camel-vertx/camel-vertx-websocket`,
      `components/camel-stub`, `components/camel-diagram`, `components/camel-platform-http`,
      `components/camel-resilience4j`, `components/camel-kafka`, `components/camel-opentelemetry2`,
      `components/camel-micrometer`, `components/camel-aws/camel-aws-secrets-manager`,
      `components/camel-quartz`, `components/camel-jfr`: `mvn verify` pass with new tests per
      console (some limited to the no-service-registered shape when spinning up a real backing
      service — MainHttpServer, MavenDependencyDownloader — is out of scope for a unit test;
      `kubernetes-configmaps`, `kubernetes-secrets`, `catalog`, `bean-model`, and `stub` are
      limited/absent per the notes above). `route-diagram`'s existing 6-test suite and `jfr`'s
      existing 18-test suite continue to pass unchanged. `source-dir`
      (`dsl/camel-jbang/camel-jbang-console`) has no test added, per the notes above.
- [x] `mvn -Psourcecheck` clean on all touched modules.
- [x] Full-reactor `mvn clean install -DskipTests` from the repo root passes clean (no stale regen
      artifacts).

## Review feedback addressed

- `GenerateDevConsoleMojo.buildTypeSchema` now guards the fallthrough `Class<?>` cast with an
  `instanceof` check, so a `TypeVariable`/`WildcardType`/`GenericArrayType` degrades to an
  unconstrained schema instead of throwing `ClassCastException` — covered by a new test using a
  generic `Response<T>(T value)` record.
- `JsonRecordSupportTest` gains coverage for an enum-typed record component.
- `JsonRecordSupport.accessorValue`'s `setAccessible(true)` call was reviewed and kept: a record
  accessor method is always `public`, but that doesn't override the accessibility restriction of a
  **non-public declaring class** when invoked reflectively from a different package (verified with
  a standalone cross-package reflection test) — `JsonRecordSupport` is generic, reusable
  infrastructure, not scoped to public-only records.

_Claude Sonnet 5 on behalf of @davsclaus_







