### PR TITLE
CAMEL-24613: camel-langchain4j-agent-api - LanguageGuardrail must not reject plain English with allowMixed=false

### DIFF
--- a/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrail.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/main/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrail.java
@@ -206,7 +206,12 @@ public class LanguageGuardrail implements InputGuardrail {
         if (!allowMixed && detectedLanguages.size() > 1) {
             // Check if all detected languages are in allowed set
             for (Language detected : detectedLanguages) {
-                if (!allowedLanguages.contains(detected) && detected != Language.ENGLISH) {
+                // ENGLISH and LATIN_SCRIPT overlap (ASCII letters match both), so LATIN_SCRIPT must not be
+                // treated as foreign when ENGLISH is allowed - otherwise plain English is falsely rejected.
+                boolean acceptable = allowedLanguages.contains(detected)
+                        || detected == Language.ENGLISH
+                        || (detected == Language.LATIN_SCRIPT && allowedLanguages.contains(Language.ENGLISH));
+                if (!acceptable) {
                     return failure("Mixed language content is not allowed.");
                 }
             }

--- a/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrailTest.java
+++ b/components/camel-ai/camel-langchain4j-agent-api/src/test/java/org/apache/camel/component/langchain4j/agent/api/guardrails/LanguageGuardrailTest.java
@@ -166,4 +166,15 @@ class LanguageGuardrailTest {
         // All-Latin text meets the ratio
         assertTrue(guardrail.validate(UserMessage.from("Hello world")).isSuccess());
     }
+
+    @Test
+    void allowMixedFalseWithEnglishAllowsPlainEnglish() {
+        LanguageGuardrail guardrail = LanguageGuardrail.builder()
+                .allowedLanguages(LanguageGuardrail.Language.ENGLISH)
+                .allowMixed(false)
+                .build();
+
+        // Plain English detects both ENGLISH and the overlapping LATIN_SCRIPT; it must not be rejected as mixed.
+        assertTrue(guardrail.validate(UserMessage.from("Hello world, this is plain English.")).isSuccess());
+    }
 }


### PR DESCRIPTION
## Issue
[CAMEL-24613](https://issues.apache.org/jira/browse/CAMEL-24613)

## Problem
With `allowMixed(false)` and `allowedLanguages={ENGLISH}`, plain English is falsely rejected as "Mixed
language content is not allowed." The `ENGLISH` and `LATIN_SCRIPT` enum patterns overlap (ASCII letters
match both), so plain English is detected as **both** `ENGLISH` and `LATIN_SCRIPT`; the mixed-content
check then treats `LATIN_SCRIPT` as a foreign language (`!allowed && != ENGLISH`) and fails.

## Fix
Treat `LATIN_SCRIPT` as acceptable when `ENGLISH` is allowed (English is Latin script), so overlapping
detection no longer triggers a false mixed-content rejection.

## Scope note
This issue originally also bundled adding a guardrail-interface check to
`AgentConfiguration.parseGuardrailClasses`. That was **withdrawn**: the method is an intentionally lenient
class loader (its Javadoc documents loading arbitrary class names, and six existing tests exercise it with
non-guardrail classes such as `java.lang.String`), and langchain4j validates guardrail types downstream.
Adding the check would break that documented contract.

## Testing
- New `allowMixedFalseWithEnglishAllowsPlainEnglish` asserts plain English passes with `allowMixed(false)`
  and `ENGLISH` allowed; verified it fails against the unpatched code. All existing `LanguageGuardrailTest`
  cases still pass.
- `mvn -Psourcecheck validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)