### PR TITLE
ci: deploy camel-4.22.x snapshots to the ASF snapshot repository

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -97,8 +97,8 @@ pipeline {
             when {
                 anyOf {
                     branch 'main'
+                    branch 'camel-4.22.x'
                     branch 'camel-4.18.x'
-                    branch 'camel-4.14.x'
                 }
             }
             steps {


### PR DESCRIPTION
## Problem

Snapshots are not being published for the `camel-4.22.x` branch. `4.22.1-SNAPSHOT` is a 404 in the ASF snapshot repository, while other maintenance branches publish fine:

| Artifact | Status |
| --- | --- |
| `camel-core:4.14.10-SNAPSHOT` | 200 |
| `camel-core:4.18.5-SNAPSHOT` | 200 |
| `camel-core:4.23.0-SNAPSHOT` | 200 |
| `camel-core:4.22.1-SNAPSHOT` | **404** |

The cause is the `Build & Deploy` stage guard in `Jenkinsfile.deploy`, which was never adapted when this branch was cut:

```groovy
branch 'main'
branch 'camel-4.18.x'
branch 'camel-4.14.x'   // camel-4.22.x missing -> stage skipped on every build
```

The `Setup llvm-mingw` stage right above it, the `nativeExe` check inside the stage, and `Jenkinsfile.jbangtest` all already list `camel-4.22.x` — only this guard was missed.

## Impact

This breaks the Camel JBang integration tests on this branch. The `jbang-it-test` profile passes `cli.jbang.version = ${project.version}` through to the CLI container build as `-Dcamel.jbang.version=4.22.1-SNAPSHOT`. That resolution happens at **image build time**, where `shared.maven.local.repo` is not yet mounted (it is a runtime `withFileSystemBind`), so the only source is the ASF snapshot repo:

```
[jbang] Resolving dependencies...
[jbang]    org.apache.camel:camel-jbang-core:4.22.1-SNAPSHOT
[jbang] [ERROR] Could not read artifact descriptor for org.apache.camel:camel-jbang-core:jar:4.22.1-SNAPSHOT
ERROR: process "/bin/sh -c source ~/.bashrc && ... jbang app install ..." did not complete successfully: exit code: 1
```

which surfaces to the test as:

```
org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(...)
Caused by: com.github.dockerjava.api.exception.DockerClientException: Could not build image
```

## Change

Add `camel-4.22.x` to the `Build & Deploy` guard. `camel-4.14.x` is dropped to match `main`; that branch evaluates its own copy of `Jenkinsfile.deploy`, so it is unaffected. `Jenkinsfile.deploy` on this branch is now byte-identical to `main`.

## Verification

Reproduced the failure locally by building the CLI container with the exact build args the IT profile passes, and confirmed it succeeds against a resolvable version:

```
--build-arg CAMEL_JBANG_VERSION=4.22.1-SNAPSHOT  ->  ERROR: exit code 1
--build-arg CAMEL_JBANG_VERSION=4.22.0           ->  [jbang] Command installed: camel
```

## Note for reviewers

This only helps if the ASF Jenkins multibranch job actually discovers `camel-4.22.x`. Worth confirming on ci-builds that the branch is in scope for the deploy job — if it is not, the guard fix alone will not produce a build.

---
_Claude Code on behalf of davsclaus_
