### PR TITLE
CAMEL-24601 - fix flakiness in SmbComponentConnectionIT

### DIFF
--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbComponentConnectionIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbComponentConnectionIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.smb;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -33,10 +32,12 @@ import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SmbComponentConnectionIT extends CamelTestSupport {
+@Isolated
+class SmbComponentConnectionIT extends CamelTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(SmbComponentIT.class);
 
     @RegisterExtension
@@ -46,16 +47,7 @@ public class SmbComponentConnectionIT extends CamelTestSupport {
     protected MockEndpoint mockResultEndpoint;
 
     @Test
-    public void testSmbRead() throws Exception {
-        MockEndpoint mock = getMockEndpoint("mock:result");
-        mock.expectedMessageCount(100);
-
-        mock.assertIsSatisfied();
-    }
-
-    @Test
-    public void testSendReceive() throws Exception {
-
+    void testSendReceive() throws Exception {
         MockEndpoint mock = getMockEndpoint("mock:received_send");
         mock.expectedMessageCount(1);
 
@@ -68,7 +60,7 @@ public class SmbComponentConnectionIT extends CamelTestSupport {
     }
 
     @Test
-    public void testDefaultIgnore() throws Exception {
+    void testDefaultIgnore() throws Exception {
 
         MockEndpoint mock = getMockEndpoint("mock:received_ignore");
         mock.expectedMessageCount(1);
@@ -83,7 +75,7 @@ public class SmbComponentConnectionIT extends CamelTestSupport {
     }
 
     @Test
-    public void testOverride() throws Exception {
+    void testOverride() throws Exception {
 
         MockEndpoint mock = getMockEndpoint("mock:received_override");
         mock.expectedMessageCount(1);
@@ -99,28 +91,12 @@ public class SmbComponentConnectionIT extends CamelTestSupport {
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
-            private void process(Exchange exchange) throws IOException {
-                final SmbFile data = exchange.getMessage().getBody(SmbFile.class);
-                final String name = exchange.getMessage().getHeader(Exchange.FILE_NAME, String.class);
-                new String((byte[]) data.getBody(), StandardCharsets.UTF_8);
-                LOG.debug("Read exchange name {} at {} with contents: {} (bytes {})", name, data.getAbsoluteFilePath(),
-                        new String((byte[]) data.getBody(), StandardCharsets.UTF_8), data.getFileLength());
-            }
-
             public void configure() {
                 SmbConfig config = SmbConfig.builder()
                         .withTimeout(120, TimeUnit.SECONDS) // Timeout sets Read, Write, and Transact timeouts (default is 60 seconds)
                         .withSoTimeout(180, TimeUnit.SECONDS) // Socket Timeout (default is 0 seconds, blocks forever)
                         .build();
                 context.getRegistry().bind("smbConfig", config);
-
-                fromF("smb:%s/%s?username=%s&password=%s&smbConfig=#smbConfig", service.address(), service.shareName(),
-                        service.userName(), service.password())
-                        .to("seda:intermediate");
-
-                from("seda:intermediate?concurrentConsumers=4")
-                        .process(this::process)
-                        .to("mock:result");
 
                 from("seda:send")
                         .toF("smb:%s/%s?username=%s&password=%s", service.address(), service.shareName(),

--- a/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbComponentConnectionReadIT.java
+++ b/components/camel-smb/src/test/java/org/apache/camel/component/smb/SmbComponentConnectionReadIT.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.smb;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import com.hierynomus.smbj.SmbConfig;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.infra.smb.services.SmbService;
+import org.apache.camel.test.infra.smb.services.SmbServiceFactory;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Isolated
+class SmbComponentConnectionReadIT extends CamelTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(SmbComponentIT.class);
+
+    @RegisterExtension
+    public static SmbService service = SmbServiceFactory.createSingletonService();
+
+    @EndpointInject("mock:result")
+    protected MockEndpoint mockResultEndpoint;
+
+    @Test
+    void testSmbRead() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(100);
+
+        mock.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            private void process(Exchange exchange) throws IOException {
+                final SmbFile data = exchange.getMessage().getBody(SmbFile.class);
+                final String name = exchange.getMessage().getHeader(Exchange.FILE_NAME, String.class);
+                new String((byte[]) data.getBody(), StandardCharsets.UTF_8);
+                LOG.debug("Read exchange name {} at {} with contents: {} (bytes {})", name, data.getAbsoluteFilePath(),
+                        new String((byte[]) data.getBody(), StandardCharsets.UTF_8), data.getFileLength());
+            }
+
+            public void configure() {
+                SmbConfig config = SmbConfig.builder()
+                        .withTimeout(120, TimeUnit.SECONDS) // Timeout sets Read, Write, and Transact timeouts (default is 60 seconds)
+                        .withSoTimeout(180, TimeUnit.SECONDS) // Socket Timeout (default is 0 seconds, blocks forever)
+                        .build();
+                context.getRegistry().bind("smbConfig", config);
+
+                fromF("smb:%s/%s?username=%s&password=%s&smbConfig=#smbConfig",
+                        service.address(), service.shareName(),
+                        service.userName(), service.password())
+                        .to("seda:intermediate");
+
+                from("seda:intermediate?concurrentConsumers=4")
+                        .process(this::process)
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
one route was potentially messing with the others. I tried to use some specific searchPattern or exclude parameter without success; The easiest is to separate in 2 test classes and Isolate them. Before I got a failure rate around 1 out of 5; now I got 60 in success.

Co-Authored-by: IBM Bob 2.0.3

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

