### PR TITLE
Reduce git fetch time for scalpel in GitHub actions

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     branches:
       - main
+      - reduceGitFetchTimeForScalpel-base-for-pr
     # CI-only changes don't need a full build. Use workflow_dispatch to
     # test CI changes: gh workflow run "Build and test" -f pr_number=XXXX -f pr_ref=branch-name
     paths-ignore:

--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -92,7 +92,7 @@ jobs:
           # Scalpel is observational — fetch failures must not break the build.
           BASE_REF="${GITHUB_BASE_REF:-main}"
           for depth in 50 200 1000; do
-            git fetch --deepen=$depth 2>/dev/null || true
+            git fetch --no-tags --deepen=$depth origin ${BASE_REF} 2>/dev/null || true
             git fetch --no-tags --depth=$depth origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
             if git merge-base HEAD "origin/${BASE_REF}" >/dev/null 2>&1; then
               echo "Merge base reachable at depth $depth"
@@ -103,7 +103,7 @@ jobs:
           # If still not reachable, fetch full history as last resort
           if ! git merge-base HEAD "origin/${BASE_REF}" >/dev/null 2>&1; then
             echo "Merge base still not reachable, fetching full history"
-            git fetch --unshallow 2>/dev/null || true
+            git fetch --no-tags --unshallow origin ${BASE_REF} 2>/dev/null || true
             git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
           fi
       - id: install-packages

--- a/.github/workflows/sonar-build.yml
+++ b/.github/workflows/sonar-build.yml
@@ -50,7 +50,7 @@ jobs:
           # Scalpel is observational — fetch failures must not break the build.
           BASE_REF="${GITHUB_BASE_REF:-main}"
           for depth in 200 1000; do
-            git fetch --deepen=$depth 2>/dev/null || true
+            git fetch --no-tags --deepen=$depth origin ${BASE_REF} 2>/dev/null || true
             git fetch --no-tags --depth=$depth origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" || true
             if git merge-base HEAD "origin/${BASE_REF}" >/dev/null 2>&1; then
               echo "Merge base reachable at depth $depth"
@@ -61,7 +61,7 @@ jobs:
           # If still not reachable, fetch full history as last resort
           if ! git merge-base HEAD "origin/${BASE_REF}" >/dev/null 2>&1; then
             echo "Merge base still not reachable, fetching full history"
-            git fetch --unshallow 2>/dev/null || true
+            git fetch --no-tags --unshallow origin ${BASE_REF} 2>/dev/null || true
             git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" || true
           fi
       - id: install-packages


### PR DESCRIPTION
currently it takes almost 5 minutes. it seems that the `git fetch --deepen=50` is fetching last 50 commits of all tags and branches. We only need from the base branch.
Locally, it goes from around 5 minutes to few seconds.

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

