### PR TITLE
CAMEL-24543: camel-langchain4j-embeddingstore - correct the endpoint @UriEndpoint syntax scheme

### DIFF
--- a/components/camel-ai/camel-langchain4j-embeddingstore/src/main/java/org/apache/camel/component/langchain4j/embeddingstore/LangChain4jEmbeddingStoreEndpoint.java
+++ b/components/camel-ai/camel-langchain4j-embeddingstore/src/main/java/org/apache/camel/component/langchain4j/embeddingstore/LangChain4jEmbeddingStoreEndpoint.java
@@ -34,7 +34,7 @@ import org.apache.camel.support.DefaultEndpoint;
              firstVersion = "4.14.0",
              scheme = LangChain4jEmbeddingStore.SCHEME,
              title = "LangChain4j Embedding Store",
-             syntax = "langchain4j-embeddings:embeddingStoreId",
+             syntax = "langchain4j-embeddingstore:embeddingStoreId",
              producerOnly = true,
              category = {
                      Category.DATABASE,


### PR DESCRIPTION
## Issue
[CAMEL-24543](https://issues.apache.org/jira/browse/CAMEL-24543)

## Problem
`LangChain4jEmbeddingStoreEndpoint`'s `@UriEndpoint` declared:

```java
syntax = "langchain4j-embeddings:embeddingStoreId",
```

using the wrong scheme (`langchain4j-embeddings`) instead of this component's own scheme,
`langchain4j-embeddingstore`.

## Fix
Correct the `syntax` to `langchain4j-embeddingstore:embeddingStoreId`.

The generated catalog `syntax` is derived from the component scheme and was already correct
(`langchain4j-embeddingstore:embeddingStoreId`), so building the module produces **no** change to the
generated metadata — this only fixes the misleading source annotation. There is no runtime or catalog
change, hence no test is applicable.

_Claude Code on behalf of oscerd_