### PR TITLE
CAMEL-24409: keep binary bodies intact in rest client request validation

### DIFF
--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredBodyTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/rest/RestJettyRequiredBodyTest.java
@@ -26,10 +26,14 @@ import org.apache.camel.model.rest.RestParamType;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit6.TestSupport.assertIsInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RestJettyRequiredBodyTest extends BaseJettyTest {
+
+    // bytes that are not valid UTF-8, so they would be replaced if the body was turned into a String
+    private static final byte[] BINARY_BODY = { 0x00, 0x01, (byte) 0xFF, (byte) 0xFE, (byte) 0x80, 0x7F, (byte) 0xC3, 0x28 };
 
     @Test
     public void testJettyValid() {
@@ -70,6 +74,18 @@ public class RestJettyRequiredBodyTest extends BaseJettyTest {
         assertEquals("The request body is missing.", cause.getResponseBody());
     }
 
+    @Test
+    public void testJettyBinaryBodyNotCorrupted() {
+        byte[] out = fluentTemplate.withHeader(Exchange.CONTENT_TYPE, "application/octet-stream")
+                .withHeader("Accept", "application/octet-stream")
+                .withHeader(Exchange.HTTP_METHOD, "post")
+                .withBody(BINARY_BODY)
+                .to("http://localhost:" + getPort() + "/users/123/upload")
+                .request(byte[].class);
+
+        assertArrayEquals(BINARY_BODY, out);
+    }
+
     @Override
     protected RouteBuilder createRouteBuilder() {
         return new RouteBuilder() {
@@ -85,6 +101,13 @@ public class RestJettyRequiredBodyTest extends BaseJettyTest {
                         .name("body").required(true).type(RestParamType.body)
                         .endParam().to("direct:update");
                 from("direct:update").setBody(constant("{ \"status\": \"ok\" }"));
+
+                // a binary service that echoes back what it received
+                rest("/users/").post("{id}/upload").consumes("application/octet-stream")
+                        .produces("application/octet-stream").param()
+                        .name("body").required(true).type(RestParamType.body)
+                        .endParam().to("direct:upload");
+                from("direct:upload").setBody(bodyAs(byte[].class));
             }
         };
     }

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultRestClientRequestValidator.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/DefaultRestClientRequestValidator.java
@@ -74,11 +74,11 @@ public class DefaultRestClientRequestValidator implements RestClientRequestValid
         Object body = exchange.getMessage().getBody();
         if (validationContext.requiredBody()) {
             // the body is required, so we need to know if we have a body or not
-            // so force reading the body as a String which we can work with
+            // so force reading the body as a String which we can work with.
+            // extractBodyAsString uses stream caching so the message body stays re-readable,
+            // and the body is deliberately not replaced with the String as that would
+            // corrupt binary payloads such as application/octet-stream
             body = MessageHelper.extractBodyAsString(exchange.getIn());
-            if (ObjectHelper.isNotEmpty(body)) {
-                exchange.getIn().setBody(body);
-            }
             if (ObjectHelper.isEmpty(body)) {
                 // this is a bad request, the client did not include a message body
                 return new ValidationError(400, "The request body is missing.");

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1252,3 +1252,10 @@ Local downloads configured with a plain `downloadFileName` directory now resolve
 path segments before checking that the destination remains inside that directory. Downloads through a
 symbolic link that resolves outside the configured directory are rejected. Valid object names using `/`
 as a pseudo-directory separator continue to work.
+
+=== camel-core - REST client request validation and binary bodies
+
+When `clientRequestValidation` is enabled and the REST service declares a required body, the incoming
+message body is no longer replaced with a `String` version of itself. That conversion corrupted binary
+payloads such as `application/octet-stream`. The body is still read to check that it is present, using
+stream caching so it stays re-readable, but it now keeps its original type.


### PR DESCRIPTION
# Description

With `clientRequestValidation` enabled and a REST service that declares a required body, binary
payloads came through corrupted. Posting `application/octet-stream` data ended up with large parts
of the content replaced by `EF BF BD`, the Unicode replacement character.

`DefaultRestClientRequestValidator` reads the body as a String to check that it is present, and then
wrote that String back onto the message:

```java
body = MessageHelper.extractBodyAsString(exchange.getIn());
if (ObjectHelper.isNotEmpty(body)) {
    exchange.getIn().setBody(body);
}
```

The write back is what destroys the payload. Bytes that are not valid UTF-8 do not survive the trip
through a String, so the route downstream receives replacement characters instead of the original
data. The write back is also not needed to keep the body readable: `MessageHelper.extractBodyAsString`
already converts the body to a `StreamCache`, sets that on the message and resets it, so the body
stays re-readable on its own. Removing the two lines keeps the required body check and leaves the
payload alone.

This was raised on Zulip and James Netherton pointed at these lines as the likely cause:
https://camel.zulipchat.com/#narrow/channel/257302-camel-quarkus/topic/Binary.20data.20issue.20using.20Rest.20DSL/with/617455026

`RestJettyRequiredBodyTest#testJettyBinaryBodyNotCorrupted` posts a small byte array that is not
valid UTF-8 to an `application/octet-stream` service with a required body, and asserts the bytes
come back unchanged. With the fix reverted the test fails, since the payload comes back with
replacement characters.

Also added a short note to the 4.23 upgrade guide, because the message body type after validation
changes for anyone who relied on it being a String.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

CAMEL-24409

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

_Claude Code on behalf of chala2001_
