### PR TITLE
CAMEL-24527: camel-huggingface - apply the configured token to every task, not only chat

### DIFF
--- a/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/AbstractTaskPredictor.java
+++ b/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/AbstractTaskPredictor.java
@@ -72,7 +72,7 @@ public abstract class AbstractTaskPredictor implements TaskPredictor {
             tmpDir = Files.createTempDirectory("hf_model");
         }
         Path handlerPath = tmpDir.resolve("handler.py");
-        String pythonScript = getPythonScript();
+        String pythonScript = withAuthToken(getPythonScript());
         Files.writeString(handlerPath, pythonScript);
         Path reqPath = tmpDir.resolve("requirements.txt");
         Files.writeString(reqPath, getRequirements());
@@ -106,6 +106,22 @@ public abstract class AbstractTaskPredictor implements TaskPredictor {
     }
 
     protected abstract String getPythonScript();
+
+    /**
+     * Prepends the configured Hugging Face token to the generated handler as the {@code HF_TOKEN} environment variable
+     * so that every task can load gated or private models. {@code transformers.pipeline()} reads {@code HF_TOKEN} from
+     * the environment when no explicit token is passed; previously only the chat task passed a token, so the other
+     * tasks failed with 401 on gated models. The token comes from the {@code authToken} option or is resolved from an
+     * OAuth profile (see {@link org.apache.camel.component.huggingface.HuggingFaceProducer}), both surfaced through
+     * {@code config.getAuthToken()}.
+     */
+    protected String withAuthToken(String pythonScript) {
+        String authToken = config.getAuthToken();
+        if (authToken == null || authToken.isEmpty()) {
+            return pythonScript;
+        }
+        return "import os\nos.environ['HF_TOKEN'] = '" + authToken + "'\n\n" + pythonScript;
+    }
 
     protected String loadPythonScript(String resourcePath, Object... args) {
         InputStream is = null;

--- a/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/AbstractTaskPredictor.java
+++ b/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/AbstractTaskPredictor.java
@@ -120,7 +120,7 @@ public abstract class AbstractTaskPredictor implements TaskPredictor {
         if (authToken == null || authToken.isEmpty()) {
             return pythonScript;
         }
-        return "import os\nos.environ['HF_TOKEN'] = '" + authToken + "'\n\n" + pythonScript;
+        return "import os\nos.environ['HF_TOKEN'] = '" + authToken.replace("'", "\\'") + "'\n\n" + pythonScript;
     }
 
     protected String loadPythonScript(String resourcePath, Object... args) {

--- a/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/AbstractTaskPredictor.java
+++ b/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/AbstractTaskPredictor.java
@@ -72,13 +72,15 @@ public abstract class AbstractTaskPredictor implements TaskPredictor {
             tmpDir = Files.createTempDirectory("hf_model");
         }
         Path handlerPath = tmpDir.resolve("handler.py");
-        String pythonScript = withAuthToken(getPythonScript());
-        Files.writeString(handlerPath, pythonScript);
-        Path reqPath = tmpDir.resolve("requirements.txt");
-        Files.writeString(reqPath, getRequirements());
+        String pythonScript = getPythonScript();
+        // logged before the token is prepended: withAuthToken writes the configured token into the
+        // script, and this now runs for every task rather than only chat
         if (LOG.isDebugEnabled()) {
             LOG.debug("Generated Python script for task {}:\n{}", config.getTask(), pythonScript);
         }
+        Files.writeString(handlerPath, withAuthToken(pythonScript));
+        Path reqPath = tmpDir.resolve("requirements.txt");
+        Files.writeString(reqPath, getRequirements());
         String modelUrl = "file://" + tmpDir.toAbsolutePath();
         Criteria.Builder<Input, Output> criteriaBuilder = Criteria.builder()
                 .setTypes(Input.class, Output.class)

--- a/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/ChatPredictor.java
+++ b/components/camel-ai/camel-huggingface/src/main/java/org/apache/camel/component/huggingface/tasks/ChatPredictor.java
@@ -110,10 +110,10 @@ public class ChatPredictor extends AbstractTaskPredictor {
     protected String getPythonScript() {
         String doSample = config.getTemperature() > 0 ? "True" : "False";
         float temperature = config.getTemperature() > 0 ? config.getTemperature() : 1.0f;
-        String tokenClause = config.getAuthToken() != null ? ", token='" + config.getAuthToken() + "'" : "";
-        return loadPythonScript("chat.py", config.getModelId(), config.getRevision(), config.getDevice(), tokenClause,
-                config.getMaxTokens(),
-                doSample, temperature);
+        // The token is applied centrally as the HF_TOKEN environment variable in
+        // AbstractTaskPredictor.withAuthToken, so no per-task token clause is needed here.
+        return loadPythonScript("chat.py", config.getModelId(), config.getRevision(), config.getDevice(),
+                config.getMaxTokens(), doSample, temperature);
     }
 
     @Override

--- a/components/camel-ai/camel-huggingface/src/main/resources/org/apache/camel/component/huggingface/tasks/chat.py
+++ b/components/camel-ai/camel-huggingface/src/main/resources/org/apache/camel/component/huggingface/tasks/chat.py
@@ -28,7 +28,7 @@ def handle(inputs: Input):
     try:
         if not pipe:
             logging.debug("Initializing pipeline")
-            pipe = pipeline(task='text-generation', model='%s', revision='%s', device_map='%s'%s)
+            pipe = pipeline(task='text-generation', model='%s', revision='%s', device_map='%s')
             logging.debug("Pipeline initialized")
 
         if inputs.content.size() == 0:

--- a/components/camel-ai/camel-huggingface/src/test/java/org/apache/camel/component/huggingface/tasks/AuthTokenInjectionTest.java
+++ b/components/camel-ai/camel-huggingface/src/test/java/org/apache/camel/component/huggingface/tasks/AuthTokenInjectionTest.java
@@ -46,5 +46,13 @@ class AuthTokenInjectionTest {
     @Test
     void noAuthTokenLeavesTheScriptUnchanged() {
         assertEquals("PIPELINE", predictorWithToken(null).withAuthToken("PIPELINE"));
+        assertEquals("PIPELINE", predictorWithToken("").withAuthToken("PIPELINE"));
+    }
+
+    @Test
+    void authTokenWithASingleQuoteIsEscaped() {
+        String result = predictorWithToken("ab'cd").withAuthToken("PIPELINE");
+        assertTrue(result.contains("os.environ['HF_TOKEN'] = 'ab\\'cd'"),
+                "a single quote in the token must be escaped so it cannot break the Python string literal");
     }
 }

--- a/components/camel-ai/camel-huggingface/src/test/java/org/apache/camel/component/huggingface/tasks/AuthTokenInjectionTest.java
+++ b/components/camel-ai/camel-huggingface/src/test/java/org/apache/camel/component/huggingface/tasks/AuthTokenInjectionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.huggingface.tasks;
+
+import org.apache.camel.component.huggingface.HuggingFaceConfiguration;
+import org.apache.camel.component.huggingface.HuggingFaceEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The configured Hugging Face token must be applied for every task, not only chat, so that gated or private models can
+ * be loaded. The token is injected centrally as the HF_TOKEN environment variable of the generated handler.
+ */
+class AuthTokenInjectionTest {
+
+    private TextGenerationPredictor predictorWithToken(String token) {
+        HuggingFaceConfiguration config = new HuggingFaceConfiguration();
+        config.setAuthToken(token);
+        return new TextGenerationPredictor(new HuggingFaceEndpoint(null, null, config));
+    }
+
+    @Test
+    void authTokenIsExposedAsHfTokenEnvForEveryTask() {
+        String result = predictorWithToken("hf_secret123").withAuthToken("PIPELINE");
+        assertTrue(result.contains("os.environ['HF_TOKEN'] = 'hf_secret123'"),
+                "generated script should export the token as HF_TOKEN");
+        assertTrue(result.endsWith("PIPELINE"), "the original task script must be preserved");
+    }
+
+    @Test
+    void noAuthTokenLeavesTheScriptUnchanged() {
+        assertEquals("PIPELINE", predictorWithToken(null).withAuthToken("PIPELINE"));
+    }
+}

--- a/components/camel-ai/camel-huggingface/src/test/java/org/apache/camel/component/huggingface/tasks/ChatScriptFormatTest.java
+++ b/components/camel-ai/camel-huggingface/src/test/java/org/apache/camel/component/huggingface/tasks/ChatScriptFormatTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.huggingface.tasks;
+
+import org.apache.camel.component.huggingface.HuggingFaceConfiguration;
+import org.apache.camel.component.huggingface.HuggingFaceEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the chat.py template's format-argument alignment after the per-task token clause was removed (the token is now
+ * applied centrally as HF_TOKEN). A misaligned placeholder would make getPythonScript throw.
+ */
+class ChatScriptFormatTest {
+
+    private DefaultCamelContext context;
+
+    @BeforeEach
+    void setUp() {
+        context = new DefaultCamelContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    @Test
+    void chatScriptFormatsAndCarriesNoTokenClause() {
+        HuggingFaceConfiguration config = new HuggingFaceConfiguration();
+        config.setModelId("gpt2");
+        HuggingFaceEndpoint endpoint = new HuggingFaceEndpoint(null, null, config);
+        endpoint.setCamelContext(context);
+
+        String script = new ChatPredictor(endpoint).getPythonScript();
+
+        assertTrue(script.contains("pipeline(task='text-generation'"), "the chat pipeline call must be rendered");
+        assertTrue(script.contains("model='gpt2'"), "the configured model must be interpolated");
+        assertFalse(script.contains("token="), "the per-task token clause must be gone (token is applied via HF_TOKEN)");
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24527](https://issues.apache.org/jira/browse/CAMEL-24527)

## Problem
The `authToken` option (and the token resolved from `oauthProfile`) was honoured by **only** the chat
task. `ChatPredictor.getPythonScript()` builds a `token='...'` clause and passes it to
`transformers.pipeline()`; none of the other nine task predictors do. As a result, text generation,
summarization, question answering, classification, sentence embeddings, ASR, TTS, text-to-image and
zero-shot classification all failed with HTTP 401 when loading a gated or private model, even with a
token configured.

## Fix
Apply the token centrally in `AbstractTaskPredictor.loadModel()` by exporting it as the standard
`HF_TOKEN` environment variable at the top of the generated handler script:

```python
import os
os.environ['HF_TOKEN'] = '<token>'
```

`transformers` / `huggingface_hub` read `HF_TOKEN` from the environment when no explicit token is
passed, so this authenticates **every** task in a single place instead of threading a token clause
through nine predictors and nine Python templates. The token is read from `config.getAuthToken()`,
which holds either the `authToken` option or the value resolved from an OAuth profile
(`HuggingFaceProducer.resolveOAuthToken`). When no token is configured, the script is unchanged.

## Testing
- New `AuthTokenInjectionTest` verifies the token is exported as `HF_TOKEN` when configured and that
  the script is left untouched when it is not.
- `mvn -Psourcecheck validate` green.

_Claude Code on behalf of oscerd_