### PR TITLE
CAMEL-24594: Log REST DSL response marshalling failures

### DIFF
--- a/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxRestBindingMarshalFailureTest.java
+++ b/components/camel-platform-http-vertx/src/test/java/org/apache/camel/component/platform/http/vertx/VertxRestBindingMarshalFailureTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.platform.http.vertx;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestBindingMode;
 import org.junit.jupiter.api.Test;
@@ -103,6 +104,43 @@ public class VertxRestBindingMarshalFailureTest {
                     // ...and it happened while the REST DSL binding marshalled the response body
                     .body(containsString("RestBindingAdvice"))
                     .body(containsString("MarshalProcessor"));
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testExplicitResponseCodeStillWinsOnMarshalFailure() throws Exception {
+        final CamelContext context = VertxPlatformHttpEngineTest.createCamelContext();
+
+        try {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    restConfiguration().bindingMode(RestBindingMode.json);
+
+                    rest("/demo")
+                            .get("/{id}").to("direct:demo");
+
+                    from("direct:demo")
+                            // an explicitly set response code must still win, even though the response marshalling
+                            // fails afterwards (the failure is logged server-side, but does not override the code)
+                            .process(e -> {
+                                e.getMessage().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+                                e.getMessage().setBody(new BadPojo());
+                            });
+                }
+            });
+
+            VertxPlatformHttpEngineTest.startCamelContext(context);
+
+            given()
+                    .when()
+                    .get("/demo/42")
+                    .then()
+                    // the explicitly set 200 wins over the marshal failure, consistent with plain routes
+                    .statusCode(200)
+                    .body(emptyString());
         } finally {
             context.stop();
         }

--- a/core/camel-support/src/main/java/org/apache/camel/support/processor/RestBindingAdvice.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/processor/RestBindingAdvice.java
@@ -38,6 +38,8 @@ import org.apache.camel.support.MessageHelper;
 import org.apache.camel.support.service.ServiceHelper;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Used for Rest DSL with binding to json/xml for incoming requests and outgoing responses.
@@ -50,6 +52,8 @@ import org.apache.camel.util.ObjectHelper;
  * @see RestBindingAdviceFactory
  */
 public class RestBindingAdvice extends ServiceSupport implements CamelInternalProcessorAdvice<Map<String, Object>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestBindingAdvice.class);
 
     private static final String STATE_KEY_DO_MARSHAL = "doMarshal";
     private static final String STATE_KEY_ACCEPT = "accept";
@@ -465,6 +469,12 @@ public class RestBindingAdvice extends ServiceSupport implements CamelInternalPr
                 }
             }
         } catch (Exception e) {
+            // the response marshalling happens after routing has completed, so this failure is not routed through
+            // the error handler and would otherwise be invisible. Log it so operators can diagnose why the response
+            // could not be bound (see CAMEL-24594).
+            LOG.warn("Error marshalling REST DSL response body for exchange: {} due to: {}."
+                     + " This exception is set on the exchange to fail the response.",
+                    exchange, e.getMessage(), e);
             exchange.setException(e);
         }
 


### PR DESCRIPTION
## Motivation

[CAMEL-24594](https://issues.apache.org/jira/browse/CAMEL-24594): when the REST DSL response binding (`bindingMode(json)` / `xml`) fails to marshal the response body, the failure is genuinely invisible.

Response marshalling happens in `RestBindingAdvice#after` (i.e. **after** routing has completed), so the exception is not routed through the error handler. Unlike an in-route exception — which `DefaultErrorHandler` still logs with a stacktrace even when the status is masked to 200 — a marshal failure was **not logged at any level**. That is the only Camel failure path where the error is completely silent, and it is what made a downstream serialization failure take a full day to diagnose after a platform upgrade.

Per the discussion on the ticket (thanks @jamesnetherton), this PR **narrows the fix to logging only** and deliberately makes **no change to response-code behaviour**:

- An explicitly set `HTTP_RESPONSE_CODE` continues to win over a failed exchange, consistent with plain routes — people rely on this.
- Hardening `RestBindingAdvice#marshal` to force `HTTP_RESPONSE_CODE=500` was considered and **rejected**, because it would make the REST binding inconsistent with every other failure path and override a code the user deliberately set.

## Changes

- `RestBindingAdvice#marshal` now logs the marshalling failure at `WARN` (with stacktrace) before setting the exception on the exchange, bringing the post-routing binding step in line with how every other failure in Camel surfaces.
- Extended `VertxRestBindingMarshalFailureTest` with a variant whose processor sets `HTTP_RESPONSE_CODE=200` before the failing marshal, pinning that the explicitly set code still wins (and the failure is logged rather than masking the code).

## Testing

`VertxRestBindingMarshalFailureTest` — 3 tests, all green.

---
_Claude Code on behalf of Claus Ibsen (davsclaus)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)