### PR TITLE
CAMEL-24592: camel-microprofile-health - only expose health check stack traces in full exposure level

### DIFF
--- a/components/camel-microprofile/camel-microprofile-health/src/main/java/org/apache/camel/microprofile/health/CamelMicroProfileHealthHelper.java
+++ b/components/camel-microprofile/camel-microprofile-health/src/main/java/org/apache/camel/microprofile/health/CamelMicroProfileHealthHelper.java
@@ -60,8 +60,11 @@ final class CamelMicroProfileHealthHelper {
             result.getError().ifPresent(error -> {
                 builder.withData("error.message", error.getMessage());
 
-                final String s = ExceptionHelper.stackTraceToString(error);
-                builder.withData("error.stacktrace", s);
+                // the stack trace is the most verbose detail there is, so only expose it in the full level
+                if (exposureLevel.equals("full")) {
+                    final String s = ExceptionHelper.stackTraceToString(error);
+                    builder.withData("error.stacktrace", s);
+                }
             });
         }
     }

--- a/components/camel-microprofile/camel-microprofile-health/src/test/java/org/apache/camel/microprofile/health/CamelMicroProfileHealthCheckTest.java
+++ b/components/camel-microprofile/camel-microprofile-health/src/test/java/org/apache/camel/microprofile/health/CamelMicroProfileHealthCheckTest.java
@@ -317,7 +317,8 @@ public class CamelMicroProfileHealthCheckTest extends CamelMicroProfileHealthTes
 
         assertHealthCheckOutput("exception-check", Status.DOWN, checks.getJsonObject(0), jsonObject -> {
             assertEquals(errorMessage, jsonObject.getString("error.message"));
-            assertNotNull(jsonObject.getString("error.stacktrace"));
+            // the stack trace is only exposed in the full level
+            assertFalse(jsonObject.containsKey("error.stacktrace"));
         });
     }
 
@@ -359,7 +360,8 @@ public class CamelMicroProfileHealthCheckTest extends CamelMicroProfileHealthTes
         assertHealthCheckOutput("failing-check", HealthCheckResponse.Status.DOWN, failedCheck, result -> {
             assertNotNull(result);
             assertEquals("Forced exception", result.getString("error.message"));
-            assertNotNull(result.getString("error.stacktrace"));
+            // the stack trace is only exposed in the full level
+            assertFalse(result.containsKey("error.stacktrace"));
         });
     }
 

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1145,6 +1145,22 @@ A custom `CamelSagaService` that relies on the header to join sagas started by a
 override the new method. Everything else is unaffected: the header is still set on the exchange, and
 routes reading it continue to work.
 
+=== camel-microprofile-health
+
+The `error.stacktrace` entry of a failed health check is now only included in the response when
+`camel.health.exposure-level` is `full`. At the `default` level the check still reports `error.message`, but no
+longer serialises the whole cause chain of the exception into the health response. The trace is unchanged in the
+application log.
+
+This aligns the MicroProfile health output (and therefore Camel Quarkus, which builds its health responses through
+this module) with the Spring Boot actuator and with the documented meaning of the levels, where `full` is the
+level that includes all details from the invoked health checks. To get the trace back in the response:
+
+[source,properties]
+----
+camel.health.exposure-level = full
+----
+
 === camel-spring-boot
 
 A set of starter defaults changed in this release. Each is a deliberate change to what an application gets


### PR DESCRIPTION
`CamelMicroProfileHealthHelper.applyHealthDetail` adds the full stack trace of a failed health check as `error.stacktrace` at every exposure level except `oneline`, so a DOWN check whose result carries an exception serialises the whole cause chain into the health response at the default level.

`error.stacktrace` is now only added when `camel.health.exposure-level` is `full`. `error.message` is still reported at the `default` level. The trace is unchanged in the application log.

### Why

- It matches the documented meaning of the levels: `full` is the level that includes all details from the invoked health checks, and the stack trace is the most verbose detail there is.
- It keeps the MicroProfile output aligned with the Spring Boot actuator, where the same gating is applied in apache/camel-spring-boot#1929 (CAMEL-18832 originally aligned the two). Camel Quarkus builds its health responses through this module, so it inherits the change with no separate work.
- camel-main's management endpoint is stricter still and includes `error-stacktrace` only when the caller asks for it with `?stackTrace=true`.

### Behaviour change

At the default exposure level the response no longer contains `error.stacktrace`. Documented in the 4.23 upgrade guide; `camel.health.exposure-level = full` restores it.

### Tests

`testHealthCheckCheckedException` and `testExposureLevelDefault` now assert the trace is absent at the default level; `testExposureLevelFull` keeps asserting it is present. `mvn test -pl components/camel-microprofile/camel-microprofile-health` is green.

_Claude Code on behalf of Croway_
