### PR TITLE
camel-docling: honor the operationId URI path segment to select the operation

### DIFF
--- a/components/camel-ai/camel-docling/src/main/java/org/apache/camel/component/docling/DoclingComponent.java
+++ b/components/camel-ai/camel-docling/src/main/java/org/apache/camel/component/docling/DoclingComponent.java
@@ -29,6 +29,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,15 @@ public class DoclingComponent extends DefaultComponent {
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         DoclingConfiguration config = this.configuration.copy();
+        // operationId (e.g. docling:CONVERT_TO_MARKDOWN) selects the operation; applied before
+        // setProperties() below so an explicit ?operation=... parameter still takes precedence.
+        if (ObjectHelper.isNotEmpty(remaining)) {
+            try {
+                config.setOperation(DoclingOperations.valueOf(remaining));
+            } catch (IllegalArgumentException e) {
+                // not a recognized operation name - leave the configured/default operation as-is
+            }
+        }
         DoclingEndpoint endpoint = new DoclingEndpoint(uri, this, remaining, config);
         setProperties(endpoint, parameters);
         return endpoint;

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/DoclingComponentTest.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/DoclingComponentTest.java
@@ -50,6 +50,27 @@ public class DoclingComponentTest extends CamelTestSupport {
     }
 
     @Test
+    public void testOperationIdSelectsOperation() throws Exception {
+        Endpoint endpoint = context.getEndpoint("docling:EXTRACT_STRUCTURED_DATA");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof DoclingEndpoint);
+
+        DoclingEndpoint doclingEndpoint = (DoclingEndpoint) endpoint;
+        assertEquals("EXTRACT_STRUCTURED_DATA", doclingEndpoint.getOperationId());
+        assertEquals(DoclingOperations.EXTRACT_STRUCTURED_DATA, doclingEndpoint.getConfiguration().getOperation());
+    }
+
+    @Test
+    public void testExplicitOperationParameterOverridesOperationId() throws Exception {
+        // a recognized operationId must still be overridable via an explicit "operation" parameter
+        Endpoint endpoint = context.getEndpoint("docling:CONVERT_TO_MARKDOWN?operation=EXTRACT_TEXT");
+        assertNotNull(endpoint);
+
+        DoclingEndpoint doclingEndpoint = (DoclingEndpoint) endpoint;
+        assertEquals(DoclingOperations.EXTRACT_TEXT, doclingEndpoint.getConfiguration().getOperation());
+    }
+
+    @Test
     public void testProducerCreation() throws Exception {
         DoclingEndpoint endpoint = (DoclingEndpoint) context.getEndpoint("docling:convert");
         assertNotNull(endpoint.createProducer());


### PR DESCRIPTION
## Summary

`DoclingEndpoint` stores the `docling:<operationId>` URI path segment (e.g. `docling:EXTRACT_STRUCTURED_DATA`, matching the component's own documented syntax `docling:operationId`), but `DoclingComponent` never applied it to `DoclingConfiguration.operation`, and `DoclingProducer.getOperation()` only consults the `CamelDoclingOperation` header or the configured/default operation (`CONVERT_TO_MARKDOWN`).

As a result, an endpoint such as:
```
docling:EXTRACT_STRUCTURED_DATA?useDoclingServe=true&doclingServeUrl=...&outputFormat=json
```
silently performs `CONVERT_TO_MARKDOWN` instead - the URI path segment is effectively ignored unless the operation is *also* passed via the `operation` query parameter or the `CamelDoclingOperation` header (the pattern already used by this component's own docs/tests, e.g. `docling:convert?operation=CONVERT_TO_MARKDOWN`).

I hit this concretely while testing the `docling` example in [camel-spring-boot-examples](https://github.com/apache/camel-spring-boot-examples): a `document-metadata-extractor` route using `docling:EXTRACT_STRUCTURED_DATA?...&outputFormat=json` was writing markdown text into `.json` files (invalid JSON), because it was actually always running `CONVERT_TO_MARKDOWN`.

- `DoclingComponent.createEndpoint()` now parses `operationId` into a `DoclingOperations` value and applies it to the endpoint's configuration *before* `setProperties()` runs, so an explicit `?operation=...` query parameter still takes precedence, and an `operationId` that isn't a recognized operation name (used as a purely descriptive endpoint id) is silently ignored rather than failing endpoint creation.
- Added two regression tests in `DoclingComponentTest`: `operationId` selecting the operation, and an explicit `operation` parameter overriding a recognized `operationId`. (The "unrecognized operationId + explicit operation parameter" case was already covered by the existing `testCreateEndpointWithParameters`.)

Related, not fixed here: once the operation is dispatched correctly, `EXTRACT_STRUCTURED_DATA` (and `CONVERT_TO_JSON` in docling-serve mode) sets the exchange body to a `DoclingDocument` POJO regardless of `outputFormat`, and there's no registered type converter to `String`/bytes for it - callers need to marshal it explicitly (e.g. via `camel-jackson`) before handing it to a byte-oriented endpoint like `file:`. Happy to file that as a separate follow-up if useful.

## Test plan

- [x] `mvn -o test -Dtest='!*IT'` in `components/camel-ai/camel-docling` - all unit tests pass, including the new regression tests
- [x] Reproduced against a live `docling-serve` container via the `camel-spring-boot-examples` docling example: before the fix, `EXTRACT_STRUCTURED_DATA` silently ran `CONVERT_TO_MARKDOWN`; after the fix, it correctly dispatches to structured-data extraction
- [x] Verified the pre-existing `docling:convert?operation=...` style (used elsewhere in this component's tests/docs) is unaffected