### PR TITLE
CAMEL-23794 - revert fedora base image version to stable version 43 for SMB Tests

### DIFF
--- a/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/container.properties
+++ b/test-infra/camel-test-infra-smb/src/main/resources/org/apache/camel/test/infra/smb/services/container.properties
@@ -14,5 +14,5 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-smb.service.from.image=mirror.gcr.io/fedora:45
+smb.service.from.image=mirror.gcr.io/fedora:43
 


### PR DESCRIPTION

it was upgraded, at one place but not everywhere, to fedora:45 which is not a stable version. On some s390x machine, it is causing this error:

```
#5 41.01 >>> Running sysusers scriptlet: systemd-udev-0:261.2-1.fc45.s390x
#5 41.01 >>> Error in sysusers scriptlet: systemd-udev-0:261.2-1.fc45.s390x
#5 41.01 >>> Scriptlet output:
#5 41.01 >>> Failed to chase '/usr/lib/sysusers.d': Protocol driver not attached
```

the visible error during build was:

```
rg.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=<resolving>, imagePullPolicy=DefaultPullPolicy(), imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@e95595b)
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1308)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:346)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:317)
	at org.apache.camel.test.infra.smb.services.SmbLocalContainerInfraService.initialize(SmbLocalContainerInfraService.java:76)
	at org.apache.camel.test.infra.common.services.SingletonService.doInitializeService(SingletonService.java:55)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at org.apache.camel.test.infra.common.services.SingletonService.addToStore(SingletonService.java:48)
	at org.apache.camel.test.infra.common.services.SingletonService.beforeAll(SingletonService.java:61)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: com.github.dockerjava.api.exception.DockerClientException: Could not build image: The command '/bin/sh -c dnf install -y samba && mkdir -p /data/rw /data/ro /data/no-delete /data/unix-security /data/fixed-delete /data/unix-owned' returned a non-zero code: 1
	at com.github.dockerjava.api.command.BuildImageResultCallback.getImageId(BuildImageResultCallback.java:71)
	at com.github.dockerjava.api.command.BuildImageResultCallback.awaitImageId(BuildImageResultCallback.java:50)
	at org.testcontainers.images.builder.ImageFromDockerfile.resolve(ImageFromDockerfile.java:165)
	at org.testcontainers.images.builder.ImageFromDockerfile.resolve(ImageFromDockerfile.java:43)
	at org.testcontainers.utility.LazyFuture.getResolvedValue(LazyFuture.java:20)
	at org.testcontainers.utility.LazyFuture.get(LazyFuture.java:41)
	at org.testcontainers.shaded.com.google.common.util.concurrent.Futures$1.get(Futures.java:538)
	at org.testcontainers.images.RemoteDockerImage.getImageName(RemoteDockerImage.java:172)
	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:76)
	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:35)
	at org.testcontainers.utility.LazyFuture.getResolvedValue(LazyFuture.java:20)
	at org.testcontainers.utility.LazyFuture.get(LazyFuture.java:41)
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1306)
	... 8 more
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

