### PR TITLE
chore: use dynamic port in CXF security tests

### DIFF
--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/security/GreeterClientCxfMessageTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/security/GreeterClientCxfMessageTest.java
@@ -17,13 +17,10 @@
 package org.apache.camel.itest.security;
 
 import org.apache.camel.test.spring.junit6.CamelSpringTest;
-import org.junit.jupiter.api.condition.EnabledIf;
 import org.springframework.test.context.ContextConfiguration;
 
 @CamelSpringTest
 @ContextConfiguration(locations = { "CxfMessageCamelContext.xml" })
-@EnabledIf(value = "org.apache.camel.itest.security.GreeterClientTest#isPortAvailable",
-           disabledReason = "This test uses a fixed port that may not be available on certain hosts")
 public class GreeterClientCxfMessageTest extends GreeterClientTest {
 
 }

--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/security/GreeterClientTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/security/GreeterClientTest.java
@@ -36,7 +36,7 @@ import org.apache.hello_world_soap_http.Greeter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -46,12 +46,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @CamelSpringTest
 @ContextConfiguration(locations = { "camel-context.xml" })
-@EnabledIf(value = "org.apache.camel.itest.security.GreeterClientTest#isPortAvailable",
-           disabledReason = "This test uses a fixed port that may not be available on certain hosts")
 public class GreeterClientTest {
+    @RegisterExtension
+    static AvailablePortFinder.Port port = AvailablePortFinder.find();
+
     private static final URL WSDL_LOC;
     static {
         WSDL_LOC = GreeterClientTest.class.getClassLoader().getResource("wsdl/hello_world.wsdl");
+        System.setProperty("GreeterClientTest.port", port.toString());
     }
     private static final QName SERVICE_QNAME = new QName("http://apache.org/hello_world_soap_http", "SOAPService");
 
@@ -74,7 +76,10 @@ public class GreeterClientTest {
         WSS4JOutInterceptor wss4jOut = new WSS4JOutInterceptor(props);
 
         client.getOutInterceptors().add(wss4jOut);
-        ((BindingProvider) greeter).getRequestContext().put("password", password);
+        Map<String, Object> requestContext = ((BindingProvider) greeter).getRequestContext();
+        requestContext.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
+                "http://localhost:" + port + "/SoapContext/SoapPort");
+        requestContext.put("password", password);
 
         return greeter.greetMe(message);
     }
@@ -124,12 +129,4 @@ public class GreeterClientTest {
         }
     }
 
-    public static boolean isPortAvailable() {
-        try {
-            AvailablePortFinder.probePort(9000);
-            return true;
-        } catch (IllegalStateException e) {
-            return false;
-        }
-    }
 }

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/security/CxfMessageCamelContext.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/security/CxfMessageCamelContext.xml
@@ -31,6 +31,8 @@
     <!-- import the spring security configuration  -->
     <import resource="classpath:org/apache/camel/itest/security/commonSecurity.xml"/>
 
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
+
     <authorizationPolicy id="admin" access="ROLE_ADMIN"
                          authenticationAdapter="myAuthenticationAdapter"
                          authenticationManager="authenticationManager"
@@ -62,7 +64,7 @@
     	endpointName="s:SoapOverHttp"
     	serviceName="s:SOAPService"
     	xmlns:s="http://apache.org/hello_world_soap_http"
-        address="http://localhost:9000/SoapContext/SoapPort">
+        address="http://localhost:${GreeterClientTest.port}/SoapContext/SoapPort">
         <cxf:inInterceptors>
             <ref bean="UsernameToken_Request"/>
         </cxf:inInterceptors>

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/security/camel-context.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/security/camel-context.xml
@@ -31,6 +31,8 @@
     <!-- import the spring security configuration  -->
     <import resource="classpath:org/apache/camel/itest/security/commonSecurity.xml"/>
 
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
+
     <authorizationPolicy id="admin"
                          authenticationAdapter="myAuthenticationAdapter"
                          authenticationManager="authenticationManager"
@@ -62,7 +64,7 @@
     	endpointName="s:SoapOverHttp"
     	serviceName="s:SOAPService"
     	xmlns:s="http://apache.org/hello_world_soap_http"
-        address="http://localhost:9000/SoapContext/SoapPort">
+        address="http://localhost:${GreeterClientTest.port}/SoapContext/SoapPort">
         <cxf:inInterceptors>
             <ref bean="UsernameToken_Request"/>
             <!-- bean class="org.apache.cxf.binding.soap.saaj.SAAJInInterceptor"/-->


### PR DESCRIPTION
The CXF security integration tests still bind to port 9000 and skip when it is unavailable. Use `AvailablePortFinder` to reserve a dynamic port, pass it into both Spring contexts, and override the WSDL-derived client address.

Tests:
- `mvn -Dtest=GreeterClientTest,GreeterClientCxfMessageTest test`
- same focused tests while port 9000 was occupied
- `mvn test` in `tests/camel-itest` (62 tests, 0 failures)

_Codex on behalf of Croway_