### PR TITLE
chore: fix spring-ai-image and docling CI failures by switching to @DisabledIfEnvironmentVariable

### DIFF
--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/BatchProcessingIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/BatchProcessingIT.java
@@ -30,7 +30,7 @@ import org.apache.camel.component.docling.DoclingComponent;
 import org.apache.camel.component.docling.DoclingConfiguration;
 import org.apache.camel.component.docling.DoclingHeaders;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Integration test for batch processing operations using test-infra for container management.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Too much resources on GitHub Actions")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Too much resources on GitHub Actions")
 class BatchProcessingIT extends DoclingITestSupport {
 
     @Test

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/ChunkingIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/ChunkingIT.java
@@ -30,11 +30,11 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.docling.DoclingHeaders;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Too much resources on GitHub Actions")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Too much resources on GitHub Actions")
 class ChunkingIT extends DoclingITestSupport {
 
     @Test

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/DoclingServeProducerIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/DoclingServeProducerIT.java
@@ -34,7 +34,7 @@ import org.apache.camel.component.docling.DoclingHeaders;
 import org.apache.camel.component.docling.DoclingOperations;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This test demonstrates how to use the camel-test-infra-docling module to automatically spin up a Docling-Serve
  * container for testing without manual setup.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Too much resources on GitHub Actions")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Too much resources on GitHub Actions")
 class DoclingServeProducerIT extends DoclingITestSupport {
 
     @TempDir

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/ExtractStructuredDataIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/ExtractStructuredDataIT.java
@@ -31,11 +31,11 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.docling.DoclingHeaders;
 import org.apache.camel.component.docling.DoclingOperations;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Too much resources on GitHub Actions")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Too much resources on GitHub Actions")
 class ExtractStructuredDataIT extends DoclingITestSupport {
 
     @Test

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/MetadataExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/MetadataExtractionIT.java
@@ -28,7 +28,7 @@ import org.apache.camel.component.docling.DoclingHeaders;
 import org.apache.camel.component.docling.DocumentMetadata;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Integration test for metadata extraction operations using test-infra for container management.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Too much resources on GitHub Actions")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Too much resources on GitHub Actions")
 class MetadataExtractionIT extends DoclingITestSupport {
 
     @Test

--- a/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
+++ b/components/camel-ai/camel-docling/src/test/java/org/apache/camel/component/docling/integration/OcrExtractionIT.java
@@ -35,7 +35,7 @@ import org.apache.camel.test.infra.docling.services.DoclingService;
 import org.apache.camel.test.infra.docling.services.DoclingServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * This test demonstrates how to use Docling's OCR capabilities to extract text from images containing text content.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Too much resources on GitHub Actions")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Too much resources on GitHub Actions")
 class OcrExtractionIT extends CamelTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(OcrExtractionIT.class);

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-image/src/test/java/org/apache/camel/component/springai/image/SpringAiImageOllamaIT.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-image/src/test/java/org/apache/camel/component/springai/image/SpringAiImageOllamaIT.java
@@ -32,7 +32,7 @@ import org.apache.camel.test.infra.ollama.services.OllamaServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
@@ -54,7 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Since Spring AI 2.0 the OpenAI models are built on the official openai-java SDK, so the Ollama endpoint is configured
  * through the SDK client options rather than through a Spring RestClient.
  */
-@DisabledIfSystemProperty(named = "ci.env.name", matches = ".*", disabledReason = "Disabled unless running in CI")
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Disabled on CI (requires Ollama with flux2-klein model)")
 @Timeout(180)
 public class SpringAiImageOllamaIT extends CamelTestSupport {
 

--- a/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-image/src/test/java/org/apache/camel/component/springai/image/SpringAiImageOllamaIT.java
+++ b/components/camel-spring-parent/camel-spring-ai/camel-spring-ai-image/src/test/java/org/apache/camel/component/springai/image/SpringAiImageOllamaIT.java
@@ -27,6 +27,7 @@ import com.openai.core.ClientOptions;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.test.infra.ollama.services.OllamaService;
+import org.apache.camel.test.infra.ollama.services.OllamaServiceConfiguration;
 import org.apache.camel.test.infra.ollama.services.OllamaServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.Test;
@@ -67,7 +68,18 @@ public class SpringAiImageOllamaIT extends CamelTestSupport {
     Path tempDir;
 
     @RegisterExtension
-    static OllamaService OLLAMA = OllamaServiceFactory.createSingletonService();
+    static OllamaService OLLAMA = OllamaServiceFactory.createSingletonServiceWithConfiguration(
+            new OllamaServiceConfiguration() {
+                @Override
+                public String modelName() {
+                    return IMAGE_MODEL_NAME;
+                }
+
+                @Override
+                public String apiKey() {
+                    return "unused";
+                }
+            });
 
     private ImageModel imageModel;
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4546,6 +4546,40 @@
             </build>
         </profile>
         <profile>
+            <!-- Propagate ci.env.name to forked surefire/failsafe JVMs so that
+                 @DisabledIfSystemProperty(named = "ci.env.name") conditions work correctly.
+                 Maven does not automatically forward user properties to forked test JVMs; this
+                 profile ensures the property is available when it is set (e.g. in MVND_OPTS). -->
+            <id>ci-env-name</id>
+            <activation>
+                <property>
+                    <name>ci.env.name</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration combine.children="merge">
+                            <systemPropertyVariables>
+                                <ci.env.name>${ci.env.name}</ci.env.name>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration combine.children="merge">
+                            <systemPropertyVariables>
+                                <ci.env.name>${ci.env.name}</ci.env.name>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>nullcheck</id>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
## Summary

- Fixes \`camel-spring-ai-image\` and \`camel-docling\` CI failures by switching the skip condition from \`@DisabledIfSystemProperty(named = \"ci.env.name\")\` to \`@DisabledIfEnvironmentVariable(named = \"CI\", matches = \"true\")\`
- Also propagates \`ci.env.name\` to forked surefire/failsafe JVMs via a new Maven profile in \`parent/pom.xml\` (helps the 99+ other test files using this pattern)
- Fixes \`SpringAiImageOllamaIT\` to pull \`x/flux2-klein:4b\` (the actual image model) rather than the default chat model

## Root cause

The \`regen.sh\` step in CI runs \`./mvnw\` (Maven Wrapper), **not** \`mvnd\`. \`MVND_OPTS\` (which carries \`-Dci.env.name=github.com\`) is specific to the Maven Daemon and is **not** applied when running \`mvnw\`. As a result, \`@DisabledIfSystemProperty(named = \"ci.env.name\")\` never fired during the regen phase — the IT tests ran instead of being skipped, and failed because they require a running Ollama/Docling container.

Switching to \`@DisabledIfEnvironmentVariable(named = \"CI\", matches = \"true\")\` works because GitHub Actions sets \`CI=true\` as an actual OS environment variable in **every** step (including the regen step), and env vars are inherited by all child processes — \`./mvnw\`, forked JVMs, and everything else.

## Test plan

- [ ] CI should show \`SpringAiImageOllamaIT\` and the camel-docling ITs as skipped (not failed)
- [ ] Locally (without \`CI=true\`), tests with this annotation still run as expected

_Claude Code on behalf of davsclaus_