### PR TITLE
[JBANG-IT] Add cleanups for tests that can produce state leaks

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelConfigITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelConfigITCase.java
@@ -17,9 +17,17 @@
 package org.apache.camel.dsl.jbang.it;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class CamelConfigITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void resetConfig() {
+        execute("config unset runtime");
+        execute("config unset gav");
+        execute("config unset directory");
+    }
 
     @Test
     public void testCamelSetAndGetConfig() {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelDebugITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelDebugITCase.java
@@ -19,12 +19,14 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
+@Tag("container-only")
 public class CamelDebugITCase extends JBangTestSupport {
     @Test
     public void testDebug() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelGetITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelGetITCase.java
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -26,6 +27,11 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
 public class CamelGetITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testGetContext() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelLogITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelLogITCase.java
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -26,6 +27,11 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
 public class CamelLogITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testLogCommand() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTopITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTopITCase.java
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -26,6 +27,11 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
 public class CamelTopITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testTop() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTraceITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelTraceITCase.java
@@ -19,6 +19,7 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -26,6 +27,11 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
 public class CamelTraceITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testTrace() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdGroupITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdGroupITCase.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.InVersion;
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -27,6 +28,11 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
 public class CmdGroupITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     @InVersion(from = "4.14.00")

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdLoadITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdLoadITCase.java
@@ -19,9 +19,16 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class CmdLoadITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
+
     @Test
     public void testCmdLoad() throws IOException {
         copyResourceInDataFolder(TestResources.ROUTE2);

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdReceiveITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdReceiveITCase.java
@@ -22,6 +22,7 @@ import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.infra.mosquitto.services.MosquittoLocalContainerService;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,11 @@ public class CmdReceiveITCase extends JBangTestSupport {
     @AfterAll
     public static void end() {
         service.shutdown();
+    }
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdStartStopITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CmdStartStopITCase.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -28,6 +29,11 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
 public class CmdStartStopITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testCmdStopByRouteID() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CustomJarsITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CustomJarsITCase.java
@@ -20,9 +20,15 @@ import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class CustomJarsITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testCustomJars() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DevModeITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/DevModeITCase.java
@@ -31,10 +31,16 @@ import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.apache.camel.dsl.jbang.it.support.JiraIssue;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class DevModeITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void cleanupProfileFiles() {
+        execInContainer("rm -f " + DEFAULT_ROUTE_FOLDER + "/" + TestResources.TEST_PROFILE_PROP.getName());
+    }
 
     private final HttpClient httpClient = HttpClient.newHttpClient();
 

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/HistoryITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/HistoryITCase.java
@@ -19,9 +19,16 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class HistoryITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void cleanupInbox() {
+        execInContainer("rm -rf inbox");
+    }
+
     @Test
     public void testHistory() throws IOException {
         copyResourceInDataFolder(TestResources.HISTORY_ROUTE);

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/InfrastructureITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/InfrastructureITCase.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -33,7 +34,14 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 public class InfrastructureITCase extends JBangTestSupport {
     private static final String SERVICE = "ftp";
     private static final String IMPL_SERVICE = "artemis";
+
     private static final String IMPLEMENTATION = "amqp";
+
+    @AfterEach
+    public void stopInfraServices() {
+        execute("infra stop " + SERVICE, false, true);
+        execute("infra stop " + IMPL_SERVICE, false, true);
+    }
 
     private String getServicePID(String message) {
         return message.split(":")[1].replaceAll("[^0-9]", "");

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/JolokiaITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/JolokiaITCase.java
@@ -22,13 +22,23 @@ import java.time.Duration;
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @DisabledOnOs(WINDOWS)
+@Tag("container-only")
 public class JolokiaITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void stopJolokiaAndHawtio() {
+        execute("jolokia FromDirectoryRoute --stop", false, true);
+        execInContainer("pkill -f 'hawtio FromDirectoryRoute' 2>/dev/null || true");
+        execute("stop FromDirectoryRoute", false, true);
+    }
 
     @Test
     public void testAttachJolokia() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ListServiceITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ListServiceITCase.java
@@ -19,9 +19,16 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class ListServiceITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
+
     @Test
     public void listServicesTest() throws IOException {
         copyResourceInDataFolder(TestResources.SERVER_ROUTE);

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/LocalKameletsITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/LocalKameletsITCase.java
@@ -19,9 +19,16 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class LocalKameletsITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
+
     @Test
     public void localKameletRunTest() throws IOException {
         copyResourceInDataFolder(TestResources.USER_SOURCE_KAMELET);

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/LoggingLevelsITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/LoggingLevelsITCase.java
@@ -19,9 +19,15 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class LoggingLevelsITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testLoggingLevelRuntime() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/MetricsObservabilityITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/MetricsObservabilityITCase.java
@@ -20,9 +20,15 @@ import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class MetricsObservabilityITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void metricsTest() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/OpenApiITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/OpenApiITCase.java
@@ -30,12 +30,22 @@ import java.util.Random;
 import org.apache.camel.dsl.jbang.it.support.InVersion;
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @Tag("container-only")
 public class OpenApiITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void cleanupOpenApiArtifacts() {
+        execInContainer(String.format(
+                "rm -f %1$s/petstore-v3.json %1$s/petstore.camel.yaml %1$s/Greetings.java %1$s/greetings-api.json %1$s/rest-dsl.yaml",
+                DEFAULT_ROUTE_FOLDER));
+        execInContainer(String.format("rm -rf %1$s/camel-mock %1$s/model", DEFAULT_ROUTE_FOLDER));
+        execute("plugin delete generate", false, true);
+    }
 
     final HttpClient httpClient = HttpClient.newHttpClient();
 

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/PlatformHttpITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/PlatformHttpITCase.java
@@ -21,9 +21,15 @@ import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class PlatformHttpITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void testPlatformHttp() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ProcessorITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ProcessorITCase.java
@@ -19,9 +19,16 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class ProcessorITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
+
     @Test
     public void testDisableEIP() throws IOException {
         copyResourceInDataFolder(TestResources.ROUTE2);

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RouteFromDirITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RouteFromDirITCase.java
@@ -19,9 +19,15 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class RouteFromDirITCase extends JBangTestSupport {
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
+    }
 
     @Test
     public void runFromDirTest() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandITCase.java
@@ -30,6 +30,7 @@ import org.apache.camel.dsl.jbang.it.support.JiraIssue;
 import org.apache.camel.test.infra.cli.common.CliProperties;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 public class RunCommandITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void cleanupContainerFiles() {
+        // files downloaded by runDownloadedFromGithubTest into DEFAULT_ROUTE_FOLDER
+        execInContainer(String.format("rm -f %1$s/Echo.java %1$s/Hello.java %1$s/README.adoc", DEFAULT_ROUTE_FOLDER));
+        // directories created by runRoutesFromMultipleFilesUsingWildcardTest
+        execInContainer("rm -rf /tmp/one /tmp/two");
+    }
 
     @Test
     @JiraIssue("CAMEL-21082")

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandOnMqttITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/RunCommandOnMqttITCase.java
@@ -23,6 +23,7 @@ import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.infra.mosquitto.services.MosquittoLocalContainerService;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,11 @@ public class RunCommandOnMqttITCase extends JBangTestSupport {
     @AfterAll
     public static void end() {
         service.shutdown();
+    }
+
+    @AfterEach
+    void stopAll() {
+        execute("stop");
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ValidatePluginITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/ValidatePluginITCase.java
@@ -19,9 +19,15 @@ package org.apache.camel.dsl.jbang.it;
 import java.io.IOException;
 
 import org.apache.camel.dsl.jbang.it.support.JBangTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class ValidatePluginITCase extends JBangTestSupport {
+
+    @AfterEach
+    public void removeValidatePlugin() {
+        execute("plugin delete validate", false, true);
+    }
 
     @Test
     public void testValidateOK() throws IOException {

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -87,6 +87,11 @@ public abstract class JBangTestSupport {
     @AfterEach
     protected void afterEach(TestInfo testInfo) {
         logger.debug("ending {}#{} using data folder {}", getClass().getName(), testInfo.getDisplayName(), getDataFolder());
+        execute("config unset runtime");
+        execute("config unset gav");
+        execute("config unset directory");
+        execute("config unset camel-version");
+        execInContainer("rm -f " + DEFAULT_ROUTE_FOLDER + "/application.properties");
         assertNoErrors();
         logger.debug("clean up data folder");
         if (containerDataFolder != null) {


### PR DESCRIPTION
When running tests on bare metal using `-Dcli.service.skip.install=true -Dcamel-cli.instance.type=local-camel-cli-process` some configurations can affect subsequent tests. This PR aims to reset the environment to the default state after each test is finished by unsetting configuration and ending camel processes in classes that run them. Also setting CamelDebugITCase as container-only.