### PR TITLE
CAMEL-24537: camel-openai - validate that a model is configured for chat completion

### DIFF
--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
@@ -154,6 +154,9 @@ public class OpenAIProducer extends DefaultAsyncProducer {
 
         // Resolve parameters from headers or configuration
         String model = resolveParameter(in, OpenAIConstants.MODEL, config.getModel(), String.class);
+        if (model == null) {
+            throw new IllegalArgumentException("Model must be specified via model parameter or CamelOpenAIModel header");
+        }
         Double temperature = resolveParameter(in, OpenAIConstants.TEMPERATURE, config.getTemperature(), Double.class);
         Double topP = resolveParameter(in, OpenAIConstants.TOP_P, config.getTopP(), Double.class);
         Integer maxTokens = resolveParameter(in, OpenAIConstants.MAX_TOKENS, config.getMaxTokens(), Integer.class);

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIChatCompletionMissingModelTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIChatCompletionMissingModelTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The chat-completion producer must fail with a clear error when no model is configured, matching the other producers,
+ * instead of passing null to the OpenAI client and surfacing an opaque NullPointerException.
+ */
+public class OpenAIChatCompletionMissingModelTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                // No model on the endpoint and no model header; a fake baseUrl is enough because the guard
+                // rejects the exchange before any request is sent.
+                from("direct:chat-no-model")
+                        .to("openai:chat-completion?apiKey=dummy&baseUrl=http://localhost:1/v1");
+            }
+        };
+    }
+
+    @Test
+    void missingModelReportsIllegalArgumentException() {
+        Exchange result = template.request("direct:chat-no-model", e -> e.getIn().setBody("Hello"));
+        assertThat(result.getException())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Model must be specified");
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24537](https://issues.apache.org/jira/browse/CAMEL-24537)

## Problem
`OpenAIProducer` resolves the model and passes it straight to the SDK without a null check:

```java
String model = resolveParameter(in, OpenAIConstants.MODEL, config.getModel(), String.class);
...
ChatCompletionCreateParams.builder().model(model);   // model may be null
```

When no `model` option is configured, no default is set and no `CamelOpenAIModel` header is supplied,
`model` is null and the call fails deep inside the OpenAI SDK with an opaque `NullPointerException`.

Every sibling producer already validates this — `OpenAIResponsesProducer`, the embeddings, moderation,
audio and image-support producers. The chat-completion path was the only one missing the guard.

## Fix
Add the same guard right after the model is resolved, throwing a clear `IllegalArgumentException`
("Model must be specified via model parameter or CamelOpenAIModel header"), matching the sibling
producers.

## Testing
- New `OpenAIChatCompletionMissingModelTest` sends an exchange to a chat-completion endpoint with no
  model configured and asserts the failure is an `IllegalArgumentException` with the clear message.
- `mvn -Psourcecheck validate` green.

_Claude Code on behalf of oscerd_