### PR TITLE
CAMEL-24544: camel-kserve / camel-tensorflow-serving - guard the gRPC channel shutdown in doStop

### DIFF
--- a/components/camel-ai/camel-kserve/src/main/java/org/apache/camel/component/kserve/KServeEndpoint.java
+++ b/components/camel-ai/camel-kserve/src/main/java/org/apache/camel/component/kserve/KServeEndpoint.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.kserve;
 
+import java.util.concurrent.TimeUnit;
+
 import inference.GRPCInferenceServiceGrpc;
 import io.grpc.ChannelCredentials;
 import io.grpc.Grpc;
@@ -73,8 +75,11 @@ public class KServeEndpoint extends DefaultEndpoint {
     public void doStop() throws Exception {
         super.doStop();
 
-        // Close the channel
-        channel.shutdown();
+        // Close the channel if it was created (doInit may have failed before assigning it)
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
     }
 
     @Override

--- a/components/camel-ai/camel-kserve/src/test/java/org/apache/camel/component/kserve/KServeEndpointDoStopTest.java
+++ b/components/camel-ai/camel-kserve/src/test/java/org/apache/camel/component/kserve/KServeEndpointDoStopTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.kserve;
+
+import java.lang.reflect.Field;
+
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class KServeEndpointDoStopTest {
+
+    @Test
+    void doStopDoesNotThrowWhenChannelWasNeverCreated() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            KServeEndpoint endpoint = context.getEndpoint("kserve:infer?target=localhost:8001", KServeEndpoint.class);
+            // Simulate doInit() failing before the gRPC channel was assigned.
+            Field channelField = KServeEndpoint.class.getDeclaredField("channel");
+            channelField.setAccessible(true);
+            channelField.set(endpoint, null);
+
+            assertDoesNotThrow(endpoint::doStop);
+        }
+    }
+}

--- a/components/camel-ai/camel-tensorflow-serving/src/main/java/org/apache/camel/component/tensorflow/serving/TensorFlowServingEndpoint.java
+++ b/components/camel-ai/camel-tensorflow-serving/src/main/java/org/apache/camel/component/tensorflow/serving/TensorFlowServingEndpoint.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.tensorflow.serving;
 
+import java.util.concurrent.TimeUnit;
+
 import io.grpc.ChannelCredentials;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
@@ -71,8 +73,11 @@ public class TensorFlowServingEndpoint extends DefaultEndpoint {
     public void doStop() throws Exception {
         super.doStop();
 
-        // Close the channel
-        channel.shutdown();
+        // Close the channel if it was created (doInit may have failed before assigning it)
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
     }
 
     @Override

--- a/components/camel-ai/camel-tensorflow-serving/src/test/java/org/apache/camel/component/tensorflow/serving/TensorFlowServingEndpointDoStopTest.java
+++ b/components/camel-ai/camel-tensorflow-serving/src/test/java/org/apache/camel/component/tensorflow/serving/TensorFlowServingEndpointDoStopTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.tensorflow.serving;
+
+import java.lang.reflect.Field;
+
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class TensorFlowServingEndpointDoStopTest {
+
+    @Test
+    void doStopDoesNotThrowWhenChannelWasNeverCreated() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            TensorFlowServingEndpoint endpoint = context.getEndpoint(
+                    "tensorflow-serving:predict?target=localhost:8500", TensorFlowServingEndpoint.class);
+            // Simulate doInit() failing before the gRPC channel was assigned.
+            Field channelField = TensorFlowServingEndpoint.class.getDeclaredField("channel");
+            channelField.setAccessible(true);
+            channelField.set(endpoint, null);
+
+            assertDoesNotThrow(endpoint::doStop);
+        }
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24544](https://issues.apache.org/jira/browse/CAMEL-24544)

## Problem
`KServeEndpoint` and `TensorFlowServingEndpoint` shut the gRPC channel down unconditionally:

```java
public void doStop() throws Exception {
    super.doStop();
    channel.shutdown();
}
```

The channel is created in `doInit()`. If `doInit()` fails before assigning it (bad `target`, credentials
error), the field is still `null`, so `doStop()` throws a `NullPointerException` that masks the original
startup failure.

## Fix
Guard the shutdown with `if (channel != null)` and add a bounded `awaitTermination(5, SECONDS)` for a
clean close.

## Testing
- New `KServeEndpointDoStopTest` and `TensorFlowServingEndpointDoStopTest` simulate the doInit-failed
  state (channel null) and assert `doStop()` no longer throws.
- `mvn -Psourcecheck validate` green for both modules.

_Claude Code on behalf of oscerd_