### PR TITLE
CAMEL-24573: CXF REST: UnsupportedOperationException when copying factory bean, backport to camel-4.18.x

### DIFF
--- a/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/main/java/org/apache/camel/component/cxf/spring/jaxrs/CxfRsSpringEndpoint.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.cxf.spring.jaxrs;
 
+import java.util.ArrayList;
+
 import org.apache.camel.Component;
 import org.apache.camel.component.cxf.jaxrs.BeanIdAware;
 import org.apache.camel.component.cxf.jaxrs.CxfRsEndpoint;
@@ -88,6 +90,7 @@ public class CxfRsSpringEndpoint extends CxfRsEndpoint implements BeanIdAware {
 
         if (bean instanceof SpringJAXRSClientFactoryBean) {
             ReflectionUtils.shallowCopyFieldState(bean, cfb);
+            cfb.setFeatures(new ArrayList<>(cfb.getFeatures()));
         }
 
         return cfb;

--- a/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSpringEndpointTest.java
+++ b/components/camel-cxf/camel-cxf-spring-rest/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsSpringEndpointTest.java
@@ -16,18 +16,21 @@
  */
 package org.apache.camel.component.cxf.jaxrs;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.camel.component.cxf.jaxrs.testbean.CustomerService;
 import org.apache.camel.component.cxf.spring.jaxrs.SpringJAXRSClientFactoryBean;
 import org.apache.camel.component.cxf.spring.jaxrs.SpringJAXRSServerFactoryBean;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
+import org.apache.cxf.feature.AbstractFeature;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -36,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
 
     private static final String BEAN_SERVICE_ENDPOINT_NAME = "serviceEndpoint";
+    private static final String FIXED_SIZE_FEATURES_ENDPOINT_NAME = "fixedSizeFeaturesEndpoint";
     private static final String BEAN_SERVICE_ADDRESS = "http://localhost/programmatically";
     private static final String BEAN_SERVICE_USERNAME = "BEAN_SERVICE_USERNAME";
     private static final String BEAN_SERVICE_PASSWORD = "BEAN_SERVICE_PASSWORD";
@@ -88,6 +92,19 @@ public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
         assertEquals(BEAN_SERVICE_PASSWORD, cfb.getPassword(), "Got the wrong password");
     }
 
+    @Test
+    public void testCreateCxfRsClientFactoryBeanWithFixedSizeFeatures() {
+        CxfRsEndpoint endpoint = resolveMandatoryEndpoint(
+                "cxfrs://bean://" + FIXED_SIZE_FEATURES_ENDPOINT_NAME, CxfRsEndpoint.class);
+
+        SpringJAXRSClientFactoryBean cfb = (SpringJAXRSClientFactoryBean) endpoint.createJAXRSClientFactoryBean();
+
+        assertEquals(1, cfb.getFeatures().size(), "The copied feature must be preserved");
+        assertDoesNotThrow(() -> cfb.getFeatures().add(new AbstractFeature() {
+        }), "The copied features list must be mutable");
+        assertEquals(2, cfb.getFeatures().size(), "The appended feature must be present");
+    }
+
     public static SpringJAXRSClientFactoryBean serviceEndpoint() {
 
         SpringJAXRSClientFactoryBean clientFactoryBean = new SpringJAXRSClientFactoryBean();
@@ -96,6 +113,13 @@ public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
         clientFactoryBean.setUsername(BEAN_SERVICE_USERNAME);
         clientFactoryBean.setPassword(BEAN_SERVICE_PASSWORD);
 
+        return clientFactoryBean;
+    }
+
+    public static SpringJAXRSClientFactoryBean fixedSizeFeaturesEndpoint() {
+        SpringJAXRSClientFactoryBean clientFactoryBean = serviceEndpoint();
+        clientFactoryBean.setFeatures(Arrays.asList(new AbstractFeature() {
+        }));
         return clientFactoryBean;
     }
 
@@ -115,5 +139,10 @@ public class CxfRsSpringEndpointTest extends CamelSpringTestSupport {
         BeanDefinitionBuilder definitionBuilder = BeanDefinitionBuilder
                 .rootBeanDefinition(CxfRsSpringEndpointTest.class.getName()).setFactoryMethod("serviceEndpoint");
         beanFactory.registerBeanDefinition(BEAN_SERVICE_ENDPOINT_NAME, definitionBuilder.getBeanDefinition());
+
+        BeanDefinitionBuilder fixedSizeFeaturesDefinitionBuilder = BeanDefinitionBuilder
+                .rootBeanDefinition(CxfRsSpringEndpointTest.class.getName()).setFactoryMethod("fixedSizeFeaturesEndpoint");
+        beanFactory.registerBeanDefinition(FIXED_SIZE_FEATURES_ENDPOINT_NAME,
+                fixedSizeFeaturesDefinitionBuilder.getBeanDefinition());
     }
 }


### PR DESCRIPTION
Backport to `camel-4.18.x` of #25967, already reviewed and merged on `main`.

- CAMEL-24573: camel-cxf - fix UnsupportedOperationException when copying a CXF JAXRS client factory bean from a Spring bean with a fixed-size `features` list (#25967, `98615a5d`)

**Problem.** `CxfRsSpringEndpoint.newInstanceWithCommonProperties()` shallow-copies the `features` field from the source Spring bean. When that bean's `features` list is fixed-size (e.g. built with `Arrays.asList()`), the copy aliases the same immutable list, and a later attempt to append to it throws `UnsupportedOperationException`.

**Fix.** Wrap the copied list in a new `ArrayList` so the copy is mutable, without touching the original Spring bean's list.

**Not a straight cherry-pick — two deviations, both surfaced by building/testing this branch:**

- Mechanical: `CxfRsSpringEndpointTest` keeps this branch's `org.apache.camel.test.spring.junit5.CamelSpringTestSupport` import rather than `main`'s `junit6` one — `camel-cxf-spring-rest` here depends on `camel-test-spring-junit5`, not `junit6`.
- Behavioural: on this branch, `CxfRsSpringEndpoint.setupJAXRSClientFactoryBean()` does not call `setupCommonFactoryProperties()` — that call was added later by CAMEL-24183, which is not on `camel-4.18.x`. So the endpoint's own features are never auto-appended to the copied list here, and the ported test's `assertEquals(2, cfb.getFeatures().size())` did not hold (it failed with `expected: <2> but was: <1>` when run on this branch). The test now asserts the copied feature is preserved (size 1) and that the list is mutable by appending a second feature directly and re-checking the size (2) — this still exercises the fix (mutability) without relying on the CAMEL-24183 auto-append behaviour this branch doesn't have.

Built and tested `camel-cxf-spring-rest` on this branch after adapting the test; all 4 tests in `CxfRsSpringEndpointTest` pass.

_Claude Code on behalf of davsclaus_

## Backport of #25967

**Original PR:** #25967 - CAMEL-24573: CXF REST: UnsupportedOperationException when copying factory bean with fixed-size features list
**Original author:** @mcarlett
**Target branch:** `camel-4.18.x`