### PR TITLE
CAMEL-24589: Fix platform-http shared path consumer removal on route stop

### DIFF
--- a/components/camel-ai/camel-mcp-server/src/main/java/org/apache/camel/component/mcp/server/vertx/VertxMcpServerEngine.java
+++ b/components/camel-ai/camel-mcp-server/src/main/java/org/apache/camel/component/mcp/server/vertx/VertxMcpServerEngine.java
@@ -147,7 +147,7 @@ public class VertxMcpServerEngine extends ServiceSupport implements McpServerEng
         PlatformHttpComponent platformHttpComponent
                 = (PlatformHttpComponent) camelContext.hasComponent("platform-http");
         if (platformHttpComponent != null && info != null) {
-            platformHttpComponent.removeHttpEndpoint(info.path());
+            platformHttpComponent.removeHttpEndpoint(info.path(), null);
         }
         transport = null;
     }

--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerUtil.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerUtil.java
@@ -17,7 +17,9 @@
 package org.apache.camel.component.platform.http.main;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.StartupListener;
@@ -35,14 +37,15 @@ public class MainHttpServerUtil {
             CamelContext camelContext, Set<HttpEndpointModel> endpoints, int serverPort, boolean ssl, String header)
             throws Exception {
         camelContext.addStartupListener(new StartupListener() {
-            private volatile Set<HttpEndpointModel> last;
+            private volatile Set<String> lastEndpointSignatures;
 
             private void logSummary() {
                 if (endpoints.isEmpty()) {
                     return;
                 }
-                // log only if changed
-                if (last == null || last.size() != endpoints.size() || !last.containsAll(endpoints)) {
+                // log only if changed (ignore consumer identity on route reload)
+                Set<String> currentSignatures = endpointSignatures(endpoints);
+                if (lastEndpointSignatures == null || !lastEndpointSignatures.equals(currentSignatures)) {
                     LOG.info(header);
                     int longestEndpoint = 0;
                     int longestVerbs = 0;
@@ -78,8 +81,19 @@ public class MainHttpServerUtil {
                     }
                 }
 
-                // use a defensive copy of last known endpoints
-                last = new HashSet<>(endpoints);
+                lastEndpointSignatures = currentSignatures;
+            }
+
+            private Set<String> endpointSignatures(Set<HttpEndpointModel> endpointModels) {
+                return endpointModels.stream()
+                        .map(this::endpointSignature)
+                        .collect(Collectors.toCollection(HashSet::new));
+            }
+
+            private String endpointSignature(HttpEndpointModel model) {
+                return model.getUri() + "|" + Objects.toString(model.getVerbs(), "") + "|"
+                        + Objects.toString(model.getConsumes(), "") + "|"
+                        + Objects.toString(model.getProduces(), "");
             }
 
             private String getEndpoint(HttpEndpointModel httpEndpointModel, boolean ssl) {

--- a/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerUtil.java
+++ b/components/camel-platform-http-main/src/main/java/org/apache/camel/component/platform/http/main/MainHttpServerUtil.java
@@ -92,8 +92,8 @@ public class MainHttpServerUtil {
 
             private String endpointSignature(HttpEndpointModel model) {
                 return model.getUri() + "|" + Objects.toString(model.getVerbs(), "") + "|"
-                        + Objects.toString(model.getConsumes(), "") + "|"
-                        + Objects.toString(model.getProduces(), "");
+                       + Objects.toString(model.getConsumes(), "") + "|"
+                       + Objects.toString(model.getProduces(), "");
             }
 
             private String getEndpoint(HttpEndpointModel httpEndpointModel, boolean ssl) {

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/DefaultPlatformHttpConsumer.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/DefaultPlatformHttpConsumer.java
@@ -107,7 +107,7 @@ public class DefaultPlatformHttpConsumer extends DefaultConsumer
     protected void doStart() throws Exception {
         super.doStart();
         ServiceHelper.startService(platformHttpConsumer);
-        if (register) {
+        if (register && platformHttpConsumer != null) {
             getComponent().addHttpEndpoint(getEndpoint().getPath(), getEndpoint().getHttpMethodRestrict(),
                     getEndpoint().getConsumes(), getEndpoint().getProduces(), platformHttpConsumer);
         }

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/DefaultPlatformHttpConsumer.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/DefaultPlatformHttpConsumer.java
@@ -117,7 +117,7 @@ public class DefaultPlatformHttpConsumer extends DefaultConsumer
     protected void doStop() throws Exception {
         super.doStop();
         if (register) {
-            getComponent().removeHttpEndpoint(getEndpoint().getPath());
+            getComponent().removeHttpEndpoint(platformHttpConsumer);
         }
         ServiceHelper.stopAndShutdownServices(platformHttpConsumer);
     }

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/DefaultPlatformHttpConsumer.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/DefaultPlatformHttpConsumer.java
@@ -116,7 +116,7 @@ public class DefaultPlatformHttpConsumer extends DefaultConsumer
     @Override
     protected void doStop() throws Exception {
         super.doStop();
-        if (register) {
+        if (register && platformHttpConsumer != null) {
             getComponent().removeHttpEndpoint(platformHttpConsumer);
         }
         ServiceHelper.stopAndShutdownServices(platformHttpConsumer);

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/HttpEndpointModel.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/HttpEndpointModel.java
@@ -25,7 +25,7 @@ import org.apache.camel.util.StringHelper;
 /**
  * Model of available http endpoints.
  */
-public class HttpEndpointModel implements Comparable<HttpEndpointModel> {
+public class HttpEndpointModel {
 
     private final String uri;
     private String verbs;
@@ -102,23 +102,5 @@ public class HttpEndpointModel implements Comparable<HttpEndpointModel> {
     @Override
     public int hashCode() {
         return Objects.hash(uri, consumer);
-    }
-
-    @Override
-    public int compareTo(HttpEndpointModel o) {
-        int cmp = uri.compareTo(o.uri);
-        if (cmp != 0) {
-            return cmp;
-        }
-        if (consumer == o.consumer) {
-            return 0;
-        }
-        if (consumer == null) {
-            return o.consumer == null ? 0 : -1;
-        }
-        if (o.consumer == null) {
-            return 1;
-        }
-        return Integer.compare(System.identityHashCode(consumer), System.identityHashCode(o.consumer));
     }
 }

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/HttpEndpointModel.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/HttpEndpointModel.java
@@ -96,16 +96,29 @@ public class HttpEndpointModel implements Comparable<HttpEndpointModel> {
             return false;
         }
         HttpEndpointModel that = (HttpEndpointModel) o;
-        return uri.equals(that.uri);
+        return uri.equals(that.uri) && consumer == that.consumer;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri);
+        return Objects.hash(uri, consumer);
     }
 
     @Override
     public int compareTo(HttpEndpointModel o) {
-        return uri.compareTo(o.uri);
+        int cmp = uri.compareTo(o.uri);
+        if (cmp != 0) {
+            return cmp;
+        }
+        if (consumer == o.consumer) {
+            return 0;
+        }
+        if (consumer == null) {
+            return o.consumer == null ? 0 : -1;
+        }
+        if (o.consumer == null) {
+            return 1;
+        }
+        return Integer.compare(System.identityHashCode(consumer), System.identityHashCode(o.consumer));
     }
 }

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/HttpEndpointModel.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/HttpEndpointModel.java
@@ -25,7 +25,7 @@ import org.apache.camel.util.StringHelper;
 /**
  * Model of available http endpoints.
  */
-public class HttpEndpointModel {
+public class HttpEndpointModel implements Comparable<HttpEndpointModel> {
 
     private final String uri;
     private String verbs;
@@ -102,5 +102,23 @@ public class HttpEndpointModel {
     @Override
     public int hashCode() {
         return Objects.hash(uri, consumer);
+    }
+
+    @Override
+    public int compareTo(HttpEndpointModel o) {
+        int cmp = uri.compareTo(o.uri);
+        if (cmp != 0) {
+            return cmp;
+        }
+        if (consumer == o.consumer) {
+            return 0;
+        }
+        if (consumer == null) {
+            return -1;
+        }
+        if (o.consumer == null) {
+            return 1;
+        }
+        return Integer.compare(System.identityHashCode(consumer), System.identityHashCode(o.consumer));
     }
 }

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
@@ -164,7 +165,7 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
      * Removes a known http endpoint managed by this component.
      */
     public void removeHttpEndpoint(String uri) {
-        this.removeHttpEndpoint(this.httpEndpoints, uri);
+        removeHttpEndpoints(this.httpEndpoints, e -> e.getUri().equals(uri));
     }
 
     /**
@@ -174,44 +175,44 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
         if (consumer == null) {
             return;
         }
-        this.removeHttpEndpoint(this.httpEndpoints, consumer);
+        removeHttpEndpoints(this.httpEndpoints, e -> e.getConsumer() == consumer);
+    }
+
+    /**
+     * Removes the http endpoint registered for the given uri and consumer reference.
+     * <p>
+     * Use this when multiple registrations share the same uri but have different consumers, or when the registration
+     * used a {@code null} consumer (for example MCP server metadata).
+     * </p>
+     */
+    public void removeHttpEndpoint(String uri, Consumer consumer) {
+        removeHttpEndpoints(this.httpEndpoints, e -> e.getUri().equals(uri) && e.getConsumer() == consumer);
     }
 
     /**
      * Removes a known http endpoint managed by this component.
      */
     public void removeHttpManagementEndpoint(String uri) {
-        this.removeHttpEndpoint(this.httpManagementEndpoints, uri);
+        removeHttpEndpoints(this.httpManagementEndpoints, e -> e.getUri().equals(uri));
     }
 
     /**
      * Removes the http management endpoint registered for the given consumer.
+     * <p>
+     * Provided for symmetry with {@link #removeHttpManagementEndpoint(String)} for callers that track a management
+     * consumer reference.
+     * </p>
      */
     public void removeHttpManagementEndpoint(Consumer consumer) {
         if (consumer == null) {
             return;
         }
-        this.removeHttpEndpoint(this.httpManagementEndpoints, consumer);
+        removeHttpEndpoints(this.httpManagementEndpoints, e -> e.getConsumer() == consumer);
     }
 
-    private void removeHttpEndpoint(Set<HttpEndpointModel> endpoints, Consumer consumer) {
+    private void removeHttpEndpoints(Set<HttpEndpointModel> endpoints, Predicate<HttpEndpointModel> filter) {
         List<HttpEndpointModel> toRemove = new ArrayList<>();
-        endpoints.stream().filter(e -> e.getConsumer() == consumer).forEach(model -> {
-            toRemove.add(model);
-            for (PlatformHttpListener listener : listeners) {
-                try {
-                    listener.unregisterHttpEndpoint(model);
-                } catch (Exception e) {
-                    LOG.warn("Error removing listener due to {}. This exception is ignored", e.getMessage(), e);
-                }
-            }
-        });
-        toRemove.forEach(endpoints::remove);
-    }
-
-    private void removeHttpEndpoint(Set<HttpEndpointModel> endpoints, String uri) {
-        List<HttpEndpointModel> toRemove = new ArrayList<>();
-        endpoints.stream().filter(e -> e.getUri().equals(uri)).forEach(model -> {
+        endpoints.stream().filter(filter).forEach(model -> {
             toRemove.add(model);
             for (PlatformHttpListener listener : listeners) {
                 try {

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
@@ -168,10 +168,39 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
     }
 
     /**
+     * Removes the http endpoint registered for the given consumer.
+     */
+    public void removeHttpEndpoint(Consumer consumer) {
+        this.removeHttpEndpoint(this.httpEndpoints, consumer);
+    }
+
+    /**
      * Removes a known http endpoint managed by this component.
      */
     public void removeHttpManagementEndpoint(String uri) {
         this.removeHttpEndpoint(this.httpManagementEndpoints, uri);
+    }
+
+    /**
+     * Removes the http management endpoint registered for the given consumer.
+     */
+    public void removeHttpManagementEndpoint(Consumer consumer) {
+        this.removeHttpEndpoint(this.httpManagementEndpoints, consumer);
+    }
+
+    private void removeHttpEndpoint(Set<HttpEndpointModel> endpoints, Consumer consumer) {
+        List<HttpEndpointModel> toRemove = new ArrayList<>();
+        endpoints.stream().filter(e -> e.getConsumer() == consumer).forEach(model -> {
+            toRemove.add(model);
+            for (PlatformHttpListener listener : listeners) {
+                try {
+                    listener.unregisterHttpEndpoint(model);
+                } catch (Exception e) {
+                    LOG.warn("Error removing listener due to {}. This exception is ignored", e.getMessage(), e);
+                }
+            }
+        });
+        toRemove.forEach(endpoints::remove);
     }
 
     private void removeHttpEndpoint(Set<HttpEndpointModel> endpoints, String uri) {

--- a/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
+++ b/components/camel-platform-http/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
@@ -18,10 +18,10 @@ package org.apache.camel.component.platform.http;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
@@ -72,8 +72,8 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
                             + " or all requests must be handled by Camel.")
     private boolean serverRequestValidation = true;
 
-    private final Set<HttpEndpointModel> httpEndpoints = new TreeSet<>();
-    private final Set<HttpEndpointModel> httpManagementEndpoints = new TreeSet<>();
+    private final Set<HttpEndpointModel> httpEndpoints = new LinkedHashSet<>();
+    private final Set<HttpEndpointModel> httpManagementEndpoints = new LinkedHashSet<>();
     private final List<PlatformHttpListener> listeners = new ArrayList<>();
     private volatile boolean localEngine;
 
@@ -171,6 +171,9 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
      * Removes the http endpoint registered for the given consumer.
      */
     public void removeHttpEndpoint(Consumer consumer) {
+        if (consumer == null) {
+            return;
+        }
         this.removeHttpEndpoint(this.httpEndpoints, consumer);
     }
 
@@ -185,6 +188,9 @@ public class PlatformHttpComponent extends HeaderFilterStrategyComponent
      * Removes the http management endpoint registered for the given consumer.
      */
     public void removeHttpManagementEndpoint(Consumer consumer) {
+        if (consumer == null) {
+            return;
+        }
         this.removeHttpEndpoint(this.httpManagementEndpoints, consumer);
     }
 

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/HttpEndpointModelTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/HttpEndpointModelTest.java
@@ -16,28 +16,30 @@
  */
 package org.apache.camel.component.platform.http;
 
-import java.util.TreeSet;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.camel.Consumer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class HttpEndpointModelTest {
 
     @Test
-    void treeSetRetainsMultipleConsumersOnSamePath() {
+    void setRetainsMultipleConsumersOnSamePath() {
         Consumer getConsumer = mock(Consumer.class);
         Consumer postConsumer = mock(Consumer.class);
 
         HttpEndpointModel getModel = new HttpEndpointModel("/shared", "GET", null, null, getConsumer);
         HttpEndpointModel postModel = new HttpEndpointModel("/shared", "POST", null, null, postConsumer);
 
-        TreeSet<HttpEndpointModel> endpoints = new TreeSet<>();
-        assertEquals(true, endpoints.add(getModel));
-        assertEquals(true, endpoints.add(postModel));
+        Set<HttpEndpointModel> endpoints = new HashSet<>();
+        assertTrue(endpoints.add(getModel));
+        assertTrue(endpoints.add(postModel));
         assertEquals(2, endpoints.size());
     }
 
@@ -52,6 +54,6 @@ class HttpEndpointModelTest {
 
         assertNotEquals(firstModel, secondModel);
         assertEquals(firstModel, sameConsumerModel);
-        assertNotEquals(firstModel.hashCode(), secondModel.hashCode());
+        assertEquals(firstModel.hashCode(), sameConsumerModel.hashCode());
     }
 }

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/HttpEndpointModelTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/HttpEndpointModelTest.java
@@ -56,4 +56,17 @@ class HttpEndpointModelTest {
         assertEquals(firstModel, sameConsumerModel);
         assertEquals(firstModel.hashCode(), sameConsumerModel.hashCode());
     }
+
+    @Test
+    void compareToIsConsistentWithEquals() {
+        Consumer first = mock(Consumer.class);
+        Consumer second = mock(Consumer.class);
+
+        HttpEndpointModel firstModel = new HttpEndpointModel("/shared", "GET", null, null, first);
+        HttpEndpointModel secondModel = new HttpEndpointModel("/shared", "POST", null, null, second);
+        HttpEndpointModel sameConsumerModel = new HttpEndpointModel("/shared", "GET", null, null, first);
+
+        assertEquals(0, firstModel.compareTo(sameConsumerModel));
+        assertNotEquals(0, firstModel.compareTo(secondModel));
+    }
 }

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/HttpEndpointModelTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/HttpEndpointModelTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import java.util.TreeSet;
+
+import org.apache.camel.Consumer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+
+class HttpEndpointModelTest {
+
+    @Test
+    void treeSetRetainsMultipleConsumersOnSamePath() {
+        Consumer getConsumer = mock(Consumer.class);
+        Consumer postConsumer = mock(Consumer.class);
+
+        HttpEndpointModel getModel = new HttpEndpointModel("/shared", "GET", null, null, getConsumer);
+        HttpEndpointModel postModel = new HttpEndpointModel("/shared", "POST", null, null, postConsumer);
+
+        TreeSet<HttpEndpointModel> endpoints = new TreeSet<>();
+        assertEquals(true, endpoints.add(getModel));
+        assertEquals(true, endpoints.add(postModel));
+        assertEquals(2, endpoints.size());
+    }
+
+    @Test
+    void equalsAndHashCodeUseConsumerIdentity() {
+        Consumer first = mock(Consumer.class);
+        Consumer second = mock(Consumer.class);
+
+        HttpEndpointModel firstModel = new HttpEndpointModel("/shared", "GET", null, null, first);
+        HttpEndpointModel secondModel = new HttpEndpointModel("/shared", "POST", null, null, second);
+        HttpEndpointModel sameConsumerModel = new HttpEndpointModel("/shared", "GET", null, null, first);
+
+        assertNotEquals(firstModel, secondModel);
+        assertEquals(firstModel, sameConsumerModel);
+        assertNotEquals(firstModel.hashCode(), secondModel.hashCode());
+    }
+}

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpSharedPathRouteLifecycleTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpSharedPathRouteLifecycleTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.platform.http;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.platform.http.spi.PlatformHttpConsumer;
+import org.apache.camel.component.platform.http.spi.PlatformHttpEngine;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultConsumer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class PlatformHttpSharedPathRouteLifecycleTest {
+
+    @Test
+    void stoppingSecondConsumerPreservesFirstConsumerOnSamePath() throws Exception {
+        RecordingPlatformHttpListener listener = new RecordingPlatformHttpListener();
+
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            PlatformHttpComponent component = new PlatformHttpComponent();
+            component.setEngine(new NoopEngine());
+            component.addPlatformHttpListener(listener);
+            context.addComponent("platform-http", component);
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/shared?httpMethodRestrict=GET")
+                            .routeId("shared-get")
+                            .setBody().constant("shared-get");
+                    from("platform-http:/shared?httpMethodRestrict=POST")
+                            .routeId("shared-post")
+                            .setBody().constant("shared-post");
+                }
+            });
+
+            context.start();
+
+            assertEquals(2, component.getHttpEndpoints().size());
+            assertEquals(2, listener.registered.size());
+
+            context.getRouteController().stopRoute("shared-post");
+
+            assertEquals(1, component.getHttpEndpoints().size());
+            assertEquals(1, listener.registered.size());
+            HttpEndpointModel remaining = listener.registered.get(0);
+            assertEquals("/shared", remaining.getUri());
+            assertEquals("GET", remaining.getVerbs());
+        }
+    }
+
+    @Test
+    void stoppingFirstConsumerPreservesSecondConsumerOnSamePath() throws Exception {
+        RecordingPlatformHttpListener listener = new RecordingPlatformHttpListener();
+
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            PlatformHttpComponent component = new PlatformHttpComponent();
+            component.setEngine(new NoopEngine());
+            component.addPlatformHttpListener(listener);
+            context.addComponent("platform-http", component);
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("platform-http:/shared?httpMethodRestrict=GET")
+                            .routeId("shared-get")
+                            .setBody().constant("shared-get");
+                    from("platform-http:/shared?httpMethodRestrict=POST")
+                            .routeId("shared-post")
+                            .setBody().constant("shared-post");
+                }
+            });
+
+            context.start();
+
+            context.getRouteController().stopRoute("shared-get");
+
+            assertEquals(1, component.getHttpEndpoints().size());
+            assertEquals(1, listener.registered.size());
+            HttpEndpointModel remaining = listener.registered.get(0);
+            assertEquals("/shared", remaining.getUri());
+            assertEquals("POST", remaining.getVerbs());
+        }
+    }
+
+    @Test
+    void removeHttpEndpointByUriRemovesAllConsumersOnPath() {
+        PlatformHttpComponent component = new PlatformHttpComponent();
+        Consumer getConsumer = mock(Consumer.class);
+        Consumer postConsumer = mock(Consumer.class);
+
+        component.addHttpEndpoint("/shared", "GET", null, null, getConsumer);
+        component.addHttpEndpoint("/shared", "POST", null, null, postConsumer);
+
+        assertEquals(2, component.getHttpEndpoints().size());
+
+        component.removeHttpEndpoint("/shared");
+
+        assertTrue(component.getHttpEndpoints().isEmpty());
+    }
+
+    private static final class RecordingPlatformHttpListener implements PlatformHttpListener {
+        private final List<HttpEndpointModel> registered = new ArrayList<>();
+
+        @Override
+        public void registerHttpEndpoint(HttpEndpointModel model) {
+            registered.add(model);
+        }
+
+        @Override
+        public void unregisterHttpEndpoint(HttpEndpointModel model) {
+            registered.remove(model);
+        }
+    }
+
+    private static final class NoopEngine implements PlatformHttpEngine {
+        @Override
+        public PlatformHttpConsumer createConsumer(PlatformHttpEndpoint platformHttpEndpoint, Processor processor) {
+            return new NoopPlatformHttpConsumer(platformHttpEndpoint, processor);
+        }
+    }
+
+    private static final class NoopPlatformHttpConsumer extends DefaultConsumer implements PlatformHttpConsumer {
+        private NoopPlatformHttpConsumer(Endpoint endpoint, Processor processor) {
+            super(endpoint, processor);
+        }
+
+        @Override
+        public PlatformHttpEndpoint getEndpoint() {
+            return (PlatformHttpEndpoint) super.getEndpoint();
+        }
+    }
+}

--- a/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpSharedPathRouteLifecycleTest.java
+++ b/components/camel-platform-http/src/test/java/org/apache/camel/component/platform/http/PlatformHttpSharedPathRouteLifecycleTest.java
@@ -40,22 +40,8 @@ class PlatformHttpSharedPathRouteLifecycleTest {
         RecordingPlatformHttpListener listener = new RecordingPlatformHttpListener();
 
         try (DefaultCamelContext context = new DefaultCamelContext()) {
-            PlatformHttpComponent component = new PlatformHttpComponent();
-            component.setEngine(new NoopEngine());
-            component.addPlatformHttpListener(listener);
-            context.addComponent("platform-http", component);
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("platform-http:/shared?httpMethodRestrict=GET")
-                            .routeId("shared-get")
-                            .setBody().constant("shared-get");
-                    from("platform-http:/shared?httpMethodRestrict=POST")
-                            .routeId("shared-post")
-                            .setBody().constant("shared-post");
-                }
-            });
-
+            PlatformHttpComponent component = createComponent(listener, context);
+            context.addRoutes(sharedPathRoutes());
             context.start();
 
             assertEquals(2, component.getHttpEndpoints().size());
@@ -76,22 +62,8 @@ class PlatformHttpSharedPathRouteLifecycleTest {
         RecordingPlatformHttpListener listener = new RecordingPlatformHttpListener();
 
         try (DefaultCamelContext context = new DefaultCamelContext()) {
-            PlatformHttpComponent component = new PlatformHttpComponent();
-            component.setEngine(new NoopEngine());
-            component.addPlatformHttpListener(listener);
-            context.addComponent("platform-http", component);
-            context.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() {
-                    from("platform-http:/shared?httpMethodRestrict=GET")
-                            .routeId("shared-get")
-                            .setBody().constant("shared-get");
-                    from("platform-http:/shared?httpMethodRestrict=POST")
-                            .routeId("shared-post")
-                            .setBody().constant("shared-post");
-                }
-            });
-
+            PlatformHttpComponent component = createComponent(listener, context);
+            context.addRoutes(sharedPathRoutes());
             context.start();
 
             context.getRouteController().stopRoute("shared-get");
@@ -101,6 +73,24 @@ class PlatformHttpSharedPathRouteLifecycleTest {
             HttpEndpointModel remaining = listener.registered.get(0);
             assertEquals("/shared", remaining.getUri());
             assertEquals("POST", remaining.getVerbs());
+        }
+    }
+
+    @Test
+    void restartRouteAfterStopReRegistersEndpoint() throws Exception {
+        RecordingPlatformHttpListener listener = new RecordingPlatformHttpListener();
+
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            PlatformHttpComponent component = createComponent(listener, context);
+            context.addRoutes(sharedPathRoutes());
+            context.start();
+
+            context.getRouteController().stopRoute("shared-post");
+            assertEquals(1, component.getHttpEndpoints().size());
+
+            context.getRouteController().startRoute("shared-post");
+            assertEquals(2, component.getHttpEndpoints().size());
+            assertEquals(2, listener.registered.size());
         }
     }
 
@@ -118,6 +108,41 @@ class PlatformHttpSharedPathRouteLifecycleTest {
         component.removeHttpEndpoint("/shared");
 
         assertTrue(component.getHttpEndpoints().isEmpty());
+    }
+
+    @Test
+    void removeHttpEndpointWithNullConsumerIsIgnored() {
+        PlatformHttpComponent component = new PlatformHttpComponent();
+        Consumer routeConsumer = mock(Consumer.class);
+
+        component.addHttpEndpoint("/static", null, null, null, null);
+        component.addHttpEndpoint("/shared", "GET", null, null, routeConsumer);
+
+        component.removeHttpEndpoint((Consumer) null);
+
+        assertEquals(2, component.getHttpEndpoints().size());
+    }
+
+    private static PlatformHttpComponent createComponent(RecordingPlatformHttpListener listener, DefaultCamelContext context) {
+        PlatformHttpComponent component = new PlatformHttpComponent();
+        component.setEngine(new NoopEngine());
+        component.addPlatformHttpListener(listener);
+        context.addComponent("platform-http", component);
+        return component;
+    }
+
+    private static RouteBuilder sharedPathRoutes() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("platform-http:/shared?httpMethodRestrict=GET")
+                        .routeId("shared-get")
+                        .setBody().constant("shared-get");
+                from("platform-http:/shared?httpMethodRestrict=POST")
+                        .routeId("shared-post")
+                        .setBody().constant("shared-post");
+            }
+        };
     }
 
     private static final class RecordingPlatformHttpListener implements PlatformHttpListener {

--- a/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/DefaultRestOpenapiProcessorStrategy.java
+++ b/components/camel-rest-openapi/src/main/java/org/apache/camel/component/rest/openapi/DefaultRestOpenapiProcessorStrategy.java
@@ -34,6 +34,7 @@ import org.apache.camel.AsyncCallback;
 import org.apache.camel.AsyncProducer;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.Consumer;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.NamedNode;
@@ -74,7 +75,7 @@ public class DefaultRestOpenapiProcessorStrategy extends ServiceSupport
     private String component = "direct";
     private String missingOperation;
     private String mockIncludePattern;
-    private final List<String> uris = new ArrayList<>();
+    private Consumer registeredPlatformHttpConsumer;
 
     @Override
     public void validateOpenApi(OpenAPI openAPI, String basePath, PlatformHttpConsumerAware platformHttpConsumer)
@@ -150,8 +151,9 @@ public class DefaultRestOpenapiProcessorStrategy extends ServiceSupport
                         }
                     }
                 }
-                phc.addHttpEndpoint(uri, verbs, consumes, produces, platformHttpConsumer.getPlatformHttpConsumer());
-                uris.add(uri);
+                Consumer consumer = platformHttpConsumer.getPlatformHttpConsumer();
+                phc.addHttpEndpoint(uri, verbs, consumes, produces, consumer);
+                registeredPlatformHttpConsumer = consumer;
             }
         }
     }
@@ -452,9 +454,9 @@ public class DefaultRestOpenapiProcessorStrategy extends ServiceSupport
 
         if (camelContext != null) {
             PlatformHttpComponent phc = (PlatformHttpComponent) camelContext.hasComponent("platform-http");
-            if (phc != null) {
-                uris.forEach(phc::removeHttpEndpoint);
-                uris.clear();
+            if (phc != null && registeredPlatformHttpConsumer != null) {
+                phc.removeHttpEndpoint(registeredPlatformHttpConsumer);
+                registeredPlatformHttpConsumer = null;
             }
         }
     }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1624,3 +1624,22 @@ The `backOffMaxAttempts` option now bounds the attempts to start the delegated c
 The retry task previously also carried the default five second duration of its budget, which ended the
 task before the second attempt for any `backOffDelay` at or above the default of five seconds. A delegate
 that fails to start is therefore retried for longer than before, up to `backOffMaxAttempts` times.
+
+=== camel-platform-http - shared path endpoint registry
+
+`HttpEndpointModel` identity now includes the registered consumer reference, so multiple consumers can
+share the same path with different HTTP methods without overwriting each other in
+`PlatformHttpComponent#getHttpEndpoints()`.
+
+* `getHttpEndpoints()` and `getHttpManagementEndpoints()` may list multiple entries for the same URI
+  (one per consumer). Ordering follows registration order (`LinkedHashSet`) instead of URI sort order
+  (`TreeSet`).
+* `DefaultPlatformHttpConsumer` removes its own registration on stop via
+  `removeHttpEndpoint(Consumer)` instead of removing every endpoint on the path.
+* `removeHttpEndpoint(String)` still removes all registrations for a URI (for example bulk cleanup).
+  Prefer `removeHttpEndpoint(Consumer)` or `removeHttpEndpoint(String, Consumer)` when only one
+  registration should be removed.
+* `HttpEndpointModel#compareTo` remains available and is consistent with the consumer-aware
+  `equals`/`hashCode` implementation.
+
+Stopping one `platform-http` route on a shared path no longer unregisters sibling consumers on that path.


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24589](https://issues.apache.org/jira/browse/CAMEL-24589): stopping one `platform-http` consumer on a shared path no longer unregisters sibling consumers registered for different HTTP methods.

## Problem

With two consumers on the same path (e.g. GET and POST on `/shared`), stopping the route registered second caused the first consumer to be unregistered from the component registry. Spring Boot's `CamelRequestHandlerMapping` listens to these registrations, so the surviving GET route returned HTTP 405 after stopping the POST route.

Root causes in `camel-platform-http`:

1. `HttpEndpointModel` used URI-only `equals`/`hashCode`, so only one model per path could be tracked reliably.
2. `DefaultPlatformHttpConsumer.doStop()` called `removeHttpEndpoint(path)`, removing **all** endpoints on that path.

## Solution

- Include the registered consumer reference in `HttpEndpointModel` identity (`equals`, `hashCode`).
- Switch endpoint registry from `TreeSet` to `LinkedHashSet` so multiple consumers on the same path coexist.
- Add `removeHttpEndpoint(Consumer)` / `removeHttpManagementEndpoint(Consumer)` with null-safe removal.
- Call `removeHttpEndpoint(platformHttpConsumer)` from `DefaultPlatformHttpConsumer.doStop()`.
- Keep `removeHttpEndpoint(String uri)` for callers that intentionally remove all endpoints on a path (e.g. rest-openapi).

## Tests

- `HttpEndpointModelTest` — set retains multiple consumers on the same path; identity is consumer-based.
- `PlatformHttpSharedPathRouteLifecycleTest` — stopping GET or POST preserves the other consumer, route restart re-registers, URI-based bulk removal, null-consumer guard.

## Notes

The Spring Boot starter integration test lives in `apache/camel-spring-boot`; this PR fixes the core component behavior that the starter depends on.

---
_AI-generated PR description on behalf of atiaomar1978-hub_