### PR TITLE
[4..22.x] Remove JDK 21 from ubuntu test matrix on Jenkins for 4.22.x stream

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,6 +107,16 @@ pipeline {
                     exclude {
                         axis {
                             name 'JDK_NAME'
+                            values 'jdk_21_latest'
+                        }
+                        axis {
+                            name 'PLATFORM'
+                            values 'ubuntu-avx'
+                        }
+                    }
+                    exclude {
+                        axis {
+                            name 'JDK_NAME'
                             values 'jdk_25_latest'
                         }
                         axis {


### PR DESCRIPTION
The Jenkins is under heavy load due to the number of backports to maintenance streams.
Remove the JDK 21 on Ubuntu build. JDK 21 is still used on s390x and ppc64le. it is also still tested on the main branch, and 4.22.x should only contain backports. So the the risk of a regression specific to JDK 21 on Linux is very very low.th

Note that it will stop to upload Sonar reports but I think that it is fine for 4.22.x stream. We are not even following very closely the main branch.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

