### PR TITLE
CAMEL-24623: camel-infinispan - report a QUERY that has no query builder

### DIFF
--- a/components/camel-infinispan/camel-infinispan-common/src/main/java/org/apache/camel/component/infinispan/InfinispanProducer.java
+++ b/components/camel-infinispan/camel-infinispan-common/src/main/java/org/apache/camel/component/infinispan/InfinispanProducer.java
@@ -25,9 +25,13 @@ import org.apache.camel.spi.InvokeOnHeader;
 import org.apache.camel.support.HeaderSelectorProducer;
 import org.apache.camel.util.ObjectHelper;
 import org.infinispan.commons.api.BasicCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class InfinispanProducer<M extends InfinispanManager, C extends InfinispanConfiguration>
         extends HeaderSelectorProducer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InfinispanProducer.class);
 
     private final String cacheName;
     private final C configuration;
@@ -430,5 +434,11 @@ public abstract class InfinispanProducer<M extends InfinispanManager, C extends 
         } else {
             message.setBody(result);
         }
+    }
+
+    protected void warnNoQueryBuilder() {
+        LOG.warn("No query to run for the {} operation on cache {}, the message is passed through unchanged."
+                 + " Set a query builder on the endpoint with the queryBuilder option, or per message with the {} header.",
+                InfinispanOperation.QUERY, getCacheName(), InfinispanConstants.QUERY_BUILDER);
     }
 }

--- a/components/camel-infinispan/camel-infinispan-embedded/src/main/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedProducer.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/main/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedProducer.java
@@ -18,6 +18,7 @@ package org.apache.camel.component.infinispan.embedded;
 
 import org.apache.camel.Message;
 import org.apache.camel.component.infinispan.InfinispanProducer;
+import org.apache.camel.component.infinispan.InfinispanQueryBuilder;
 import org.apache.camel.spi.InvokeOnHeader;
 import org.infinispan.Cache;
 import org.infinispan.commons.api.query.Query;
@@ -47,11 +48,16 @@ public class InfinispanEmbeddedProducer extends InfinispanProducer<InfinispanEmb
     @SuppressWarnings("unchecked")
     @InvokeOnHeader("QUERY")
     public void onQuery(Message message) {
-        final Cache<Object, Object> cache = getManager().getCache(message, getCacheName(), Cache.class);
-        final Query<?> query = InfinispanEmbeddedUtil.buildQuery(getConfiguration(), cache, message);
-
-        if (query != null) {
-            setResult(message, query.execute().list());
+        // resolved before the cache is looked up, so a misconfigured route is reported the same way everywhere
+        final InfinispanQueryBuilder builder = InfinispanEmbeddedUtil.resolveQueryBuilder(getConfiguration(), message);
+        if (builder == null) {
+            warnNoQueryBuilder();
+            return;
         }
+
+        final Cache<Object, Object> cache = getManager().getCache(message, getCacheName(), Cache.class);
+        final Query<?> query = InfinispanEmbeddedUtil.buildQuery(builder, cache);
+
+        setResult(message, query.execute().list());
     }
 }

--- a/components/camel-infinispan/camel-infinispan-embedded/src/main/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedUtil.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/main/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedUtil.java
@@ -40,12 +40,20 @@ public final class InfinispanEmbeddedUtil extends InfinispanUtil {
     public static Query<?> buildQuery(
             InfinispanConfiguration configuration, Cache<Object, Object> cache, Message message) {
 
+        return buildQuery(resolveQueryBuilder(configuration, message), cache);
+    }
+
+    /**
+     * The query builder to use for a message: the one carried by the {@link InfinispanConstants#QUERY_BUILDER} header
+     * if there is one, the one configured on the endpoint otherwise. Returns {@code null} when neither is set.
+     */
+    public static InfinispanQueryBuilder resolveQueryBuilder(InfinispanConfiguration configuration, Message message) {
         InfinispanQueryBuilder builder = message.getHeader(InfinispanConstants.QUERY_BUILDER, InfinispanQueryBuilder.class);
         if (builder == null) {
             builder = configuration.getQueryBuilder();
         }
 
-        return buildQuery(builder, cache);
+        return builder;
     }
 
     public static Query<?> buildQuery(InfinispanConfiguration configuration, Cache<Object, Object> cache) {

--- a/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteProducer.java
+++ b/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteProducer.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.infinispan.remote;
 import org.apache.camel.Message;
 import org.apache.camel.component.infinispan.InfinispanEndpoint;
 import org.apache.camel.component.infinispan.InfinispanProducer;
+import org.apache.camel.component.infinispan.InfinispanQueryBuilder;
 import org.apache.camel.spi.InvokeOnHeader;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.commons.api.query.Query;
@@ -49,11 +50,16 @@ public class InfinispanRemoteProducer extends InfinispanProducer<InfinispanRemot
     @SuppressWarnings("unchecked")
     @InvokeOnHeader("QUERY")
     public void onQuery(Message message) {
-        final RemoteCache<Object, Object> cache = getManager().getCache(message, getCacheName(), RemoteCache.class);
-        final Query<?> query = InfinispanRemoteUtil.buildQuery(getConfiguration(), cache, message);
-
-        if (query != null) {
-            setResult(message, query.execute().list());
+        // resolved before the cache is opened, so a misconfigured route does not pay a remote call
+        final InfinispanQueryBuilder builder = InfinispanRemoteUtil.resolveQueryBuilder(getConfiguration(), message);
+        if (builder == null) {
+            warnNoQueryBuilder();
+            return;
         }
+
+        final RemoteCache<Object, Object> cache = getManager().getCache(message, getCacheName(), RemoteCache.class);
+        final Query<?> query = InfinispanRemoteUtil.buildQuery(builder, cache);
+
+        setResult(message, query.execute().list());
     }
 }

--- a/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteUtil.java
+++ b/components/camel-infinispan/camel-infinispan/src/main/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteUtil.java
@@ -42,6 +42,14 @@ public final class InfinispanRemoteUtil extends InfinispanUtil {
     public static Query<?> buildQuery(
             InfinispanRemoteConfiguration configuration, RemoteCache<Object, Object> cache, Message message) {
 
+        return buildQuery(resolveQueryBuilder(configuration, message), cache);
+    }
+
+    /**
+     * The query builder to use for a message: the one carried by the {@link InfinispanConstants#QUERY_BUILDER} header
+     * if there is one, the one configured on the endpoint otherwise. Returns {@code null} when neither is set.
+     */
+    public static InfinispanQueryBuilder resolveQueryBuilder(InfinispanRemoteConfiguration configuration, Message message) {
         InfinispanQueryBuilder builder = message.getHeader(InfinispanConstants.QUERY_BUILDER, InfinispanQueryBuilder.class);
         if (builder == null) {
             builder = configuration.getQueryBuilder();
@@ -52,7 +60,7 @@ public final class InfinispanRemoteUtil extends InfinispanUtil {
             vectorQueryBuilder.setTypeName(EmbeddingStoreUtil.getTypeName(configuration));
         }
 
-        return buildQuery(builder, cache);
+        return builder;
     }
 
     public static Query<?> buildQuery(InfinispanConfiguration configuration, RemoteCache<Object, Object> cache) {

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteProducerQueryTest.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteProducerQueryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.infinispan.remote;
+
+import org.apache.camel.Message;
+import org.apache.camel.Producer;
+import org.apache.camel.component.infinispan.InfinispanConstants;
+import org.apache.camel.component.infinispan.InfinispanQueryBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Verifies how the QUERY operation resolves its query builder. Builds the endpoint directly so that nothing tries to
+ * reach an Infinispan server.
+ */
+class InfinispanRemoteProducerQueryTest {
+
+    private DefaultCamelContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    private InfinispanRemoteProducer producer(InfinispanRemoteConfiguration configuration) throws Exception {
+        context = new DefaultCamelContext();
+
+        InfinispanRemoteComponent component = new InfinispanRemoteComponent(context);
+        InfinispanRemoteEndpoint endpoint
+                = new InfinispanRemoteEndpoint("infinispan:misc", "misc", component, configuration);
+
+        Producer producer = endpoint.createProducer();
+        return (InfinispanRemoteProducer) producer;
+    }
+
+    private Message message() {
+        return new DefaultExchange(context).getMessage();
+    }
+
+    @Test
+    void aQueryWithoutABuilderTouchesNoCache() throws Exception {
+        InfinispanRemoteProducer producer = producer(new InfinispanRemoteConfiguration());
+
+        Message message = message();
+        message.setBody("unchanged");
+
+        // the message is still passed through (CAMEL-9624 behaviour), but without reaching for a cache first:
+        // the manager here was never started, so any remote call would fail
+        assertThatCode(() -> producer.onQuery(message)).doesNotThrowAnyException();
+        assertThat(message.getBody()).isEqualTo("unchanged");
+    }
+
+    @Test
+    void theBuilderComesFromTheConfiguration() {
+        context = new DefaultCamelContext();
+
+        InfinispanQueryBuilder configured = cache -> null;
+        InfinispanRemoteConfiguration configuration = new InfinispanRemoteConfiguration();
+        configuration.setQueryBuilder(configured);
+
+        assertThat(InfinispanRemoteUtil.resolveQueryBuilder(configuration, message())).isSameAs(configured);
+    }
+
+    @Test
+    void theHeaderWinsOverTheConfiguration() {
+        context = new DefaultCamelContext();
+
+        InfinispanQueryBuilder configured = cache -> null;
+        InfinispanQueryBuilder fromHeader = cache -> null;
+        InfinispanRemoteConfiguration configuration = new InfinispanRemoteConfiguration();
+        configuration.setQueryBuilder(configured);
+
+        Message message = message();
+        message.setHeader(InfinispanConstants.QUERY_BUILDER, fromHeader);
+
+        assertThat(InfinispanRemoteUtil.resolveQueryBuilder(configuration, message)).isSameAs(fromHeader);
+    }
+
+    @Test
+    void noBuilderAnywhereResolvesToNull() {
+        context = new DefaultCamelContext();
+
+        assertThat(InfinispanRemoteUtil.resolveQueryBuilder(new InfinispanRemoteConfiguration(), message())).isNull();
+    }
+}


### PR DESCRIPTION
Found by a source audit of `components/camel-infinispan`.

### The problem

Both producers run the `QUERY` operation through an unguarded `if`:

```java
final Query<?> query = InfinispanRemoteUtil.buildQuery(getConfiguration(), cache, message);

if (query != null) {
    setResult(message, query.execute().list());
}
```

and `buildQuery` returns `null` when neither the `queryBuilder` endpoint option nor the
`CamelInfinispanQueryBuilder` header is set. A route running `operation=QUERY` without a builder therefore
gets its own message back — no result, no exception, no log line — which is indistinguishable from a query
that legitimately matched nothing.

### The change

**The pass-through is kept.** `producerQueryOperationWithoutQueryBuilder` has asserted "no exception, no
result" since the operation was contributed in CAMEL-9624 (2016), and the same test exists on the embedded
side, so failing the exchange would revert a deliberate, decade-old contract and would need an
upgrade-guide entry — disproportionate for what is a route misconfiguration.

What changes is only the silence:

* both producers log a WARN naming the cache, the `queryBuilder` option and the `CamelInfinispanQueryBuilder`
  header;
* the builder is resolved **before** the cache is looked up, so a misconfigured remote route no longer pays a
  Hot Rod round trip to do nothing;
* `InfinispanEmbeddedProducer.onQuery` carried the identical defect — the audit only cited the remote one —
  and is fixed the same way.

If you would rather have it throw, that is a one-line change plus those two tests and an upgrade note; say
so and I will follow up.

### Tests

`InfinispanRemoteProducerQueryTest` (new, 4 tests): the pass-through still happens and reaches no cache (the
manager it runs against was never started, so any remote call would fail), and the header-vs-option
precedence of the builder, which had no coverage at all.

`mvn test` on both modules is green — 89 embedded tests, including the 2016 `producerQueryOperationWithoutQueryBuilder`
against a real embedded cache, and 13 remote ones. Full reactor `mvn clean install -DskipTests -Dquickly` green.

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
