### PR TITLE
CAMEL-24558: Warn on unconsumed camel.aiObservability.* properties in Main

### DIFF
--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -1817,6 +1817,11 @@ public abstract class BaseMainSupport extends BaseService {
                 LOG.warn("Property not auto-configured: camel.errorRegistry.{}={}", k, v);
             });
         }
+        if (!aiObservabilityProperties.isEmpty()) {
+            aiObservabilityProperties.forEach((k, v) -> {
+                LOG.warn("Property not auto-configured: camel.aiObservability.{}={}", k, v);
+            });
+        }
         if (!devConsoleProperties.isEmpty()) {
             devConsoleProperties.forEach((k, v) -> {
                 LOG.warn("Property not auto-configured: camel.devConsole.{}={}", k, v);

--- a/core/camel-main/src/test/java/org/apache/camel/main/AiObservabilityConfigurationPropertiesTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/AiObservabilityConfigurationPropertiesTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.camel.main;
 
+import org.apache.camel.PropertyBindingException;
 import org.apache.camel.component.ai.observability.GenAiObservability;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.util.OrderedLocationProperties;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AiObservabilityConfigurationPropertiesTest {
 
@@ -61,5 +65,101 @@ class AiObservabilityConfigurationPropertiesTest {
         } finally {
             main.stop();
         }
+    }
+
+    @Test
+    void shouldLeaveUnknownAiObservabilityPropertyWhenFailFastIsDisabled() throws Exception {
+        DefaultCamelContext context = new DefaultCamelContext();
+        MainConfigurationProperties mainConfig = new MainConfigurationProperties();
+        AiObservabilityConfigurationProperties config = mainConfig.aiObservability();
+        OrderedLocationProperties properties = new OrderedLocationProperties();
+        properties.put("test", "enable", "false");
+        OrderedLocationProperties autoConfiguredProperties = new OrderedLocationProperties();
+
+        MainHelper.setPropertiesOnTarget(context, config, properties, "camel.aiObservability.",
+                false, true, autoConfiguredProperties);
+
+        assertThat(properties.asMap()).containsEntry("enable", "false");
+        assertThat(autoConfiguredProperties.asMap()).doesNotContainKey("camel.aiObservability.enable");
+    }
+
+    @Test
+    void shouldLeaveOnlyUnknownAiObservabilityPropertyWhenKnownPropertyIsPresent() throws Exception {
+        DefaultCamelContext context = new DefaultCamelContext();
+        MainConfigurationProperties mainConfig = new MainConfigurationProperties();
+        AiObservabilityConfigurationProperties config = mainConfig.aiObservability();
+        OrderedLocationProperties properties = new OrderedLocationProperties();
+        properties.put("test", "enabled", "false");
+        properties.put("test", "enable", "true");
+        OrderedLocationProperties autoConfiguredProperties = new OrderedLocationProperties();
+
+        MainHelper.setPropertiesOnTarget(context, config, properties, "camel.aiObservability.",
+                false, true, autoConfiguredProperties);
+
+        assertThat(properties.asMap()).containsEntry("enable", "true");
+        assertThat(config.isEnabled()).isFalse();
+        assertThat(autoConfiguredProperties.asMap()).containsEntry("camel.aiObservability.enabled", "false");
+    }
+
+    @Test
+    void shouldFailFastWhenUnknownAiObservabilityPropertyIsPresent() {
+        Main main = new Main();
+        try {
+            main.addInitialProperty("camel.aiObservability.enable", "true");
+            assertThatThrownBy(main::start)
+                    .hasRootCauseInstanceOf(PropertyBindingException.class)
+                    .rootCause()
+                    .hasMessageContaining("enable");
+        } finally {
+            main.stop();
+        }
+    }
+
+    @Test
+    void shouldIgnoreUnknownAiObservabilityPropertyWhenFailFastIsDisabled() throws Exception {
+        Main main = new Main();
+        main.configure().withAutoConfigurationFailFast(false);
+        main.addInitialProperty("camel.aiObservability.enabled", "false");
+        main.addInitialProperty("camel.aiObservability.enable", "true");
+
+        main.start();
+
+        try {
+            assertThat(GenAiObservability.isEnabled(main.getCamelContext())).isFalse();
+        } finally {
+            main.stop();
+        }
+    }
+
+    @Test
+    void shouldIgnoreUnknownAiObservabilityPropertyFromPropertiesFileWhenFailFastIsDisabled() throws Exception {
+        Main main = new Main();
+        main.configure().withAutoConfigurationFailFast(false);
+        main.setDefaultPropertyPlaceholderLocation("classpath:ai-observability-unknown.properties");
+
+        main.start();
+
+        try {
+            assertThat(GenAiObservability.isEnabled(main.getCamelContext())).isTrue();
+        } finally {
+            main.stop();
+        }
+    }
+
+    @Test
+    void shouldConsumeKnownAiObservabilityPropertyWithoutLeavingItForWarning() throws Exception {
+        DefaultCamelContext context = new DefaultCamelContext();
+        MainConfigurationProperties mainConfig = new MainConfigurationProperties();
+        AiObservabilityConfigurationProperties config = mainConfig.aiObservability();
+        OrderedLocationProperties properties = new OrderedLocationProperties();
+        properties.put("test", "enabled", "false");
+        OrderedLocationProperties autoConfiguredProperties = new OrderedLocationProperties();
+
+        MainHelper.setPropertiesOnTarget(context, config, properties, "camel.aiObservability.",
+                false, true, autoConfiguredProperties);
+
+        assertThat(properties.asMap()).isEmpty();
+        assertThat(config.isEnabled()).isFalse();
+        assertThat(autoConfiguredProperties.asMap()).containsEntry("camel.aiObservability.enabled", "false");
     }
 }

--- a/core/camel-main/src/test/resources/ai-observability-unknown.properties
+++ b/core/camel-main/src/test/resources/ai-observability-unknown.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# typo: enable instead of enabled
+camel.aiObservability.enable = false


### PR DESCRIPTION
## Summary

Fixes [CAMEL-24558](https://issues.apache.org/jira/browse/CAMEL-24558) by logging a warning for leftover `camel.aiObservability.*` keys during Camel Main auto-configuration, matching the existing pattern used by `camel.health`, `camel.opentelemetry2`, and other configuration groups.

## Problem

Typos such as `camel.aiObservability.enable` (instead of `enabled`) were not reported in the unconsumed-property warning pass, unlike other Main configuration groups.

## Solution

After GenAI observability auto-configuration in `BaseMainSupport`, emit:

`Property not auto-configured: camel.aiObservability.<key>=<value>`

for any remaining `aiObservabilityProperties` entries.

## Testing

Extended `AiObservabilityConfigurationPropertiesTest` with coverage for:

- Unknown properties left unconsumed when `autoConfigurationFailFast=false`
- Known `enabled` consumed while unknown `enable` remains unconsumed
- Fail-fast exception when `autoConfigurationFailFast=true` (default)
- Main startup ignores unknown typo properties when fail-fast is disabled (using `enable=false` so default `enabled=true` cannot mask accidental binding)
- Properties-file typo scenario via `ai-observability-unknown.properties`

```bash
mvn test -pl core/camel-main -am -Dtest=AiObservabilityConfigurationPropertiesTest
```

## Reviews

- Bugbot: no issues found
- Grok review feedback addressed (stronger typo tests, fail-fast cleanup, auto-configured property assertions)

## CI note

Fork PR workflows may show **action required** until a Camel maintainer approves the GitHub Actions run.

_AI-generated on behalf of atiaomar1978-hub_