### PR TITLE
CAMEL-24557: Remove stale langchain4j-tools from AI observability docs

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
@@ -23,7 +23,7 @@ Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when
 via `camel.aiObservability.enabled` in application.properties or programmatically with
 `main.configure().aiObservability().withEnabled(false)`.
 
-Phase 1 coverage: `langchain4j-chat`, `langchain4j-tools`, `langchain4j-agent`, `langchain4j-embeddings`,
+Phase 1 coverage: `langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`,
 and `openai`.
 
 Phase 3 coverage: `spring-ai-chat`.
@@ -37,7 +37,6 @@ component when GenAI observability is enabled so model metadata is always popula
 New exchange headers for model identification on langchain4j components:
 
 * `CamelLangChain4jChatRequestModel` / `CamelLangChain4jChatResponseModel`
-* `CamelLangChain4jToolsRequestModel` / `CamelLangChain4jToolsResponseModel`
 * `CamelLangChain4jAgentRequestModel` / `CamelLangChain4jAgentResponseModel`
 * `CamelLangChain4jEmbeddingsRequestModel` / `CamelLangChain4jEmbeddingsResponseModel`
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
@@ -23,10 +23,7 @@ Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when
 via `camel.aiObservability.enabled` in application.properties or programmatically with
 `main.configure().aiObservability().withEnabled(false)`.
 
-Phase 1 coverage: `langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`,
-and `openai`.
-
-Phase 3 coverage: `spring-ai-chat`.
+Supported producers: `langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`, `openai`, and `spring-ai-chat`.
 
 When using `spring-ai-chat` with only a pre-built `chatClient` (no `chatModel` on the endpoint), Camel attempts to read
 the backing Spring AI `ChatModel` via a private field on Spring AI's internal `ChatClientRequestSpec` implementation.
@@ -76,7 +73,7 @@ Low-cardinality keys: `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.
 `camel.component`, and `error.type` on failure. Prompts, completions, and token counts are not used
 as Observation keys.
 
-== Camel TUI integration (Phase 2)
+== Camel TUI integration
 
 When monitoring a running integration with `camel tui` and observability enabled, the AI panel usage view
 (*Ctrl+U* while the AI panel is open) combines:

--- a/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
+++ b/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
@@ -23,7 +23,7 @@ Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when
 via `camel.aiObservability.enabled` in application.properties or programmatically with
 `main.configure().aiObservability().withEnabled(false)`.
 
-Phase 1 coverage: `langchain4j-chat`, `langchain4j-tools`, `langchain4j-agent`, `langchain4j-embeddings`,
+Phase 1 coverage: `langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`,
 and `openai`.
 
 Phase 3 coverage: `spring-ai-chat`.
@@ -37,7 +37,6 @@ component when GenAI observability is enabled so model metadata is always popula
 New exchange headers for model identification on langchain4j components:
 
 * `CamelLangChain4jChatRequestModel` / `CamelLangChain4jChatResponseModel`
-* `CamelLangChain4jToolsRequestModel` / `CamelLangChain4jToolsResponseModel`
 * `CamelLangChain4jAgentRequestModel` / `CamelLangChain4jAgentResponseModel`
 * `CamelLangChain4jEmbeddingsRequestModel` / `CamelLangChain4jEmbeddingsResponseModel`
 

--- a/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
+++ b/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
@@ -23,10 +23,7 @@ Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when
 via `camel.aiObservability.enabled` in application.properties or programmatically with
 `main.configure().aiObservability().withEnabled(false)`.
 
-Phase 1 coverage: `langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`,
-and `openai`.
-
-Phase 3 coverage: `spring-ai-chat`.
+Supported producers: `langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`, `openai`, and `spring-ai-chat`.
 
 When using `spring-ai-chat` with only a pre-built `chatClient` (no `chatModel` on the endpoint), Camel attempts to read
 the backing Spring AI `ChatModel` via a private field on Spring AI's internal `ChatClientRequestSpec` implementation.
@@ -76,7 +73,7 @@ Low-cardinality keys: `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.
 `camel.component`, and `error.type` on failure. Prompts, completions, and token counts are not used
 as Observation keys.
 
-== Camel TUI integration (Phase 2)
+== Camel TUI integration
 
 When monitoring a running integration with `camel tui` and observability enabled, the AI panel usage view
 (*Ctrl+U* while the AI panel is open) combines:

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -250,12 +250,10 @@ unchanged and still does not permit any of the ranges above.
 
 === camel-ai-observability (GenAI observability)
 
-LangChain4j and OpenAI producers now emit GenAI observability data (OpenTelemetry span attributes and
+LangChain4j, OpenAI, and Spring AI chat (`spring-ai-chat`) producers now emit GenAI observability data (OpenTelemetry span attributes and
 Micrometer metrics) when `camel-opentelemetry2` and/or `camel-micrometer` is on the classpath.
 Disable globally with `camel.aiObservability.enabled=false` (default is enabled). Camel Main also
 exposes the same setting via `main.configure().aiObservability().withEnabled(false)`.
-
-Spring AI chat (`spring-ai-chat`) producers emit the same GenAI spans and metrics in Phase 3.
 
 When a non-NOOP `ObservationRegistry` is bound in the Camel registry, GenAI client calls are recorded
 as Micrometer Observations (`gen_ai.client.operation`). Camel then skips the `camel-telemetry` CLIENT


### PR DESCRIPTION
## Summary

Updates GenAI observability documentation for Camel 4.23 now that all rollout phases are complete and `camel-langchain4j-tools` has been removed.

## Changes

- **ai-observability.adoc**: remove stale `langchain4j-tools` references; replace phased coverage lists with a single supported-producers section; drop phase numbering from Camel TUI heading
- **catalog** `ai-observability.adoc` (generated): regenerated to match source
- **upgrade guide 4.23**: list `spring-ai-chat` alongside LangChain4j and OpenAI without phase references

## Supported producers (current)

`langchain4j-chat`, `langchain4j-agent`, `langchain4j-embeddings`, `openai`, and `spring-ai-chat`

## JIRA

https://issues.apache.org/jira/browse/CAMEL-24557

_AI-generated on behalf of atiaomar1978-hub_