### PR TITLE
CAMEL-24588: camel-jms - disable IBM MQ tests on GitHub Actions

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/JmsComponentIbmMQTest.java
@@ -28,11 +28,14 @@ import org.apache.camel.test.infra.ibmmq.services.IbmMQService;
 import org.apache.camel.test.infra.ibmmq.services.IbmMQServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+                          disabledReason = "The IBM MQ image on icr.io is not reliably pullable from GitHub Actions")
 @DisabledOnOs(architectures = { "aarch64", "aarch_64" }, disabledReason = "IBM MQ has no Linux ARM64 native image")
 public class JmsComponentIbmMQTest extends CamelTestSupport {
 

--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsReplyToIbmMQTest.java
@@ -26,12 +26,15 @@ import org.apache.camel.test.infra.ibmmq.services.IbmMQService;
 import org.apache.camel.test.infra.ibmmq.services.IbmMQServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.component.jms.JmsComponent.jmsComponentAutoAcknowledge;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com",
+                          disabledReason = "The IBM MQ image on icr.io is not reliably pullable from GitHub Actions")
 @DisabledOnOs(architectures = { "aarch64", "aarch_64" }, disabledReason = "IBM MQ has no Linux ARM64 native image")
 class JmsReplyToIbmMQTest extends CamelTestSupport {
 


### PR DESCRIPTION
_Claude Code on behalf of Croway_

## Summary

- `JmsComponentIbmMQTest` and `JmsReplyToIbmMQTest` start `icr.io/ibm-messaging/mq:10.0.0.0-r3` via Testcontainers. icr.io is not reliably reachable from GitHub Actions runners: when the pull hits the Testcontainers 2-minute limit the class errors with `ContainerFetchException`, surefire retries it twice, and a single registry hiccup costs ~18 minutes and fails the PR build (see [PR #26024, run 33542426658](https://github.com/apache/camel/actions/runs/33542426658): 292 s + 507 s + 292 s in camel-jms).
- Disable both tests on GitHub Actions only, using the existing `@DisabledIfSystemProperty(named = "ci.env.name", matches = "github.com")` convention. Jenkins sets `ci.env.name=apache.org` and keeps running them.
- The incremental build already detects this annotation and warns in the PR comment that the tests need manual verification.

Fixes [CAMEL-24588](https://issues.apache.org/jira/browse/CAMEL-24588).

## Test plan

- [x] `mvn test -pl components/camel-jms -Dtest='JmsComponentIbmMQTest,JmsReplyToIbmMQTest' -Dci.env.name=github.com` reports both as skipped with the reason
- [x] Without the property the tests are unaffected (still gated by `@DisabledOnOs` on ARM64)
