### PR TITLE
CAMEL-24648: camel-openai - add storeFullResponse tests for audio operations and document it for embeddings/audio

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/openai-operations.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/openai-operations.adoc
@@ -168,6 +168,8 @@ The following headers are set after an embeddings request:
 | `CamelOpenAISimilarityScore` | Double | Cosine similarity (if reference embedding provided)
 |===
 
+Set `storeFullResponse=true` to keep the complete SDK response in the `CamelOpenAIEmbeddingsResponse` exchange property.
+
 == Moderation Operation
 
 The `moderation` operation checks text against the OpenAI usage policies. It is the canonical pre-filter for untrusted
@@ -362,6 +364,8 @@ Supported audio formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.
 | `CamelOpenAIAudioDetectedLanguage` | String | Language detected in the audio (verbose_json only)
 |===
 
+Set `storeFullResponse=true` to keep the complete SDK response in the `CamelOpenAIAudioTranscriptionResponse` exchange property.
+
 === Audio Models by Provider
 
 [cols="1,2,3"]
@@ -500,6 +504,8 @@ NOTE: The translation operation always outputs English text, so it does not acce
 | `CamelOpenAIAudioDuration` | Double | Duration of the audio in seconds (verbose_json only)
 | `CamelOpenAIAudioDetectedLanguage` | String | Source language detected in the audio (verbose_json only)
 |===
+
+Set `storeFullResponse=true` to keep the complete SDK response in the `CamelOpenAIAudioTranslationResponse` exchange property.
 
 == Audio Speech (Text-to-Speech) Operation
 

--- a/components/camel-ai/camel-openai/src/main/docs/openai-operations.adoc
+++ b/components/camel-ai/camel-openai/src/main/docs/openai-operations.adoc
@@ -168,6 +168,8 @@ The following headers are set after an embeddings request:
 | `CamelOpenAISimilarityScore` | Double | Cosine similarity (if reference embedding provided)
 |===
 
+Set `storeFullResponse=true` to keep the complete SDK response in the `CamelOpenAIEmbeddingsResponse` exchange property.
+
 == Moderation Operation
 
 The `moderation` operation checks text against the OpenAI usage policies. It is the canonical pre-filter for untrusted
@@ -362,6 +364,8 @@ Supported audio formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.
 | `CamelOpenAIAudioDetectedLanguage` | String | Language detected in the audio (verbose_json only)
 |===
 
+Set `storeFullResponse=true` to keep the complete SDK response in the `CamelOpenAIAudioTranscriptionResponse` exchange property.
+
 === Audio Models by Provider
 
 [cols="1,2,3"]
@@ -500,6 +504,8 @@ NOTE: The translation operation always outputs English text, so it does not acce
 | `CamelOpenAIAudioDuration` | Double | Duration of the audio in seconds (verbose_json only)
 | `CamelOpenAIAudioDetectedLanguage` | String | Source language detected in the audio (verbose_json only)
 |===
+
+Set `storeFullResponse=true` to keep the complete SDK response in the `CamelOpenAIAudioTranslationResponse` exchange property.
 
 == Audio Speech (Text-to-Speech) Operation
 

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIAudioTranscriptionMockTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIAudioTranscriptionMockTest.java
@@ -64,6 +64,10 @@ public class OpenAIAudioTranscriptionMockTest extends CamelTestSupport {
                         .to("openai:audio-transcription?apiKey=dummy&baseUrl="
                             + openAIMock.getBaseUrl() + "/v1");
 
+                from("direct:transcribe-store-response")
+                        .to("openai:audio-transcription?audioModel=whisper-1&apiKey=dummy&storeFullResponse=true&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+
                 from("file:" + tempDir.toString() + "?noop=true&initialDelay=0&delay=100")
                         .to("openai:audio-transcription?audioModel=whisper-1&apiKey=dummy&baseUrl="
                             + openAIMock.getBaseUrl() + "/v1")
@@ -155,5 +159,18 @@ public class OpenAIAudioTranscriptionMockTest extends CamelTestSupport {
         assertNotNull(result.getException());
         assertTrue(result.getException() instanceof IllegalArgumentException);
         assertTrue(result.getException().getMessage().contains("Audio model must be specified"));
+    }
+
+    @Test
+    void storeFullResponseStoresTranscriptionResponse() {
+        byte[] audioBytes = new byte[] { 0x00, 0x01, 0x02 };
+
+        Exchange result = template.request("direct:transcribe-store-response", e -> e.getIn().setBody(audioBytes));
+
+        assertNull(result.getException());
+        assertNotNull(result.getProperty(OpenAIConstants.AUDIO_TRANSCRIPTION_RESPONSE),
+                "storeFullResponse=true must store the full transcription response in the CamelOpenAIAudioTranscriptionResponse property");
+        assertNull(result.getProperty(OpenAIConstants.RESPONSE),
+                "the transcription response must not be stored under the chat-completion CamelOpenAIResponse property");
     }
 }

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIAudioTranslationMockTest.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/OpenAIAudioTranslationMockTest.java
@@ -61,6 +61,10 @@ public class OpenAIAudioTranslationMockTest extends CamelTestSupport {
                         .to("openai:audio-translation?apiKey=dummy&baseUrl="
                             + openAIMock.getBaseUrl() + "/v1");
 
+                from("direct:translate-store-response")
+                        .to("openai:audio-translation?audioModel=whisper-1&apiKey=dummy&storeFullResponse=true&baseUrl="
+                            + openAIMock.getBaseUrl() + "/v1");
+
                 from("file:" + tempDir.toString() + "?noop=true&initialDelay=0&delay=100")
                         .to("openai:audio-translation?audioModel=whisper-1&apiKey=dummy&baseUrl="
                             + openAIMock.getBaseUrl() + "/v1")
@@ -152,5 +156,20 @@ public class OpenAIAudioTranslationMockTest extends CamelTestSupport {
         assertThat(result.getException())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Audio model must be specified");
+    }
+
+    @Test
+    void storeFullResponseStoresTranslationResponse() {
+        byte[] audioBytes = new byte[] { 0x00, 0x01, 0x02 };
+
+        Exchange result = template.request("direct:translate-store-response", e -> e.getIn().setBody(audioBytes));
+
+        assertThat(result.getException()).isNull();
+        assertThat(result.getProperty(OpenAIConstants.AUDIO_TRANSLATION_RESPONSE))
+                .as("storeFullResponse=true must store the full translation response under CamelOpenAIAudioTranslationResponse")
+                .isNotNull();
+        assertThat(result.getProperty(OpenAIConstants.RESPONSE))
+                .as("the translation response must not be stored under the chat-completion CamelOpenAIResponse property")
+                .isNull();
     }
 }


### PR DESCRIPTION
## Issue
[CAMEL-24648](https://issues.apache.org/jira/browse/CAMEL-24648)

## Context
Follow-up to [CAMEL-24539](https://issues.apache.org/jira/browse/CAMEL-24539) / #26110, which moved the
embeddings and audio full responses to operation-specific exchange properties. That PR merged before the
review feedback below was addressed, so this PR lands it.

## Changes
- **Tests** — add `storeFullResponse` coverage to `OpenAIAudioTranscriptionMockTest` and
  `OpenAIAudioTranslationMockTest`, each asserting the full response lands under the operation-specific
  property (`CamelOpenAIAudioTranscriptionResponse` / `CamelOpenAIAudioTranslationResponse`) and is
  **not** set under the chat-completion `CamelOpenAIResponse` — the exact regression class CAMEL-24539
  fixed.
- **Docs** — `openai-operations.adoc` now documents `storeFullResponse` for the embeddings, audio
  transcription and audio translation operations, mirroring the image operation.

Test-and-docs only; no production code change.

## Testing
- `OpenAIAudioTranscriptionMockTest` and `OpenAIAudioTranslationMockTest` green (8 tests each).
- `mvn -Psourcecheck validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)