### PR TITLE
CAMEL-24640: Fix flaky MasterQuartzEndpointIT

### DIFF
--- a/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/MasterQuartzEndpointIT.java
+++ b/components/camel-zookeeper-master/src/test/java/org/apache/camel/component/zookeepermaster/MasterQuartzEndpointIT.java
@@ -16,12 +16,15 @@
  */
 package org.apache.camel.component.zookeepermaster;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.infra.zookeeper.services.ZooKeeperService;
 import org.apache.camel.test.infra.zookeeper.services.ZooKeeperServiceFactory;
 import org.apache.camel.test.spring.junit6.CamelSpringTest;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +44,15 @@ public class MasterQuartzEndpointIT {
 
     @Test
     public void testEndpoint() throws Exception {
+        // Wait for the master election to complete before expecting messages
+        MasterConsumer masterConsumer
+                = (MasterConsumer) camelContext.getRoute("zookeeper-master-quartz").getConsumer();
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> masterConsumer.isMaster() && masterConsumer.isConnected());
+
         resultEndpoint.expectedMinimumMessageCount(2);
+        // Allow enough time for at least 2 quartz cron fires (every 2 seconds)
+        resultEndpoint.setResultWaitTime(TimeUnit.SECONDS.toMillis(30));
 
         MockEndpoint.assertIsSatisfied(camelContext);
     }

--- a/components/camel-zookeeper-master/src/test/resources/org/apache/camel/component/zookeepermaster/MasterQuartzEndpointIT-context.xml
+++ b/components/camel-zookeeper-master/src/test/resources/org/apache/camel/component/zookeepermaster/MasterQuartzEndpointIT-context.xml
@@ -40,7 +40,7 @@
   </bean>
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" depends-on="curator">
-    <route>
+    <route id="zookeeper-master-quartz">
       <from uri="zookeeper-master:master-000:quartz://masterTest?cron=0/2+0/1+*+1/1+*+?+*"/>
       <to uri="mock:results"/>
     </route>


### PR DESCRIPTION
## Problem

`MasterQuartzEndpointIT` is flaky because it asserts `expectedMinimumMessageCount(2)` with only the default 10-second wait time. The startup chain (ZooKeeper container → Curator connection (3s timeout) → master election → quartz scheduler init → first cron fire) can easily exceed 10 seconds under CI load, causing the test to fail intermittently.

The sibling test `MasterEndpointIT` already handles this correctly by waiting for master election with Awaitility before proceeding.

## Fix

- **Wait for master election**: Added `Awaitility.await()` to wait until `masterConsumer.isMaster() && masterConsumer.isConnected()` before setting mock expectations, consistent with `MasterEndpointIT`.
- **Increase `resultWaitTime`**: Set to 30 seconds (from default 10s) to give enough time for ≥2 quartz cron fires (every 2 seconds) after election completes.
- **Add route id**: Added `id="zookeeper-master-quartz"` to the XML route definition for clean consumer access (previously the route had no id).

## Testing

- `MasterQuartzEndpointIT` passes consistently.
- `MasterEndpointIT` (sibling test) still passes — no regressions.

_AI agent (Hermes on behalf of gnodet)_