### PR TITLE
[backport camel-4.22.x] CAMEL-24611: camel-chatscript - fix resetChat, chatUserName, socket timeout and non-String body handling

### DIFF
--- a/components/camel-ai/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptBot.java
+++ b/components/camel-ai/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptBot.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 
 import org.slf4j.Logger;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 public class ChatScriptBot {
 
     private static final transient Logger LOG = LoggerFactory.getLogger(ChatScriptBot.class);
+    private static final int CONNECT_TIMEOUT_MILLIS = 30000;
+    private static final int READ_TIMEOUT_MILLIS = 30000;
     String host;
     int port;
     String message;
@@ -64,7 +67,9 @@ public class ChatScriptBot {
     private String doMessage(String msg) throws Exception {
         String resp = "";
 
-        try (Socket echoSocket = new Socket(this.host, this.port)) {
+        try (Socket echoSocket = new Socket()) {
+            echoSocket.connect(new InetSocketAddress(this.host, this.port), CONNECT_TIMEOUT_MILLIS);
+            echoSocket.setSoTimeout(READ_TIMEOUT_MILLIS);
             try (PrintWriter out = new PrintWriter(echoSocket.getOutputStream(), true)) {
                 try (BufferedReader in = new BufferedReader(new InputStreamReader(echoSocket.getInputStream()))) {
                     out.println(msg);
@@ -92,6 +97,12 @@ public class ChatScriptBot {
     }
 
     public void reset() {
+        try {
+            doMessage(new ChatScriptMessage(this.userName, this.botName, ":reset").toCSFormat());
+            initialized = false;
+        } catch (Exception e) {
+            LOG.warn("Failed to reset the ChatScript conversation: {}", e.getMessage(), e);
+        }
     }
 
     public String getHost() {

--- a/components/camel-ai/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptEndpoint.java
+++ b/components/camel-ai/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptEndpoint.java
@@ -76,8 +76,6 @@ public class ChatScriptEndpoint extends DefaultEndpoint {
             throw new IllegalArgumentException(ChatScriptConstants.URI_ERROR);
         }
         botName = botName.substring(1);
-        setBot(new ChatScriptBot(getHost(), getPort(), getBotName(), ""));
-
     }
 
     public boolean isResetChat() {
@@ -135,6 +133,13 @@ public class ChatScriptEndpoint extends DefaultEndpoint {
     }
 
     public ChatScriptBot getBot() {
+        if (bot == null) {
+            // Created lazily so the chatUserName option (bound after the constructor) is honoured as the
+            // conversation user name instead of the previous hardcoded empty string.
+            bot = new ChatScriptBot(
+                    getHost(), getPort(), getBotName(),
+                    ObjectHelper.isNotEmpty(chatUserName) ? chatUserName : "");
+        }
         return bot;
     }
 

--- a/components/camel-ai/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptProducer.java
+++ b/components/camel-ai/camel-chatscript/src/main/java/org/apache/camel/component/chatscript/ChatScriptProducer.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.chatscript;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultProducer;
+import org.apache.camel.util.ObjectHelper;
 
 /**
  * The ChatScript producer.
@@ -30,14 +31,14 @@ public class ChatScriptProducer extends DefaultProducer {
     public ChatScriptProducer(ChatScriptEndpoint endpoint) {
         super(endpoint);
         this.endpoint = endpoint;
-
-        if (endpoint.isResetChat()) {
-            this.endpoint.getBot().reset();
-        }
     }
 
     @Override
     public void process(Exchange exchange) throws Exception {
+        // Start a fresh conversation on every exchange when requested (resetChat).
+        if (endpoint.isResetChat()) {
+            endpoint.getBot().reset();
+        }
 
         Object body = exchange.getIn().getBody();
         ChatScriptMessage inputMessage;
@@ -48,17 +49,22 @@ public class ChatScriptProducer extends DefaultProducer {
             inputMessage = (ChatScriptMessage) body;
         }
         inputMessage.setBotName(endpoint.getBotName());
+        // Honour the configured chatUserName as the conversation user when the message does not carry one.
+        if (ObjectHelper.isEmpty(inputMessage.getUserName())) {
+            inputMessage.setUserName(endpoint.getBot().getUserName());
+        }
         String response = this.endpoint.getBot().sendChat(inputMessage);
         inputMessage.setReply(response);
         exchange.getOut().setBody(inputMessage);
     }
 
     private ChatScriptMessage buildMessage(Object body) throws Exception {
-
         if (body instanceof String) {
             return createMessage(String.valueOf(body));
         }
-        return null;
+        throw new IllegalArgumentException(
+                "Unsupported ChatScript body type: " + (body == null ? "null" : body.getClass().getName())
+                                           + ". The body must be a ChatScriptMessage or a String (its JSON form).");
     }
 
     private ChatScriptMessage createMessage(String message) throws Exception {

--- a/components/camel-ai/camel-chatscript/src/test/java/org/apache/camel/component/chatscript/ChatScriptProducerTest.java
+++ b/components/camel-ai/camel-chatscript/src/test/java/org/apache/camel/component/chatscript/ChatScriptProducerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.chatscript;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Producer;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChatScriptProducerTest {
+
+    private CamelContext context;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        context = new DefaultCamelContext();
+        context.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    @Test
+    void chatUserNameIsAppliedToTheBot() {
+        ChatScriptEndpoint endpoint = context.getEndpoint(
+                "chatscript:localhost:1024/testbot?chatUserName=alice", ChatScriptEndpoint.class);
+        assertEquals("alice", endpoint.getBot().getUserName(),
+                "the configured chatUserName must be the conversation user name");
+    }
+
+    @Test
+    void nonStringBodyIsRejectedWithAClearError() throws Exception {
+        ChatScriptEndpoint endpoint = context.getEndpoint(
+                "chatscript:localhost:1024/testbot", ChatScriptEndpoint.class);
+        Producer producer = endpoint.createProducer();
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(new byte[] { 1, 2, 3 });
+
+        // Previously this returned null from buildMessage and NPE'd; it must now fail with a clear error.
+        assertThrows(IllegalArgumentException.class, () -> producer.process(exchange));
+    }
+}


### PR DESCRIPTION
<!-- camel-backport-bot -->

## Backport of #26076

Cherry-pick of #26076 onto `camel-4.22.x`.

**Original PR:** #26076 - CAMEL-24611: camel-chatscript - fix resetChat, chatUserName, socket timeout and non-String body handling
**Original author:** @oscerd
**Target branch:** `camel-4.22.x`
