### PR TITLE
  CAMEL-24604: camel-jpa - Mark KeyValueEntry.isExpired() as @Transient

### DIFF
--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -32,7 +32,7 @@
     <description>Camel JPA support</description>
 
     <properties>
-        <camel.surefire.fork.additional-vmargs>-javaagent:${project.basedir}/target/openjpa-${openjpa-version}.jar -Xmx3G</camel.surefire.fork.additional-vmargs>
+        <camel.surefire.fork.additional-vmargs>-Xmx3G</camel.surefire.fork.additional-vmargs>
         <camel.surefire.forkTimeout>240</camel.surefire.forkTimeout>
     </properties>
 
@@ -94,7 +94,15 @@
             <artifactId>h2</artifactId>
             <version>${h2-version}</version>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <!-- always on the test classpath (not only in the hibernate profile) so that
+                 KeyValueEntryHibernateMappingTest verifies Hibernate entity mapping in every build -->
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate-version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -134,6 +142,11 @@
                     <name>!hibernate</name>
                 </property>
             </activation>
+            <properties>
+                <!-- the OpenJPA enhancer agent must only be attached when the OpenJPA provider is in use;
+                     with -Dhibernate the agent jar is not copied and the forked JVM would fail to start -->
+                <camel.surefire.fork.additional-vmargs>-javaagent:${project.basedir}/target/openjpa-${openjpa-version}.jar -Xmx3G</camel.surefire.fork.additional-vmargs>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -231,8 +244,11 @@
                                 <goals>
                                     <goal>copy-resources</goal>
                                 </goals>
-                                <phase>generate-test-resources</phase>
+                                <!-- must run after the default testResources goal so the Hibernate
+                                     variant reliably replaces the default OpenJPA persistence.xml -->
+                                <phase>process-test-resources</phase>
                                 <configuration>
+                                    <overwrite>true</overwrite>
                                     <resources>
                                         <resource>
                                             <directory>
@@ -247,14 +263,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <dependencies>
-                <dependency>
-                    <groupId>org.hibernate.orm</groupId>
-                    <artifactId>hibernate-core</artifactId>
-                    <version>${hibernate-version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>full</id>

--- a/components/camel-jpa/src/main/java/org/apache/camel/processor/keyvalue/jpa/KeyValueEntry.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/processor/keyvalue/jpa/KeyValueEntry.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 /**
  * JPA entity representing a single key-value entry in the {@code CAMEL_KEYVALUE} table.
@@ -97,6 +98,7 @@ public class KeyValueEntry implements Serializable {
      *
      * @return whether the entry is expired
      */
+    @Transient
     public boolean isExpired() {
         return expiresAt > 0 && System.currentTimeMillis() >= expiresAt;
     }

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/keyvalue/jpa/KeyValueEntryHibernateMappingTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/keyvalue/jpa/KeyValueEntryHibernateMappingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.keyvalue.jpa;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Verifies in every build (not only with -Dhibernate) that Hibernate can map {@link KeyValueEntry}. The entity is
+ * shipped in the camel-jpa jar and e.g. Quarkus auto-discovers it from the classpath and always maps it with Hibernate,
+ * so a mapping problem breaks applications that never use the KeyValueRepository (CAMEL-24604: a derived getter
+ * without @Transient made Hibernate fail with "Could not locate setter method for property 'expired'").
+ * <p>
+ * Uses the native Hibernate bootstrap on purpose: it does not go through jakarta.persistence provider resolution, so
+ * the rest of the test suite keeps using the provider selected by the active maven profile.
+ */
+class KeyValueEntryHibernateMappingTest {
+
+    @Test
+    void hibernateMustBeAbleToMapKeyValueEntry() {
+        StandardServiceRegistry registry = new StandardServiceRegistryBuilder()
+                .applySetting("hibernate.connection.driver_class", "org.h2.Driver")
+                .applySetting("hibernate.connection.url", "jdbc:h2:mem:camel24604")
+                .build();
+        try {
+            assertDoesNotThrow(() -> new MetadataSources(registry)
+                    .addAnnotatedClass(KeyValueEntry.class)
+                    .buildMetadata()
+                    .buildSessionFactory()
+                    .close(),
+                    "Hibernate should be able to build a SessionFactory for KeyValueEntry");
+        } finally {
+            StandardServiceRegistryBuilder.destroy(registry);
+        }
+    }
+}

--- a/components/camel-jpa/src/test/resources/META-INF/persistence.xml
+++ b/components/camel-jpa/src/test/resources/META-INF/persistence.xml
@@ -50,6 +50,7 @@
   </persistence-unit>
 
   <persistence-unit name="custom" transaction-type="RESOURCE_LOCAL">
+    <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
     <class>org.apache.camel.examples.MultiSteps</class>
     <class>org.apache.camel.examples.SendEmail</class>
 
@@ -63,6 +64,7 @@
   </persistence-unit>
 
   <persistence-unit name="pooling" transaction-type="RESOURCE_LOCAL">
+    <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
     <class>org.apache.camel.examples.SendEmail</class>
 
     <properties>
@@ -80,6 +82,7 @@
   </persistence-unit>
 
   <persistence-unit name="keyvalueDb" transaction-type="RESOURCE_LOCAL">
+    <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
     <class>org.apache.camel.processor.keyvalue.jpa.KeyValueEntry</class>
 
     <properties>
@@ -93,6 +96,7 @@
 
   <!-- START SNIPPET: e1 -->
   <persistence-unit name="idempotentDb" transaction-type="RESOURCE_LOCAL">
+    <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
     <class>org.apache.camel.processor.idempotent.jpa.MessageProcessed</class>
 
     <properties>

--- a/components/camel-jpa/src/test/resources/profiles/hibernate/META-INF/persistence.xml
+++ b/components/camel-jpa/src/test/resources/profiles/hibernate/META-INF/persistence.xml
@@ -79,6 +79,18 @@
     </properties>
   </persistence-unit>
 
+  <persistence-unit name="keyvalueDb" transaction-type="RESOURCE_LOCAL">
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+
+    <class>org.apache.camel.processor.keyvalue.jpa.KeyValueEntry</class>
+
+    <properties>
+      <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:./target/keyvalueTest;DB_CLOSE_DELAY=-1"/>
+      <property name="hibernate.hbm2ddl.auto" value="create"/>
+    </properties>
+  </persistence-unit>
+
   <persistence-unit name="skipLockedEntiy" transaction-type="RESOURCE_LOCAL">
     <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 


### PR DESCRIPTION
Fixes [CAMEL-24604](https://issues.apache.org/jira/browse/CAMEL-24604)
Follow-up ticket: https://issues.apache.org/jira/browse/CAMEL-24615

 `KeyValueEntry` uses property access, so the derived `isExpired()` getter was treated as a persistent property without a setter and Hibernate failed to build the SessionFactory (`Could not locate setter method for property 'expired'`). On Quarkus, where every classpath `@Entity` is auto-discovered and mapped with Hibernate, this broke any application having camel-jpa on the classpath. `@Transient` excludes the helper from the persistent metamodel — no schema or behavior change.

The fix is covered by the new `KeyValueEntryHibernateMappingTest`, which verifies the Hibernate mapping in every build (native Hibernate bootstrap, so the rest of the suite keeps using OpenJPA; the default persistence units are pinned to the OpenJPA provider to keep resolution deterministic with two providers on the classpath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

