### PR TITLE
CAMEL-24607: camel-langchain4j-agent-api - CodeInjectionGuardrail must count distinct injection types

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/guardrails/CodeInjectionGuardrail.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/guardrails/CodeInjectionGuardrail.java
@@ -226,7 +226,11 @@ public class CodeInjectionGuardrail implements InputGuardrail {
             }
 
             if (pattern.getPattern().matcher(text).find()) {
-                detected.add(pattern.getType());
+                // Only record distinct types: the non-strict check below blocks on "multiple different types",
+                // and several patterns share a type, so counting duplicates would false-positive on a single type.
+                if (!detected.contains(pattern.getType())) {
+                    detected.add(pattern.getType());
+                }
 
                 if (strict) {
                     return failure(String.format(

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/guardrails/CodeInjectionGuardrailTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/guardrails/CodeInjectionGuardrailTest.java
@@ -123,6 +123,15 @@ class CodeInjectionGuardrailTest {
     }
 
     @Test
+    void testNonStrictModeDoesNotBlockMultipleMatchesOfTheSameType() {
+        CodeInjectionGuardrail guardrail = new CodeInjectionGuardrail();
+
+        // Both {{...}} and ${...} are TEMPLATE_INJECTION patterns, i.e. a single type - a legitimate
+        // templating question must not be blocked just because two same-type patterns matched.
+        assertTrue(guardrail.validate(UserMessage.from("render {{name}} and ${value}")).isSuccess());
+    }
+
+    @Test
     void testForSpecificTypes() {
         // Use builder with strict mode to fail on single match
         CodeInjectionGuardrail guardrail = CodeInjectionGuardrail.builder()


### PR DESCRIPTION
## Issue
[CAMEL-24607](https://issues.apache.org/jira/browse/CAMEL-24607)

## Problem
In non-strict mode `CodeInjectionGuardrail.validate()` collects every matched pattern's `InjectionType`
into a `List` **without de-duplication**, then blocks the input when `detected.size() >= 2`. The inline
comment says the intent is to require "multiple **different** types", but several patterns share a type
(4 SHELL_COMMAND, 4 SQL_INJECTION, 3 JAVASCRIPT, 2 HTML_XSS, 3 TEMPLATE_INJECTION).

So a single legitimate input matching two patterns of **one** type is falsely blocked — e.g. a normal
templating question `render {{name}} and ${value}` matches both `{{...}}` and `${...}` (both
`TEMPLATE_INJECTION`) and is rejected. The sibling `PromptInjectionGuardrail` de-duplicates correctly.

## Fix
Only add a type when it is not already present, so `detected.size() >= 2` genuinely means two distinct
types matched.

## Testing
- New `testNonStrictModeDoesNotBlockMultipleMatchesOfTheSameType` asserts the templating example passes;
  verified it **fails** against the unpatched code and passes with the fix. All existing
  `CodeInjectionGuardrailTest` cases still pass.
- `mvn -Psourcecheck validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
