### PR TITLE
CAMEL-24622: camel-infinispan - keep completed exchanges for recovery

### DIFF
--- a/components/camel-infinispan/camel-infinispan-common/src/main/java/org/apache/camel/component/infinispan/InfinispanAggregationRepository.java
+++ b/components/camel-infinispan/camel-infinispan-common/src/main/java/org/apache/camel/component/infinispan/InfinispanAggregationRepository.java
@@ -19,6 +19,7 @@ package org.apache.camel.component.infinispan;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
@@ -38,6 +39,12 @@ public abstract class InfinispanAggregationRepository
         implements RecoverableAggregationRepository, CamelContextAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(InfinispanAggregationRepository.class);
+
+    /**
+     * Prefix of the keys under which completed exchanges are kept for recovery. Recovery entries are keyed by exchange
+     * id, aggregations in progress by correlation key, and the prefix keeps the two apart in the same cache.
+     */
+    private static final String RECOVERY_KEY_PREFIX = "camel-recovery:";
 
     private CamelContext camelContext;
 
@@ -96,32 +103,66 @@ public abstract class InfinispanAggregationRepository
     @Override
     public void remove(CamelContext camelContext, String key, Exchange exchange) {
         LOG.trace("Removing an exchange with ID {} for key {}", exchange.getExchangeId(), key);
-        getCache().remove(key);
+        DefaultExchangeHolder holder = getCache().remove(key);
+
+        if (useRecovery) {
+            // the aggregation is complete but the exchange has not been processed yet, so keep a copy that
+            // recovery can pick up if the processing never confirms it
+            if (holder == null) {
+                holder = DefaultExchangeHolder.marshal(exchange, true, allowSerializedHeaders);
+            }
+            LOG.trace("Putting an exchange with ID {} into the recovery store", exchange.getExchangeId());
+            getCache().put(recoveryKey(exchange.getExchangeId()), holder);
+        }
     }
 
     @Override
     public void confirm(CamelContext camelContext, String exchangeId) {
         LOG.trace("Confirming an exchange with ID {}.", exchangeId);
-        getCache().remove(exchangeId);
+        if (useRecovery) {
+            getCache().remove(recoveryKey(exchangeId));
+        }
     }
 
     @Override
     public Set<String> getKeys() {
-        return Collections.unmodifiableSet(getCache().keySet());
+        return getCache().keySet().stream()
+                .filter(key -> !isRecoveryKey(key))
+                .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
     }
 
     @Override
     public Set<String> scan(CamelContext camelContext) {
+        if (!useRecovery) {
+            LOG.debug("Recovery is disabled on the repository of {} context, nothing to scan", camelContext.getName());
+            return Collections.emptySet();
+        }
+
         LOG.trace("Scanning for exchanges to recover in {} context", camelContext.getName());
-        Set<String> scanned = Collections.unmodifiableSet(getCache().keySet());
-        LOG.trace("Found {} keys for exchanges to recover in {} context", scanned.size(), camelContext.getName());
+        Set<String> scanned = getCache().keySet().stream()
+                .filter(InfinispanAggregationRepository::isRecoveryKey)
+                .map(InfinispanAggregationRepository::exchangeIdOf)
+                .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+        LOG.trace("Found {} exchanges to recover in {} context", scanned.size(), camelContext.getName());
         return scanned;
     }
 
     @Override
     public Exchange recover(CamelContext camelContext, String exchangeId) {
         LOG.trace("Recovering an Exchange with ID {}.", exchangeId);
-        return useRecovery ? unmarshallExchange(camelContext, getCache().get(exchangeId)) : null;
+        return useRecovery ? unmarshallExchange(camelContext, getCache().get(recoveryKey(exchangeId))) : null;
+    }
+
+    private static String recoveryKey(String exchangeId) {
+        return RECOVERY_KEY_PREFIX + exchangeId;
+    }
+
+    private static boolean isRecoveryKey(String key) {
+        return key.startsWith(RECOVERY_KEY_PREFIX);
+    }
+
+    private static String exchangeIdOf(String recoveryKey) {
+        return recoveryKey.substring(RECOVERY_KEY_PREFIX.length());
     }
 
     public void setCacheName(String cacheName) {

--- a/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedAggregationRepositoryOperationsTest.java
+++ b/components/camel-infinispan/camel-infinispan-embedded/src/test/java/org/apache/camel/component/infinispan/embedded/InfinispanEmbeddedAggregationRepositoryOperationsTest.java
@@ -147,19 +147,20 @@ public class InfinispanEmbeddedAggregationRepositoryOperationsTest extends Infin
         // cleanup
         aggregationRepository.getCache().clear();
         // Given
-        for (int i = 1; i < 4; i++) {
-            String key = "Confirm_" + i;
-            Exchange exchange = new DefaultExchange(context());
-            exchange.setExchangeId("Exchange_" + i);
-            aggregationRepository.add(context(), key, exchange);
-            assertTrue(exists(key));
-        }
+        Exchange exchange = new DefaultExchange(context());
+        exchange.setExchangeId("Exchange_Confirm");
+        aggregationRepository.add(context(), "Confirm_1", exchange);
+        // completing the aggregation moves the exchange into the recovery store
+        aggregationRepository.remove(context(), "Confirm_1", exchange);
+        assertFalse(exists("Confirm_1"));
+        assertNotNull(aggregationRepository.recover(context(), "Exchange_Confirm"));
+
         // When
-        aggregationRepository.confirm(context(), "Confirm_2");
+        aggregationRepository.confirm(context(), "Exchange_Confirm");
+
         // Then
-        assertTrue(exists("Confirm_1"));
-        assertFalse(exists("Confirm_2"));
-        assertTrue(exists("Confirm_3"));
+        assertNull(aggregationRepository.recover(context(), "Exchange_Confirm"));
+        assertTrue(aggregationRepository.scan(context()).isEmpty());
     }
 
     @Test
@@ -200,11 +201,19 @@ public class InfinispanEmbeddedAggregationRepositoryOperationsTest extends Infin
         // Given
         String[] keys = { "Scan1", "Scan2" };
         addExchanges(keys);
+        for (String key : keys) {
+            Exchange exchange = new DefaultExchange(context());
+            exchange.setExchangeId("Exchange-" + key);
+            aggregationRepository.remove(context(), key, exchange);
+        }
+
         // When
         Set<String> exchangeIdSet = aggregationRepository.scan(context());
-        // Then
+
+        // Then - the scan reports exchange ids to recover, not the correlation keys still aggregating
         for (String key : keys) {
-            assertTrue(exchangeIdSet.contains(key));
+            assertTrue(exchangeIdSet.contains("Exchange-" + key));
+            assertFalse(exchangeIdSet.contains(key));
         }
     }
 
@@ -213,14 +222,37 @@ public class InfinispanEmbeddedAggregationRepositoryOperationsTest extends Infin
         // cleanup
         aggregationRepository.getCache().clear();
         // Given
-        String[] keys = { "Recover1", "Recover2" };
-        addExchanges(keys);
+        Exchange exchange = new DefaultExchange(context());
+        exchange.setExchangeId("Exchange-Recover1");
+        aggregationRepository.add(context(), "Recover1", exchange);
+        aggregationRepository.remove(context(), "Recover1", exchange);
+
         // When
-        Exchange exchange2 = aggregationRepository.recover(context(), "Recover2");
-        Exchange exchange3 = aggregationRepository.recover(context(), "Recover3");
+        Exchange recovered = aggregationRepository.recover(context(), "Exchange-Recover1");
+        Exchange unknown = aggregationRepository.recover(context(), "Exchange-Recover2");
+
         // Then
-        assertNotNull(exchange2);
-        assertNull(exchange3);
+        assertNotNull(recovered);
+        assertNull(unknown);
+    }
+
+    @Test
+    public void testGetKeysIgnoresExchangesToRecover() {
+        // cleanup
+        aggregationRepository.getCache().clear();
+        // Given
+        Exchange exchange = new DefaultExchange(context());
+        exchange.setExchangeId("Exchange-Keys1");
+        aggregationRepository.add(context(), "Keys1", exchange);
+        aggregationRepository.add(context(), "Keys2", exchange);
+        aggregationRepository.remove(context(), "Keys1", exchange);
+
+        // When
+        Set<String> keys = aggregationRepository.getKeys();
+
+        // Then - only the aggregation still in progress is reported
+        assertEquals(1, keys.size());
+        assertTrue(keys.contains("Keys2"));
     }
 
 }

--- a/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteAggregationRepositoryOperationsIT.java
+++ b/components/camel-infinispan/camel-infinispan/src/test/java/org/apache/camel/component/infinispan/remote/InfinispanRemoteAggregationRepositoryOperationsIT.java
@@ -145,19 +145,20 @@ public class InfinispanRemoteAggregationRepositoryOperationsIT extends Infinispa
     @Test
     public void testConfirmExist() {
         // Given
-        for (int i = 1; i < 4; i++) {
-            String key = "Confirm_" + i;
-            Exchange exchange = new DefaultExchange(context());
-            exchange.setExchangeId("Exchange_" + i);
-            aggregationRepository.add(context(), key, exchange);
-            assertTrue(exists(key));
-        }
+        Exchange exchange = new DefaultExchange(context());
+        exchange.setExchangeId("Exchange_Confirm");
+        aggregationRepository.add(context(), "Confirm_1", exchange);
+        // completing the aggregation moves the exchange into the recovery store
+        aggregationRepository.remove(context(), "Confirm_1", exchange);
+        assertFalse(exists("Confirm_1"));
+        assertNotNull(aggregationRepository.recover(context(), "Exchange_Confirm"));
+
         // When
-        aggregationRepository.confirm(context(), "Confirm_2");
+        aggregationRepository.confirm(context(), "Exchange_Confirm");
+
         // Then
-        assertTrue(exists("Confirm_1"));
-        assertFalse(exists("Confirm_2"));
-        assertTrue(exists("Confirm_3"));
+        assertNull(aggregationRepository.recover(context(), "Exchange_Confirm"));
+        assertTrue(aggregationRepository.scan(context()).isEmpty());
     }
 
     @Test
@@ -194,25 +195,54 @@ public class InfinispanRemoteAggregationRepositoryOperationsIT extends Infinispa
         // Given
         String[] keys = { "Scan1", "Scan2" };
         addExchanges(keys);
+        for (String key : keys) {
+            Exchange exchange = new DefaultExchange(context());
+            exchange.setExchangeId("Exchange-" + key);
+            aggregationRepository.remove(context(), key, exchange);
+        }
+
         // When
         Set<String> exchangeIdSet = aggregationRepository.scan(context());
-        // Then
+
+        // Then - the scan reports exchange ids to recover, not the correlation keys still aggregating
         for (String key : keys) {
-            assertTrue(exchangeIdSet.contains(key));
+            assertTrue(exchangeIdSet.contains("Exchange-" + key));
+            assertFalse(exchangeIdSet.contains(key));
         }
     }
 
     @Test
     public void testRecover() {
         // Given
-        String[] keys = { "Recover1", "Recover2" };
-        addExchanges(keys);
+        Exchange exchange = new DefaultExchange(context());
+        exchange.setExchangeId("Exchange-Recover1");
+        aggregationRepository.add(context(), "Recover1", exchange);
+        aggregationRepository.remove(context(), "Recover1", exchange);
+
         // When
-        Exchange exchange2 = aggregationRepository.recover(context(), "Recover2");
-        Exchange exchange3 = aggregationRepository.recover(context(), "Recover3");
+        Exchange recovered = aggregationRepository.recover(context(), "Exchange-Recover1");
+        Exchange unknown = aggregationRepository.recover(context(), "Exchange-Recover2");
+
         // Then
-        assertNotNull(exchange2);
-        assertNull(exchange3);
+        assertNotNull(recovered);
+        assertNull(unknown);
+    }
+
+    @Test
+    public void testGetKeysIgnoresExchangesToRecover() {
+        // Given
+        Exchange exchange = new DefaultExchange(context());
+        exchange.setExchangeId("Exchange-Keys1");
+        aggregationRepository.add(context(), "Keys1", exchange);
+        aggregationRepository.add(context(), "Keys2", exchange);
+        aggregationRepository.remove(context(), "Keys1", exchange);
+
+        // When
+        Set<String> keys = aggregationRepository.getKeys();
+
+        // Then - only the aggregation still in progress is reported
+        assertEquals(1, keys.size());
+        assertTrue(keys.contains("Keys2"));
     }
 
 }

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1695,3 +1695,21 @@ changes.
 Downloads to a configured `localWorkDirectory` now resolve existing filesystem path segments before
 checking that the destination remains inside that directory. Downloads through a symbolic link that
 resolves outside the `localWorkDirectory` are rejected. Valid nested download paths continue to work.
+
+=== camel-infinispan - the aggregation repository keeps completed exchanges for recovery
+
+`InfinispanAggregationRepository` implements `RecoverableAggregationRepository`, but it had no recovery
+store: `remove` deleted the completed exchange outright, `confirm` removed the exchange id from a cache
+keyed by correlation key, and `scan` returned the correlation keys of the aggregations still in progress.
+The recovery task therefore re-delivered aggregations that were still accumulating, marked them
+`CamelRedelivered`, and sent them to the dead letter channel once `maximumRedeliveries` was reached, while
+exchanges that genuinely failed after completion could never be recovered.
+
+A completed exchange is now kept in the same cache under a `camel-recovery:<exchange id>` key until it is
+confirmed, which is what `scan` reports and `recover` reads. `getKeys` continues to report only the
+aggregations in progress.
+
+Routes that set `useRecovery=false` are unaffected. Routes that left recovery enabled, which is the
+default, stop seeing in-progress aggregations re-delivered, and start seeing genuine recovery. The cache
+now also holds one entry per completed and not yet confirmed exchange; those entries are removed on
+confirmation.


### PR DESCRIPTION
Found by a source audit of `components/camel-infinispan`.

### The problem

`InfinispanAggregationRepository` implements `RecoverableAggregationRepository`, but it keeps a single cache
keyed by the aggregation correlation key and has no recovery store, so all four recovery methods work on the
wrong key space:

| method | contract | what it did |
|---|---|---|
| `remove(ctx, key, exchange)` | move the holder into a recovery store keyed by **exchange id** | plain `cache.remove(key)` — the completed exchange is gone |
| `confirm(ctx, exchangeId)` | delete it from the recovery store | `cache.remove(exchangeId)` against the correlation-keyed cache — never matches |
| `scan(ctx)` | return **exchange ids** to recover | returns the correlation keys of aggregations still in progress |
| `recover(ctx, exchangeId)` | load a completed, unconfirmed exchange | returns an exchange that is still aggregating |

With `useRecovery` defaulting to `true`, the consequences are visible at runtime:

* `AggregateProcessor` treats the `scan()` result as exchange ids and checks it against
  `inProgressCompleteExchanges`, so the duplicate-delivery guard never matches;
* the still-open aggregation is marked `CamelRedelivered` and re-submitted on every recovery interval
  (default 5s);
* after `maximumRedeliveries` (default 3) it goes to the dead letter channel;
* and an exchange that genuinely failed after completion can never be recovered, which is the whole point of
  the interface.

Neither the remote nor the embedded subclass overrides these methods, so both are affected.

### The change

A completed exchange is kept in the same cache under a `camel-recovery:<exchange id>` key until it is
confirmed. `scan()` reports those ids, `recover()` reads them, `confirm()` deletes one, and `getKeys()`
filters them out so it still reports only the aggregations in progress. `scan()` returns an empty set when
`useRecovery=false`.

The recovery entry is keyed by `exchange.getExchangeId()` of the exchange handed to `remove()`, which is what
`JdbcAggregationRepository` does (`final String confirmKey = exchange.getExchangeId()`), so the confirm path
lines up with the canonical implementation.

**On the single-cache design.** `RedisAggregationRepository` and `JdbcAggregationRepository` use a second
map/table for the recovery store, and that was the first thing I tried. For Hot Rod it means the user has to
provision a second cache server-side — a deployment change I do not think belongs in a bug fix — so this
keeps one cache and namespaces the recovery keys instead. If you would rather have the second cache with an
option to name it, say so and I will rework it.

### Tests

The three existing tests encoded the broken key space — `testConfirmExist` confirmed with a correlation key
while the exchanges carried `Exchange_N` ids, `testScan` named its result `exchangeIdSet` and asserted
correlation keys, `testRecover` recovered by correlation key. They are rewritten around the real contract
(add → remove → scan sees the exchange id → recover returns it → confirm clears it) in both the embedded
test and the remote IT, plus a new test that `getKeys()` ignores recovery entries.

`mvn clean install` on `components/camel-infinispan` is green — 111 remote tests, including the rewritten
`InfinispanRemoteAggregationRepositoryOperationsIT` against a Hot Rod testcontainer, and 12 embedded
aggregation tests. Full reactor `mvn clean install -DskipTests -Dquickly` green. Upgrade-guide entry added
for 4.23.

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
