### PR TITLE
CAMEL-24541: camel-djl - guard ImageNetUtil against class names without a space

### DIFF
--- a/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/ImageNetUtil.java
+++ b/components/camel-ai/camel-djl/src/main/java/org/apache/camel/component/djl/ImageNetUtil.java
@@ -37,7 +37,12 @@ public class ImageNetUtil {
 
     public void extractClassName(Exchange exchange) {
         Classifications body = exchange.getMessage().getBody(Classifications.class);
-        String className = body.best().getClassName().split(",")[0].split(" ", 2)[1];
+        // ImageNet class names look like "n01440764 tench, Tinca tinca": keep the label after the id and
+        // before the first comma. Fall back to the whole token when there is no space, so a class name
+        // without the expected "<id> <label>" shape does not throw ArrayIndexOutOfBoundsException.
+        String firstLabel = body.best().getClassName().split(",")[0];
+        String[] parts = firstLabel.split(" ", 2);
+        String className = parts.length > 1 ? parts[1] : parts[0];
         exchange.getMessage().setBody(className);
     }
 

--- a/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/ImageNetUtilTest.java
+++ b/components/camel-ai/camel-djl/src/test/java/org/apache/camel/component/djl/ImageNetUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.djl;
+
+import java.util.List;
+
+import ai.djl.modality.Classifications;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ImageNetUtilTest {
+
+    private Exchange exchangeWithClassName(String className) {
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getMessage().setBody(new Classifications(List.of(className), List.of(1.0)));
+        return exchange;
+    }
+
+    @Test
+    void extractsTheLabelFromAnImageNetClassName() {
+        Exchange exchange = exchangeWithClassName("n01440764 tench, Tinca tinca");
+        new ImageNetUtil().extractClassName(exchange);
+        assertEquals("tench", exchange.getMessage().getBody(String.class));
+    }
+
+    @Test
+    void classNameWithoutSpaceDoesNotThrow() {
+        Exchange exchange = exchangeWithClassName("tench");
+        assertDoesNotThrow(() -> new ImageNetUtil().extractClassName(exchange));
+        assertEquals("tench", exchange.getMessage().getBody(String.class));
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24541](https://issues.apache.org/jira/browse/CAMEL-24541)

## Problem
`ImageNetUtil.extractClassName` parses the winning classification with:

```java
String className = body.best().getClassName().split(",")[0].split(" ", 2)[1];
```

It assumes every class name has the ImageNet `"<id> <label>"` shape (e.g. `n01440764 tench, Tinca tinca`).
A class name without a space — a bare id, a custom label, or a malformed synset entry — makes
`split(" ", 2)` return a single-element array, so `[1]` throws `ArrayIndexOutOfBoundsException`.

## Fix
Guard on the split length and fall back to the whole token when there is no space, so a class name that
does not match the expected shape no longer crashes the route.

## Testing
- New `ImageNetUtilTest` covers a normal ImageNet class name (extracts the label) and a class name with no
  space (no exception, returns the token).
- `mvn -Psourcecheck validate` green.

_Claude Code on behalf of oscerd_