### PR TITLE
CAMEL-24585: Fix catalog validateLanguageExpression NPE for simple expressions using jsonpath/jq/xpath functions

### DIFF
--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1244,6 +1244,18 @@ public class CamelCatalogTest {
     }
 
     @Test
+    public void testValidateSimpleJSonPathFunction() {
+        // CAMEL-24585: a simple expression that delegates to the jsonpath language must validate
+        // even though the tooling uses a bare CamelContext without a type converter
+        LanguageValidationResult result = catalog.validateLanguageExpression(null, "simple", "${jsonpath($.foo)}");
+        assertTrue(result.isSuccess());
+        assertEquals("${jsonpath($.foo)}", result.getText());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${jsonpath($.store.book[?(@.price < 10)])} != null");
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
     public void testValidateJQLanguage() {
         LanguageValidationResult result = catalog.validateLanguagePredicate(null, "jq", ".foo == \"bar\"");
         assertTrue(result.isSuccess());

--- a/core/camel-support/src/main/java/org/apache/camel/support/LanguageSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/LanguageSupport.java
@@ -24,6 +24,7 @@ import org.apache.camel.CamelContextAware;
 import org.apache.camel.ExpressionIllegalSyntaxException;
 import org.apache.camel.IsSingleton;
 import org.apache.camel.NoSuchBeanException;
+import org.apache.camel.TypeConverter;
 import org.apache.camel.spi.Language;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.TimeUtils;
@@ -176,11 +177,13 @@ public abstract class LanguageSupport implements Language, IsSingleton, CamelCon
         if (value == null) {
             return null;
         }
-        if (camelContext != null) {
-            return camelContext.getTypeConverter().convertTo(type, value);
-        } else {
-            return (T) value;
+        TypeConverter converter = camelContext != null ? camelContext.getTypeConverter() : null;
+        if (converter != null) {
+            return converter.convertTo(type, value);
         }
+        // no type converter is available (e.g. when using a bare CamelContext for tooling/validation
+        // that has not been initialized) so return the value as-is
+        return (T) value;
     }
 
 }


### PR DESCRIPTION
## Description

[CAMEL-24585](https://issues.apache.org/jira/browse/CAMEL-24585)

`CamelCatalog.validateLanguageExpression(cl, "simple", "${jsonpath($.foo)}")` fails with:

```
Cannot invoke "org.apache.camel.TypeConverter.convertTo(java.lang.Class, Object)"
because the return value of "org.apache.camel.CamelContext.getTypeConverter()" is null
```

This regressed for simple expressions that embed a delegating language function
(`${jsonpath(...)}`, `${jq(...)}`, `${xpath(...)}`). Plain simple expressions
(`${header.foo}`, `${bodyAs(String)}`) are unaffected.

## Root cause

The catalog validates simple expressions by parsing them against a deliberately
**uninitialized** `SimpleCamelContext` (no type converter). When the simple parser
encounters a delegating function it eagerly initializes the target language
(via `ExpressionBuilder.languageExpression`), which resolves the target language's
default option values through `LanguageSupport.property()`. That method
unconditionally called `camelContext.getTypeConverter().convertTo(type, value)`
— even for values that are already the correct type (e.g. the `suppressExceptions`
boolean default) — and `getTypeConverter()` is `null` on the bare tooling context,
producing an NPE.

## Fix

Guard `LanguageSupport.property()` against a null type converter: when no converter
is available (i.e. a bare `CamelContext` used only for tooling/validation), return
the value as-is, mirroring the existing `camelContext == null` branch. In a fully
initialized runtime context the type converter is always present, so runtime
behavior is unchanged.

## Testing

- Added a regression test `CamelCatalogTest#testValidateSimpleJSonPathFunction`
  validating `${jsonpath($.foo)}` (expression and predicate) succeeds.
- Reproduced the original NPE on 4.22.0 and confirmed the fix resolves it.
- Full reactor build (`mvn clean install -Dquickly`) passes.

---
_Claude Code on behalf of davsclaus_