### PR TITLE
[backport camel-4.18.x] CAMEL-24605: align FopProducer XML transformation with Camel's standard secure XML processing configuration

### DIFF
--- a/components/camel-fop/src/main/java/org/apache/camel/component/fop/FopProducer.java
+++ b/components/camel-fop/src/main/java/org/apache/camel/component/fop/FopProducer.java
@@ -92,6 +92,17 @@ public class FopProducer extends DefaultProducer {
         Fop fop = fopFactory.newFop(outputFormat, userAgent, out);
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+        // align with Camel's standard secure XML processing: do not allow access to external DTD/stylesheet
+        try {
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        } catch (Exception e) {
+            // ignore if the factory does not support the attribute
+        }
+        try {
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (Exception e) {
+            // ignore if the factory does not support the attribute
+        }
         Transformer transformer = transformerFactory.newTransformer();
 
         Result res = new SAXResult(fop.getDefaultHandler());

--- a/components/camel-fop/src/test/java/org/apache/camel/component/fop/FopExternalEntityTest.java
+++ b/components/camel-fop/src/test/java/org/apache/camel/component/fop/FopExternalEntityTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.fop;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that the FOP producer configures its {@code TransformerFactory} to not resolve external DTDs/stylesheets,
+ * consistent with Camel's standard secure XML processing configuration.
+ */
+public class FopExternalEntityTest extends CamelTestSupport {
+
+    @Test
+    public void externalDtdIsNotResolved(@TempDir Path tempDir) throws IOException {
+        // the referenced DTD exists and is perfectly readable, so the transformation would succeed if the
+        // producer resolved it. The failure below therefore proves the external DTD was never fetched, without
+        // depending on the wording of the JDK error message (which differs across JDK releases)
+        Path dtd = tempDir.resolve("external.dtd");
+        Files.writeString(dtd, "<!ELEMENT fo:root ANY>\n");
+
+        String body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                      + "<!DOCTYPE fo:root SYSTEM \"" + dtd.toUri() + "\">\n"
+                      + FopHelper.decorateTextWithXSLFO("Hello");
+
+        assertThrows(CamelExecutionException.class, () -> template.sendBody("direct:start", body));
+    }
+
+    @Test
+    public void documentWithoutExternalDtdIsRendered() {
+        // guards the test above from passing for the wrong reason: the very same document renders fine as long
+        // as it does not point at an external DTD
+        assertDoesNotThrow(() -> template.sendBody("direct:start", FopHelper.decorateTextWithXSLFO("Hello")));
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start")
+                        .to("fop:pdf")
+                        .to("mock:result");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Backport of #26108

Cherry-pick of #26108 onto `camel-4.18.x`.

**Original PR:** #26108 - CAMEL-24605: align FopProducer XML transformation with Camel's standard secure XML processing configuration
**Original author:** @oscerd
**Target branch:** `camel-4.18.x`

### Original description

`FopProducer` builds a `javax.xml.transform.TransformerFactory` that only enables `FEATURE_SECURE_PROCESSING` before transforming the incoming message body. This change also sets `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_STYLESHEET` to empty strings, matching the secure XML processing pattern used in `XmlConverter` and elsewhere in Camel.

A new `FopExternalEntityTest` verifies the restriction is enforced using a real, readable DTD in a `@TempDir` — failure proves the access was blocked rather than relying on JDK error message text.

**Note:** The test import was adjusted from `junit6` to `junit5` (`org.apache.camel.test.junit5.CamelTestSupport`) to match the test base class available on the `camel-4.18.x` branch.