### PR TITLE
chore: camel-smb - fix SmbConsumerStartingDirectoryMustExistIT for route-start exception wrapping

### DIFF
--- a/components/camel-smb/pom.xml
+++ b/components/camel-smb/pom.xml
@@ -72,6 +72,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbConsumerStartingDirectoryMustExistIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbConsumerStartingDirectoryMustExistIT.java
@@ -16,10 +16,11 @@
  */
 package org.apache.camel.component.smb;
 
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.file.GenericFileOperationFailedException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SmbConsumerStartingDirectoryMustExistIT extends SmbServerTestSupport {
 
@@ -42,12 +43,10 @@ public class SmbConsumerStartingDirectoryMustExistIT extends SmbServerTestSuppor
                 from(getSbmUrl()).to("mock:result");
             }
         });
-        try {
-            context.start();
-            Assertions.fail();
-        } catch (GenericFileOperationFailedException e) {
-            Assertions.assertEquals("Starting directory does not exist: doesnotexist", e.getMessage());
-        }
+
+        assertThatThrownBy(context::start)
+                .isInstanceOf(FailedToStartRouteException.class)
+                .cause().hasMessage("Starting directory does not exist: doesnotexist");
     }
 
 }


### PR DESCRIPTION
## Summary

`SmbConsumerStartingDirectoryMustExistIT.testStartingDirectoryMustExist` has been failing on `main` since CAMEL-24404 (#25554) merged. That change made `InternalRouteStartupManager.doStartOrResumeRouteConsumers()` always wrap consumer startup failures in `FailedToStartRouteException`.

This test still did:

```java
try {
    context.start();
    Assertions.fail();
} catch (GenericFileOperationFailedException e) {
    ...
}
```

Since `context.start()` now throws `FailedToStartRouteException` (wrapping the original `GenericFileOperationFailedException` as its cause), the `catch` clause no longer matched, so the exception propagated uncaught and the test failed with an error on every run — spotted as a CI failure on an unrelated PR (#25892).

`#25554` already updated 7 other modules for this same wrapping change (`DefaultSupervisingRouteControllerTest`, `MainSupervisingRouteControllerTest`, `AiToolEndpointLifecycleTest`, etc.) but missed this SMB test since it lives outside that PR's scope.

## Fix

Rewritten with AssertJ's `assertThatThrownBy`, asserting `FailedToStartRouteException` as the outer type and checking the original message via `.cause()`, matching the pattern used for the other tests updated by CAMEL-24404. `assertj-core` was added as a test dependency to `camel-smb/pom.xml` (version centrally managed in the parent POM) since it wasn't previously present in this module.

I checked the rest of `camel-smb`'s tests for the same `try { context.start(); fail(); } catch (...)` pattern — this was the only one affected.

## Test plan

- [x] `mvn -o compile test-compile` in `components/camel-smb` — compiles clean
- [x] `mvn -o verify -Dit.test=SmbConsumerStartingDirectoryMustExistIT` — passes
- [x] `mvn formatter:format impsort:sort` — no changes needed

_Claude Code on behalf of davsclaus_