### PR TITLE
chore: fix Vertex AI global region URL in LlmClient (backport)

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/LlmClient.java
@@ -1226,9 +1226,13 @@ public class LlmClient {
     private String resolveAnthropicUrl() {
         if (isVertexAi()) {
             String vertexModel = resolveVertexModel(model);
+            // The "global" location uses the global host with no region prefix;
+            // regional locations (e.g. us-east5) prefix the host with the region.
+            String host
+                    = "global".equals(vertexRegion) ? "aiplatform.googleapis.com" : vertexRegion + "-aiplatform.googleapis.com";
             return String.format(
-                    "https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict",
-                    vertexRegion, vertexProjectId, vertexRegion, vertexModel);
+                    "https://%s/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict",
+                    host, vertexProjectId, vertexRegion, vertexModel);
         }
         String base = url != null ? url : DEFAULT_ANTHROPIC_URL;
         if (base.endsWith("/")) {


### PR DESCRIPTION
Straight cherry-pick backport of #25936 (squash-merged as e3f7f4cf5282 on `main`) onto `camel-4.22.x`. No conflicts.

## Summary
- `LlmClient.resolveAnthropicUrl()` built the Vertex AI Anthropic endpoint by always prefixing the host with `<region>-`. That's correct for regional locations (e.g. `us-east5`) but wrong for the `global` location, whose actual host is `aiplatform.googleapis.com` with no region prefix.
- With `CLOUD_ML_REGION=global` set, requests went to the non-existent host `global-aiplatform.googleapis.com`, causing the TUI's F8 AI panel and `camel ask`/`explain`/`harden` to fail with a generic "LLM request failed" error whenever the Vertex AI auto-detect path was used with the global region.

## Test plan
- [x] `mvn -q -DskipTests install` on `camel-jbang-core` (this branch)
- [x] Clean cherry-pick, no conflicts

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)