### PR TITLE
CAMEL-24427: camel-servlet, camel-jetty - enforce fileNameExtWhitelist on the submitted file name

### DIFF
--- a/components/camel-jetty/src/main/java/org/apache/camel/component/jetty12/AttachmentHttpBinding.java
+++ b/components/camel-jetty/src/main/java/org/apache/camel/component/jetty12/AttachmentHttpBinding.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.Map;
 
 import jakarta.activation.DataHandler;
@@ -37,6 +38,7 @@ import org.apache.camel.attachment.DefaultAttachmentMessage;
 import org.apache.camel.component.jetty.MultiPartFilter;
 import org.apache.camel.http.common.DefaultHttpBinding;
 import org.apache.camel.http.common.HttpHelper;
+import org.apache.camel.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +61,16 @@ final class AttachmentHttpBinding extends DefaultHttpBinding {
             try {
                 parts = request.getParts();
                 for (Part part : parts) {
+                    // the whitelist accepts file name extensions, so it must be checked against the submitted
+                    // file name and not against Part.getName(), which is the multipart field name
+                    String fileName = part.getSubmittedFileName();
+                    if (!isFileNameAccepted(fileName)) {
+                        LOG.debug(
+                                "Cannot add file as attachment: {} because the file is not accepted according to fileNameExtWhitelist: {}",
+                                fileName, getFileNameExtWhitelist());
+                        continue;
+                    }
+
                     DataSource ds = new PartDataSource(part);
                     Attachment attachment = new DefaultAttachment(ds);
                     for (String headerName : part.getHeaderNames()) {
@@ -67,21 +79,40 @@ final class AttachmentHttpBinding extends DefaultHttpBinding {
                         }
                     }
                     AttachmentMessage am = new DefaultAttachmentMessage(message);
-                    am.addAttachmentObject(part.getName(), attachment);
-                    String name = part.getSubmittedFileName();
-                    Object value = am.getAttachment(name);
-                    Map<String, Object> headers = message.getHeaders();
-                    if (getHeaderFilterStrategy() != null
-                            && !getHeaderFilterStrategy().applyFilterToExternalHeaders(name, value, message.getExchange())
-                            && name != null) {
-                        HttpHelper.appendHeader(headers, name, value);
+                    String name = part.getName();
+                    am.addAttachmentObject(name, attachment);
+                    // a file part is also exposed as a header carrying the DataHandler. The attachment is keyed on
+                    // the multipart field name, so the header must be looked up and named by that same key and not
+                    // by the client supplied file name. A plain form field carries no file name and is mapped by
+                    // populateRequestParameters instead, so it is left alone here.
+                    if (fileName != null && name != null) {
+                        Object value = am.getAttachment(name);
+                        Map<String, Object> headers = message.getHeaders();
+                        if (getHeaderFilterStrategy() != null
+                                && !getHeaderFilterStrategy().applyFilterToExternalHeaders(name, value,
+                                        message.getExchange())) {
+                            HttpHelper.appendHeader(headers, name, value);
+                        }
                     }
-
                 }
             } catch (Exception e) {
                 throw new RuntimeCamelException("Cannot populate attachments", e);
             }
         }
+    }
+
+    private boolean isFileNameAccepted(String fileName) {
+        String whitelist = getFileNameExtWhitelist();
+        if (whitelist == null) {
+            return true;
+        }
+        String ext = FileUtil.onlyExt(fileName);
+        if (ext == null) {
+            return true;
+        }
+        ext = ext.toLowerCase(Locale.US);
+        whitelist = whitelist.toLowerCase(Locale.US);
+        return whitelist.equals("*") || whitelist.contains(ext);
     }
 
     @Override

--- a/components/camel-jetty/src/main/java/org/apache/camel/component/jetty12/AttachmentHttpBinding.java
+++ b/components/camel-jetty/src/main/java/org/apache/camel/component/jetty12/AttachmentHttpBinding.java
@@ -67,7 +67,7 @@ final class AttachmentHttpBinding extends DefaultHttpBinding {
                     if (!isFileNameAccepted(fileName)) {
                         LOG.debug(
                                 "Cannot add file as attachment: {} because the file is not accepted according to fileNameExtWhitelist: {}",
-                                fileName, getFileNameExtWhitelist());
+                                HttpHelper.sanitizeLog(fileName), getFileNameExtWhitelist());
                         continue;
                     }
 
@@ -112,7 +112,17 @@ final class AttachmentHttpBinding extends DefaultHttpBinding {
         }
         ext = ext.toLowerCase(Locale.US);
         whitelist = whitelist.toLowerCase(Locale.US);
-        return whitelist.equals("*") || whitelist.contains(ext);
+        if (whitelist.equals("*")) {
+            return true;
+        }
+        // compare against each comma-separated extension exactly, not as a substring: a whitelist of "txt"
+        // must not accept an upload named "evil.x" just because "txt".contains("x")
+        for (String allowed : whitelist.split(",")) {
+            if (allowed.trim().equals(ext)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormFileNameExtWhitelistTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormFileNameExtWhitelistTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.jetty;
+
+import java.io.File;
+
+import jakarta.activation.DataHandler;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.attachment.AttachmentMessage;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The uploaded part carries the multipart field name {@code upload} and the submitted file name
+ * {@code log4j2.properties}. The two differ, which is what tells the field name apart from the file name in both the
+ * whitelist check and the header that exposes the attachment.
+ */
+public class MultiPartFormFileNameExtWhitelistTest extends BaseJettyTest {
+
+    private static final String FIELD_NAME = "upload";
+    private static final String FILE_NAME = "log4j2.properties";
+
+    @Test
+    public void testUploadAcceptedWhenExtensionIsWhitelisted() {
+        // the attachment is keyed on the field name, and so is the header that exposes it. The client supplied
+        // file name must not become a header name.
+        assertThat(upload("/allowed")).isEqualTo("attachment=true,headerIsAttachment=true,fileNameHeader=false");
+    }
+
+    @Test
+    public void testUploadRejectedWhenExtensionIsNotWhitelisted() {
+        assertThat(upload("/rejected")).isEqualTo("attachment=false,headerIsAttachment=false,fileNameHeader=false");
+    }
+
+    private String upload(String path) {
+        File file = new File("src/test/resources/log4j2.properties");
+        HttpEntity entity = MultipartEntityBuilder.create()
+                .addBinaryBody(FIELD_NAME, file, ContentType.APPLICATION_OCTET_STREAM, FILE_NAME)
+                .build();
+        return template.requestBody("http://localhost:" + getPort() + path, entity, String.class);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                getContext().getGlobalOptions().put("CamelJettyTempDir", "target");
+
+                from(whitelisted("/allowed", "properties"))
+                        .process(MultiPartFormFileNameExtWhitelistTest::reportAttachment);
+                from(whitelisted("/rejected", "pdf"))
+                        .process(MultiPartFormFileNameExtWhitelistTest::reportAttachment);
+            }
+
+            private JettyHttpEndpoint whitelisted(String path, String whitelist) {
+                // the whitelist is not exposed as a jetty endpoint option, it is configured on the binding
+                JettyHttpEndpoint endpoint = getContext().getEndpoint(
+                        "jetty://http://localhost:" + getPort() + path, JettyHttpEndpoint.class);
+                endpoint.getHttpBinding().setFileNameExtWhitelist(whitelist);
+                return endpoint;
+            }
+        };
+    }
+
+    private static void reportAttachment(Exchange exchange) {
+        AttachmentMessage in = exchange.getIn(AttachmentMessage.class);
+        DataHandler attachment = in.getAttachment(FIELD_NAME);
+        Object headerByField = in.getHeader(FIELD_NAME);
+        exchange.getMessage().setBody("attachment=" + (attachment != null)
+                                      + ",headerIsAttachment=" + (attachment != null && headerByField == attachment)
+                                      + ",fileNameHeader=" + (in.getHeader(FILE_NAME) != null));
+    }
+}

--- a/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormFileNameExtWhitelistTest.java
+++ b/components/camel-jetty/src/test/java/org/apache/camel/component/jetty/MultiPartFormFileNameExtWhitelistTest.java
@@ -52,6 +52,12 @@ public class MultiPartFormFileNameExtWhitelistTest extends BaseJettyTest {
         assertThat(upload("/rejected")).isEqualTo("attachment=false,headerIsAttachment=false,fileNameHeader=false");
     }
 
+    @Test
+    public void testUploadRejectedWhenExtensionIsOnlyASubstringOfTheWhitelist() {
+        // "propertiesx".contains("properties") is true, but exact matching must reject the upload
+        assertThat(upload("/substring")).isEqualTo("attachment=false,headerIsAttachment=false,fileNameHeader=false");
+    }
+
     private String upload(String path) {
         File file = new File("src/test/resources/log4j2.properties");
         HttpEntity entity = MultipartEntityBuilder.create()
@@ -69,6 +75,8 @@ public class MultiPartFormFileNameExtWhitelistTest extends BaseJettyTest {
                 from(whitelisted("/allowed", "properties"))
                         .process(MultiPartFormFileNameExtWhitelistTest::reportAttachment);
                 from(whitelisted("/rejected", "pdf"))
+                        .process(MultiPartFormFileNameExtWhitelistTest::reportAttachment);
+                from(whitelisted("/substring", "propertiesx"))
                         .process(MultiPartFormFileNameExtWhitelistTest::reportAttachment);
             }
 

--- a/components/camel-servlet/pom.xml
+++ b/components/camel-servlet/pom.xml
@@ -70,6 +70,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
             <scope>test</scope>

--- a/components/camel-servlet/pom.xml
+++ b/components/camel-servlet/pom.xml
@@ -70,11 +70,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
             <scope>test</scope>

--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/AttachmentHttpBinding.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/AttachmentHttpBinding.java
@@ -54,7 +54,9 @@ public final class AttachmentHttpBinding extends DefaultHttpBinding {
         try {
             Collection<Part> parts = request.getParts();
             for (Part part : parts) {
-                String fileName = part.getName();
+                // the whitelist accepts file name extensions, so it must be checked against the submitted file
+                // name and not against Part.getName(), which is the multipart field name
+                String fileName = part.getSubmittedFileName();
                 // is the file name accepted
                 boolean accepted = true;
                 if (getFileNameExtWhitelist() != null) {

--- a/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/AttachmentHttpBinding.java
+++ b/components/camel-servlet/src/main/java/org/apache/camel/component/servlet/AttachmentHttpBinding.java
@@ -33,6 +33,7 @@ import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.attachment.DefaultAttachment;
 import org.apache.camel.attachment.DefaultAttachmentMessage;
 import org.apache.camel.http.common.DefaultHttpBinding;
+import org.apache.camel.http.common.HttpHelper;
 import org.apache.camel.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,9 +65,7 @@ public final class AttachmentHttpBinding extends DefaultHttpBinding {
                     if (ext != null) {
                         ext = ext.toLowerCase(Locale.US);
                         String whiteList = getFileNameExtWhitelist().toLowerCase(Locale.US);
-                        if (!whiteList.equals("*") && !whiteList.contains(ext)) {
-                            accepted = false;
-                        }
+                        accepted = whiteList.equals("*") || isExtWhitelisted(whiteList, ext);
                     }
                 }
 
@@ -83,12 +82,23 @@ public final class AttachmentHttpBinding extends DefaultHttpBinding {
                 } else {
                     LOG.debug(
                             "Cannot add file as attachment: {} because the file is not accepted according to fileNameExtWhitelist: {}",
-                            fileName, getFileNameExtWhitelist());
+                            HttpHelper.sanitizeLog(fileName), getFileNameExtWhitelist());
                 }
             }
         } catch (Exception e) {
             throw new RuntimeCamelException("Cannot populate attachments", e);
         }
+    }
+
+    // compare against each comma-separated extension exactly, not as a substring: a whitelist of "txt"
+    // must not accept an upload named "evil.x" just because "txt".contains("x")
+    private static boolean isExtWhitelisted(String whitelist, String ext) {
+        for (String allowed : whitelist.split(",")) {
+            if (allowed.trim().equals(ext)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public final class PartDataSource implements DataSource {

--- a/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/MultipartUploadFileNameExtWhitelistTest.java
+++ b/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/MultipartUploadFileNameExtWhitelistTest.java
@@ -28,7 +28,7 @@ import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.builder.RouteBuilder;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The test harness posts a part whose multipart field name is {@code file} and whose submitted file name is
@@ -45,12 +45,18 @@ public class MultipartUploadFileNameExtWhitelistTest extends ServletCamelRouterT
 
     @Test
     void testUploadAcceptedWhenExtensionIsWhitelisted() throws IOException {
-        assertThat(upload("allowed")).isEqualTo("accepted");
+        assertEquals("accepted", upload("allowed"));
     }
 
     @Test
     void testUploadRejectedWhenExtensionIsNotWhitelisted() throws IOException {
-        assertThat(upload("rejected")).isEqualTo("no attachment");
+        assertEquals("no attachment", upload("rejected"));
+    }
+
+    @Test
+    void testUploadRejectedWhenExtensionIsOnlyASubstringOfTheWhitelist() throws IOException {
+        // the whitelist "txtdoc" must not accept a "test.txt" upload just because "txtdoc".contains("txt")
+        assertEquals("no attachment", upload("substring"));
     }
 
     private String upload(String path) throws IOException {
@@ -69,6 +75,9 @@ public class MultipartUploadFileNameExtWhitelistTest extends ServletCamelRouterT
                         .process(MultipartUploadFileNameExtWhitelistTest::reportAttachment);
 
                 from("servlet:rejected?attachmentMultipartBinding=true&fileNameExtWhitelist=pdf")
+                        .process(MultipartUploadFileNameExtWhitelistTest::reportAttachment);
+
+                from("servlet:substring?attachmentMultipartBinding=true&fileNameExtWhitelist=txtdoc")
                         .process(MultipartUploadFileNameExtWhitelistTest::reportAttachment);
             }
         };

--- a/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/MultipartUploadFileNameExtWhitelistTest.java
+++ b/components/camel-servlet/src/test/java/org/apache/camel/component/servlet/MultipartUploadFileNameExtWhitelistTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.servlet;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import jakarta.servlet.MultipartConfigElement;
+
+import io.undertow.servlet.api.DeploymentInfo;
+import org.apache.camel.Exchange;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.attachment.AttachmentMessage;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The test harness posts a part whose multipart field name is {@code file} and whose submitted file name is
+ * {@code test.txt}. The field name carries no extension, so checking the whitelist against it never rejects anything.
+ */
+public class MultipartUploadFileNameExtWhitelistTest extends ServletCamelRouterTestSupport {
+
+    @Override
+    protected DeploymentInfo getDeploymentInfo() {
+        DeploymentInfo deploymentInfo = super.getDeploymentInfo();
+        deploymentInfo.setDefaultMultipartConfig(new MultipartConfigElement(System.getProperty("java.io.tmpdir")));
+        return deploymentInfo;
+    }
+
+    @Test
+    void testUploadAcceptedWhenExtensionIsWhitelisted() throws IOException {
+        assertThat(upload("allowed")).isEqualTo("accepted");
+    }
+
+    @Test
+    void testUploadRejectedWhenExtensionIsNotWhitelisted() throws IOException {
+        assertThat(upload("rejected")).isEqualTo("no attachment");
+    }
+
+    private String upload(String path) throws IOException {
+        InputStream body = context.getTypeConverter().convertTo(InputStream.class, "Hello World");
+        PostMethodWebRequest request = new PostMethodWebRequest(
+                contextUrl + "/services/" + path, body, "multipart/form-data; boundary=----Boundary");
+        return query(request).getText();
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("servlet:allowed?attachmentMultipartBinding=true&fileNameExtWhitelist=txt")
+                        .process(MultipartUploadFileNameExtWhitelistTest::reportAttachment);
+
+                from("servlet:rejected?attachmentMultipartBinding=true&fileNameExtWhitelist=pdf")
+                        .process(MultipartUploadFileNameExtWhitelistTest::reportAttachment);
+            }
+        };
+    }
+
+    private static void reportAttachment(Exchange exchange) {
+        AttachmentMessage message = exchange.getMessage(AttachmentMessage.class);
+        boolean present = message.getAttachment("file") != null;
+        exchange.getMessage().setBody(present ? "accepted" : "no attachment");
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1775,5 +1775,7 @@ again by the submitted file name, and passed that file name to `HttpHelper.appen
 therefore only succeeded when the two happened to be equal, and when it did the header was named by
 the client-supplied file name. The attachment is now looked up and exposed under the field name it is
 stored with, and only for parts that carry a file name — a plain form field is mapped by
-`populateRequestParameters` as before. A route that read the attachment header under the uploaded file
-name must read it under the multipart field name instead.
+`populateRequestParameters` as before. Because the old lookup by file name returned `null` whenever the
+two names differed, that header never carried a usable `DataHandler` in the first place; only when the
+names happened to be equal did it resolve, and then the name is unchanged. A route that expected the
+attachment header under the uploaded file name should read it under the multipart field name.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -1753,3 +1753,27 @@ custom `headerFilterStrategy` is used as-is and is unaffected.
 
 Routes that relied on one of those headers reaching the wire must set it through the endpoint
 configuration or supply a `headerFilterStrategy` that permits it.
+
+=== camel-servlet, camel-jetty - the multipart upload whitelist is enforced against the submitted file name
+
+`fileNameExtWhitelist` accepts file name extensions, but `camel-servlet`'s `AttachmentHttpBinding`
+checked it against `Part.getName()`, which is the multipart *field* name rather than the submitted
+file name. A field named `file` carries no extension, so the check found nothing to compare and every
+upload was accepted. The option is now checked against `Part.getSubmittedFileName()`, which is what
+`camel-platform-http-vertx` already does.
+
+A `camel-servlet` consumer that sets `fileNameExtWhitelist` together with `attachmentMultipartBinding=true`
+therefore starts rejecting uploads whose file extension is not listed, which is what the option always
+advertised. Uploads with no file name, such as plain form fields, are unaffected, and a route that does
+not set the option is unaffected. Review the configured extension list before upgrading.
+
+The `camel-jetty` binding performed no whitelist check at all, although `fileNameExtWhitelist` can be
+set on its `HttpBinding`. It now applies the same check.
+
+The `camel-jetty` binding also stored the attachment under the multipart field name but looked it up
+again by the submitted file name, and passed that file name to `HttpHelper.appendHeader`. The lookup
+therefore only succeeded when the two happened to be equal, and when it did the header was named by
+the client-supplied file name. The attachment is now looked up and exposed under the field name it is
+stored with, and only for parts that carry a file name — a plain form field is mapped by
+`populateRequestParameters` as before. A route that read the attachment header under the uploaded file
+name must read it under the multipart field name instead.


### PR DESCRIPTION
## Issue

[CAMEL-24427](https://issues.apache.org/jira/browse/CAMEL-24427)

## Problem

The three HTTP server components that accept multipart uploads disagreed about the upload filename check.

**camel-servlet** — `AttachmentHttpBinding.populateAttachments()` checked the whitelist against
`Part.getName()`:

```java
String fileName = part.getName();
if (getFileNameExtWhitelist() != null) {
    String ext = FileUtil.onlyExt(fileName);
```

`Part.getName()` is the multipart *field* name, not the submitted file name. A field named `file`
has no extension, so `FileUtil.onlyExt` returned `null`, `accepted` stayed `true`, and the whitelist
never rejected anything.

**camel-jetty** (`jetty12/AttachmentHttpBinding`) had no whitelist check at all, although
`fileNameExtWhitelist` can be set on its `HttpBinding`.

**camel-platform-http-vertx** checks `upload.fileName()` against the whitelist while keying the
attachment on `upload.name()` — the correct reference implementation, unchanged here.

### Second defect in the camel-jetty binding

```java
am.addAttachmentObject(part.getName(), attachment);
String name = part.getSubmittedFileName();
Object value = am.getAttachment(name);
```

The attachment is stored under the field name and then looked up by the submitted file name. The
lookup only succeeded when the two happened to be equal, and when it did, the header was named by
the client-supplied file name.

## Investigation

The block was added in `CAMEL-14105` (2019) when `MultiPartInputStreamParser` was replaced by
`request.getParts()`, to keep exposing multipart parts as headers. `MultiPartFormTest` locks the
intent in — it asserts `in.getHeader("log4j2.properties")` is the attachment's `DataHandler` — and
passes today only because `addBinaryBody(file.getName(), file)` makes the field name and the file
name identical.

`populateRequestParameters` runs **before** `populateAttachments` (`DefaultHttpBinding` lines 198 /
208) and already maps plain form fields to headers, and `HttpHelper.appendHeader` *appends*. Exposing
every part here would therefore have turned `MultiPartFormTest`'s `comment` header into a `List`. The
header exposure is consequently gated on the part carrying a file name.

## Fix

- `camel-servlet` — check `part.getSubmittedFileName()`.
- `camel-jetty` — apply the same check, extracted into `isFileNameAccepted`.
- `camel-jetty` — look the attachment up under the key it was stored with (`part.getName()`) and name
  the header after it, only for parts that carry a file name.

Attachment keying is unchanged in both components: still the multipart field name.

## Tests

- `MultipartUploadFileNameExtWhitelistTest` (camel-servlet) — the existing harness posts
  `name="file"; filename="test.txt"`, which is exactly the field-name vs file-name split. Asserts
  `fileNameExtWhitelist=txt` accepts and `fileNameExtWhitelist=pdf` rejects.
- `MultiPartFormFileNameExtWhitelistTest` (camel-jetty) — uploads with field name `upload` and file
  name `log4j2.properties` so the two differ. Asserts the whitelist accepts/rejects, that the header
  exposing the attachment is named by the field name, and that the file name does **not** become a
  header name.

Both verified failing before the change and passing after. Full module suites: camel-servlet 98/98,
camel-jetty 393/393 (including the existing `MultiPartForm*` tests). Full reactor build clean.

## Documentation

Behaviour change documented in `camel-4x-upgrade-guide-4_23.adoc` — a `camel-servlet` route that sets
`fileNameExtWhitelist` starts rejecting uploads it previously let through, and a route reading the
jetty attachment header under the uploaded file name must read it under the field name.

## Out of scope

`fileNameExtWhitelist` is not exposed as a `camel-jetty` component or endpoint option at all; it can
only be set programmatically on the binding. Adding the option is a separate change.

## Review follow-up

A second commit addresses review feedback:

- the client-controlled submitted file name is passed through `HttpHelper.sanitizeLog` before being
  logged, matching the convention already used elsewhere in these files and closing the CWE-117
  log-injection the raw value would introduce;
- the whitelist is matched per comma-separated extension **exactly** rather than with a substring
  test. The original `whiteList.contains(ext)` meant `fileNameExtWhitelist=txt` accepted an upload
  named `evil.x`, because `"txt".contains("x")`. A substring-bypass test was added in both modules;
- the new camel-servlet test uses JUnit assertions to match the module's existing style, and the
  `assertj-core` test dependency it had added was dropped;
- the upgrade-guide note was reworded so it no longer reads as removing working behaviour — the old
  file-name header lookup returned `null` whenever the field name and file name differed.

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
