### PR TITLE
chore: camel-grpc - fix RouteControlledStreamObserverTest for route-start exception wrapping

### DIFF
--- a/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
+++ b/components/camel-grpc/src/test/java/org/apache/camel/component/grpc/RouteControlledStreamObserverTest.java
@@ -26,6 +26,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
+import org.apache.camel.FailedToStartRouteException;
 import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -188,7 +189,8 @@ public class RouteControlledStreamObserverTest extends GrpcTestSupport {
                         .to("log:foo");
             }
         });
-        assertThrows(IllegalArgumentException.class, camelContext::start);
+        FailedToStartRouteException exception = assertThrows(FailedToStartRouteException.class, camelContext::start);
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
     }
 
     @Override


### PR DESCRIPTION
## Summary

`RouteControlledStreamObserverTest.unsupportedEndpointConfigurationFailureTest` started failing on `main` (seen on `BuildAndTest / Matrix - jdk_25_latest / ubuntu-avx`) since CAMEL-24404 (#25554) merged. That change made `InternalRouteStartupManager.doStartOrResumeRouteConsumers()` always wrap consumer startup failures in `FailedToStartRouteException`.

The test did:

```java
assertThrows(IllegalArgumentException.class, camelContext::start);
```

`GrpcConsumer.initializeServer()` still throws the raw `IllegalArgumentException` for the unsupported `AGGREGATION` + `routeControlledStreamObserver` combination, but `camelContext.start()` now wraps it in `FailedToStartRouteException`, so the assertion no longer matched the actual thrown type.

This is the same regression class as #25903 (fixed for `camel-smb`): #25554 updated 7 modules for this wrapping change but this gRPC test lives outside that PR's scope and was missed.

## Fix

```java
FailedToStartRouteException exception = assertThrows(FailedToStartRouteException.class, camelContext::start);
assertInstanceOf(IllegalArgumentException.class, exception.getCause());
```

This matches the pattern already used in `DefaultSupervisingRouteControllerTest` (one of the tests #25554 itself updated).

I checked the rest of `camel-grpc`'s tests for other exception assertions around `camelContext.start()` / `context.start()` — `GrpcProducerSecurityTest` also has a try/catch, but it wraps a producer call (`template.requestBody`), not route startup, so it's unaffected.

## Test plan

- [x] `mvn -o compile test-compile` in `components/camel-grpc` — compiles clean
- [x] `mvn -o test -Dtest=RouteControlledStreamObserverTest` — all 7 tests pass
- [x] `mvn formatter:format impsort:sort` — no changes needed

_Claude Code on behalf of davsclaus_