### PR TITLE
CAMEL-24608: camel-langchain4j-agent-api - enforce LanguageGuardrail minLanguageRatio

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrail.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrail.java
@@ -212,7 +212,36 @@ public class LanguageGuardrail implements InputGuardrail {
             }
         }
 
+        // Enforce the minimum ratio of allowed-language characters, when configured
+        if (minLanguageRatio > 0.0) {
+            double ratio = allowedLanguageRatio(text);
+            if (ratio < minLanguageRatio) {
+                return failure(String.format(
+                        "Message does not meet the minimum allowed-language ratio (required %.2f, found %.2f).",
+                        minLanguageRatio, ratio));
+            }
+        }
+
         return success();
+    }
+
+    /**
+     * Fraction of the non-whitespace characters that belong to at least one allowed language/script. Returns 1.0 when
+     * there are no non-whitespace characters.
+     */
+    private double allowedLanguageRatio(String text) {
+        long total = text.codePoints().filter(cp -> !Character.isWhitespace(cp)).count();
+        if (total == 0) {
+            return 1.0;
+        }
+        long allowed = text.codePoints()
+                .filter(cp -> !Character.isWhitespace(cp))
+                .filter(cp -> {
+                    String ch = new String(Character.toChars(cp));
+                    return allowedLanguages.stream().anyMatch(lang -> lang.isPresent(ch));
+                })
+                .count();
+        return (double) allowed / total;
     }
 
     /**
@@ -227,6 +256,13 @@ public class LanguageGuardrail implements InputGuardrail {
      */
     public Set<Language> getBlockedLanguages() {
         return new HashSet<>(blockedLanguages);
+    }
+
+    /**
+     * @return the minimum required ratio of allowed-language characters (0.0 disables the check)
+     */
+    public double getMinLanguageRatio() {
+        return minLanguageRatio;
     }
 
     /**

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrailTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrailTest.java
@@ -153,4 +153,17 @@ class LanguageGuardrailTest {
 
         assertTrue(guardrail.getBlockedLanguages().contains(LanguageGuardrail.Language.CYRILLIC));
     }
+
+    @Test
+    void testMinLanguageRatioIsEnforced() {
+        LanguageGuardrail guardrail = LanguageGuardrail.builder()
+                .allowedLanguages(LanguageGuardrail.Language.LATIN_SCRIPT)
+                .minLanguageRatio(0.8)
+                .build();
+
+        // "Hello 你好世界": 5 Latin characters out of 9 non-whitespace ~= 0.56, below the 0.8 threshold
+        assertFalse(guardrail.validate(UserMessage.from("Hello 你好世界")).isSuccess());
+        // All-Latin text meets the ratio
+        assertTrue(guardrail.validate(UserMessage.from("Hello world")).isSuccess());
+    }
 }


### PR DESCRIPTION
## Issue
[CAMEL-24608](https://issues.apache.org/jira/browse/CAMEL-24608)

## Problem
`LanguageGuardrail` declares `minLanguageRatio`, sets it from the constructor and the builder method
`minLanguageRatio(double)`, and stores it — but `validate()` never reads it (and there was no getter).
A user who configures `minLanguageRatio(0.8)` expects at least 80% of the characters to be in an allowed
language; the ratio was silently ignored, so text that is mostly a foreign script with a single
allowed-language character still passed.

## Fix
Enforce the ratio in `validate()`: compute the fraction of non-whitespace characters that belong to at
least one allowed language/script and fail when it is below `minLanguageRatio`. The check is a no-op at
the default `0.0`. Also add the missing `getMinLanguageRatio()` getter.

Note: the ratio is meaningful for the per-character script languages (LATIN_SCRIPT, CYRILLIC, CHINESE, …).
`ENGLISH` uses a whole-string ASCII pattern, so a message that reaches the ratio check under
`allowedLanguages={ENGLISH}` is already all-ASCII (ratio 1.0) — consistent with the existing detection.

## Testing
- New `testMinLanguageRatioIsEnforced` asserts a mostly-CJK message with `LATIN_SCRIPT` allowed and
  `minLanguageRatio(0.8)` is rejected, while all-Latin text passes. All existing `LanguageGuardrailTest`
  cases still pass.
- `mvn -Psourcecheck validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
