### PR TITLE
[backport camel-4.22.x] CAMEL-24585: Fix catalog validateLanguageExpression NPE for simple expressions using jsonpath/jq/xpath functions

### DIFF
--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1243,6 +1243,18 @@ public class CamelCatalogTest {
     }
 
     @Test
+    public void testValidateSimpleJSonPathFunction() {
+        // CAMEL-24585: a simple expression that delegates to the jsonpath language must validate
+        // even though the tooling uses a bare CamelContext without a type converter
+        LanguageValidationResult result = catalog.validateLanguageExpression(null, "simple", "${jsonpath($.foo)}");
+        assertTrue(result.isSuccess());
+        assertEquals("${jsonpath($.foo)}", result.getText());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${jsonpath($.store.book[?(@.price < 10)])} != null");
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
     public void testValidateJQLanguage() {
         LanguageValidationResult result = catalog.validateLanguagePredicate(null, "jq", ".foo == \"bar\"");
         assertTrue(result.isSuccess());

--- a/core/camel-support/src/main/java/org/apache/camel/support/LanguageSupport.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/LanguageSupport.java
@@ -24,6 +24,7 @@ import org.apache.camel.CamelContextAware;
 import org.apache.camel.ExpressionIllegalSyntaxException;
 import org.apache.camel.IsSingleton;
 import org.apache.camel.NoSuchBeanException;
+import org.apache.camel.TypeConverter;
 import org.apache.camel.spi.Language;
 import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.TimeUtils;
@@ -176,11 +177,13 @@ public abstract class LanguageSupport implements Language, IsSingleton, CamelCon
         if (value == null) {
             return null;
         }
-        if (camelContext != null) {
-            return camelContext.getTypeConverter().convertTo(type, value);
-        } else {
-            return (T) value;
+        TypeConverter converter = camelContext != null ? camelContext.getTypeConverter() : null;
+        if (converter != null) {
+            return converter.convertTo(type, value);
         }
+        // no type converter is available (e.g. when using a bare CamelContext for tooling/validation
+        // that has not been initialized) so return the value as-is
+        return (T) value;
     }
 
 }


### PR DESCRIPTION
## Backport of #26036

Straight cherry-pick (`-x`) of #26036 onto `camel-4.22.x`. No conflicts; mechanical port.

**Original PR:** #26036
**Original author:** @davsclaus
**Target branch:** `camel-4.22.x`

### Original description

Guards `LanguageSupport.property()` against a null type converter so simple expressions embedding a delegating language function (`${jsonpath(...)}`, `${jq(...)}`, `${xpath(...)}`) validate against the bare tooling `CamelContext` used by the catalog. When no type converter is available the value is returned as-is, mirroring the existing `camelContext == null` branch; runtime behavior is unchanged.

Includes regression test `CamelCatalogTest#testValidateSimpleJSonPathFunction`.

_Claude Code on behalf of davsclaus_