### PR TITLE
CAMEL-24344/CAMEL-24345: add the 4.18.5 upgrade notes for the backported camel-google fixes

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -51,6 +51,24 @@ from("spring-redis://localhost:6379?command=SUBSCRIBE&channels=myChannel"
 Setting the `serializer` option to a custom `RedisSerializer` bypasses the filter entirely, since
 Camel then no longer controls how the payload is read.
 
+=== camel-google-mail - the raw option now returns the message
+
+The `google-mail-stream` consumer always asked the Gmail API for the `FULL` message format, but the
+`raw` field is only populated for the `RAW` format, so `raw=true` produced a `null` body. The consumer
+now requests the format that matches the option.
+
+Because the Gmail API does not return the parsed `payload` for the `RAW` format, a route running with
+`raw=true` no longer receives the `CamelGoogleMailStreamSubject`, `...From`, `...To`, `...Cc`, `...Bcc`
+and `...MessageId` headers — those values are part of the RFC 2822 content that is now in the body.
+`CamelGoogleMailStreamId`, `...ThreadId` and `...LabelIds` are still set. Routes that need the parsed
+headers should keep the default `raw=false`.
+
+=== camel-google-vertexai - the jsonMode option is now applied
+
+The option was declared and documented but never read, so it had no effect. `jsonMode=true` now sets
+the response MIME type of the request to `application/json`, so the model is asked to answer with
+JSON. The default `false` leaves the request untouched.
+
 == Upgrading from 4.18.3 to 4.18.4
 
 === camel-core - Multicast EIP honors UseOriginalAggregationStrategy


### PR DESCRIPTION
Follow-up to #25814, which backported CAMEL-24344 and CAMEL-24345 to `camel-4.18.x` and is now merged.

The upgrade guides of every release line live on `main`, so the notes describing those two changes for
4.18.5 have to be added here rather than on the branch the fixes landed on. Without this, `main`'s
`camel-4x-upgrade-guide-4_18.adoc` does not describe what actually ships in 4.18.5.

* **camel-google-mail** — with `raw=true` the consumer now asks the Gmail API for the `RAW` format, the only
  one that populates the `raw` field. The API does not return the parsed `payload` for that format, so the
  `Subject`, `From`, `To`, `Cc`, `Bcc` and `MessageId` headers stop being set; those values are part of the
  RFC 2822 content that now reaches the body. Same wording as the 4.22 entry, since it is the same change.
* **camel-google-vertexai** — only the `jsonMode` half. `camel-4.18.x` has no streaming implementation for
  `streamOutputMode` to apply to, so the backport left that option inert and the note does not mention it.

Documentation only.

---
_Claude Code on behalf of oscerd_
