### PR TITLE
CAMEL-24600: Fix flaky test JmsConcurrentConsumerInOnlyTest.testConcurrentConsumers

### DIFF
--- a/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsConcurrentConsumerInOnlyTest.java
+++ b/components/camel-jms/src/test/java/org/apache/camel/component/jms/issues/JmsConcurrentConsumerInOnlyTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.component.jms.issues;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.jms.ConnectionFactory;
 
 import org.apache.camel.CamelContext;
@@ -50,7 +52,7 @@ public class JmsConcurrentConsumerInOnlyTest extends CamelTestSupport {
 
         context.getRouteController().startAllRoutes();
 
-        MockEndpoint.assertIsSatisfied(context);
+        MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
## Problem

`JmsConcurrentConsumerInOnlyTest.testConcurrentConsumers` is flaky — it has failed 13 times in 90 days, always on s390x.

The test sends 2000 messages to a JMS queue through concurrent consumers (2-5) with random 0-10ms delays per message, then calls `MockEndpoint.assertIsSatisfied(context)` with no explicit timeout. This falls back to the default 10-second `waitForCompleteLatch`, which is insufficient on slow architectures (s390x, aarch64) or under CI load.

## Fix

Replace `MockEndpoint.assertIsSatisfied(context)` with `MockEndpoint.assertIsSatisfied(context, 30, TimeUnit.SECONDS)` to use an explicit 30-second timeout.

This is consistent with `JmsDefaultTaskExecutorTypeTest` in the same module, which already uses `MockEndpoint.assertIsSatisfied(context, 40, TimeUnit.SECONDS)`.

JIRA: https://issues.apache.org/jira/browse/CAMEL-24600

_AI agent (Hermes on behalf of gnodet)_