### PR TITLE
CAMEL-24536: camel-langchain4j-embeddings - apply logResponses in OpenAiEmbeddingModelBuilder

### DIFF
--- a/components/camel-ai/camel-langchain4j-embeddings/src/main/java/org/apache/camel/component/langchain4j/embeddings/openai/OpenAiEmbeddingModelBuilder.java
+++ b/components/camel-ai/camel-langchain4j-embeddings/src/main/java/org/apache/camel/component/langchain4j/embeddings/openai/OpenAiEmbeddingModelBuilder.java
@@ -73,7 +73,7 @@ public final class OpenAiEmbeddingModelBuilder {
                 .maxRetries(maxRetries)
                 .dimensions(dimensions)
                 .logRequests(logRequests)
-                .logRequests(logResponses)
+                .logResponses(logResponses)
                 .build();
     }
 }


### PR DESCRIPTION
## Issue
[CAMEL-24536](https://issues.apache.org/jira/browse/CAMEL-24536)

## Problem
`OpenAiEmbeddingModelBuilder.build()` configures the model with:

```java
.logRequests(logRequests)
.logRequests(logResponses)   // <-- wrong setter
```

The second call re-sets `logRequests` using the `logResponses` flag instead of calling
`.logResponses(logResponses)`. So the `logResponses` option is never applied (response logging can't be
turned on) and `logRequests` is silently overwritten by the `logResponses` value. Both fields and their
setters exist on the builder (lines 30-31, 58-66).

## Fix
Call `.logResponses(logResponses)`.

## Testing
No unit test is added: the fix is a one-line correction of an obviously-wrong setter, and the resulting
flag is stored inside langchain4j's internal `OpenAiClient` (not exposed on the built `OpenAiEmbeddingModel`),
so it is not observable without fragile deep reflection into a third-party type. The change compiles and
`mvn -Psourcecheck validate` is green.

_Claude Code on behalf of oscerd_