### PR TITLE
[backport camel-4.22.x] camel-docling: honor the operationId URI path segment to select the operation

### DIFF
--- a/components/camel-ai/camel-docling/src/main/java/org/apache/camel/component/docling/DoclingComponent.java
+++ b/components/camel-ai/camel-docling/src/main/java/org/apache/camel/component/docling/DoclingComponent.java
@@ -29,6 +29,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,15 @@ public class DoclingComponent extends DefaultComponent {
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         DoclingConfiguration config = this.configuration.copy();
+        // operationId (e.g. docling:CONVERT_TO_MARKDOWN) selects the operation; applied before
+        // setProperties() below so an explicit ?operation=... parameter still takes precedence.
+        if (ObjectHelper.isNotEmpty(remaining)) {
+            try {
+                config.setOperation(DoclingOperations.valueOf(remaining));
+            } catch (IllegalArgumentException e) {
+                // not a recognized operation name - leave the configured/default operation as-is
+            }
+        }
         DoclingEndpoint endpoint = new DoclingEndpoint(uri, this, remaining, config);
         setProperties(endpoint, parameters);
         return endpoint;

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/DoclingComponentTest.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/DoclingComponentTest.java
@@ -50,6 +50,27 @@ public class DoclingComponentTest extends CamelTestSupport {
     }
 
     @Test
+    public void testOperationIdSelectsOperation() throws Exception {
+        Endpoint endpoint = context.getEndpoint("docling:EXTRACT_STRUCTURED_DATA");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof DoclingEndpoint);
+
+        DoclingEndpoint doclingEndpoint = (DoclingEndpoint) endpoint;
+        assertEquals("EXTRACT_STRUCTURED_DATA", doclingEndpoint.getOperationId());
+        assertEquals(DoclingOperations.EXTRACT_STRUCTURED_DATA, doclingEndpoint.getConfiguration().getOperation());
+    }
+
+    @Test
+    public void testExplicitOperationParameterOverridesOperationId() throws Exception {
+        // a recognized operationId must still be overridable via an explicit "operation" parameter
+        Endpoint endpoint = context.getEndpoint("docling:CONVERT_TO_MARKDOWN?operation=EXTRACT_TEXT");
+        assertNotNull(endpoint);
+
+        DoclingEndpoint doclingEndpoint = (DoclingEndpoint) endpoint;
+        assertEquals(DoclingOperations.EXTRACT_TEXT, doclingEndpoint.getConfiguration().getOperation());
+    }
+
+    @Test
     public void testProducerCreation() throws Exception {
         DoclingEndpoint endpoint = (DoclingEndpoint) context.getEndpoint("docling:convert");
         assertNotNull(endpoint.createProducer());


### PR DESCRIPTION
<!-- camel-backport-bot -->

## Backport of #26102

Cherry-pick of #26102 onto `camel-4.22.x`.

**Original PR:** #26102 - camel-docling: honor the operationId URI path segment to select the operation
**Original author:** @Croway
**Target branch:** `camel-4.22.x`
