### PR TITLE
CAMEL-24622: docs - add the infinispan recovery note to the 4.22 and 4.18 upgrade guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -127,6 +127,24 @@ The option was declared and documented but never read, so it had no effect. `jso
 the response MIME type of the request to `application/json`, so the model is asked to answer with
 JSON. The default `false` leaves the request untouched.
 
+=== camel-infinispan - the aggregation repository keeps completed exchanges for recovery
+
+`InfinispanAggregationRepository` implements `RecoverableAggregationRepository`, but it had no recovery
+store: `remove` deleted the completed exchange outright, `confirm` removed the exchange id from a cache
+keyed by correlation key, and `scan` returned the correlation keys of the aggregations still in progress.
+The recovery task therefore re-delivered aggregations that were still accumulating, marked them
+`CamelRedelivered`, and sent them to the dead letter channel once `maximumRedeliveries` was reached, while
+exchanges that genuinely failed after completion could never be recovered.
+
+A completed exchange is now kept in the same cache under a `camel-recovery:<exchange id>` key until it is
+confirmed, which is what `scan` reports and `recover` reads. `getKeys` continues to report only the
+aggregations in progress.
+
+Routes that set `useRecovery=false` are unaffected. Routes that left recovery enabled, which is the
+default, stop seeing in-progress aggregations re-delivered, and start seeing genuine recovery. The cache
+now also holds one entry per completed and not yet confirmed exchange; those entries are removed on
+confirmation.
+
 == Upgrading from 4.18.3 to 4.18.4
 
 === camel-core - Multicast EIP honors UseOriginalAggregationStrategy

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -127,6 +127,24 @@ from("spring-redis://localhost:6379?command=SUBSCRIBE&channels=myChannel"
 Setting the `serializer` option to a custom `RedisSerializer` bypasses the filter entirely, since
 Camel then no longer controls how the payload is read.
 
+=== camel-infinispan - the aggregation repository keeps completed exchanges for recovery
+
+`InfinispanAggregationRepository` implements `RecoverableAggregationRepository`, but it had no recovery
+store: `remove` deleted the completed exchange outright, `confirm` removed the exchange id from a cache
+keyed by correlation key, and `scan` returned the correlation keys of the aggregations still in progress.
+The recovery task therefore re-delivered aggregations that were still accumulating, marked them
+`CamelRedelivered`, and sent them to the dead letter channel once `maximumRedeliveries` was reached, while
+exchanges that genuinely failed after completion could never be recovered.
+
+A completed exchange is now kept in the same cache under a `camel-recovery:<exchange id>` key until it is
+confirmed, which is what `scan` reports and `recover` reads. `getKeys` continues to report only the
+aggregations in progress.
+
+Routes that set `useRecovery=false` are unaffected. Routes that left recovery enabled, which is the
+default, stop seeing in-progress aggregations re-delivered, and start seeing genuine recovery. The cache
+now also holds one entry per completed and not yet confirmed exchange; those entries are removed on
+confirmation.
+
 == Upgrading Camel 4.21 to 4.22
 
 === camel-tika


### PR DESCRIPTION
Follow-up to #26115 (CAMEL-24622) and its backports #26140 (`camel-4.22.x`) and #26141 (`camel-4.18.x`),
all merged.

Each backport added the upgrade note to the guide **on its own branch**, so `camel-4.22.x` and
`camel-4.18.x` describe the change correctly. The guides for every release line are also kept on `main` as
the canonical history, and there the note was missing — so `main`'s `camel-4x-upgrade-guide-4_22.adoc` and
`camel-4x-upgrade-guide-4_18.adoc` did not describe what 4.22.1 and 4.18.5 actually change.

Same text as the branches, so the three copies agree. One difference on purpose: on the branches the note
was appended at the end of the file, which puts it under the oldest section (`Upgrading Camel 4.21 to 4.22`
/ `4.17 to 4.18`); here it is placed under the patch section the change ships in — `Upgrading from 4.22.0 to
4.22.1` and `Upgrading from 4.18.4 to 4.18.5`.

Documentation only.

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
