### PR TITLE
[backport camel-4.18.x] camel-docling: honor the operationId URI path segment to select the operation

### DIFF
--- a/components/camel-ai/camel-docling/src/main/java/org/apache/camel/component/docling/DoclingComponent.java
+++ b/components/camel-ai/camel-docling/src/main/java/org/apache/camel/component/docling/DoclingComponent.java
@@ -23,6 +23,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.spi.Metadata;
 import org.apache.camel.spi.annotations.Component;
 import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.ObjectHelper;
 
 /**
  * Component for integrating with Docling document processing library.
@@ -45,6 +46,15 @@ public class DoclingComponent extends DefaultComponent {
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
         DoclingConfiguration config = this.configuration.copy();
+        // operationId (e.g. docling:CONVERT_TO_MARKDOWN) selects the operation; applied before
+        // setProperties() below so an explicit ?operation=... parameter still takes precedence.
+        if (ObjectHelper.isNotEmpty(remaining)) {
+            try {
+                config.setOperation(DoclingOperations.valueOf(remaining));
+            } catch (IllegalArgumentException e) {
+                // not a recognized operation name - leave the configured/default operation as-is
+            }
+        }
         DoclingEndpoint endpoint = new DoclingEndpoint(uri, this, remaining, config);
         setProperties(endpoint, parameters);
         return endpoint;

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/DoclingComponentTest.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/DoclingComponentTest.java
@@ -50,6 +50,27 @@ public class DoclingComponentTest extends CamelTestSupport {
     }
 
     @Test
+    public void testOperationIdSelectsOperation() throws Exception {
+        Endpoint endpoint = context.getEndpoint("docling:EXTRACT_STRUCTURED_DATA");
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof DoclingEndpoint);
+
+        DoclingEndpoint doclingEndpoint = (DoclingEndpoint) endpoint;
+        assertEquals("EXTRACT_STRUCTURED_DATA", doclingEndpoint.getOperationId());
+        assertEquals(DoclingOperations.EXTRACT_STRUCTURED_DATA, doclingEndpoint.getConfiguration().getOperation());
+    }
+
+    @Test
+    public void testExplicitOperationParameterOverridesOperationId() throws Exception {
+        // a recognized operationId must still be overridable via an explicit "operation" parameter
+        Endpoint endpoint = context.getEndpoint("docling:CONVERT_TO_MARKDOWN?operation=EXTRACT_TEXT");
+        assertNotNull(endpoint);
+
+        DoclingEndpoint doclingEndpoint = (DoclingEndpoint) endpoint;
+        assertEquals(DoclingOperations.EXTRACT_TEXT, doclingEndpoint.getConfiguration().getOperation());
+    }
+
+    @Test
     public void testProducerCreation() throws Exception {
         DoclingEndpoint endpoint = (DoclingEndpoint) context.getEndpoint("docling:convert");
         assertNotNull(endpoint.createProducer());


### PR DESCRIPTION
## Backport of #26102

Cherry-pick of b9649aafde2c743723b78edf753c56f1eecb40d7 to camel-4.18.x.
Conflicts resolved automatically by backport bot agent.