### PR TITLE
[backport camel-4.18.x] CAMEL-24574: camel-google-bigquery - document ${name} substitution and warn on non-identifier values

### DIFF
--- a/components/camel-google/camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc
+++ b/components/camel-google/camel-google-bigquery/src/main/docs/google-bigquery-sql-component.adoc
@@ -81,10 +81,8 @@ google-bigquery-sql://project-17248459:delete * from test.table where id=@myId
 
 google-bigquery-sql://project-17248459:delete * from ${datasetId}.${tableId} where id=@myId
 --------------------------------------------------------
-where
-
- * parameters in form $\{name} are extracted from message headers and formed the translated query.
- * parameters in form @name are extracted from body or message headers and sent to Google Bigquery. The `com.google.cloud.bigquery.StandardSQLTypeName` of the parameter is detected from the type of the parameter using `<T> QueryParameterValue<T>.of(T value, Class<T> type)`
+The query can contain two kinds of placeholder, `@name` and `$\{name}`. They are not
+interchangeable: see xref:#_query_placeholders[Query Placeholders] below.
 
 You can externalize your SQL queries to files in the classpath or file system as shown:
 
@@ -102,6 +100,57 @@ include::partial$component-endpoint-headers.adoc[]
 == Producer Endpoints
 
 Google BigQuery SQL endpoint expects the payload to be either empty or a map of query parameters.
+
+== Query Placeholders
+
+A query may contain two kinds of placeholder. They cover different positions in a SQL
+statement and are not interchangeable.
+
+[cols="1,2,3",options="header"]
+|===
+|Form |Substitutes |Mechanism
+
+|`@name`
+|Values
+|Sent to BigQuery as a named query parameter, separately from the query text.
+
+|`$\{name}`
+|Identifiers, such as dataset and table names
+|Spliced into the query text as literal characters before the query is sent.
+|===
+
+=== @name - query parameters
+
+Use `@name` for every value.
+
+Parameters in the form `@name` are taken from the message body when it is a `Map`,
+otherwise from the message headers, and are bound as BigQuery named query parameters.
+The `com.google.cloud.bigquery.StandardSQLTypeName` of the parameter is detected from
+the Java type of the value using `<T> QueryParameterValue<T>.of(T value, Class<T> type)`.
+
+Because the value is sent to BigQuery separately from the query text, it cannot alter
+the structure of the query. It is always treated as data.
+
+=== $\{name} - literal identifier substitution
+
+Parameters in the form `$\{name}` are replaced with the `String` value of the matching
+message header, or of the exchange property when no such header exists, before the query
+is sent. If neither is present, the exchange fails with a `RuntimeExchangeException`.
+
+The substitution is a literal text splice: the value is inserted into the query exactly
+as it appears, with no quoting or escaping applied. This form exists because BigQuery
+named query parameters can bind values but cannot bind identifiers, so a dataset or table
+name cannot be supplied through `@name`:
+
+--------------------------------------------------------
+google-bigquery-sql://project-17248459:delete * from ${datasetId}.${tableId} where id=@myId
+--------------------------------------------------------
+
+IMPORTANT: `$\{name}` is not parameter binding. Use it only for identifiers such as dataset
+and table names, and only with values that your route controls. A value containing SQL
+syntax changes the structure of the executed query instead of being treated as data, so a
+`$\{name}` placeholder must never be populated from message content supplied by an untrusted
+sender. Use `@name` for values.
 
 == Query Types
 

--- a/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/SqlHelper.java
+++ b/components/camel-google/camel-google-bigquery/src/main/java/org/apache/camel/component/google/bigquery/sql/SqlHelper.java
@@ -29,8 +29,19 @@ import org.apache.camel.Message;
 import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.support.ResourceHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class SqlHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SqlHelper.class);
+
+    /**
+     * Shape accepted for a placeholder substitution: a dot-separated sequence of project, dataset and table parts, each
+     * starting with a letter or an underscore.
+     */
+    private static final Pattern IDENTIFIER_PATTERN
+            = Pattern.compile("[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*");
 
     private static Pattern pattern = Pattern.compile("\\$\\{(\\w+)}");
     private static Pattern parameterPattern = Pattern.compile("@(\\w+)");
@@ -58,6 +69,10 @@ public final class SqlHelper {
     /**
      * Replaces pattern in query in form of "${param}" with values from message header Raises an error if param value
      * not found in headers
+     * <p>
+     * The value is spliced into the query text verbatim, so this form is meant for dataset and table identifiers. A
+     * substitution that does not have the shape of an identifier is reported at WARN level; use a query parameter in
+     * the form {@code @name} to pass values.
      *
      * @param  exchange
      * @return          Translated query text
@@ -78,11 +93,33 @@ public final class SqlHelper {
                 }
             }
 
+            if (!isValidIdentifier(value)) {
+                LOG.warn("Placeholder '{}' was substituted with a value that is not a valid BigQuery identifier."
+                         + " Placeholders in the form ${name} are spliced into the query text verbatim and are"
+                         + " intended for dataset and table names; use a query parameter in the form @name to pass"
+                         + " values.",
+                        paramKey);
+            }
+
             String replacement = Matcher.quoteReplacement(value);
             matcher.appendReplacement(stringBuffer, replacement);
         }
         matcher.appendTail(stringBuffer);
         return stringBuffer.toString();
+    }
+
+    /**
+     * Whether the given value has the shape of a BigQuery identifier: a dot-separated sequence of project, dataset and
+     * table parts, each starting with a letter or an underscore.
+     * <p>
+     * Values that do not match are spliced into the query text verbatim and can therefore alter its structure, so
+     * {@link #translateQuery(String, Exchange)} reports them.
+     *
+     * @param  value the substituted value
+     * @return       true if the value has the shape of a BigQuery identifier
+     */
+    static boolean isValidIdentifier(String value) {
+        return IDENTIFIER_PATTERN.matcher(value).matches();
     }
 
     /**

--- a/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/sql/SqlHelperIdentifierTest.java
+++ b/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/sql/SqlHelperIdentifierTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.google.bigquery.sql;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SqlHelperIdentifierTest {
+
+    @Test
+    public void testIdentifierShapedValuesAreAccepted() {
+        assertThat(SqlHelper.isValidIdentifier("report_data")).isTrue();
+        assertThat(SqlHelper.isValidIdentifier("_private")).isTrue();
+        assertThat(SqlHelper.isValidIdentifier("test.table")).isTrue();
+        assertThat(SqlHelper.isValidIdentifier("project-17248459.dataset.table")).isTrue();
+    }
+
+    @Test
+    public void testValuesCarryingSqlSyntaxAreNotIdentifiers() {
+        assertThat(SqlHelper.isValidIdentifier("")).isFalse();
+        assertThat(SqlHelper.isValidIdentifier("1dataset")).isFalse();
+        assertThat(SqlHelper.isValidIdentifier("dataset table")).isFalse();
+        assertThat(SqlHelper.isValidIdentifier("table; DROP TABLE other")).isFalse();
+        assertThat(SqlHelper.isValidIdentifier("nope' UNION ALL SELECT 1 --")).isFalse();
+    }
+}

--- a/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/sql/SqlHelperTest.java
+++ b/components/camel-google/camel-google-bigquery/src/test/java/org/apache/camel/component/google/bigquery/unit/sql/SqlHelperTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -107,6 +108,16 @@ public class SqlHelperTest {
         when(message.getHeader(eq("report"), eq(String.class))).thenReturn("report_data");
         assertThrows(RuntimeExchangeException.class,
                 () -> SqlHelper.translateQuery(query, exchange));
+    }
+
+    @Test
+    public void testTranslateQueryKeepsSubstitutingNonIdentifierValues() {
+        when(exchange.getMessage()).thenReturn(message);
+        when(message.getHeader(eq("custId"), eq(String.class))).thenReturn("O'Brien");
+
+        String answer = SqlHelper.translateQuery("SELECT id FROM orders WHERE customer_id = '${custId}'", exchange);
+
+        assertThat(answer).isEqualTo("SELECT id FROM orders WHERE customer_id = 'O'Brien'");
     }
 
     @Test


### PR DESCRIPTION
Backport of #26007 to `camel-4.18.x`.

**This one is not a straight cherry-pick — it needed manual conflict resolution, so it is not claiming the backport review exemption.** The Java is a mechanical port; the documentation needed adapting to this branch. Details below.

## What it does

The `google-bigquery-sql` endpoint accepts two placeholder forms that behave differently: `@name` is bound as a BigQuery named query parameter, while `${name}` is spliced into the query text verbatim. Both are needed, because BigQuery named parameters can bind values but cannot bind identifiers, so a dataset or table name can only be supplied through `${name}`.

The documentation described `${name}` only as "extracted from message headers and formed the translated query", which does not convey that the substitution is literal text rather than parameter binding, and gave no guidance to use `@name` for values.

This adds a `Query Placeholders` section documenting the split, and reports at WARN level when a `${name}` substitution does not have the shape of a BigQuery identifier. Only the placeholder name is logged, never the substituted value.

The substitution behaviour itself is unchanged, so no upgrade-guide entry is needed (and per project convention upgrade guides live on `main` regardless).

## Divergences from the `main` commit

1. **The catalog doc mirror is dropped.** `catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/google-bigquery-sql-component.adoc` does not exist on `camel-4.18.x` — this branch carries 1 file under that directory versus 702 on `camel-4.22.x`, so the per-component catalog doc mirror is not maintained here. Adding it would introduce a file the branch does not otherwise ship.
2. **AsciiDoc fence style adapted.** This branch uses long-dash delimiters throughout that file (12 of them, zero `----`). The cherry-pick would have introduced three `----` fences; they were converted so the file stays internally consistent. Purely cosmetic — both forms are valid AsciiDoc.

**All three Java files are byte-identical to `main`.** Verified by direct comparison against `origin/main`: `SqlHelper.java`, `SqlHelperIdentifierTest.java`, `SqlHelperTest.java`. No behavioural difference from the change reviewed on #26007.

## Verification

- Resulting changeset: 4 files, +142 −4. No conflict markers, no `----` fences remaining.
- Module build green: 9 unit tests, 0 failures.

_Claude Code on behalf of oscerd_