### PR TITLE
chore: regenerate catalog docs for structured_error_exchange_properties anchor fix

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-agent-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-agent-component.adoc
@@ -1178,7 +1178,6 @@ You can also define the `ResponseFormat` at the `ChatModel` level. See the https
 * The same schema file can be shared across `camel-openai` and `camel-langchain4j-agent` components
 ====
 
-[[structured_error_exchange_properties]]
 === Structured error exchange properties
 
 When a LangChain4j agent call fails, Camel sets structured metadata on the exchange **before** the model exception propagates. This works even when GenAI observability is disabled.

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-embeddings-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/langchain4j-embeddings-component.adoc
@@ -395,7 +395,6 @@ YAML::
 ----
 ====
 
-[[structured_error_exchange_properties]]
 === Structured error exchange properties
 
 When a LangChain4j embeddings call fails, Camel sets structured metadata on the exchange **before** the model exception propagates. This works even when GenAI observability is disabled.

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-ai-chat-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/spring-ai-chat-component.adoc
@@ -1407,7 +1407,6 @@ The component automatically adds Spring AI's `SimpleLoggerAdvisor` to log reques
 logging.level.org.springframework.ai.chat.client.advisor=DEBUG
 ----
 
-[[structured_error_exchange_properties]]
 === Structured error exchange properties
 
 When a Spring AI chat call fails, Camel sets structured metadata on the exchange **before** the Spring AI exception propagates. This works even when GenAI observability is disabled.


### PR DESCRIPTION
## Summary
- Follow-up to 767b01c1e45b, which removed the explicit `[[structured_error_exchange_properties]]` anchor from the `langchain4j-agent`, `langchain4j-embeddings`, and `spring-ai-chat` source docs but missed regenerating the corresponding `catalog/camel-catalog` generated resources.
- That left the generated catalog docs out of sync with source, breaking the "Fail if there are uncommitted changes" CI check on every subsequent PR (surfaced while reviewing #25900).
- This just removes the same anchor line from the 3 generated copies to match source — no other content changes.

## Test plan
- [x] Diffed each generated file against its `src/main/docs` source — confirmed the anchor line was the only difference
- [x] `git diff` matches exactly the diff CI reported as "uncommitted changes"

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)