### PR TITLE
CAMEL-24618: Fix flaky SpringFileAntPathMatcherRemoteFileFilterTest

### DIFF
--- a/tests/camel-itest/src/test/java/org/apache/camel/itest/ftp/SpringFileAntPathMatcherRemoteFileFilterTest.java
+++ b/tests/camel-itest/src/test/java/org/apache/camel/itest/ftp/SpringFileAntPathMatcherRemoteFileFilterTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.itest.ftp;
 
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
@@ -46,6 +49,8 @@ public class SpringFileAntPathMatcherRemoteFileFilterTest {
 
     protected String expectedBody = "Godday World";
     @Autowired
+    protected CamelContext context;
+    @Autowired
     protected ProducerTemplate template;
     @EndpointInject("ref:myFTPEndpoint")
     protected Endpoint inputFTP;
@@ -63,6 +68,6 @@ public class SpringFileAntPathMatcherRemoteFileFilterTest {
         template.sendBodyAndHeader(inputFTP, "Day world", Exchange.FILE_NAME, "day.xml");
         template.sendBodyAndHeader(inputFTP, expectedBody, Exchange.FILE_NAME, "subfolder/foo/godday.txt");
 
-        result.assertIsSatisfied();
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 }

--- a/tests/camel-itest/src/test/resources/org/apache/camel/itest/ftp/SpringFileAntPathMatcherRemoteFileFilterTest-context.xml
+++ b/tests/camel-itest/src/test/resources/org/apache/camel/itest/ftp/SpringFileAntPathMatcherRemoteFileFilterTest-context.xml
@@ -30,7 +30,9 @@
         <template id="camelTemplate"/>
 
         <!-- use myFilter as filter to allow setting ANT paths for which files to scan for -->
-        <endpoint id="myFTPEndpoint" uri="ftp://admin@localhost:${SpringFileAntPathMatcherRemoteFileFilterTest.ftpPort}/antpath?password=admin&amp;recursive=true&amp;delay=10000&amp;initialDelay=2000&amp;filter=#myAntFilter"/>
+        <!-- delete=true prevents state contamination: files are removed after processing so they
+             don't accumulate across retries (FtpServiceExtension never resets the FTP directory) -->
+        <endpoint id="myFTPEndpoint" uri="ftp://admin@localhost:${SpringFileAntPathMatcherRemoteFileFilterTest.ftpPort}/antpath?password=admin&amp;recursive=true&amp;delay=10000&amp;initialDelay=0&amp;delete=true&amp;filter=#myAntFilter"/>
 
         <route>
             <from uri="ref:myFTPEndpoint"/>


### PR DESCRIPTION
## Problem

`SpringFileAntPathMatcherRemoteFileFilterTest.testAntPatchMatcherFilter` is flaky with two distinct failure modes:

1. **`expected <1> but was <9>` — state contamination**: The FTP consumer URI had no `delete` option, so consumed files remained on the FTP server. Since `FtpServiceExtension.afterAll()` is a no-op (the FTP server is never stopped/reset), files accumulated across test retries, causing the mock to receive duplicate messages.

2. **`expected <1> but was <0>` — timing race**: The consumer had `initialDelay=2000ms`, and with the default `MockEndpoint.resultWaitTime` (10s), the assertion could expire before the first poll completed on slow CI environments.

## Fix

- **Add `delete=true`** to the FTP consumer URI in the Spring XML context — files are deleted after processing, preventing accumulation across retries
- **Change `initialDelay` from 2000 to 0** — the consumer starts polling immediately
- **Set `resultWaitTime(30000)`** on the mock endpoint — generous timeout for slow CI