### PR TITLE
CAMEL-24614: camel-langchain4j-agent - clear error when no agent can be resolved (validated at process time)

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -164,6 +164,18 @@ public class LangChain4jAgentProducer extends DefaultProducer {
         String tags = endpoint.getConfiguration().getTags();
 
         Agent agent = agentFactory != null ? agentFactory.createAgent(exchange) : this.agent;
+        if (agent == null && agentFactory == null) {
+            // Support an agent configured on the endpoint after the route started, and give a clear error
+            // instead of an opaque NullPointerException when nothing resolves to an agent.
+            agent = endpoint.getConfiguration().getAgent();
+            if (agent == null) {
+                throw new IllegalArgumentException(
+                        "No agent could be resolved for endpoint " + endpoint.getEndpointUri()
+                                                   + ". Configure 'agent', 'agentConfiguration' or 'agentFactory', or bind a bean named '"
+                                                   + endpoint.getAgentId() + "' of type " + Agent.class.getName()
+                                                   + " in the registry.");
+            }
+        }
 
         AiAgentBody<?> aiAgentBody = exchange.getMessage().getMandatoryBody(AiAgentBody.class);
 
@@ -588,16 +600,6 @@ public class LangChain4jAgentProducer extends DefaultProducer {
                 }
                 LOG.debug("Materialized {} MCP clients from server definitions", materializedMcpClients.size());
             }
-        }
-
-        // Fail fast with a clear message instead of a later NullPointerException in process() when nothing
-        // resolves to an agent (no agent/agentConfiguration/agentFactory and no matching registry bean).
-        if (agent == null && agentFactory == null) {
-            throw new IllegalArgumentException(
-                    "No agent could be resolved for endpoint " + endpoint.getEndpointUri()
-                                               + ". Configure 'agent', 'agentConfiguration' or 'agentFactory', or bind a bean named '"
-                                               + endpoint.getAgentId() + "' of type " + Agent.class.getName()
-                                               + " in the registry.");
         }
     }
 

--- a/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/main/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentProducer.java
@@ -589,6 +589,16 @@ public class LangChain4jAgentProducer extends DefaultProducer {
                 LOG.debug("Materialized {} MCP clients from server definitions", materializedMcpClients.size());
             }
         }
+
+        // Fail fast with a clear message instead of a later NullPointerException in process() when nothing
+        // resolves to an agent (no agent/agentConfiguration/agentFactory and no matching registry bean).
+        if (agent == null && agentFactory == null) {
+            throw new IllegalArgumentException(
+                    "No agent could be resolved for endpoint " + endpoint.getEndpointUri()
+                                               + ". Configure 'agent', 'agentConfiguration' or 'agentFactory', or bind a bean named '"
+                                               + endpoint.getAgentId() + "' of type " + Agent.class.getName()
+                                               + " in the registry.");
+        }
     }
 
     /**

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentMissingAgentTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentMissingAgentTest.java
@@ -16,27 +16,34 @@
  */
 package org.apache.camel.component.langchain4j.agent;
 
-import org.apache.camel.Producer;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.langchain4j.agent.api.AiAgentBody;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LangChain4jAgentMissingAgentTest {
 
     @Test
-    void missingAgentFailsFastWithAClearError() throws Exception {
+    void missingAgentReportsAClearError() throws Exception {
         try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    // No agent / agentConfiguration / agentFactory, and no registry bean named "noSuchAgent".
+                    from("direct:x").to("langchain4j-agent:noSuchAgent");
+                }
+            });
             context.start();
 
-            // No agent / agentConfiguration / agentFactory, and no registry bean named "noSuchAgent".
-            LangChain4jAgentEndpoint endpoint
-                    = context.getEndpoint("langchain4j-agent:noSuchAgent", LangChain4jAgentEndpoint.class);
-            Producer producer = endpoint.createProducer();
+            Exchange result = context.createProducerTemplate()
+                    .request("direct:x", e -> e.getIn().setBody(new AiAgentBody<>("hello")));
 
-            Exception ex = assertThrows(Exception.class, producer::start);
-            Throwable cause = ex;
+            Throwable cause = result.getException();
+            assertNotNull(cause, "an error was expected");
             boolean clearError = false;
             while (cause != null) {
                 if (cause instanceof IllegalArgumentException && cause.getMessage() != null
@@ -46,7 +53,8 @@ class LangChain4jAgentMissingAgentTest {
                 }
                 cause = cause.getCause();
             }
-            assertTrue(clearError, "expected a clear 'No agent could be resolved' IllegalArgumentException, got: " + ex);
+            assertTrue(clearError, "expected a clear 'No agent could be resolved' IllegalArgumentException, got: "
+                                   + result.getException());
         }
     }
 }

--- a/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentMissingAgentTest.java
+++ b/components/camel-ai/camel-langchain4j-agent/src/test/java/org/apache/camel/component/langchain4j/agent/LangChain4jAgentMissingAgentTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.langchain4j.agent;
+
+import org.apache.camel.Producer;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LangChain4jAgentMissingAgentTest {
+
+    @Test
+    void missingAgentFailsFastWithAClearError() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.start();
+
+            // No agent / agentConfiguration / agentFactory, and no registry bean named "noSuchAgent".
+            LangChain4jAgentEndpoint endpoint
+                    = context.getEndpoint("langchain4j-agent:noSuchAgent", LangChain4jAgentEndpoint.class);
+            Producer producer = endpoint.createProducer();
+
+            Exception ex = assertThrows(Exception.class, producer::start);
+            Throwable cause = ex;
+            boolean clearError = false;
+            while (cause != null) {
+                if (cause instanceof IllegalArgumentException && cause.getMessage() != null
+                        && cause.getMessage().contains("No agent could be resolved")) {
+                    clearError = true;
+                    break;
+                }
+                cause = cause.getCause();
+            }
+            assertTrue(clearError, "expected a clear 'No agent could be resolved' IllegalArgumentException, got: " + ex);
+        }
+    }
+}


### PR DESCRIPTION
## Issue
[CAMEL-24614](https://issues.apache.org/jira/browse/CAMEL-24614)

## Problem
`LangChain4jAgentProducer` resolves the agent from the registry with
`lookupByNameAndType(agentId, Agent.class)`, which returns `null` when no matching bean exists. With no
`agent`/`agentConfiguration`/`agentFactory` configured and no registry bean named `agentId`, `agent`
stays `null` and `process()` fails with an opaque `NullPointerException` at `agent.chat(...)` instead of
a clear configuration error.

## Fix
Resolve the agent and report the error in `process()` rather than at `doStart()`. When no
`agent`/`agentFactory` is set, re-resolve from the endpoint configuration
(`endpoint.getConfiguration().getAgent()`) and, only if that still yields nothing, throw a clear
`IllegalArgumentException` naming the endpoint and the configuration options.

Doing this at process time (instead of failing fast in `doStart()`) preserves the supported pattern of
configuring an agent on the endpoint **after** the route has started — used by dynamic wiring and by
several existing tests that call `endpoint.getConfiguration().setAgent(...)` post-start. Failing fast in
`doStart()` broke those flows (e.g. `LangChain4jAgentMcpToolProviderFilterTest`).

## Testing
- New `LangChain4jAgentMissingAgentTest` sends an exchange through a route whose endpoint has an
  unresolvable agent and asserts the clear `IllegalArgumentException` ("No agent could be resolved")
  surfaces on the exchange.
- Full `camel-langchain4j-agent` unit suite green (includes the late-configuration tests).
- `mvn -Psourcecheck validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)