### PR TITLE
CAMEL-24481 - Fix Jbang IT tests - revert to stable fedora version the container image

### DIFF
--- a/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/container.properties
+++ b/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/container.properties
@@ -17,4 +17,4 @@
 #
 # NOTE: make sure to run integration tests locally when changing in order to
 # validate potential breaking changes compatibility when building the container
-cli.service.from.image=mirror.gcr.io/fedora:45
+cli.service.from.image=mirror.gcr.io/fedora:43


### PR DESCRIPTION
used

with Fedora 45 there is this kind of error:

```
Caused by: com.github.dockerjava.api.exception.DockerClientException:
Could not build image: The command '/bin/sh -c dnf update -y     && dnf
install java-21-openjdk-devel openssh-server xauth -y' returned a
non-zero code: 1
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

