### PR TITLE
ci: scope the local docs build to components 4.18.x so PR doc validation resolves xrefs

### DIFF
--- a/docs/source-watch.yml
+++ b/docs/source-watch.yml
@@ -23,8 +23,7 @@
           branch_includes: main
           start_path_includes: docs/components,components-starter
       components:
-# uncomment to work only on components
-#        - name: components
-#          version: next
+        - name: components
+          version: 4.18.x
 # uncomment to work only on the user manual
 #        - name: manual


### PR DESCRIPTION
## What

Same fix `camel-4.22.x` received in **#25748**, applied to this branch.

`docs/source-watch.yml` had its `components:` filter commented out, so it is an empty key:

```yaml
      components:
-# uncomment to work only on components
-#        - name: components
-#          version: next
+        - name: components
+          version: 4.18.x
```

## Why it matters

The `PR doc validation` job runs camel-website's `antora-local-build.sh` in `quick` mode, which builds the local checkout and resolves everything else from the published `site-manifest.json`. That filter is what declares which components come from local sources.

With it empty the local build is unscoped, so Antora tries to resolve the whole `components` namespace out of a checkout that does not carry every page, and every `components::` xref fails.

`4.18.x` matches what both `docs/components/antora.yml` and `core/camel-core-engine/src/main/docs/antora.yml` already declare here.

## Evidence

On `camel-4.22.x` this exact gap produced **433 asciidoctor errors on every PR**, in files the PRs never touched, while a main-based run reported 0. #25748 took it from 433 to 0.

Here it is **latent** — no recent PR targeting `camel-4.18.x` has triggered doc validation, so nothing has surfaced it yet. The workflow is present on this branch, so the first docs-touching PR would hit it.

## Verification

The same reasoning and change that was proven on `camel-4.22.x`. I could not run the Antora build locally (camel-website has no toolchain installed here, and installing it hits the same native-dependency problem that intermittently breaks this job), so the doc-validation job on this PR is the test.

Since the failure is latent on this branch, a green run here does not by itself prove much — the meaningful evidence is #25748, where the identical change fixed a reproducible 433-error failure.