### PR TITLE
CAMEL-24645: camel-opa - cover the bearerToken option with an integration test

### DIFF
--- a/components/camel-opa/src/test/java/org/apache/camel/component/opa/OpaBearerTokenIT.java
+++ b/components/camel-opa/src/test/java/org/apache/camel/component/opa/OpaBearerTokenIT.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.opa;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.test.infra.common.LocalPropertyResolver;
+import org.apache.camel.test.infra.opa.common.OpaProperties;
+import org.apache.camel.test.infra.opa.services.OpaLocalContainerInfraService;
+import org.apache.camel.test.infra.opa.services.OpaService;
+import org.apache.camel.test.infra.opa.services.OpaServiceFactory;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the {@code bearerToken} option actually authenticates against an OPA server that requires it.
+ * <p/>
+ * The server runs with {@code --authentication=token --authorization=basic} and the system authorization policy in
+ * {@code system-authz.rego}, so a request without the configured token is rejected by OPA rather than answered.
+ */
+public class OpaBearerTokenIT extends CamelTestSupport {
+
+    private static final String TOKEN = "s3cr3t-opa-token";
+    private static final String PATH = "authz/allow";
+
+    @RegisterExtension
+    static OpaService service = OpaServiceFactory.builder()
+            .addLocalMapping(() -> new AuthenticatingOpaService(authenticatingContainer()))
+            .addRemoteMapping(OpaServiceFactory.OpaRemoteTestService::new)
+            .build();
+
+    public static class AuthenticatingOpaService extends OpaLocalContainerInfraService implements OpaService {
+        public AuthenticatingOpaService(GenericContainer<?> container) {
+            super(container);
+        }
+    }
+
+    @SuppressWarnings("resource")
+    private static GenericContainer<?> authenticatingContainer() {
+        // the image comes from the test-infra container.properties, so it stays in one place
+        String image = LocalPropertyResolver.getProperty(
+                OpaLocalContainerInfraService.class, OpaProperties.OPA_CONTAINER);
+
+        return new GenericContainer<>(image) // NOSONAR
+                .withExposedPorts(OpaLocalContainerInfraService.OPA_PORT)
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource("system-authz.rego"), "/policies/system-authz.rego")
+                .withCommand("run", "--server", "--addr=0.0.0.0:" + OpaLocalContainerInfraService.OPA_PORT,
+                        "--authentication=token", "--authorization=basic", "/policies")
+                .waitingFor(Wait.forHttp("/health").forPort(OpaLocalContainerInfraService.OPA_PORT)
+                        .forStatusCode(200));
+    }
+
+    @BeforeAll
+    static void uploadPolicy() throws Exception {
+        String rego;
+        try (InputStream in = OpaBearerTokenIT.class.getResourceAsStream("/authz.rego")) {
+            rego = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        // uploading already requires the token, since the system authorization policy protects every endpoint
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create(service.getOpaUrl() + "/v1/policies/authz"))
+                        .header("Content-Type", "text/plain")
+                        .header("Authorization", "Bearer " + TOKEN)
+                        .PUT(HttpRequest.BodyPublishers.ofString(rego))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new IOException("Could not load the test policy into OPA: " + response.body());
+        }
+    }
+
+    @Test
+    void evaluatesThePolicyWhenTheTokenIsConfigured() {
+        Exchange out = template.request(
+                "opa:" + PATH + "?serverUrl=" + service.getOpaUrl() + "&bearerToken=" + TOKEN,
+                e -> e.getMessage().setHeader("user", "alice"));
+
+        assertThat(out.getException()).isNull();
+        assertThat(out.getMessage().getHeader(OpaConstants.DECISION_ALLOW)).isEqualTo(true);
+    }
+
+    @Test
+    void failsClosedWhenNoTokenIsConfigured() {
+        Exchange out = template.request(
+                "opa:" + PATH + "?serverUrl=" + service.getOpaUrl(),
+                e -> e.getMessage().setHeader("user", "alice"));
+
+        assertThat(out.getException()).isInstanceOf(OpaPolicyEvaluationException.class);
+        assertThat(out.getMessage().getHeader(OpaConstants.DECISION_ALLOW)).isNull();
+    }
+
+    @Test
+    void failsClosedWhenTheTokenIsWrong() {
+        Exchange out = template.request(
+                "opa:" + PATH + "?serverUrl=" + service.getOpaUrl() + "&bearerToken=not-the-token",
+                e -> e.getMessage().setHeader("user", "alice"));
+
+        assertThat(out.getException()).isInstanceOf(OpaPolicyEvaluationException.class);
+        assertThat(out.getMessage().getHeader(OpaConstants.DECISION_ALLOW)).isNull();
+    }
+}

--- a/components/camel-opa/src/test/resources/system-authz.rego
+++ b/components/camel-opa/src/test/resources/system-authz.rego
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# OPA system authorization policy used by OpaBearerTokenIT.
+#
+# The server is started with --authentication=token --authorization=basic, which makes OPA
+# evaluate data.system.authz.allow for every API request. input.identity is the bearer token
+# presented by the caller, so this policy is what turns the camel-opa bearerToken option into
+# something observable: without the right token, requests are rejected with 401.
+
+package system.authz
+
+default allow := false
+
+# The container wait strategy has no token to present, so let the health endpoint through.
+allow if {
+	input.path == ["health"]
+}
+
+# Everything else requires the token the test configures on the endpoint.
+allow if {
+	input.identity == "s3cr3t-opa-token"
+}


### PR DESCRIPTION
## What

Adds `OpaBearerTokenIT`, covering the `bearerToken` option against an OPA server that actually requires it.

## Why

`bearerToken` was exercised by no test at all. The unit tests inject a mocked `OPAClient`, which bypasses `OpaPolicyEvaluator.createClient` — the only place the token is applied — and `OpaIT` runs an unauthenticated OPA container, so nothing verified the token reaches the server as an `Authorization` header.

That is the wrong gap to leave in a security option: if it silently failed to be applied, a deployment would believe it was authenticating to its policy decision point when it was not, and every existing test would still pass.

## What changed

The new IT starts OPA with `--authentication=token --authorization=basic` plus a `system-authz.rego` system authorization policy, so the server genuinely rejects callers that do not present the token rather than ignoring the header. It asserts both directions:

- the configured token evaluates the policy and returns a decision;
- no token, and a wrong token, fail closed with `OpaPolicyEvaluationException` and no verdict header.

The positive case is the real assertion — it would fail outright if `bearerToken` were not wired through — and the two negatives prove the server is enforcing rather than allowing everything. Uploading the test policy also requires the token, which exercises it a second way.

Two things worth noting:

- **`camel-test-infra-opa` is unchanged.** It deliberately starts a plain server so it stays independent of any particular policy. The IT builds its own authenticating container and passes it to the existing `OpaLocalContainerInfraService(GenericContainer)` constructor, so the service's lifecycle and property registration are still reused. The image is resolved through `LocalPropertyResolver` + `OpaProperties.OPA_CONTAINER`, so the tag stays single-sourced in `container.properties` rather than being duplicated in a test.
- **The system policy lets `/health` through unauthenticated**, otherwise `--authorization=basic` would also protect it and the container's own Testcontainers wait strategy could never start the server.

## Testing

10 integration tests in the module (7 existing + 3 new), green against real OPA containers. Full reactor build green — as expected for a test-only change, it regenerated nothing.

`main` only — test-only.

_Claude Code on behalf of @oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
