### PR TITLE
CAMEL-24559: Extend GenAI observability to OpenAI embeddings, moderation, and responses

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
@@ -19,7 +19,8 @@ When `camel-opentelemetry2` and/or `camel-micrometer` is on the classpath, langc
 producers emit child spans and metrics per LLM call with attributes such as `gen_ai.operation.name`, `gen_ai.system`,
 `gen_ai.request.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens`.
 
-OpenAI coverage includes `chat-completion` (including streaming), `embeddings`, `moderation`, and `responses`.
+OpenAI coverage includes `chat-completion` (including streaming), `responses`, `embeddings`, and `moderation`.
+Each maps to a `gen_ai.operation.name` span attribute (`chat`, `embeddings`, `moderation`; moderation has no token usage).
 
 Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when a tracing or metrics backend is present). Camel Main exposes the same setting
 via `camel.aiObservability.enabled` in application.properties or programmatically with

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/ai-observability.adoc
@@ -19,6 +19,8 @@ When `camel-opentelemetry2` and/or `camel-micrometer` is on the classpath, langc
 producers emit child spans and metrics per LLM call with attributes such as `gen_ai.operation.name`, `gen_ai.system`,
 `gen_ai.request.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens`.
 
+OpenAI coverage includes `chat-completion` (including streaming), `embeddings`, `moderation`, and `responses`.
+
 Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when a tracing or metrics backend is present). Camel Main exposes the same setting
 via `camel.aiObservability.enabled` in application.properties or programmatically with
 `main.configure().aiObservability().withEnabled(false)`.

--- a/components/camel-ai/camel-ai-observability-api/src/main/java/org/apache/camel/component/ai/observability/GenAiOperationName.java
+++ b/components/camel-ai/camel-ai-observability-api/src/main/java/org/apache/camel/component/ai/observability/GenAiOperationName.java
@@ -17,7 +17,8 @@
 package org.apache.camel.component.ai.observability;
 
 /**
- * GenAI operation names from the OpenTelemetry semantic conventions.
+ * GenAI operation names aligned with the OpenTelemetry GenAI semantic conventions where applicable. Custom values (for
+ * example {@link #MODERATION}) are Camel extensions for operations not yet defined in the stable OTel subset.
  */
 public enum GenAiOperationName {
     CHAT("chat"),

--- a/components/camel-ai/camel-ai-observability-api/src/main/java/org/apache/camel/component/ai/observability/GenAiOperationName.java
+++ b/components/camel-ai/camel-ai-observability-api/src/main/java/org/apache/camel/component/ai/observability/GenAiOperationName.java
@@ -22,7 +22,9 @@ package org.apache.camel.component.ai.observability;
 public enum GenAiOperationName {
     CHAT("chat"),
     EMBEDDINGS("embeddings"),
-    GENERATE_CONTENT("generate_content");
+    GENERATE_CONTENT("generate_content"),
+    /** OpenAI moderation and similar content-policy checks. */
+    MODERATION("moderation");
 
     private final String value;
 

--- a/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
+++ b/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
@@ -19,7 +19,8 @@ When `camel-opentelemetry2` and/or `camel-micrometer` is on the classpath, langc
 producers emit child spans and metrics per LLM call with attributes such as `gen_ai.operation.name`, `gen_ai.system`,
 `gen_ai.request.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens`.
 
-OpenAI coverage includes `chat-completion` (including streaming), `embeddings`, `moderation`, and `responses`.
+OpenAI coverage includes `chat-completion` (including streaming), `responses`, `embeddings`, and `moderation`.
+Each maps to a `gen_ai.operation.name` span attribute (`chat`, `embeddings`, `moderation`; moderation has no token usage).
 
 Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when a tracing or metrics backend is present). Camel Main exposes the same setting
 via `camel.aiObservability.enabled` in application.properties or programmatically with

--- a/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
+++ b/components/camel-ai/camel-ai-observability/src/main/docs/ai-observability.adoc
@@ -19,6 +19,8 @@ When `camel-opentelemetry2` and/or `camel-micrometer` is on the classpath, langc
 producers emit child spans and metrics per LLM call with attributes such as `gen_ai.operation.name`, `gen_ai.system`,
 `gen_ai.request.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens`.
 
+OpenAI coverage includes `chat-completion` (including streaming), `embeddings`, `moderation`, and `responses`.
+
 Global toggle: set `camel.aiObservability.enabled=false` (default is `true` when a tracing or metrics backend is present). Camel Main exposes the same setting
 via `camel.aiObservability.enabled` in application.properties or programmatically with
 `main.configure().aiObservability().withEnabled(false)`.

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
@@ -112,31 +112,9 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
                 .componentScheme("openai")
                 .build();
         GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
+        CreateEmbeddingResponse response;
         try {
-            CreateEmbeddingResponse response = getEndpoint().getClient()
-                    .embeddings().create(params);
-
-            if (config.isStoreFullResponse()) {
-                exchange.setProperty(OpenAIConstants.RESPONSE, response);
-            }
-
-            List<List<Float>> embeddings = new ArrayList<>();
-            for (Embedding embedding : response.data()) {
-                embeddings.add(embedding.embedding());
-            }
-
-            Message out = exchange.getMessage();
-            if (inputs.size() == 1) {
-                out.setBody(embeddings.isEmpty() ? List.of() : embeddings.get(0));
-                out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs.get(0));
-            } else {
-                out.setBody(embeddings);
-                out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs);
-            }
-
-            setResponseHeaders(out, response, embeddings);
-            calculateSimilarityIfRequested(exchange, embeddings);
-
+            response = getEndpoint().getClient().embeddings().create(params);
             var usage = response.usage();
             observation.recordSuccess(GenAiUsage.of(
                     usage != null ? toTokenCount(usage.promptTokens()) : null,
@@ -150,6 +128,27 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
         } finally {
             observation.close();
         }
+
+        if (config.isStoreFullResponse()) {
+            exchange.setProperty(OpenAIConstants.RESPONSE, response);
+        }
+
+        List<List<Float>> embeddings = new ArrayList<>();
+        for (Embedding embedding : response.data()) {
+            embeddings.add(embedding.embedding());
+        }
+
+        Message out = exchange.getMessage();
+        if (inputs.size() == 1) {
+            out.setBody(embeddings.isEmpty() ? List.of() : embeddings.get(0));
+            out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs.get(0));
+        } else {
+            out.setBody(embeddings);
+            out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs);
+        }
+
+        setResponseHeaders(out, response, embeddings);
+        calculateSimilarityIfRequested(exchange, embeddings);
     }
 
     private static Integer toTokenCount(long tokens) {

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
@@ -29,6 +29,12 @@ import com.openai.models.embeddings.EmbeddingCreateParams.EncodingFormat;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.component.ai.observability.GenAiErrorSupport;
+import org.apache.camel.component.ai.observability.GenAiObservability;
+import org.apache.camel.component.ai.observability.GenAiObservation;
+import org.apache.camel.component.ai.observability.GenAiObservationContext;
+import org.apache.camel.component.ai.observability.GenAiOperationName;
+import org.apache.camel.component.ai.observability.GenAiUsage;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.util.ObjectHelper;
 
@@ -99,32 +105,55 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
 
         EmbeddingCreateParams params = paramsBuilder.build();
 
-        // Execute request
-        CreateEmbeddingResponse response = getEndpoint().getClient()
-                .embeddings().create(params);
+        GenAiObservationContext observationContext = GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.EMBEDDINGS)
+                .system("openai")
+                .requestModel(model)
+                .componentScheme("openai")
+                .build();
+        GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
+        try {
+            CreateEmbeddingResponse response = getEndpoint().getClient()
+                    .embeddings().create(params);
 
-        if (config.isStoreFullResponse()) {
-            exchange.setProperty(OpenAIConstants.RESPONSE, response);
+            if (config.isStoreFullResponse()) {
+                exchange.setProperty(OpenAIConstants.RESPONSE, response);
+            }
+
+            List<List<Float>> embeddings = new ArrayList<>();
+            for (Embedding embedding : response.data()) {
+                embeddings.add(embedding.embedding());
+            }
+
+            Message out = exchange.getMessage();
+            if (inputs.size() == 1) {
+                out.setBody(embeddings.isEmpty() ? List.of() : embeddings.get(0));
+                out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs.get(0));
+            } else {
+                out.setBody(embeddings);
+                out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs);
+            }
+
+            setResponseHeaders(out, response, embeddings);
+            calculateSimilarityIfRequested(exchange, embeddings);
+
+            var usage = response.usage();
+            observation.recordSuccess(GenAiUsage.of(
+                    usage != null ? toTokenCount(usage.promptTokens()) : null,
+                    null,
+                    null,
+                    response.model()));
+        } catch (Exception e) {
+            GenAiErrorSupport.apply(exchange, e);
+            observation.recordError(e);
+            throw e;
+        } finally {
+            observation.close();
         }
+    }
 
-        // Extract embeddings
-        List<List<Float>> embeddings = new ArrayList<>();
-        for (Embedding embedding : response.data()) {
-            embeddings.add(embedding.embedding());
-        }
-
-        // Set output body (metadata is exposed via headers)
-        Message out = exchange.getMessage();
-        if (inputs.size() == 1) {
-            out.setBody(embeddings.isEmpty() ? List.of() : embeddings.get(0));
-            out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs.get(0));
-        } else {
-            out.setBody(embeddings);
-            out.setHeader(OpenAIConstants.ORIGINAL_TEXT, inputs);
-        }
-
-        setResponseHeaders(out, response, embeddings);
-        calculateSimilarityIfRequested(exchange, embeddings);
+    private static Integer toTokenCount(long tokens) {
+        return Math.toIntExact(tokens);
     }
 
     @SuppressWarnings("unchecked")

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIEmbeddingsProducer.java
@@ -117,7 +117,7 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
             response = getEndpoint().getClient().embeddings().create(params);
             var usage = response.usage();
             observation.recordSuccess(GenAiUsage.of(
-                    usage != null ? toTokenCount(usage.promptTokens()) : null,
+                    usage != null ? usage.promptTokens() : null,
                     null,
                     null,
                     response.model()));
@@ -149,10 +149,6 @@ public class OpenAIEmbeddingsProducer extends DefaultAsyncProducer {
 
         setResponseHeaders(out, response, embeddings);
         calculateSimilarityIfRequested(exchange, embeddings);
-    }
-
-    private static Integer toTokenCount(long tokens) {
-        return Math.toIntExact(tokens);
     }
 
     @SuppressWarnings("unchecked")

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIModerationProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIModerationProducer.java
@@ -100,23 +100,9 @@ public class OpenAIModerationProducer extends DefaultAsyncProducer {
                 .componentScheme("openai")
                 .build();
         GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
+        ModerationCreateResponse response;
         try {
-            ModerationCreateResponse response = getEndpoint().getClient()
-                    .moderations().create(paramsBuilder.build());
-
-            if (response.results().size() != inputs.size()) {
-                throw new CamelExchangeException(
-                        "Moderation returned " + response.results().size() + " result(s) for " + inputs.size()
-                                                 + " input(s)",
-                        exchange);
-            }
-
-            if (config.isStoreFullResponse()) {
-                exchange.setProperty(OpenAIConstants.MODERATION_RESPONSE, response);
-            }
-
-            setResponseHeaders(exchange.getMessage(), response, inputs, batch);
-
+            response = getEndpoint().getClient().moderations().create(paramsBuilder.build());
             observation.recordSuccess(GenAiUsage.of(null, null, null, response.model()));
         } catch (Exception e) {
             GenAiErrorSupport.apply(exchange, e);
@@ -125,6 +111,19 @@ public class OpenAIModerationProducer extends DefaultAsyncProducer {
         } finally {
             observation.close();
         }
+
+        if (response.results().size() != inputs.size()) {
+            throw new CamelExchangeException(
+                    "Moderation returned " + response.results().size() + " result(s) for " + inputs.size()
+                                             + " input(s)",
+                    exchange);
+        }
+
+        if (config.isStoreFullResponse()) {
+            exchange.setProperty(OpenAIConstants.MODERATION_RESPONSE, response);
+        }
+
+        setResponseHeaders(exchange.getMessage(), response, inputs, batch);
     }
 
     private List<String> extractInputs(Exchange exchange) {

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIModerationProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIModerationProducer.java
@@ -28,6 +28,12 @@ import org.apache.camel.AsyncCallback;
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.component.ai.observability.GenAiErrorSupport;
+import org.apache.camel.component.ai.observability.GenAiObservability;
+import org.apache.camel.component.ai.observability.GenAiObservation;
+import org.apache.camel.component.ai.observability.GenAiObservationContext;
+import org.apache.camel.component.ai.observability.GenAiOperationName;
+import org.apache.camel.component.ai.observability.GenAiUsage;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.util.ObjectHelper;
 
@@ -87,24 +93,38 @@ public class OpenAIModerationProducer extends DefaultAsyncProducer {
             paramsBuilder.inputOfStrings(inputs);
         }
 
-        ModerationCreateResponse response = getEndpoint().getClient()
-                .moderations().create(paramsBuilder.build());
+        GenAiObservationContext observationContext = GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.MODERATION)
+                .system("openai")
+                .requestModel(model)
+                .componentScheme("openai")
+                .build();
+        GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
+        try {
+            ModerationCreateResponse response = getEndpoint().getClient()
+                    .moderations().create(paramsBuilder.build());
 
-        // this operation is used to gate untrusted content, so a missing verdict must fail the exchange
-        // instead of leaving CamelOpenAIModerationFlagged false and letting the message through
-        if (response.results().size() != inputs.size()) {
-            throw new CamelExchangeException(
-                    "Moderation returned " + response.results().size() + " result(s) for " + inputs.size()
-                                             + " input(s)",
-                    exchange);
+            if (response.results().size() != inputs.size()) {
+                throw new CamelExchangeException(
+                        "Moderation returned " + response.results().size() + " result(s) for " + inputs.size()
+                                                 + " input(s)",
+                        exchange);
+            }
+
+            if (config.isStoreFullResponse()) {
+                exchange.setProperty(OpenAIConstants.MODERATION_RESPONSE, response);
+            }
+
+            setResponseHeaders(exchange.getMessage(), response, inputs, batch);
+
+            observation.recordSuccess(GenAiUsage.of(null, null, null, response.model()));
+        } catch (Exception e) {
+            GenAiErrorSupport.apply(exchange, e);
+            observation.recordError(e);
+            throw e;
+        } finally {
+            observation.close();
         }
-
-        // stored only once the response is known to be complete, so a failed exchange carries no verdict
-        if (config.isStoreFullResponse()) {
-            exchange.setProperty(OpenAIConstants.MODERATION_RESPONSE, response);
-        }
-
-        setResponseHeaders(exchange.getMessage(), response, inputs, batch);
     }
 
     private List<String> extractInputs(Exchange exchange) {

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIModerationProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIModerationProducer.java
@@ -103,7 +103,7 @@ public class OpenAIModerationProducer extends DefaultAsyncProducer {
         ModerationCreateResponse response;
         try {
             response = getEndpoint().getClient().moderations().create(paramsBuilder.build());
-            observation.recordSuccess(GenAiUsage.of(null, null, null, response.model()));
+            observation.recordSuccess(GenAiUsage.of((Long) null, null, null, response.model()));
         } catch (Exception e) {
             GenAiErrorSupport.apply(exchange, e);
             observation.recordError(e);
@@ -112,6 +112,8 @@ public class OpenAIModerationProducer extends DefaultAsyncProducer {
             observation.close();
         }
 
+        // this operation is used to gate untrusted content, so a missing verdict must fail the exchange
+        // instead of leaving CamelOpenAIModerationFlagged false and letting the message through
         if (response.results().size() != inputs.size()) {
             throw new CamelExchangeException(
                     "Moderation returned " + response.results().size() + " result(s) for " + inputs.size()
@@ -119,6 +121,7 @@ public class OpenAIModerationProducer extends DefaultAsyncProducer {
                     exchange);
         }
 
+        // stored only once the response is known to be complete, so a failed exchange carries no verdict
         if (config.isStoreFullResponse()) {
             exchange.setProperty(OpenAIConstants.MODERATION_RESPONSE, response);
         }

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIResponsesProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIResponsesProducer.java
@@ -165,7 +165,7 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
 
     private Response createResponse(Exchange exchange, String model, ResponseCreateParams params) throws Exception {
         GenAiObservationContext observationContext = GenAiObservationContext.builder()
-                .operationName(GenAiOperationName.GENERATE_CONTENT)
+                .operationName(GenAiOperationName.CHAT)
                 .system("openai")
                 .requestModel(model)
                 .componentScheme("openai")
@@ -188,7 +188,7 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
             Exchange exchange, String model, StructuredResponseCreateParams<?> structuredParams)
             throws Exception {
         GenAiObservationContext observationContext = GenAiObservationContext.builder()
-                .operationName(GenAiOperationName.GENERATE_CONTENT)
+                .operationName(GenAiOperationName.CHAT)
                 .system("openai")
                 .requestModel(model)
                 .componentScheme("openai")

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIResponsesProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIResponsesProducer.java
@@ -25,6 +25,12 @@ import com.openai.models.responses.StructuredResponseCreateParams;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.component.ai.observability.GenAiErrorSupport;
+import org.apache.camel.component.ai.observability.GenAiObservability;
+import org.apache.camel.component.ai.observability.GenAiObservation;
+import org.apache.camel.component.ai.observability.GenAiObservationContext;
+import org.apache.camel.component.ai.observability.GenAiOperationName;
+import org.apache.camel.component.ai.observability.GenAiUsage;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.util.ObjectHelper;
@@ -136,7 +142,7 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
 
         Class<?> responseClass = resolveOutputClass(in, outputClass);
         if (responseClass != null) {
-            processStructured(exchange, config, paramsBuilder, responseClass);
+            processStructured(exchange, config, paramsBuilder, responseClass, model);
             return;
         }
         if (ObjectHelper.isNotEmpty(jsonSchema)) {
@@ -144,18 +150,79 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
         }
 
         ResponseCreateParams params = paramsBuilder.build();
-        Response response = getEndpoint().getClient().responses().create(params);
+        Response response = createResponse(exchange, model, params);
         finishExchange(exchange, config, response, OpenAIResponsesSupport.extractAssistantText(response));
     }
 
     private void processStructured(
             Exchange exchange, OpenAIConfiguration config, ResponseCreateParams.Builder paramsBuilder,
-            Class<?> responseClass)
+            Class<?> responseClass, String model)
             throws Exception {
         StructuredResponseCreateParams<?> structuredParams = paramsBuilder.text(responseClass).build();
-        StructuredResponse<?> structured = getEndpoint().getClient().responses().create(structuredParams);
-        Response raw = structured.rawResponse();
+        Response raw = createStructuredResponse(exchange, model, structuredParams);
         finishExchange(exchange, config, raw, OpenAIResponsesSupport.extractAssistantText(raw));
+    }
+
+    private Response createResponse(Exchange exchange, String model, ResponseCreateParams params) throws Exception {
+        GenAiObservationContext observationContext = GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.GENERATE_CONTENT)
+                .system("openai")
+                .requestModel(model)
+                .componentScheme("openai")
+                .build();
+        GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
+        try {
+            Response response = getEndpoint().getClient().responses().create(params);
+            recordResponseSuccess(observation, response);
+            return response;
+        } catch (Exception e) {
+            GenAiErrorSupport.apply(exchange, e);
+            observation.recordError(e);
+            throw e;
+        } finally {
+            observation.close();
+        }
+    }
+
+    private Response createStructuredResponse(
+            Exchange exchange, String model, StructuredResponseCreateParams<?> structuredParams)
+            throws Exception {
+        GenAiObservationContext observationContext = GenAiObservationContext.builder()
+                .operationName(GenAiOperationName.GENERATE_CONTENT)
+                .system("openai")
+                .requestModel(model)
+                .componentScheme("openai")
+                .build();
+        GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
+        try {
+            StructuredResponse<?> structured = getEndpoint().getClient().responses().create(structuredParams);
+            Response raw = structured.rawResponse();
+            recordResponseSuccess(observation, raw);
+            return raw;
+        } catch (Exception e) {
+            GenAiErrorSupport.apply(exchange, e);
+            observation.recordError(e);
+            throw e;
+        } finally {
+            observation.close();
+        }
+    }
+
+    private static void recordResponseSuccess(GenAiObservation observation, Response response) {
+        String finishReason = OpenAIResponsesSupport.extractFinishStatus(response)
+                .map(OpenAIResponsesProducer::mapFinishReason)
+                .orElse(null);
+        response.usage().ifPresentOrElse(
+                usage -> observation.recordSuccess(GenAiUsage.of(
+                        toTokenCount(usage.inputTokens()),
+                        toTokenCount(usage.outputTokens()),
+                        finishReason,
+                        response.model().toString())),
+                () -> observation.recordSuccess(GenAiUsage.of(null, null, finishReason, response.model().toString())));
+    }
+
+    private static Integer toTokenCount(long tokens) {
+        return Math.toIntExact(tokens);
     }
 
     private void finishExchange(Exchange exchange, OpenAIConfiguration config, Response response, String body) {

--- a/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIResponsesProducer.java
+++ b/components/camel-ai/camel-openai/src/main/java/org/apache/camel/component/openai/OpenAIResponsesProducer.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
-import com.openai.models.responses.StructuredResponse;
 import com.openai.models.responses.StructuredResponseCreateParams;
 import org.apache.camel.AsyncCallback;
 import org.apache.camel.Exchange;
@@ -34,6 +33,7 @@ import org.apache.camel.component.ai.observability.GenAiUsage;
 import org.apache.camel.support.DefaultAsyncProducer;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.function.ThrowingSupplier;
 
 /**
  * OpenAI producer for the Responses API (non-streaming).
@@ -164,28 +164,17 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
     }
 
     private Response createResponse(Exchange exchange, String model, ResponseCreateParams params) throws Exception {
-        GenAiObservationContext observationContext = GenAiObservationContext.builder()
-                .operationName(GenAiOperationName.CHAT)
-                .system("openai")
-                .requestModel(model)
-                .componentScheme("openai")
-                .build();
-        GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
-        try {
-            Response response = getEndpoint().getClient().responses().create(params);
-            recordResponseSuccess(observation, response);
-            return response;
-        } catch (Exception e) {
-            GenAiErrorSupport.apply(exchange, e);
-            observation.recordError(e);
-            throw e;
-        } finally {
-            observation.close();
-        }
+        return observedCall(exchange, model, () -> getEndpoint().getClient().responses().create(params));
     }
 
     private Response createStructuredResponse(
             Exchange exchange, String model, StructuredResponseCreateParams<?> structuredParams)
+            throws Exception {
+        return observedCall(exchange, model,
+                () -> getEndpoint().getClient().responses().create(structuredParams).rawResponse());
+    }
+
+    private Response observedCall(Exchange exchange, String model, ThrowingSupplier<Response, Exception> call)
             throws Exception {
         GenAiObservationContext observationContext = GenAiObservationContext.builder()
                 .operationName(GenAiOperationName.CHAT)
@@ -195,10 +184,9 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
                 .build();
         GenAiObservation observation = GenAiObservability.start(exchange, observationContext);
         try {
-            StructuredResponse<?> structured = getEndpoint().getClient().responses().create(structuredParams);
-            Response raw = structured.rawResponse();
-            recordResponseSuccess(observation, raw);
-            return raw;
+            Response response = call.get();
+            recordResponseSuccess(observation, response);
+            return response;
         } catch (Exception e) {
             GenAiErrorSupport.apply(exchange, e);
             observation.recordError(e);
@@ -214,15 +202,11 @@ public class OpenAIResponsesProducer extends DefaultAsyncProducer {
                 .orElse(null);
         response.usage().ifPresentOrElse(
                 usage -> observation.recordSuccess(GenAiUsage.of(
-                        toTokenCount(usage.inputTokens()),
-                        toTokenCount(usage.outputTokens()),
+                        usage.inputTokens(),
+                        usage.outputTokens(),
                         finishReason,
                         response.model().toString())),
-                () -> observation.recordSuccess(GenAiUsage.of(null, null, finishReason, response.model().toString())));
-    }
-
-    private static Integer toTokenCount(long tokens) {
-        return Math.toIntExact(tokens);
+                () -> observation.recordSuccess(GenAiUsage.of((Long) null, null, finishReason, response.model().toString())));
     }
 
     private void finishExchange(Exchange exchange, OpenAIConfiguration config, Response response, String body) {

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmbeddingsObservabilityTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmbeddingsObservabilityTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.camel.component.openai;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.ai.observability.GenAiAttributes;
 import org.apache.camel.component.ai.observability.GenAiObservabilityProperties;
@@ -32,9 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenAIEmbeddingsObservabilityTest extends CamelTestSupport {
 
+    private static final String INPUT = "What is Apache Camel?";
+
     @RegisterExtension
     static OpenAIMock openAIMock = new OpenAIMock().builder()
-            .whenEmbedding("What is Apache Camel?")
+            .whenEmbedding(INPUT)
             .replyWithEmbedding(new float[] { 0.1f, 0.2f, 0.3f, 0.4f })
             .end()
             .build();
@@ -58,7 +62,11 @@ class OpenAIEmbeddingsObservabilityTest extends CamelTestSupport {
 
     @Test
     void shouldEmitGenAiSpanFromEmbeddingsProducer() {
-        template.sendBody("direct:embedding", "What is Apache Camel?");
+        Exchange result = template.request("direct:embedding", e -> e.getIn().setBody(INPUT));
+
+        @SuppressWarnings("unchecked")
+        List<Float> embedding = result.getMessage().getBody(List.class);
+        assertThat(embedding).hasSize(4);
 
         OpenAIObservabilityTestSupport.RecordingTracer tracer
                 = OpenAIObservabilityTestSupport.tracer(context);
@@ -68,16 +76,16 @@ class OpenAIEmbeddingsObservabilityTest extends CamelTestSupport {
         assertThat(tags.get(GenAiAttributes.SYSTEM)).isEqualTo("openai");
         assertThat(tags.get(GenAiAttributes.REQUEST_MODEL)).isEqualTo("text-embedding-ada-002");
         assertThat(tags.get(GenAiAttributes.CAMEL_COMPONENT)).isEqualTo("openai");
-        assertThat(tags.get(GenAiAttributes.INPUT_TOKENS)).isNotBlank();
+        assertThat(tags.get(GenAiAttributes.INPUT_TOKENS)).isEqualTo(Integer.toString(INPUT.length()));
     }
 
     @Test
     void shouldNotEmitSpanWhenObservabilityDisabled() throws Exception {
         Properties properties = new Properties();
         properties.setProperty(GenAiObservabilityProperties.ENABLED, "false");
-        context.getPropertiesComponent().setInitialProperties(properties);
+        context.getPropertiesComponent().setOverrideProperties(properties);
 
-        template.sendBody("direct:embedding", "What is Apache Camel?");
+        template.sendBody("direct:embedding", INPUT);
 
         assertThat(OpenAIObservabilityTestSupport.tracer(context).genAiSpans()).isEmpty();
     }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmbeddingsObservabilityTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIEmbeddingsObservabilityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.ai.observability.GenAiAttributes;
+import org.apache.camel.component.ai.observability.GenAiObservabilityProperties;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAIEmbeddingsObservabilityTest extends CamelTestSupport {
+
+    @RegisterExtension
+    static OpenAIMock openAIMock = new OpenAIMock().builder()
+            .whenEmbedding("What is Apache Camel?")
+            .replyWithEmbedding(new float[] { 0.1f, 0.2f, 0.3f, 0.4f })
+            .end()
+            .build();
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        return OpenAIObservabilityTestSupport.registerRecordingTracer(super.createCamelContext());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:embedding")
+                        .to("openai:embeddings?embeddingModel=text-embedding-ada-002&apiKey=dummy&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+            }
+        };
+    }
+
+    @Test
+    void shouldEmitGenAiSpanFromEmbeddingsProducer() {
+        template.sendBody("direct:embedding", "What is Apache Camel?");
+
+        OpenAIObservabilityTestSupport.RecordingTracer tracer
+                = OpenAIObservabilityTestSupport.tracer(context);
+        assertThat(tracer.genAiSpans()).hasSize(1);
+        Map<String, String> tags = tracer.genAiSpans().get(0).tags();
+        assertThat(tags.get(GenAiAttributes.OPERATION_NAME)).isEqualTo("embeddings");
+        assertThat(tags.get(GenAiAttributes.SYSTEM)).isEqualTo("openai");
+        assertThat(tags.get(GenAiAttributes.REQUEST_MODEL)).isEqualTo("text-embedding-ada-002");
+        assertThat(tags.get(GenAiAttributes.CAMEL_COMPONENT)).isEqualTo("openai");
+        assertThat(tags.get(GenAiAttributes.INPUT_TOKENS)).isNotBlank();
+    }
+
+    @Test
+    void shouldNotEmitSpanWhenObservabilityDisabled() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(GenAiObservabilityProperties.ENABLED, "false");
+        context.getPropertiesComponent().setInitialProperties(properties);
+
+        template.sendBody("direct:embedding", "What is Apache Camel?");
+
+        assertThat(OpenAIObservabilityTestSupport.tracer(context).genAiSpans()).isEmpty();
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIModerationObservabilityTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIModerationObservabilityTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.openai;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.ai.observability.GenAiAttributes;
 import org.apache.camel.test.infra.openai.mock.OpenAIMock;
@@ -30,9 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenAIModerationObservabilityTest extends CamelTestSupport {
 
+    private static final String INPUT = "Apache Camel is an integration framework";
+
     @RegisterExtension
     static OpenAIMock openAIMock = new OpenAIMock().builder()
-            .whenModeration("Apache Camel is an integration framework")
+            .whenModeration(INPUT)
             .replyWithModerationAllowed()
             .end()
             .build();
@@ -56,7 +59,9 @@ class OpenAIModerationObservabilityTest extends CamelTestSupport {
 
     @Test
     void shouldEmitGenAiSpanFromModerationProducer() {
-        template.sendBody("direct:moderation", "Apache Camel is an integration framework");
+        Exchange result = template.request("direct:moderation", e -> e.getIn().setBody(INPUT));
+
+        assertThat(result.getMessage().getHeader(OpenAIConstants.MODERATION_FLAGGED, Boolean.class)).isFalse();
 
         OpenAIObservabilityTestSupport.RecordingTracer tracer
                 = OpenAIObservabilityTestSupport.tracer(context);
@@ -66,5 +71,6 @@ class OpenAIModerationObservabilityTest extends CamelTestSupport {
         assertThat(tags.get(GenAiAttributes.SYSTEM)).isEqualTo("openai");
         assertThat(tags.get(GenAiAttributes.REQUEST_MODEL)).isEqualTo("omni-moderation-latest");
         assertThat(tags.get(GenAiAttributes.CAMEL_COMPONENT)).isEqualTo("openai");
+        assertThat(tags.get(GenAiAttributes.INPUT_TOKENS)).isNull();
     }
 }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIModerationObservabilityTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIModerationObservabilityTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.ai.observability.GenAiAttributes;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAIModerationObservabilityTest extends CamelTestSupport {
+
+    @RegisterExtension
+    static OpenAIMock openAIMock = new OpenAIMock().builder()
+            .whenModeration("Apache Camel is an integration framework")
+            .replyWithModerationAllowed()
+            .end()
+            .build();
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        return OpenAIObservabilityTestSupport.registerRecordingTracer(super.createCamelContext());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:moderation")
+                        .to("openai:moderation?moderationModel=omni-moderation-latest&apiKey=dummy&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+            }
+        };
+    }
+
+    @Test
+    void shouldEmitGenAiSpanFromModerationProducer() {
+        template.sendBody("direct:moderation", "Apache Camel is an integration framework");
+
+        OpenAIObservabilityTestSupport.RecordingTracer tracer
+                = OpenAIObservabilityTestSupport.tracer(context);
+        assertThat(tracer.genAiSpans()).hasSize(1);
+        Map<String, String> tags = tracer.genAiSpans().get(0).tags();
+        assertThat(tags.get(GenAiAttributes.OPERATION_NAME)).isEqualTo("moderation");
+        assertThat(tags.get(GenAiAttributes.SYSTEM)).isEqualTo("openai");
+        assertThat(tags.get(GenAiAttributes.REQUEST_MODEL)).isEqualTo("omni-moderation-latest");
+        assertThat(tags.get(GenAiAttributes.CAMEL_COMPONENT)).isEqualTo("openai");
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIObservabilityTestSupport.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIObservabilityTestSupport.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.component.ai.observability.GenAiAttributes;
+import org.apache.camel.telemetry.Span;
+import org.apache.camel.telemetry.SpanContextPropagationExtractor;
+import org.apache.camel.telemetry.SpanContextPropagationInjector;
+import org.apache.camel.telemetry.SpanLifecycleManager;
+import org.apache.camel.telemetry.Tracer;
+
+/**
+ * Shared recording tracer for OpenAI GenAI observability tests.
+ */
+final class OpenAIObservabilityTestSupport {
+
+    private OpenAIObservabilityTestSupport() {
+    }
+
+    static CamelContext registerRecordingTracer(CamelContext context) {
+        RecordingTracer tracer = new RecordingTracer();
+        CamelContextAware.trySetCamelContext(tracer, context);
+        tracer.init(context);
+        context.getRegistry().bind("openAiObservabilityTestTracer", tracer);
+        return context;
+    }
+
+    static RecordingTracer tracer(CamelContext context) {
+        return context.getRegistry().lookupByNameAndType("openAiObservabilityTestTracer", RecordingTracer.class);
+    }
+
+    static final class RecordingTracer extends Tracer {
+
+        private final List<RecordingSpan> closedSpans = new ArrayList<>();
+
+        @Override
+        protected void initTracer() {
+            setSpanLifecycleManager(new RecordingSpanLifecycleManager());
+        }
+
+        List<RecordingSpan> genAiSpans() {
+            return closedSpans.stream()
+                    .filter(span -> span.tags().containsKey(GenAiAttributes.OPERATION_NAME))
+                    .toList();
+        }
+
+        private final class RecordingSpanLifecycleManager implements SpanLifecycleManager {
+
+            @Override
+            public Span create(String spanName, String spanKind, Span parent, SpanContextPropagationExtractor extractor) {
+                return new RecordingSpan(spanName);
+            }
+
+            @Override
+            public void activate(Span span) {
+                // noop
+            }
+
+            @Override
+            public void deactivate(Span span) {
+                // noop
+            }
+
+            @Override
+            public void close(Span span) {
+                closedSpans.add((RecordingSpan) span);
+            }
+
+            @Override
+            public void inject(Span span, SpanContextPropagationInjector injector, boolean includeTracing) {
+                // noop
+            }
+        }
+    }
+
+    static final class RecordingSpan implements Span {
+
+        private final Map<String, String> tags = new HashMap<>();
+
+        private RecordingSpan(String name) {
+            tags.put("name", name);
+        }
+
+        Map<String, String> tags() {
+            return tags;
+        }
+
+        @Override
+        public void log(Map<String, String> fields) {
+            // noop
+        }
+
+        @Override
+        public void setTag(String key, String value) {
+            tags.put(key, value);
+        }
+
+        @Override
+        public void setComponent(String component) {
+            tags.put("component", component);
+        }
+
+        @Override
+        public void setError(boolean isError) {
+            // noop
+        }
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIResponsesObservabilityTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIResponsesObservabilityTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.openai;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.ai.observability.GenAiAttributes;
 import org.apache.camel.test.infra.openai.mock.OpenAIMock;
@@ -55,15 +56,20 @@ class OpenAIResponsesObservabilityTest extends CamelTestSupport {
 
     @Test
     void shouldEmitGenAiSpanFromResponsesProducer() {
-        template.sendBody("direct:responses", "hello-responses");
+        Exchange result = template.request("direct:responses", e -> e.getIn().setBody("hello-responses"));
+
+        assertThat(result.getMessage().getBody(String.class)).isEqualTo("Hi from responses mock");
 
         OpenAIObservabilityTestSupport.RecordingTracer tracer
                 = OpenAIObservabilityTestSupport.tracer(context);
         assertThat(tracer.genAiSpans()).hasSize(1);
         Map<String, String> tags = tracer.genAiSpans().get(0).tags();
-        assertThat(tags.get(GenAiAttributes.OPERATION_NAME)).isEqualTo("generate_content");
+        assertThat(tags.get(GenAiAttributes.OPERATION_NAME)).isEqualTo("chat");
         assertThat(tags.get(GenAiAttributes.SYSTEM)).isEqualTo("openai");
         assertThat(tags.get(GenAiAttributes.REQUEST_MODEL)).isEqualTo("gpt-4o");
         assertThat(tags.get(GenAiAttributes.CAMEL_COMPONENT)).isEqualTo("openai");
+        assertThat(tags.get(GenAiAttributes.INPUT_TOKENS)).isEqualTo("10");
+        assertThat(tags.get(GenAiAttributes.OUTPUT_TOKENS)).isEqualTo("5");
+        assertThat(tags.get(GenAiAttributes.FINISH_REASONS)).isEqualTo("stop");
     }
 }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIResponsesObservabilityTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIResponsesObservabilityTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.ai.observability.GenAiAttributes;
+import org.apache.camel.test.infra.openai.mock.OpenAIMock;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAIResponsesObservabilityTest extends CamelTestSupport {
+
+    @RegisterExtension
+    static OpenAIMock openAIMock = new OpenAIMock().builder()
+            .when("hello-responses")
+            .replyWith("Hi from responses mock")
+            .end()
+            .build();
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        return OpenAIObservabilityTestSupport.registerRecordingTracer(super.createCamelContext());
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:responses")
+                        .to("openai:responses?model=gpt-4o&apiKey=dummy&baseUrl=" + openAIMock.getBaseUrl() + "/v1");
+            }
+        };
+    }
+
+    @Test
+    void shouldEmitGenAiSpanFromResponsesProducer() {
+        template.sendBody("direct:responses", "hello-responses");
+
+        OpenAIObservabilityTestSupport.RecordingTracer tracer
+                = OpenAIObservabilityTestSupport.tracer(context);
+        assertThat(tracer.genAiSpans()).hasSize(1);
+        Map<String, String> tags = tracer.genAiSpans().get(0).tags();
+        assertThat(tags.get(GenAiAttributes.OPERATION_NAME)).isEqualTo("generate_content");
+        assertThat(tags.get(GenAiAttributes.SYSTEM)).isEqualTo("openai");
+        assertThat(tags.get(GenAiAttributes.REQUEST_MODEL)).isEqualTo("gpt-4o");
+        assertThat(tags.get(GenAiAttributes.CAMEL_COMPONENT)).isEqualTo("openai");
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -442,8 +442,9 @@ that report `long` token counts are recorded without lossy casts.
 OpenAI streaming chat sets `stream_options.include_usage=true` only when GenAI observability is enabled,
 adding a final chunk with token usage for span/metric recording.
 
-OpenAI `embeddings`, `moderation`, and `responses` producers emit the same GenAI spans and metrics as
-`chat-completion`.
+OpenAI `embeddings`, `moderation`, and `responses` producers emit GenAI spans with the same attribute keys as
+`chat-completion`. Moderation records model metadata only (no token usage). Embeddings records input tokens when
+the API returns usage.
 
 LangChain4j components also expose request model names on new exchange headers
 (`CamelLangChain4j*RequestModel`). The response model header (`CamelLangChain4j*ResponseModel`) is set when

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -442,6 +442,9 @@ that report `long` token counts are recorded without lossy casts.
 OpenAI streaming chat sets `stream_options.include_usage=true` only when GenAI observability is enabled,
 adding a final chunk with token usage for span/metric recording.
 
+OpenAI `embeddings`, `moderation`, and `responses` producers emit the same GenAI spans and metrics as
+`chat-completion`.
+
 LangChain4j components also expose request model names on new exchange headers
 (`CamelLangChain4j*RequestModel`). The response model header (`CamelLangChain4j*ResponseModel`) is set when
 the underlying client exposes it (for example langchain4j-chat); the agent and embeddings producers omit it when


### PR DESCRIPTION
## Summary

Follow-up to CAMEL-23861 / [CAMEL-24559](https://issues.apache.org/jira/browse/CAMEL-24559): extend GenAI observability to additional OpenAI producer operations beyond `chat-completion`.

This PR instruments **OpenAI embeddings, moderation, and responses** with the existing `GenAiObservability` API.

| Operation | `gen_ai.operation.name` |
|-----------|-------------------------|
| `openai:embeddings` | `embeddings` |
| `openai:moderation` | `moderation` (Camel extension) |
| `openai:responses` | `chat` |
| `openai:chat-completion` | `chat` (unchanged) |

## Changes

- Instrument `OpenAIEmbeddingsProducer`, `OpenAIModerationProducer`, `OpenAIResponsesProducer`
- Add `GenAiOperationName.MODERATION`
- Tests: `OpenAIEmbeddingsObservabilityTest`, `OpenAIModerationObservabilityTest`, `OpenAIResponsesObservabilityTest`
- Docs: `ai-observability.adoc`, catalog mirror, 4.23 upgrade guide

## Test plan

```bash
./mvnw -pl components/camel-ai/camel-openai -am test -Dtest=OpenAIEmbeddingsObservabilityTest,OpenAIModerationObservabilityTest,OpenAIResponsesObservabilityTest
```

Images, audio, Spring AI modules, and cloud LLMs remain for future CAMEL-24559 follow-ups.

---
_AI-generated PR description on behalf of @atiaomar1978-hub_