### PR TITLE
ci: apply threshold to Scalpel-detected modules in incremental build

### DIFF
--- a/.github/actions/incremental-build/incremental-build.sh
+++ b/.github/actions/incremental-build/incremental-build.sh
@@ -860,6 +860,21 @@ main() {
       if [[ ${totalTestableProjects} -gt ${maxNumberOfTestableProjects} ]]; then
         echo "Too many dependent modules (${totalTestableProjects} > ${maxNumberOfTestableProjects}), testing only the affected modules"
         testedDependents=false
+        # Strip dependency-detected modules (grep + Scalpel) from the build list.
+        # These are "dependents" just like -amd expansion and should be subject
+        # to the same threshold. Without this, Scalpel-detected modules bypass
+        # the threshold and all ~N dependents get tested anyway.
+        dep_module_ids=""
+        final_pl=""
+        if [ -n "$testable_pl" ]; then
+          final_pl="$testable_pl"
+        fi
+        if [ -n "$pom_only_pl" ]; then
+          final_pl="${final_pl:+${final_pl},}${pom_only_pl}"
+        fi
+        if [ -n "$extraModules" ]; then
+          final_pl="${final_pl:+${final_pl},}${extraModules}"
+        fi
       else
         echo "Testing affected modules and their dependents (${totalTestableProjects} modules)"
         use_amd=true


### PR DESCRIPTION
## Summary

_Claude Code on behalf of gnodet_

- Before Scalpel, when the `-amd` expansion of changed modules exceeded the threshold (50), the build would only test the directly changed modules. The CI comment correctly reported "Dependent modules were not tested because the total number of affected modules exceeded the threshold."
- With Scalpel, detected dependent modules are added explicitly to `-pl` (merged at step 2c), **bypassing the threshold entirely**. For core module changes (`camel-api`, `camel-support`), this means ~591 modules get tested regardless of the threshold — making the comment misleading.
- This fix strips dependency-detected modules (grep + Scalpel) from the build list when the threshold is exceeded, restoring the pre-Scalpel behavior. The `test-dependents` label still forces testing all dependents.

## Test plan

- [x] Verify that CI changes are under `.github/` path-ignore and won't trigger a full build
- [ ] Validate by opening a test PR that touches `core/camel-support` — should only test the directly changed modules, not ~591 dependents
- [ ] Verify `test-dependents` label still overrides the threshold

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>