### PR TITLE
CAMEL-24628: camel-cli - camel dependency update propagate route files to export pipeline

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdate.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdate.java
@@ -93,6 +93,10 @@ public class DependencyUpdate extends DependencyList {
             String ext = FileUtil.onlyExt(name, true);
             if ("pom.xml".equals(name) || "java".equals(ext)) {
                 updateTargets.add(file);
+            } else {
+                // route definition files (YAML, XML) are used as source files
+                // for the export pipeline dependency resolution
+                this.files.add(file.toString());
             }
         }
 

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdateTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/DependencyUpdateTest.java
@@ -132,6 +132,43 @@ class DependencyUpdateTest extends CamelCommandBaseTestSupport {
         Assertions.assertEquals(0, exportCommand.doCall(), exportCommandPrinter.getLines().toString());
     }
 
+    // ==================== explicit route file as positional argument ====================
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    void shouldDependencyUpdateWithExplicitRouteFile(RuntimeType rt) throws Exception {
+        prepareFixtureProject(rt);
+
+        // add arangodb to the route
+        addArangodbToCamelFile();
+
+        // pass BOTH pom.xml AND route file as positional arguments
+        // (this is the calling convention used by IDE tooling)
+        StringPrinter updatePrinter = new StringPrinter();
+        DependencyUpdate command = new DependencyUpdate(new CamelJBangMain().withPrinter(updatePrinter));
+        CommandLine.populateCommand(command,
+                "--camel-version=4.13.0",
+                "--dir=" + workingDir,
+                CamelCommandBaseTestSupport.quarkusExtRegistry(),
+                new File(workingDir, "pom.xml").getAbsolutePath(),
+                new File(workingDir, "src/main/resources/camel/my.camel.yaml").getAbsolutePath());
+        int exit = command.doCall();
+        Assertions.assertEquals(0, exit, updatePrinter.getLines().toString());
+
+        String pomContent = Files.readString(new File(workingDir, "pom.xml").toPath());
+        switch (rt) {
+            case quarkus:
+                assertThat(pomContent).contains("camel-quarkus-arangodb");
+                break;
+            case springBoot:
+                assertThat(pomContent).contains("camel-arangodb-starter");
+                break;
+            case main:
+                assertThat(pomContent).contains("camel-arangodb<");
+                break;
+        }
+    }
+
     // ==================== scan-routes with Maven (fixture-based tests) ====================
 
     @ParameterizedTest


### PR DESCRIPTION
# Description

## Problem

Since CAMEL-22544, `camel dependency update pom.xml route.camel.yaml` silently drops the route file and resolves zero dependencies.

The `@Parameters(arity="1..*")` change causes all positional arguments to be consumed by `DependencyUpdate.targetFiles`. Non-update files (YAML/XML route definitions) are correctly classified but never propagated to `ExportBaseCommand.files`, so the export pipeline runs with no routes and discovers no components.

This is a regression from Camel 4.20, where `arity="1"` let the second positional flow to `ExportBaseCommand.files` via `FilesConsumer`.

IDE tooling uses this two-argument calling convention, as confirmed by prior issues CAMEL-22447 and CAMEL-22446.

## Fix

Add an `else` branch in `DependencyUpdate.doCall()` that forwards non-target files (YAML, XML routes) to `this.files` for the export pipeline — exactly as the `@Parameters` description already promises.

Add a test that passes both `pom.xml` and a route file as positional arguments to verify the route is used for dependency resolution.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

resolves https://issues.apache.org/jira/browse/CAMEL-24628