### PR TITLE
CAMEL-24548 CAMEL-24549: Sync backport upgrade guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -30,6 +30,19 @@ resolves back inside the polled directory remains accepted. Two configurations c
 server that reports names navigating above the polled directory, and a `fileName` expression (used when
 `useList=false`) that navigates above it. Set `jailStartingDirectory=false` if such a path is intended.
 
+=== camel-azure-storage-blob and camel-azure-storage-datalake
+
+Local downloads configured with `fileDir` now resolve existing filesystem path segments before checking
+that the destination remains inside the configured directory. Downloads through a symbolic link that
+resolves outside `fileDir` are rejected. Valid nested download paths continue to work.
+
+=== camel-google-storage
+
+Local downloads configured with a plain `downloadFileName` directory now resolve existing filesystem
+path segments before checking that the destination remains inside that directory. Downloads through a
+symbolic link that resolves outside the configured directory are rejected. Valid object names using `/`
+as a pseudo-directory separator continue to work.
+
 === camel-spring-redis - the default serializer applies a deserialization filter
 
 The default serializer, `JdkSerializationRedisSerializer`, now installs a

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -42,6 +42,19 @@ resolves back inside the polled directory remains accepted. Two configurations c
 server that reports names navigating above the polled directory, and a `fileName` expression (used when
 `useList=false`) that navigates above it. Set `jailStartingDirectory=false` if such a path is intended.
 
+=== camel-azure-storage-blob and camel-azure-storage-datalake
+
+Local downloads configured with `fileDir` now resolve existing filesystem path segments before checking
+that the destination remains inside the configured directory. Downloads through a symbolic link that
+resolves outside `fileDir` are rejected. Valid nested download paths continue to work.
+
+=== camel-google-storage
+
+Local downloads configured with a plain `downloadFileName` directory now resolve existing filesystem
+path segments before checking that the destination remains inside that directory. Downloads through a
+symbolic link that resolves outside the configured directory are rejected. Valid object names using `/`
+as a pseudo-directory separator continue to work.
+
 === camel-spring-redis - the default serializer applies a deserialization filter
 
 The default serializer, `JdkSerializationRedisSerializer`, now installs a JEP-290


### PR DESCRIPTION
Adds the 4.18.5 and 4.22.1 symlink-aware download-containment notes to the canonical versioned upgrade guides on `main`. The text mirrors the documentation shipped by backport PRs #25991 and #25990.

This is a documentation-only follow-up to #25873; no runtime code changes are included.

_Generated by Codex via OSS Helper on behalf of oscerd_

Co-authored-by: Codex <noreply@openai.com>