### PR TITLE
CAMEL-24409: sync REST client request validation upgrade-guide note to 4.22 and 4.18 guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -2099,3 +2099,10 @@ that resolve outside the configured directory are rejected.
 
 If `downloadFileName` is configured with an expression (i.e. it contains `$`), the local
 path is built by that expression as before and is not subject to this check.
+
+=== camel-core - REST client request validation and binary bodies
+
+When `clientRequestValidation` is enabled and the REST service declares a required body, the incoming
+message body is no longer replaced with a `String` version of itself. That conversion corrupted binary
+payloads such as `application/octet-stream`. The body is still read to check that it is present, using
+stream caching so it stays re-readable, but it now keeps its original type.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1851,3 +1851,10 @@ they say:
   `CamelGoogleVertexAIStreamOutputMode` header.
 * `jsonMode=true` sets the response MIME type of the request to `application/json`, so the model is
   asked to answer with JSON. The default `false` leaves the request untouched.
+
+=== camel-core - REST client request validation and binary bodies
+
+When `clientRequestValidation` is enabled and the REST service declares a required body, the incoming
+message body is no longer replaced with a `String` version of itself. That conversion corrupted binary
+payloads such as `application/octet-stream`. The body is still read to check that it is present, using
+stream caching so it stays re-readable, but it now keeps its original type.


### PR DESCRIPTION
## Doc-sync follow-up for CAMEL-24409

The binary-body fix ([#26024](https://github.com/apache/camel/pull/26024)) was backported to:
- `camel-4.22.x` — [#26070](https://github.com/apache/camel/pull/26070)
- `camel-4.18.x` — [#26071](https://github.com/apache/camel/pull/26071)

Each backport added the upgrade-guide note to the matching version-specific guide on its own
branch (`camel-4x-upgrade-guide-4_22.adoc` / `camel-4x-upgrade-guide-4_18.adoc`). Per the project's
backport upgrade-guide policy, `main` holds the canonical version-specific history, so this PR adds
the same note to the 4.22 and 4.18 guides on `main` (the note currently only exists in the 4.23 guide
on `main`, added by the original PR).

Docs only — no code changes.

_Claude Code on behalf of davsclaus_