### PR TITLE
CAMEL-24560: Use Long for GenAiUsage token counts

### DIFF
--- a/components/camel-ai/camel-ai-observability-api/src/main/java/org/apache/camel/component/ai/observability/GenAiUsage.java
+++ b/components/camel-ai/camel-ai-observability-api/src/main/java/org/apache/camel/component/ai/observability/GenAiUsage.java
@@ -20,13 +20,24 @@ package org.apache.camel.component.ai.observability;
  * Token usage and completion metadata captured after a GenAI operation.
  */
 public record GenAiUsage(
-        Integer inputTokens,
-        Integer outputTokens,
+        Long inputTokens,
+        Long outputTokens,
         String finishReason,
         String responseModel) {
 
-    public static GenAiUsage of(Integer inputTokens, Integer outputTokens, Object finishReason, String responseModel) {
+    public static GenAiUsage of(Long inputTokens, Long outputTokens, Object finishReason, String responseModel) {
         String reason = finishReason == null ? null : finishReason.toString();
         return new GenAiUsage(inputTokens, outputTokens, reason, responseModel);
+    }
+
+    /**
+     * Convenience factory when token counts come from APIs that expose {@code Integer} counts (e.g. LangChain4j).
+     */
+    public static GenAiUsage of(Integer inputTokens, Integer outputTokens, Object finishReason, String responseModel) {
+        return of(toLong(inputTokens), toLong(outputTokens), finishReason, responseModel);
+    }
+
+    private static Long toLong(Integer value) {
+        return value == null ? null : value.longValue();
     }
 }

--- a/components/camel-ai/camel-ai-observability-api/src/test/java/org/apache/camel/component/ai/observability/GenAiUsageTest.java
+++ b/components/camel-ai/camel-ai-observability-api/src/test/java/org/apache/camel/component/ai/observability/GenAiUsageTest.java
@@ -62,6 +62,14 @@ class GenAiUsageTest {
     }
 
     @Test
+    void shouldConvertNullIntegerFactoryArgumentsToNullLongFields() {
+        GenAiUsage usage = GenAiUsage.of((Integer) null, (Integer) null, null, "gpt-4o");
+
+        assertThat(usage.inputTokens()).isNull();
+        assertThat(usage.outputTokens()).isNull();
+    }
+
+    @Test
     void shouldStringifyNonStringFinishReason() {
         GenAiUsage usage = GenAiUsage.of(1L, 2L, FinishReason.STOP, "model");
 

--- a/components/camel-ai/camel-ai-observability-api/src/test/java/org/apache/camel/component/ai/observability/GenAiUsageTest.java
+++ b/components/camel-ai/camel-ai-observability-api/src/test/java/org/apache/camel/component/ai/observability/GenAiUsageTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.ai.observability;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GenAiUsageTest {
+
+    @Test
+    void shouldCreateUsageWithLongTokenCounts() {
+        GenAiUsage usage = GenAiUsage.of(100L, 50L, "stop", "gpt-4o");
+
+        assertThat(usage.inputTokens()).isEqualTo(100L);
+        assertThat(usage.outputTokens()).isEqualTo(50L);
+        assertThat(usage.finishReason()).isEqualTo("stop");
+        assertThat(usage.responseModel()).isEqualTo("gpt-4o");
+    }
+
+    @Test
+    void shouldAcceptTokenCountsBeyondIntegerMaxValue() {
+        long largeInput = Integer.MAX_VALUE + 1024L;
+        long largeOutput = Integer.MAX_VALUE + 2048L;
+
+        GenAiUsage usage = GenAiUsage.of(largeInput, largeOutput, "length", "gpt-4.1");
+
+        assertThat(usage.inputTokens()).isEqualTo(largeInput);
+        assertThat(usage.outputTokens()).isEqualTo(largeOutput);
+    }
+
+    @Test
+    void shouldConvertIntegerFactoryArgumentsToLong() {
+        GenAiUsage usage = GenAiUsage.of(12, 8, "stop", "gpt-4o-mini");
+
+        assertThat(usage.inputTokens()).isEqualTo(12L);
+        assertThat(usage.outputTokens()).isEqualTo(8L);
+    }
+
+    @Test
+    void shouldAllowNullTokenCountsAndFinishReason() {
+        GenAiUsage usage = GenAiUsage.of((Long) null, null, null, "gpt-4o");
+
+        assertThat(usage.inputTokens()).isNull();
+        assertThat(usage.outputTokens()).isNull();
+        assertThat(usage.finishReason()).isNull();
+        assertThat(usage.responseModel()).isEqualTo("gpt-4o");
+    }
+
+    @Test
+    void shouldStringifyNonStringFinishReason() {
+        GenAiUsage usage = GenAiUsage.of(1L, 2L, FinishReason.STOP, "model");
+
+        assertThat(usage.finishReason()).isEqualTo("STOP");
+    }
+
+    private enum FinishReason {
+        STOP
+    }
+}

--- a/components/camel-ai/camel-ai-observability/src/main/java/org/apache/camel/component/ai/observability/GenAiMicrometerSupport.java
+++ b/components/camel-ai/camel-ai-observability/src/main/java/org/apache/camel/component/ai/observability/GenAiMicrometerSupport.java
@@ -71,7 +71,7 @@ final class GenAiMicrometerSupport implements GenAiMetricsBackend {
     }
 
     private void recordTokenCounter(
-            Integer tokens, String tokenType, GenAiObservationContext context, Throwable error) {
+            Long tokens, String tokenType, GenAiObservationContext context, Throwable error) {
         if (tokens == null || tokens <= 0) {
             return;
         }
@@ -79,7 +79,7 @@ final class GenAiMicrometerSupport implements GenAiMetricsBackend {
                 .tags(baseTags(context, error))
                 .tag(GenAiMetrics.TAG_TOKEN_TYPE, tokenType)
                 .register(meterRegistry)
-                .increment(tokens);
+                .increment(tokens.doubleValue());
     }
 
     private static Iterable<Tag> baseTags(GenAiObservationContext context, Throwable error) {

--- a/components/camel-ai/camel-ai-observability/src/test/java/org/apache/camel/component/ai/observability/GenAiObservabilitySpanTest.java
+++ b/components/camel-ai/camel-ai-observability/src/test/java/org/apache/camel/component/ai/observability/GenAiObservabilitySpanTest.java
@@ -75,6 +75,26 @@ class GenAiObservabilitySpanTest extends ExchangeTestSupport {
     }
 
     @Test
+    void shouldRecordLargeTokenCountsOnSpanAttributes() {
+        long largeInput = Integer.MAX_VALUE + 4096L;
+        long largeOutput = Integer.MAX_VALUE + 8192L;
+
+        Exchange exchange = new DefaultExchange(context);
+        GenAiObservation observation = GenAiObservability.start(exchange, GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.CHAT)
+                .system("openai")
+                .requestModel("gpt-4.1")
+                .componentScheme("openai")
+                .build());
+        observation.recordSuccess(GenAiUsage.of(largeInput, largeOutput, "stop", "gpt-4.1"));
+        observation.close();
+
+        Map<String, String> tags = tracer.closedSpans().get(0).tags();
+        assertThat(tags.get(GenAiAttributes.INPUT_TOKENS)).isEqualTo(Long.toString(largeInput));
+        assertThat(tags.get(GenAiAttributes.OUTPUT_TOKENS)).isEqualTo(Long.toString(largeOutput));
+    }
+
+    @Test
     void shouldMarkSpanAsErrorWhenFailureRecorded() {
         Exchange exchange = new DefaultExchange(context);
         GenAiObservation observation = GenAiObservability.start(exchange, GenAiObservationContext.builder()

--- a/components/camel-ai/camel-ai-observability/src/test/java/org/apache/camel/component/ai/observability/GenAiObservabilityTest.java
+++ b/components/camel-ai/camel-ai-observability/src/test/java/org/apache/camel/component/ai/observability/GenAiObservabilityTest.java
@@ -99,6 +99,24 @@ class GenAiObservabilityTest extends ExchangeTestSupport {
     }
 
     @Test
+    void shouldSkipMicrometerTokenCountersWhenUsageIsNullOrZero() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        context.getRegistry().bind("metricsRegistry", registry);
+
+        Exchange exchange = new DefaultExchange(context);
+        GenAiObservation observation = GenAiObservability.start(exchange, GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.CHAT)
+                .system("openai")
+                .requestModel("gpt-4o")
+                .componentScheme("openai")
+                .build());
+        observation.recordSuccess(GenAiUsage.of((Long) null, 0L, "stop", "gpt-4o"));
+        observation.close();
+
+        assertThat(registry.find(GenAiMetrics.CLIENT_TOKEN_USAGE).counter()).isNull();
+    }
+
+    @Test
     void shouldReturnNoopWhenDisabled() {
         Properties properties = new Properties();
         properties.setProperty(GenAiObservabilityProperties.ENABLED, "false");

--- a/components/camel-ai/camel-ai-observability/src/test/java/org/apache/camel/component/ai/observability/GenAiObservabilityTest.java
+++ b/components/camel-ai/camel-ai-observability/src/test/java/org/apache/camel/component/ai/observability/GenAiObservabilityTest.java
@@ -71,6 +71,34 @@ class GenAiObservabilityTest extends ExchangeTestSupport {
     }
 
     @Test
+    void shouldRecordLargeTokenCountsInMicrometerMetrics() {
+        long largeInput = Integer.MAX_VALUE + 1024L;
+        long largeOutput = Integer.MAX_VALUE + 2048L;
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        context.getRegistry().bind("metricsRegistry", registry);
+
+        Exchange exchange = new DefaultExchange(context);
+        GenAiObservation observation = GenAiObservability.start(exchange, GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.CHAT)
+                .system("openai")
+                .requestModel("gpt-4.1")
+                .componentScheme("openai")
+                .build());
+        observation.recordSuccess(GenAiUsage.of(largeInput, largeOutput, "stop", "gpt-4.1"));
+        observation.close();
+
+        assertThat(registry.find(GenAiMetrics.CLIENT_TOKEN_USAGE)
+                .tag(GenAiMetrics.TAG_TOKEN_TYPE, GenAiMetrics.TOKEN_TYPE_INPUT)
+                .counter()
+                .count()).isEqualTo((double) largeInput);
+        assertThat(registry.find(GenAiMetrics.CLIENT_TOKEN_USAGE)
+                .tag(GenAiMetrics.TAG_TOKEN_TYPE, GenAiMetrics.TOKEN_TYPE_OUTPUT)
+                .counter()
+                .count()).isEqualTo((double) largeOutput);
+    }
+
+    @Test
     void shouldReturnNoopWhenDisabled() {
         Properties properties = new Properties();
         properties.setProperty(GenAiObservabilityProperties.ENABLED, "false");

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
@@ -156,8 +156,8 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
         if (response != null) {
             message.setHeader(OpenAIConstants.EMBEDDING_RESPONSE_MODEL, response.model());
             if (response.usage() != null) {
-                message.setHeader(OpenAIConstants.PROMPT_TOKENS, (int) response.usage().promptTokens());
-                message.setHeader(OpenAIConstants.TOTAL_TOKENS, (int) response.usage().totalTokens());
+                message.setHeader(OpenAIConstants.PROMPT_TOKENS, response.usage().promptTokens());
+                message.setHeader(OpenAIConstants.TOTAL_TOKENS, response.usage().totalTokens());
             }
         }
         message.setHeader(OpenAIConstants.EMBEDDING_COUNT, embeddings.size());

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIProducer.java
@@ -680,8 +680,8 @@ public class OpenAIProducer extends DefaultAsyncProducer {
                 CompletionUsage usage = usageRef.get();
                 String responseModel = responseModelRef.get() != null ? responseModelRef.get() : requestModel;
                 observation.recordSuccess(GenAiUsage.of(
-                        usage != null ? toTokenCount(usage.promptTokens()) : null,
-                        usage != null ? toTokenCount(usage.completionTokens()) : null,
+                        usage != null ? usage.promptTokens() : null,
+                        usage != null ? usage.completionTokens() : null,
                         null,
                         responseModel));
                 observation.close();
@@ -731,10 +731,6 @@ public class OpenAIProducer extends DefaultAsyncProducer {
                 .orElse("stop");
     }
 
-    private static Integer toTokenCount(long tokens) {
-        return Math.toIntExact(tokens);
-    }
-
     private ChatCompletion createChatCompletion(Exchange exchange, ChatCompletionCreateParams params) {
         String requestModel = params.model().toString();
         GenAiObservationContext observationContext = GenAiObservationContext.builder()
@@ -748,8 +744,8 @@ public class OpenAIProducer extends DefaultAsyncProducer {
             ChatCompletion response = getEndpoint().getClient().chat().completions().create(params);
             CompletionUsage usage = response.usage().orElse(null);
             observation.recordSuccess(GenAiUsage.of(
-                    usage != null ? toTokenCount(usage.promptTokens()) : null,
-                    usage != null ? toTokenCount(usage.completionTokens()) : null,
+                    usage != null ? usage.promptTokens() : null,
+                    usage != null ? usage.completionTokens() : null,
                     response.choices().isEmpty() ? null : getFinishReasonString(response.choices().get(0)),
                     response.model()));
             return response;

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -436,6 +436,9 @@ the registry has tracing and meter handlers respectively. Token usage counters s
 `MeterRegistry`. Applications without an `ObservationRegistry` bean keep the previous OpenTelemetry
 and MeterRegistry behavior. `camel-micrometer-observability` is not required.
 
+`GenAiUsage` token fields (`inputTokens`, `outputTokens`) are `Long` so OpenAI and other providers
+that report `long` token counts are recorded without lossy casts.
+
 OpenAI streaming chat sets `stream_options.include_usage=true` only when GenAI observability is enabled,
 adding a final chunk with token usage for span/metric recording.
 


### PR DESCRIPTION
## Summary

Changes `GenAiUsage` token fields from `Integer` to `Long` so OpenAI and other providers that report `long` token counts are recorded without lossy `(int)` casts or `Math.toIntExact` failures.

Follow-up to CAMEL-23861 / review on PR #25337.

## Changes

- **`GenAiUsage`**: `inputTokens` and `outputTokens` are now `Long`; primary factory accepts `Long`; convenience overload keeps `Integer` for LangChain4j/Spring AI call sites
- **`OpenAIProducer`**: passes `usage.promptTokens()` / `usage.completionTokens()` directly (removed `toTokenCount` helper)
- **`OpenAIEmbeddingsProducer`**: sets prompt/total token headers as `long` (no `(int)` cast)
- **`GenAiMicrometerSupport`**: records token counters with `increment(double)` for large values
- **Tests**: `GenAiUsageTest` plus large-token, null/zero, and span coverage
- **Upgrade guide**: note that `GenAiUsage` uses `Long` token fields

## Testing

```bash
./mvnw -pl components/camel-ai/camel-ai-observability-api,components/camel-ai/camel-ai-observability -am test \
  -Dtest=GenAiUsageTest,GenAiObservabilityTest,GenAiObservabilitySpanTest
```

## Review notes (Bugbot + Grok)

- Fixed embeddings producer header truncation flagged by Bugbot
- Added null/zero Micrometer counter guard test per Grok review

_AI-generated PR description on behalf of atiaomar1978-hub_