### PR TITLE
CAMEL-24400: camel-jbang - honor camel.jbang.camel-version system property

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/Export.java
@@ -223,6 +223,7 @@ public class Export extends ExportBaseCommand {
      */
     private void overrideFromSystemProperties() {
         this.quarkusPlatform = QuarkusPlatformMixin.of(System.getProperties(), this.quarkusPlatform);
+        this.camelVersion = PropertyResolver.fromSystemProperty(CAMEL_VERSION, () -> this.camelVersion);
         this.camelSpringBootVersion
                 = PropertyResolver.fromSystemProperty(CAMEL_SPRING_BOOT_VERSION, () -> this.camelSpringBootVersion);
     }

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -989,6 +989,28 @@ class ExportTest {
                 System.getProperty(CamelJBangConstants.QUARKUS_VERSION));
     }
 
+    @Test
+    @SetSystemProperty(key = CamelJBangConstants.CAMEL_VERSION, value = RELEASED_CAMEL_VERSION)
+    public void shouldOverrideCamelVersionFromSystemProperty() throws Exception {
+        LOG.info("shouldOverrideCamelVersionFromSystemProperty");
+
+        Export command = createCommand(RuntimeType.main, new String[] { "classpath:route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+
+        Model model = readMavenModel();
+        assertThat(model.getDependencyManagement().getDependencies())
+                .as("Expected camel-bom to use the version from the %s system property",
+                        CamelJBangConstants.CAMEL_VERSION)
+                .anySatisfy(dep -> {
+                    assertThat(dep.getGroupId()).isEqualTo("org.apache.camel");
+                    assertThat(dep.getArtifactId()).isEqualTo("camel-bom");
+                    assertThat(dep.getVersion()).isEqualTo(RELEASED_CAMEL_VERSION);
+                });
+    }
+
     @ParameterizedTest
     @MethodSource("runtimeProvider")
     public void shouldExportHawtio(RuntimeType rt) throws Exception {


### PR DESCRIPTION
# Description

`camel export` documents `camel.jbang.camel-version` as a supported option, but setting it as a
system property had no effect. The exported project kept the default Camel version, while the
equivalent `--camel-version` flag worked, so the two ways of setting the same thing disagreed.

`Export.overrideFromSystemProperties()` only read the Quarkus platform and
`camel.jbang.camelSpringBootVersion`. The Camel version was read from `application.properties`
but had no system property path, unlike `camelSpringBootVersion` which has both. This adds the
missing line so the two options behave the same way.

Reproducer from the issue:

```bash
camel export --runtime=quarkus -Dcamel.jbang.camel-version=4.8.0 hello.java
```

Before this change the exported pom used the running Camel version, after it the pom uses 4.8.0.

`ExportTest#shouldOverrideCamelVersionFromSystemProperty` was added next to the existing Spring Boot
and Quarkus system property tests. It asserts the exported pom imports `camel-bom` at the requested
version. With the fix reverted it fails with `expected: "4.13.0" but was: "4.23.0-SNAPSHOT"`, which
is the symptom described in the issue.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

CAMEL-24400

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code on behalf of chala2001_
