### PR TITLE
CAMEL-24573: CXF REST: UnsupportedOperationException when copying factory bean, backport to camel-4.22.x

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.cxf.spring.jaxrs;
 
+import java.util.ArrayList;
+
 import org.apache.camel.Component;
 import org.apache.camel.component.cxf.jaxrs.BeanIdAware;
 import org.apache.camel.component.cxf.jaxrs.CxfRsEndpoint;
@@ -110,6 +112,7 @@ public class CxfRsSpringEndpoint extends CxfRsEndpoint implements BeanIdAware {
 
         if (bean instanceof SpringJAXRSClientFactoryBean) {
             ReflectionUtils.shallowCopyFieldState(bean, cfb);
+            cfb.setFeatures(new ArrayList<>(cfb.getFeatures()));
         }
 
         return cfb;

--- a/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSpringEndpointTest.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSpringEndpointTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.camel.component.cxf.jaxrs;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.camel.component.cxf.jaxrs.testbean.CustomerService;
 import org.apache.camel.component.cxf.spring.jaxrs.SpringJAXRSClientFactoryBean;
 import org.apache.camel.component.cxf.spring.jaxrs.SpringJAXRSServerFactoryBean;
 import org.apache.camel.test.spring.junit6.CamelSpringTestSupport;
+import org.apache.cxf.feature.AbstractFeature;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -36,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
 
     private static final String BEAN_SERVICE_ENDPOINT_NAME = "serviceEndpoint";
+    private static final String FIXED_SIZE_FEATURES_ENDPOINT_NAME = "fixedSizeFeaturesEndpoint";
     private static final String BEAN_SERVICE_ADDRESS = "http://localhost/programmatically";
     private static final String BEAN_SERVICE_USERNAME = "BEAN_SERVICE_USERNAME";
     private static final String BEAN_SERVICE_PASSWORD = "BEAN_SERVICE_PASSWORD";
@@ -88,6 +91,16 @@ public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
         assertEquals(BEAN_SERVICE_PASSWORD, cfb.getPassword(), "Got the wrong password");
     }
 
+    @Test
+    public void testCreateCxfRsClientFactoryBeanWithFixedSizeFeatures() {
+        CxfRsEndpoint endpoint = resolveMandatoryEndpoint(
+                "cxfrs://bean://" + FIXED_SIZE_FEATURES_ENDPOINT_NAME, CxfRsEndpoint.class);
+
+        SpringJAXRSClientFactoryBean cfb = (SpringJAXRSClientFactoryBean) endpoint.createJAXRSClientFactoryBean();
+
+        assertEquals(2, cfb.getFeatures().size(), "The endpoint features must be appended to the copied feature list");
+    }
+
     public static SpringJAXRSClientFactoryBean serviceEndpoint() {
 
         SpringJAXRSClientFactoryBean clientFactoryBean = new SpringJAXRSClientFactoryBean();
@@ -96,6 +109,13 @@ public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
         clientFactoryBean.setUsername(BEAN_SERVICE_USERNAME);
         clientFactoryBean.setPassword(BEAN_SERVICE_PASSWORD);
 
+        return clientFactoryBean;
+    }
+
+    public static SpringJAXRSClientFactoryBean fixedSizeFeaturesEndpoint() {
+        SpringJAXRSClientFactoryBean clientFactoryBean = serviceEndpoint();
+        clientFactoryBean.setFeatures(Arrays.asList(new AbstractFeature() {
+        }));
         return clientFactoryBean;
     }
 
@@ -115,5 +135,10 @@ public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
         BeanDefinitionBuilder definitionBuilder = BeanDefinitionBuilder
                 .rootBeanDefinition(CxfRsSpringEndpointTest.class.getName()).setFactoryMethod("serviceEndpoint");
         beanFactory.registerBeanDefinition(BEAN_SERVICE_ENDPOINT_NAME, definitionBuilder.getBeanDefinition());
+
+        BeanDefinitionBuilder fixedSizeFeaturesDefinitionBuilder = BeanDefinitionBuilder
+                .rootBeanDefinition(CxfRsSpringEndpointTest.class.getName()).setFactoryMethod("fixedSizeFeaturesEndpoint");
+        beanFactory.registerBeanDefinition(FIXED_SIZE_FEATURES_ENDPOINT_NAME,
+                fixedSizeFeaturesDefinitionBuilder.getBeanDefinition());
     }
 }


### PR DESCRIPTION
Backport to `camel-4.22.x` of #25967, a straight cherry-pick already reviewed and merged on `main`.

- CAMEL-24573: camel-cxf - fix UnsupportedOperationException when copying a CXF JAXRS client factory bean from a Spring bean with a fixed-size `features` list (#25967, `98615a5d`)

**Problem.** `CxfRsSpringEndpoint.newInstanceWithCommonProperties()` shallow-copies the `features` field from the source Spring bean. When that bean's `features` list is fixed-size (e.g. built with `Arrays.asList()`), the copy aliases the same immutable list. A later `addAll()` call in `setupCommonFactoryProperties()` then throws `UnsupportedOperationException`.

**Fix.** Wrap the copied list in a new `ArrayList` so the copy is mutable, without touching the original Spring bean's list.

Straight cherry-pick of the squash-merge commit, no manual adaptation needed. Built and tested `camel-cxf-spring-rest` on this branch, including the new `testCreateCxfRsClientFactoryBeanWithFixedSizeFeatures`.

_Claude Code on behalf of davsclaus_

## Backport of #25967

**Original PR:** #25967 - CAMEL-24573: CXF REST: UnsupportedOperationException when copying factory bean with fixed-size features list
**Original author:** @mcarlett
**Target branch:** `camel-4.22.x`