### PR TITLE
[backport camel-4.22.x] CAMEL-24418: camel-http/http-common/netty-http/undertow/vertx-http - do not resolve property placeholders in HTTP URI override headers

### DIFF
--- a/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
+++ b/components/camel-http-common/src/main/java/org/apache/camel/http/common/HttpHelper.java
@@ -33,7 +33,6 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
-import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.converter.stream.CachedOutputStream;
 import org.apache.camel.support.CamelObjectInputStream;
 import org.apache.camel.support.DeserializationFilterHelper;
@@ -211,12 +210,9 @@ public final class HttpHelper {
             uri = endpoint.getHttpUri().toASCIIString();
         }
 
-        // resolve placeholders in uri
-        try {
-            uri = exchange.getContext().resolvePropertyPlaceholders(uri);
-        } catch (Exception e) {
-            throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uri, exchange, e);
-        }
+        // NOTE: no placeholder resolution here. When uri came from the endpoint it was already resolved at
+        // build time, and when it came from the CamelHttpUri header it carries message content
+        // (see CAMEL-24282 / CAMEL-24418)
 
         // append HTTP_PATH to HTTP_URI if it is provided in the header
         String path = exchange.getIn().getHeader(Exchange.HTTP_PATH, String.class);
@@ -331,12 +327,8 @@ public final class HttpHelper {
         String queryString = exchange.getIn().getHeader(Exchange.HTTP_QUERY, String.class);
         // We need also check the HTTP_URI header query part
         String uriString = exchange.getIn().getHeader(Exchange.HTTP_URI, String.class);
-        // resolve placeholders in uriString
-        try {
-            uriString = exchange.getContext().resolvePropertyPlaceholders(uriString);
-        } catch (Exception e) {
-            throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uriString, exchange, e);
-        }
+        // NOTE: property placeholders are resolved at build time on the endpoint uri written in the route,
+        // never on this header value, which carries message content (see CAMEL-24282 / CAMEL-24418)
         if (uriString != null) {
             // in case the URI string contains unsafe characters
             uriString = UnsafeUriCharactersEncoder.encodeHttpURI(uriString);

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/helper/HttpMethodHelper.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/helper/HttpMethodHelper.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.StreamCache;
 import org.apache.camel.component.http.HttpConstants;
 import org.apache.camel.component.http.HttpEndpoint;
@@ -46,12 +45,8 @@ public final class HttpMethodHelper {
             uriString = exchange.getIn().getHeader(HttpConstants.HTTP_URI, String.class);
         }
         if (uriString != null) {
-            // resolve placeholders in uriString
-            try {
-                uriString = exchange.getContext().resolvePropertyPlaceholders(uriString);
-            } catch (Exception e) {
-                throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uriString, exchange, e);
-            }
+            // NOTE: property placeholders are resolved at build time on the endpoint uri written in the route,
+            // never on this header value, which carries message content (see CAMEL-24282 / CAMEL-24418)
             // in case the URI string contains unsafe characters
             uriString = UnsafeUriCharactersEncoder.encodeHttpURI(uriString);
             URI uri = new URI(uriString);

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpUriHeaderPlaceholderTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpUriHeaderPlaceholderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http;
+
+import java.util.Properties;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.http.common.HttpHelper;
+import org.apache.camel.http.common.HttpMethods;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Property placeholders are resolved at build time on the endpoint uri written in the route, never on the
+ * {@code CamelHttpUri} header, which carries message content. See CAMEL-24282 / CAMEL-24418.
+ */
+class HttpUriHeaderPlaceholderTest {
+
+    @Test
+    void placeholderInHttpUriHeaderIsNotResolved() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            Properties prop = new Properties();
+            prop.setProperty("secretValue", "s3cr3t");
+            context.getPropertiesComponent().setInitialProperties(prop);
+            context.start();
+
+            HttpEndpoint endpoint = context.getEndpoint("http://localhost/base", HttpEndpoint.class);
+            Exchange exchange = new DefaultExchange(context);
+            exchange.getIn().setHeader(Exchange.HTTP_URI, "http://localhost/api?k={{secretValue}}");
+
+            // the token survives as a literal (percent-encoded by UnsafeUriCharactersEncoder, as any other
+            // unsafe character in a header-supplied uri would be) and is never expanded
+            assertThat(HttpHelper.createURL(exchange, endpoint))
+                    .isEqualTo("http://localhost/api?k=%7B%7BsecretValue%7D%7D")
+                    .doesNotContain("s3cr3t");
+        }
+    }
+
+    @Test
+    void placeholderInHttpUriHeaderQueryIsNotResolvedByCreateMethod() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+
+            HttpEndpoint endpoint = context.getEndpoint("http://localhost/base", HttpEndpoint.class);
+            Exchange exchange = new DefaultExchange(context);
+            // createMethod parses the query out of this header too, and bridgeEndpoint does not bound it the
+            // way it bounds createURL. The key is deliberately NOT a defined property: had the header been run
+            // through the placeholder resolver, an unknown key would fail fast rather than survive as a literal.
+            exchange.getIn().setHeader(Exchange.HTTP_URI, "http://localhost/api?k={{noSuchProperty}}");
+
+            // a query string is present, so GET is selected, and the token never reaches the resolver
+            assertThat(HttpHelper.createMethod(exchange, endpoint, false)).isEqualTo(HttpMethods.GET);
+        }
+    }
+
+    @Test
+    void placeholderInHttpUriHeaderIsNotResolvedByCreateUrlEither() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+
+            HttpEndpoint endpoint = context.getEndpoint("http://localhost/base", HttpEndpoint.class);
+            Exchange exchange = new DefaultExchange(context);
+            exchange.getIn().setHeader(Exchange.HTTP_URI, "http://localhost/api?k={{noSuchProperty}}");
+
+            // same guarantee on the createURL path, again with an undefined key so that any future
+            // resolution of this header would surface as a failure rather than silently expanding
+            assertThat(HttpHelper.createURL(exchange, endpoint))
+                    .isEqualTo("http://localhost/api?k=%7B%7BnoSuchProperty%7D%7D");
+        }
+    }
+
+    @Test
+    void placeholderInEndpointUriIsResolvedAtBuildTime() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            Properties prop = new Properties();
+            prop.setProperty("basePath", "resolved");
+            context.getPropertiesComponent().setInitialProperties(prop);
+            context.start();
+
+            // control: a placeholder written in the route's endpoint uri is still resolved, as before
+            HttpEndpoint endpoint = context.getEndpoint("http://localhost/{{basePath}}", HttpEndpoint.class);
+            Exchange exchange = new DefaultExchange(context);
+
+            assertThat(HttpHelper.createURL(exchange, endpoint)).isEqualTo("http://localhost/resolved");
+        }
+    }
+}

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpEndpointUriEncodingIssueTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/HttpEndpointUriEncodingIssueTest.java
@@ -21,12 +21,13 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
  */
-public class HttpEndpointUriEncodingIssueTest extends BaseJettyTest {
+class HttpEndpointUriEncodingIssueTest extends BaseJettyTest {
 
     @Test
     public void testEndpointUriEncodingIssue() {
@@ -45,11 +46,13 @@ public class HttpEndpointUriEncodingIssueTest extends BaseJettyTest {
     }
 
     @Test
-    public void testEndpointHeaderUriEncodingIssue() {
-        String uri = "http://localhost:{{port}}/myapp/mytest?columns=totalsens,upsens&username=apiuser";
+    void testEndpointHeaderUriEncodingIssue() {
+        // the uri is supplied via the CamelHttpUri header, which is message content and therefore not
+        // subject to property placeholder resolution, so the port must be resolved up-front here
+        String uri = "http://localhost:" + getPort() + "/myapp/mytest?columns=totalsens,upsens&username=apiuser";
         String out = template.requestBodyAndHeader("http://localhost/dummy", null, Exchange.HTTP_URI, uri, String.class);
 
-        assertEquals("We got totalsens,upsens columns", out);
+        assertThat(out).isEqualTo("We got totalsens,upsens columns");
     }
 
     @Override

--- a/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpHelper.java
+++ b/components/camel-netty-http/src/main/java/org/apache/camel/component/netty/http/NettyHttpHelper.java
@@ -27,7 +27,6 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.support.DeserializationFilterHelper;
 import org.apache.camel.util.CollectionHelper;
 import org.apache.camel.util.IOHelper;
@@ -165,12 +164,8 @@ public final class NettyHttpHelper {
             uri = endpoint.getEndpointUri();
         }
 
-        // resolve placeholders in uri
-        try {
-            uri = exchange.getContext().resolvePropertyPlaceholders(uri);
-        } catch (Exception e) {
-            throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uri, exchange, e);
-        }
+        // NOTE: property placeholders are resolved at build time on the endpoint uri written in the route,
+        // never on the message-supplied override headers (see CAMEL-24282 / CAMEL-24418)
 
         // append HTTP_PATH to HTTP_URI if it is provided in the header
         String path = exchange.getIn().getHeader(NettyHttpConstants.HTTP_PATH, String.class);

--- a/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHelper.java
+++ b/components/camel-undertow/src/main/java/org/apache/camel/component/undertow/UndertowHelper.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import org.apache.camel.Exchange;
-import org.apache.camel.RuntimeExchangeException;
 import org.apache.camel.util.CollectionHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
@@ -51,12 +50,8 @@ public final class UndertowHelper {
             uri = endpoint.getHttpURI().toASCIIString();
         }
 
-        // resolve placeholders in uri
-        try {
-            uri = exchange.getContext().resolvePropertyPlaceholders(uri);
-        } catch (Exception e) {
-            throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uri, exchange, e);
-        }
+        // NOTE: property placeholders are resolved at build time on the endpoint uri written in the route,
+        // never on the message-supplied override headers (see CAMEL-24282 / CAMEL-24418)
 
         // append HTTP_PATH to HTTP_URI if it is provided in the header
         String path = exchange.getIn().getHeader(UndertowConstants.HTTP_PATH, String.class);
@@ -126,12 +121,8 @@ public final class UndertowHelper {
         String queryString = exchange.getIn().getHeader(UndertowConstants.HTTP_QUERY, String.class);
         // We need also check the HTTP_URI header query part
         String uriString = exchange.getIn().getHeader(UndertowConstants.HTTP_URI, String.class);
-        // resolve placeholders in uriString
-        try {
-            uriString = exchange.getContext().resolvePropertyPlaceholders(uriString);
-        } catch (Exception e) {
-            throw new RuntimeExchangeException("Cannot resolve property placeholders with uri: " + uriString, exchange, e);
-        }
+        // NOTE: property placeholders are resolved at build time on the endpoint uri written in the route,
+        // never on this header value, which carries message content (see CAMEL-24282 / CAMEL-24418)
         if (uriString != null) {
             URI uri = new URI(uriString);
             queryString = uri.getQuery();

--- a/components/camel-vertx/camel-vertx-http/src/main/java/org/apache/camel/component/vertx/http/VertxHttpHelper.java
+++ b/components/camel-vertx/camel-vertx-http/src/main/java/org/apache/camel/component/vertx/http/VertxHttpHelper.java
@@ -54,8 +54,8 @@ public final class VertxHttpHelper {
             uri = endpoint.getConfiguration().getHttpUri().toASCIIString();
         }
 
-        // Resolve property placeholders that may be present in the URI
-        uri = exchange.getContext().resolvePropertyPlaceholders(uri);
+        // NOTE: property placeholders are resolved at build time on the endpoint uri written in the route,
+        // never on the message-supplied override headers (see CAMEL-24282 / CAMEL-24418)
 
         // Append HTTP_PATH header value if is present
         String path = message.getHeader(VertxHttpConstants.HTTP_PATH, String.class);


### PR DESCRIPTION
## Backport of #25571 to `camel-4.22.x`

Cherry-pick of `ba5aced7f6a1` (CAMEL-24418) onto `camel-4.22.x`.

**Original PR:** #25571 — CAMEL-24418: camel-http/http-common/netty-http/undertow/vertx-http - do not resolve property placeholders in HTTP URI override headers
**Original author:** @oscerd
**JIRA:** [CAMEL-24418](https://issues.apache.org/jira/browse/CAMEL-24418)

### What changed

The HTTP producers no longer resolve property placeholders (`{{...}}`) on the message-supplied
endpoint-URI override headers `CamelHttpUri` and `CamelRestHttpUri`. Placeholders written in the
route's endpoint URI continue to resolve at build time exactly as before.

### Straight cherry-pick

Clean pick — the seven source and test files applied without conflict and with no hand edits.

The only conflict was `docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc`,
which does not exist on this branch (`modify/delete`). It is intentionally **not** part of the
backport: the upgrade guides for every release line live on `main`, so the 4.22 note is added to
`camel-4x-upgrade-guide-4_22.adoc` there instead.

### Verification

Full reactor `mvn clean install -DskipTests` on this branch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDvCTjCXTvWTZxJQws95UH
