### PR TITLE
Revert "chore(deps): Bump maven-surefire-plugin-version from 3.5.6 to 3.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <maven-javadoc-plugin-version>3.12.0</maven-javadoc-plugin-version>
         <maven-release-plugin-version>3.3.1</maven-release-plugin-version>
         <maven-remote-resources-plugin-version>3.3.0</maven-remote-resources-plugin-version>
-        <maven-surefire-plugin-version>3.6.0</maven-surefire-plugin-version>
+        <maven-surefire-plugin-version>3.5.6</maven-surefire-plugin-version>
         <templating-maven-plugin-version>3.1.0</templating-maven-plugin-version>
         <versions-maven-plugin-version>2.21.0</versions-maven-plugin-version>
 


### PR DESCRIPTION
Reverts apache/camel#26127

```
Caused by: org.apache.maven.plugin.MojoExecutionException: Surefire is not compatible with JUnit 4.11 or older. Project version is 4.7
	
    at org.apache.maven.plugin.surefire.AbstractSurefireMojo$JUnitPlatformProviderInfo.getProviderClasspath (AbstractSurefireMojo.java:3224)
```

due to compnent camel-drill:
drill-jdbc 1.22.0 -> dril-common 1.22.0 -> msgpack 0.6.6 -> json-simple 1.1.1 -> junit 4.10

the json-simpe; has been removed from dependencies of msgpack in 0.7 https://github.com/msgpack/msgpack-java/wiki/QuickStart-for-msgpack-java-0.6.x-(obsolete)
but drill-common still has msgpack 0.6.6 https://github.com/apache/drill/blob/f69d5bf20f41cc29d12d81545597e1410da6d416/pom.xml#L130 which is at least 2 years old and also mention junit 4 https://github.com/apache/drill/blame/f69d5bf20f41cc29d12d81545597e1410da6d416/pom.xml#L111 (but should be only test dependencies)

reverting for now as the PR was failing also for another test (spring-ai-image) to let time to investigate correctly
