### PR TITLE
CAMEL-24616: Build and test with JDK 27

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -78,6 +78,10 @@ jobs:
             # JDK 17 is kept for runtime compatibility testing.
             # Skip the enforcer which requires JDK 21+ (needed to compile JDK 21-specific classes).
             maven_extra_args: '-Denforcer.phase=none'
+          - java: '27-ea'
+            # JDK 27 EA: early-access build to catch compatibility issues ahead of the Sep 2026 GA.
+            # Experimental — failures do not block PR merges.
+            experimental: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Jenkinsfile.jdk27
+++ b/Jenkinsfile.jdk27
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def MAVEN_PARAMS = "-B -e -fae -V -Dnoassembly -Dsurefire.rerunFailingTestsCount=2 -Dfailsafe.rerunFailingTestsCount=1"
+def MAVEN_TEST_PARAMS = env.MAVEN_TEST_PARAMS ?: "-Dci.env.name=apache.org"
+def MAVEN_TEST_PARAMS_UBUNTU = env.MAVEN_TEST_PARAMS ?: "-Dci.env.name=apache.org"
+
+/*
+Below parameters are required for camel/core/camel-core module's test cases to pass on ppc64 and s390x
+- xpathExprGrpLimit: limits the number of groups an Xpath expression can contain
+- xpathExprOpLimit: limits the number of operators an Xpath expression can contain
+The Kafka parameter is because the apache/kafka image is not working on alternative OSes
+*/
+def MAVEN_TEST_PARAMS_ALT_ARCHS = "-Djdk.xml.xpathExprGrpLimit=100 -Djdk.xml.xpathExprOpLimit=2000 -Dkafka.instance.type=local-strimzi-container"
+
+pipeline {
+
+    triggers {
+        // weekly
+        cron('H H * * H')
+    }
+
+    environment {
+        MAVEN_SKIP_RC = true
+        DEVELOCITY_ACCESS_KEY = credentials('CAMEL_DEVELOCITY_ACCESS_KEY')
+    }
+
+    options {
+        buildDiscarder(
+            logRotator(artifactNumToKeepStr: '5', numToKeepStr: '10')
+        )
+        disableConcurrentBuilds()
+        throttleJobProperty(
+          categories: ['camel'],
+          throttleEnabled: true,
+          throttleOption: 'category',
+          maxConcurrentPerNode: 1
+      )
+
+        // This is required if you want to clean before build
+        skipDefaultCheckout(true)
+    }
+
+    parameters {
+        booleanParam(name: 'VIRTUAL_THREAD', defaultValue: false, description: 'Perform the build using virtual threads')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'ppc64le', 's390x', 'ubuntu-avx'], description: 'Run on specific platform')
+        choice(name: 'JDK_FILTER', choices: ['jdk_27_latest'], description: 'Run on specific jdk')
+    }
+    agent none
+    stages {
+        stage('BuildAndTest') {
+            matrix {
+                agent {
+                    label "${PLATFORM}"
+                }
+                options {
+                    throttle(['camel'])
+                }
+                when { allOf {
+                    anyOf {
+                        expression { params.PLATFORM_FILTER == 'all' }
+                        expression { params.PLATFORM_FILTER == env.PLATFORM }
+                    }
+                    anyOf {
+                        expression { params.JDK_FILTER == 'all' }
+                        expression { params.JDK_FILTER == env.JDK_NAME }
+                    }
+                } }
+                axes {
+                    axis {
+                        name 'JDK_NAME'
+                        values 'jdk_27_latest'
+                    }
+                    axis {
+                        name 'PLATFORM'
+                        values 'ppc64le', 's390x', 'ubuntu-avx'
+                    }
+                }
+                tools {
+                    jdk "${JDK_NAME}"
+                }
+                stages {
+                    stage('Clean workspace') {
+                        steps {
+                            cleanWs()
+                            sh 'rm -rvf /home/jenkins/.m2/repository/org/apache/camel'
+                            checkout([
+                                $class: 'GitSCM',
+                                branches: scm.branches,
+                                extensions: [
+                                    [$class: 'CloneOption', depth: 1, noTags: true, shallow: true]
+                                ],
+                                userRemoteConfigs: scm.userRemoteConfigs
+                            ])
+                        }
+                    }
+
+                    stage('Build and test') {
+                        steps {
+                            echo "Do Build and test for ${PLATFORM}-${JDK_NAME}"
+                            sh 'java -version'
+                            timeout(unit: 'MINUTES', time: 450) {
+                                script {
+                                    if ("${PLATFORM}" == "ubuntu-avx") {
+                                        sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true install"
+                                    } else {
+                                        // Skip the test case execution of modules which are either not supported on ppc64le or vendor images are not available for ppc64le.
+                                        sh "./mvnw $MAVEN_PARAMS $MAVEN_TEST_PARAMS $MAVEN_TEST_PARAMS_ALT_ARCHS -Darchetype.test.skip -Dmaven.test.failure.ignore=true -Dcheckstyle.skip=true install -pl '!docs'"
+                                        echo "Code quality review disabled for ${PLATFORM} with JDK ${JDK_NAME}"
+                                    }
+                                }
+                            }
+                        }
+                        post {
+                            always {
+                                junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml', skipPublishingChecks: true
+                                junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/*.xml', skipPublishingChecks: true
+                            }
+                        }
+                    }
+                }
+                post {
+                    always {
+                        echo "Sending report CI email for developers"
+                        emailext(
+                            subject: '${DEFAULT_SUBJECT}',
+                            body: '${DEFAULT_CONTENT}',
+                            recipientProviders: [[$class: 'DevelopersRecipientProvider']]
+                        )
+                        cleanWs(
+                            cleanWhenNotBuilt: false,
+                            cleanWhenUnstable: false,
+                            cleanWhenFailure: false,
+                            cleanWhenAborted: false,
+                            cleanWhenSuccess: true,
+                            deleteDirs: true,
+                            disableDeferredWipeout: true,
+                            notFailBuild: true)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Add CI infrastructure to build and test Camel with JDK 27 (EA), as a checkpoint toward the next LTS (JDK 29, September 2027).

### Changes

1. **`Jenkinsfile.jdk27`** — Weekly Jenkins CI build on JDK 27 EA, modeled on the existing `Jenkinsfile.jdk26`. Runs the full build+test matrix on `ppc64le`, `s390x`, and `ubuntu-avx` platforms using the `jdk_27_latest` tool.

2. **GitHub Actions PR build** (`.github/workflows/pr-build-main.yml`) — Added JDK `27-ea` as an experimental matrix entry with `continue-on-error: true`. This gives early visibility into JDK 27 compatibility on every PR without blocking merges.

### Notes

- JDK 27 GA is planned for September 2026. The reporter confirmed that `mvn clean install -DskipTests` succeeds with JDK 27 EA.
- The Jenkins `jdk_27_latest` tool must be configured on the ASF Jenkins infrastructure for the Jenkinsfile to work (similar to how `jdk_26_latest` was set up for CAMEL-23660).
- The GHA experimental entry uses `actions/setup-java` with `java-version: 27-ea` and `distribution: temurin`, which is supported per the [setup-java docs](https://github.com/actions/setup-java#supported-version-syntax).

Fixes: https://issues.apache.org/jira/browse/CAMEL-24616

_AI agent (Hermes on behalf of gnodet)_