### PR TITLE
CAMEL-24579: DataFormat.marshal graph parameter should be @Nullable

### DIFF
--- a/core/camel-api/src/main/java/org/apache/camel/spi/DataFormat.java
+++ b/core/camel-api/src/main/java/org/apache/camel/spi/DataFormat.java
@@ -24,6 +24,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Service;
 import org.apache.camel.util.IOHelper;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Pluggable strategy for converting message bodies to and from a serialised byte-stream format, as described in the
@@ -48,11 +49,13 @@ public interface DataFormat extends Service {
      * Marshals the object to the given Stream.
      *
      * @param  exchange  the current exchange
-     * @param  graph     the object to be marshalled
+     * @param  graph     the object to be marshalled, can be <tt>null</tt> if the message body is null (for example on
+     *                   an error route) or if the implementation marshals from the exchange rather than from this
+     *                   parameter
      * @param  stream    the output stream to write the marshalled result to
      * @throws Exception can be thrown
      */
-    void marshal(Exchange exchange, Object graph, OutputStream stream) throws Exception;
+    void marshal(Exchange exchange, @Nullable Object graph, OutputStream stream) throws Exception;
 
     /**
      * Unmarshals the given stream into an object.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -155,6 +155,19 @@ The component camel-threadpoolfactory-vertx was deprecated in 4.21. The componen
 
 `camel-zeebe` component was deprecated in 4.19 and has a straightforward replacement with `camel-camunda`. It is removed in 4.23.
 
+=== camel-core - DataFormat.marshal graph parameter is now @Nullable
+
+`org.apache.camel.spi.DataFormat#marshal(Exchange, Object, OutputStream)` now declares its `graph`
+parameter `@Nullable`, matching what `MarshalProcessor` actually passes: the message body, which is
+itself `@Nullable` and can be null (for example on an error route, or for a `DataFormat` that
+marshals from `Exchange` state rather than from `graph`).
+
+This is a contract-only correction; `MarshalProcessor`'s runtime behavior is unchanged. Java
+implementations are unaffected. A Kotlin implementation of `DataFormat` previously had to accept a
+non-null `graph`, so the Kotlin compiler emitted a non-null assertion that threw `NullPointerException`
+whenever a null body reached `marshal`. Kotlin implementations can now declare `graph: Any?` directly
+instead of working around the assertion with a Java bridge class.
+
 === camel-core - MemoryIdempotentRepository and MemoryAggregationRepository deprecated
 
 `MemoryIdempotentRepository` and `MemoryAggregationRepository` are deprecated in favor of the new

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -155,19 +155,6 @@ The component camel-threadpoolfactory-vertx was deprecated in 4.21. The componen
 
 `camel-zeebe` component was deprecated in 4.19 and has a straightforward replacement with `camel-camunda`. It is removed in 4.23.
 
-=== camel-core - DataFormat.marshal graph parameter is now @Nullable
-
-`org.apache.camel.spi.DataFormat#marshal(Exchange, Object, OutputStream)` now declares its `graph`
-parameter `@Nullable`, matching what `MarshalProcessor` actually passes: the message body, which is
-itself `@Nullable` and can be null (for example on an error route, or for a `DataFormat` that
-marshals from `Exchange` state rather than from `graph`).
-
-This is a contract-only correction; `MarshalProcessor`'s runtime behavior is unchanged. Java
-implementations are unaffected. A Kotlin implementation of `DataFormat` previously had to accept a
-non-null `graph`, so the Kotlin compiler emitted a non-null assertion that threw `NullPointerException`
-whenever a null body reached `marshal`. Kotlin implementations can now declare `graph: Any?` directly
-instead of working around the assertion with a Java bridge class.
-
 === camel-core - MemoryIdempotentRepository and MemoryAggregationRepository deprecated
 
 `MemoryIdempotentRepository` and `MemoryAggregationRepository` are deprecated in favor of the new


### PR DESCRIPTION
## Summary

- `org.apache.camel.spi` is `@NullMarked` (since 4.21, CAMEL-22640), and `DataFormat.marshal`'s `graph` parameter had no `@Nullable`, so it was implicitly declared non-null.
- `MarshalProcessor` (camel-support) passes the message body straight through with no null guard, and `Message.getBody()` is itself `@Nullable` and documented as possibly null.
- Java implementations never noticed the mismatch, but a Kotlin implementation of `DataFormat` gets a compiler-generated non-null assertion on `graph`, which throws `NullPointerException` before user code runs whenever the body is legitimately null — for example on an error route, or for a `DataFormat` that marshals from `Exchange` state rather than from `graph`.
- `DataFormat.java` was not touched by the original CAMEL-22640 annotation sweep, so this parameter was never actually reviewed for nullability; it just inherited non-null-by-default from the package-level `@NullMarked`.
- Fix: annotate `graph` as `@Nullable` to match actual runtime behavior. This is a contract/Javadoc-only change — `MarshalProcessor`'s behavior is unchanged, so no existing Java implementation is affected.

Reported by Petr H. on the dev mailing list.

_Claude Code on behalf of davsclaus_

## Test plan

- [x] `mvn -pl core/camel-api -am install -DskipTests` builds cleanly
- [x] `mvn formatter:format impsort:sort` produces no diff
- [ ] CI green

Jira: https://issues.apache.org/jira/browse/CAMEL-24579