### PR TITLE
chore: upgrade Hawtio to 5.2.1

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -421,7 +421,8 @@ class ExportSpringBoot extends Export {
         }
         if (hawtio) {
             answer.add("mvn:org.apache.camel:camel-management");
-            answer.add("mvn:io.hawt:hawtio-springboot:" + hawtioVersion);
+            String hawtioArtifact = springBootVersion.startsWith("4.") ? "hawtio-springboot4" : "hawtio-springboot";
+            answer.add("mvn:io.hawt:" + hawtioArtifact + ":" + hawtioVersion);
         }
 
         return answer;

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -1018,7 +1018,7 @@ class ExportTest {
                             null));
             Assertions.assertTrue(
                     containsDependency(model.getDependencies(), "io.hawt",
-                            "hawtio-springboot", HawtioVersion.HAWTIO_VERSION));
+                            "hawtio-springboot4", HawtioVersion.HAWTIO_VERSION));
             // Application properties
             File appProperties = new File(workingDir + "/src/main/resources", "application.properties");
             String content = IOHelper.loadText(new FileInputStream(appProperties));
@@ -1040,6 +1040,21 @@ class ExportTest {
             Assertions.assertTrue(content.contains("quarkus.hawtio.authenticationEnabled=false"),
                     "should contain quarkus.hawtio.authenticationEnabled property, was " + content);
         }
+    }
+
+    @Test
+    public void shouldExportHawtioWithSpringBoot3() throws Exception {
+        LOG.info("shouldExportHawtioWithSpringBoot3");
+        Export command = new Export(new CamelJBangMain());
+        CommandLine.populateCommand(command, "--gav=examples:route:1.0.0", "--dir=" + workingDir,
+                "--runtime=spring-boot", "--camel-version=" + RELEASED_CAMEL_VERSION,
+                "--spring-boot-version=3.5.14", "--hawtio=true", "target/test-classes/route.yaml");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+        Assertions.assertTrue(containsDependency(model.getDependencies(), "io.hawt",
+                "hawtio-springboot", HawtioVersion.HAWTIO_VERSION));
     }
 
     @ParameterizedTest

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -229,7 +229,7 @@
         <hapi-base-version>2.6.0</hapi-base-version>
         <hapi-fhir-version>8.12.0</hapi-fhir-version>
         <hapi-fhir-core-version>6.10.3</hapi-fhir-core-version>
-        <hawtio-version>4.6.2</hawtio-version>
+        <hawtio-version>5.2.1</hawtio-version>
         <!-- https://issues.apache.org/jira/browse/CAMEL-22041
             hazelcast needs to stay at 5.4.0 for 4.19.0 due to changes where the CP subsystem is only available in
             the enterprise hazelcast product -->


### PR DESCRIPTION
## Summary

- upgrade the shared Hawtio version from 4.6.2 to 5.2.1
- select `hawtio-springboot4` when exporting for Spring Boot 4, while retaining `hawtio-springboot` for Spring Boot 3
- cover both Spring Boot artifact selections in the JBang export tests

## Validation

- `mvn -pl dsl/camel-jbang/camel-jbang-core -Dtest=ExportTest#shouldExportHawtio+shouldExportHawtioWithSpringBoot3 test`
- generated, packaged, and started Spring Boot and Quarkus Hawtio exports
- launched `camel hawtio` standalone with Hawtio 5.2.1

_AI-generated on behalf of Croway._