### PR TITLE
CAMEL-24464: Sync 4.22 upgrade guide with camel-4.22.x backport

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -13,6 +13,18 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading from 4.22.0 to 4.22.1
 
+=== camel-exec
+
+`allowControlHeaders` is now annotated `security = "insecure:dev"`.
+With `camel.main.profile = prod` the default policy for that category is `fail`,
+so an endpoint or component that sets `allowControlHeaders=true` will not start
+unless you relax `camel.security.insecureDevPolicy`.
+
+When the flag is `false` (the default), any remaining `CamelExecCommand*`,
+`CamelExecExitValues`, or `CamelExecUseStderrOnEmptyStdout` headers are ignored
+and a WARN is logged once per exec endpoint. Those headers never overrode the
+URI without the flag; they were just silent before.
+
 === camel-ftp, camel-sftp, camel-ftps, camel-mina-sftp, camel-azure-files, camel-smb
 
 The remote-file consumers now ensure the path resolved for a polled file stays within the directory being


### PR DESCRIPTION
## Context

Backport #25982 of #25846 to `camel-4.22.x` adds a `camel-exec` entry to that branch's
`camel-4x-upgrade-guide-4_22.adoc` under `Upgrading from 4.22.0 to 4.22.1`, documenting the
new `allowControlHeaders` `security = "insecure:dev"` annotation and the once-per-endpoint WARN.

Per the project's upgrade-guide policy, `main` hosts the canonical copy of every numbered
upgrade guide, including historical ones like `camel-4x-upgrade-guide-4_22.adoc`. This PR
mirrors the same entry onto `main` so the two copies stay in sync.

Doc-only change, no code.

_Claude Code on behalf of davsclaus_