### PR TITLE
chore(deps): upgrade Apache Avro to 1.12.2

### DIFF
--- a/components/camel-avro-rpc/camel-avro-rpc-component/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc-component/pom.xml
@@ -31,6 +31,11 @@
     <name>Camel :: Avro RPC</name>
     <description>Camel Avro  RPC component</description>
 
+    <properties>
+        <!-- Avro 1.12.2 requires the IPC and test protocol model packages to be explicitly trusted. -->
+        <camel.surefire.fork.additional-vmargs>-Dorg.apache.avro.SERIALIZABLE_PACKAGES=org.apache.avro,org.apache.camel.avro</camel.surefire.fork.additional-vmargs>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/components/camel-avro/pom.xml
+++ b/components/camel-avro/pom.xml
@@ -32,6 +32,8 @@
     <description>Camel Avro data format</description>
 
     <properties>
+        <!-- Avro 1.12.2 requires application model packages to be explicitly trusted. -->
+        <camel.surefire.fork.additional-vmargs>-Dorg.apache.avro.SERIALIZABLE_PACKAGES=org.apache.camel.dataformat.avro.example</camel.surefire.fork.additional-vmargs>
     </properties>
 
     <dependencies>

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -13,6 +13,32 @@ See the xref:camel-upgrade-recipes-tool.adoc[documentation] page for details.
 
 == Upgrading Camel 4.22 to 4.23
 
+=== Apache Avro trusted packages
+
+Camel now uses Apache Avro 1.12.2. Avro validates classes resolved from schemas
+and no longer trusts application packages by default. If your routes use Avro
+specific records, reflected POJOs, or schemas with Java class names, configure
+the `org.apache.avro.SERIALIZABLE_PACKAGES` JVM system property with the
+comma-separated packages that contain only your trusted Avro model classes.
+
+For example, if generated records are in `com.example.orders.avro`, add the
+following JVM option:
+
+[source]
+----
+-Dorg.apache.avro.SERIALIZABLE_PACKAGES=com.example.orders.avro
+----
+
+If you use `camel-avro-rpc`, also include `org.apache.avro`, which contains the
+Avro IPC handshake classes:
+
+[source]
+----
+-Dorg.apache.avro.SERIALIZABLE_PACKAGES=org.apache.avro,com.example.orders.avro
+----
+
+Do not use `*`, as it disables Avro's class-loading protection.
+
 === camel-exec
 
 `allowControlHeaders` is now annotated `security = "insecure:dev"`.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -86,9 +86,9 @@
         <asterisk-java-version>3.42.2</asterisk-java-version>
         <atlassian-fugue-version>6.1.5</atlassian-fugue-version>
         <atmosphere-version>3.1.0</atmosphere-version>
-        <avro-version>1.12.1</avro-version>
-        <avro-ipc-jetty-version>1.12.1</avro-ipc-jetty-version>
-        <avro-ipc-netty-version>1.12.1</avro-ipc-netty-version>
+        <avro-version>1.12.2</avro-version>
+        <avro-ipc-jetty-version>1.12.2</avro-ipc-jetty-version>
+        <avro-ipc-netty-version>1.12.2</avro-ipc-netty-version>
         <awaitility-version>4.3.0</awaitility-version>
         <aws-java-sdk2-version>2.54.7</aws-java-sdk2-version>
         <azure-sdk-bom-version>1.3.3</azure-sdk-bom-version>


### PR DESCRIPTION
Upgrades Apache Avro, Avro compiler, and Avro RPC transports from 1.12.1 to 1.12.2.

Avro 1.12.2 validates classes loaded from schemas and requires explicit trusted packages. Configure the affected Camel test JVMs with the minimum packages needed by their test models, and document the required application migration.

This replaces #26001, which was closed because the version bump is a user-visible compatibility change. It is intentionally not proposed for the camel-4.22.x or camel-4.18.x maintenance branches.