### PR TITLE
CAMEL-24627: resolve symlinks when containing local work directory downloads

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/GenericFileHelper.java
@@ -17,6 +17,10 @@
 package org.apache.camel.component.file;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 import org.apache.camel.Exchange;
@@ -47,6 +51,43 @@ public final class GenericFileHelper {
                                                           + " as it is jailed to the local work directory: "
                                                           + compactWork);
         }
+        // defense-in-depth: the lexical check above cannot see symbolic links, so also resolve the existing
+        // filesystem path segments (following links) and re-check. This prevents a symbolic link inside the
+        // local work directory that resolves outside of it from being used to write files elsewhere. Valid
+        // nested paths continue to work unchanged. Skipped when no work directory boundary is configured.
+        if (!compactWork.isEmpty()) {
+            try {
+                Path resolvedWork = resolveExistingPathSegments(localWorkDirectory.toPath());
+                Path resolvedTarget = resolveExistingPathSegments(target.toPath());
+                if (!resolvedTarget.startsWith(resolvedWork)) {
+                    throw new GenericFileOperationFailedException(
+                            "Cannot retrieve file to local work file: " + compactTarget
+                                                                  + " as it is jailed to the local work directory: "
+                                                                  + compactWork);
+                }
+            } catch (IOException e) {
+                throw new GenericFileOperationFailedException(
+                        "Cannot verify local work file: " + compactTarget
+                                                              + " is within the local work directory: " + compactWork,
+                        e);
+            }
+        }
+    }
+
+    private static Path resolveExistingPathSegments(Path path) throws IOException {
+        // Preserve the raw path segments here. Normalizing before resolving links changes the filesystem meaning of
+        // paths such as link/../file when link points to another directory.
+        final Path absolutePath = path.toAbsolutePath();
+        Path existingPath = absolutePath;
+        while (existingPath != null && !Files.exists(existingPath, LinkOption.NOFOLLOW_LINKS)) {
+            existingPath = existingPath.getParent();
+        }
+        if (existingPath == null) {
+            throw new IOException("No existing ancestor found for " + path);
+        }
+
+        final Path resolvedExistingPath = existingPath.toRealPath();
+        return resolvedExistingPath.resolve(existingPath.relativize(absolutePath)).normalize();
     }
 
     /**

--- a/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
+++ b/components/camel-file/src/test/java/org/apache/camel/component/file/GenericFileHelperTest.java
@@ -17,8 +17,13 @@
 package org.apache.camel.component.file;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -49,6 +54,30 @@ public class GenericFileHelperTest {
         // a sibling directory whose name merely extends the work directory name must also be rejected
         assertThrows(GenericFileOperationFailedException.class,
                 () -> GenericFileHelper.jailToLocalWorkDirectory(new File(workDir, "../localworkEVIL/file.txt"), workDir));
+    }
+
+    @Test
+    public void shouldRejectSymlinkEscapingLocalWorkDirectory(@TempDir Path tmp) throws IOException {
+        Path work = Files.createDirectories(tmp.resolve("work"));
+        Path outside = Files.createDirectories(tmp.resolve("outside"));
+
+        // a symbolic link inside the work directory that points outside of it
+        Path link = work.resolve("link");
+        try {
+            Files.createSymbolicLink(link, outside);
+        } catch (UnsupportedOperationException | IOException e) {
+            Assumptions.abort("Symbolic links are not supported on this platform: " + e.getMessage());
+        }
+
+        // a file written through the symlink resolves outside the work directory and must be rejected, even though
+        // it passes a lexical-only containment check
+        File escaping = new File(link.toFile(), "evil.txt");
+        assertThrows(GenericFileOperationFailedException.class,
+                () -> GenericFileHelper.jailToLocalWorkDirectory(escaping, work.toFile()));
+
+        // a legitimate file within a real (not-yet-existing) subdirectory of the work directory is still allowed
+        File legit = new File(work.toFile(), "sub/ok.txt");
+        assertDoesNotThrow(() -> GenericFileHelper.jailToLocalWorkDirectory(legit, work.toFile()));
     }
 
     @Test

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1689,3 +1689,9 @@ it the result is placed in the message body, as before.
 The `CamelInfinispanIgnoreReturnValues` header is now documented as a producer header rather than a consumer
 one. It has always been read on the producer path, so only its group in the catalog and in the documentation
 changes.
+
+=== camel-file, camel-ftp, camel-smb, camel-mina-sftp and camel-azure-files
+
+Downloads to a configured `localWorkDirectory` now resolve existing filesystem path segments before
+checking that the destination remains inside that directory. Downloads through a symbolic link that
+resolves outside the `localWorkDirectory` are rejected. Valid nested download paths continue to work.


### PR DESCRIPTION
# Description

`GenericFileHelper.jailToLocalWorkDirectory` — used by the file-based components to keep downloads within the configured `localWorkDirectory` — performed a **lexical** path-boundary check only. A symbolic link inside the work directory that resolves outside of it could therefore be used to write files elsewhere on the filesystem.

This change brings it to parity with the cloud storage hardening done in CAMEL-24548 / CAMEL-24549 (`AzureFileNameHelper` / `GoogleCloudStorageFileNameHelper`): after the lexical check, the existing filesystem path segments are resolved (following symbolic links) and the containment is re-verified. Valid nested download paths continue to work unchanged.

## Affected components

Fix lives in the shared `camel-file` helper, so all callers benefit:

- `camel-file`, `camel-ftp` (FTP + SFTP), `camel-smb`, `camel-mina-sftp`, `camel-azure-files`

## Changes

- `GenericFileHelper.jailToLocalWorkDirectory` now resolves existing path segments and re-checks containment (defensively guarded; skipped when no work directory boundary is configured).
- Added `resolveExistingPathSegments` mirroring the approach in `AzureFileNameHelper`.
- Added a symlink-escape test case to `GenericFileHelperTest`.
- Upgrade guide note added for 4.23.

## Testing

- `mvn test -Dtest=GenericFileHelperTest` in `components/camel-file` — all green (existing lexical cases + new symlink case; the symlink test self-skips on platforms without symlink support).

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)