### PR TITLE
CAMEL-24610: camel-langchain4j-web-search - guard against a null maxResults from a custom WebSearchRequest

### DIFF
--- a/components/camel-ai/camel-langchain4j-web-search/src/main/java/org/apache/camel/component/langchain4j/web/search/LangChain4jWebSearchProducer.java
+++ b/components/camel-ai/camel-langchain4j-web-search/src/main/java/org/apache/camel/component/langchain4j/web/search/LangChain4jWebSearchProducer.java
@@ -91,8 +91,8 @@ public class LangChain4jWebSearchProducer extends DefaultProducer {
             return;
         }
 
-        // return a single object as a response
-        if (maxResults == 1) {
+        // return a single object as a response (maxResults may be null when a custom WebSearchRequest omits it)
+        if (maxResults != null && maxResults == 1) {
             switch (getEndpoint().getConfiguration().getResultType()) {
                 case LANGCHAIN4J_WEB_SEARCH_ORGANIC_RESULT -> exchange.getIn().setBody(webSearchOrganicResults.get(0));
                 case CONTENT -> exchange.getIn().setBody(webSearchOrganicResults.get(0).content());

--- a/components/camel-ai/camel-langchain4j-web-search/src/test/java/org/apache/camel/component/langchain4j/web/search/LangChain4jWebSearchCustomRequestTest.java
+++ b/components/camel-ai/camel-langchain4j-web-search/src/test/java/org/apache/camel/component/langchain4j/web/search/LangChain4jWebSearchCustomRequestTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.langchain4j.web.search;
+
+import java.net.URI;
+import java.util.List;
+
+import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.WebSearchInformationResult;
+import dev.langchain4j.web.search.WebSearchOrganicResult;
+import dev.langchain4j.web.search.WebSearchRequest;
+import dev.langchain4j.web.search.WebSearchResults;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class LangChain4jWebSearchCustomRequestTest extends CamelTestSupport {
+
+    private final WebSearchEngine engine = request -> WebSearchResults.from(
+            WebSearchInformationResult.from(1L),
+            List.of(WebSearchOrganicResult.from(
+                    "Title", URI.create("https://example.com"), "snippet", "content")));
+
+    // A custom (advanced) WebSearchRequest that deliberately does not set maxResults, so maxResults() is null.
+    private final WebSearchRequest customRequest = WebSearchRequest.builder().searchTerms("apache camel").build();
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        context.getRegistry().bind("engine", engine);
+        context.getRegistry().bind("customRequest", customRequest);
+
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:advanced")
+                        .to("langchain4j-web-search:test?webSearchEngine=#engine&webSearchRequest=#customRequest");
+            }
+        };
+    }
+
+    @Test
+    void customRequestWithoutMaxResultsDoesNotThrow() {
+        Exchange result = template.request("direct:advanced", e -> e.getIn().setBody("apache camel"));
+
+        // Before the fix this NPE'd unboxing a null Integer at `maxResults == 1`.
+        assertNull(result.getException());
+        assertNotNull(result.getMessage().getBody());
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24610](https://issues.apache.org/jira/browse/CAMEL-24610)

## Problem
`LangChain4jWebSearchProducer.process()` passes `webSearchRequest.maxResults()` into
`computeResponse(..., Integer maxResults)`, which does:

```java
if (maxResults == 1) {   // auto-unbox of a nullable Integer
```

In the **advanced** path — where the user supplies a custom `WebSearchRequest`
(`getConfiguration().getWebSearchRequest() != null`) that does not set `maxResults` — langchain4j's
`WebSearchRequest.maxResults()` is `null`, so the unboxing throws `NullPointerException`. The default
builder path is safe only because the configuration `maxResults` defaults to `1`.

## Fix
Null-guard the comparison (`if (maxResults != null && maxResults == 1)`), so a null `maxResults` falls
through to the multi-result branch.

## Testing
- New `LangChain4jWebSearchCustomRequestTest` drives the advanced path with a custom `WebSearchRequest`
  that omits `maxResults`; verified it fails with the described NPE against the unpatched code and passes
  with the fix.
- `mvn -Psourcecheck validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
