### PR TITLE
chore: bump mvnd install version to 1.0.6

### DIFF
--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -21,7 +21,7 @@ inputs:
   version:
     description: 'The version of the maven daemon to install'
     required: true
-    default: '1.0.5'
+    default: '1.0.6'
   distribution:
     description: 'The maven distribution to use'
     required: true


### PR DESCRIPTION
## Backport of #25888

Cherry-pick of #25888 onto `camel-4.18.x`.

**Original PR:** #25888 - chore: bump mvnd install version to 1.0.6
**Original author:** @davsclaus
**Target branch:** `camel-4.18.x`

### Original description

mvnd 1.0.5 was pruned from `downloads.apache.org` after 1.0.6 was released, breaking CI's `install-mvnd` composite action with a 404. Bumps the action's default `version` input from `1.0.5` to `1.0.6`.

_Claude Code on behalf of davsclaus_