### PR TITLE
chore: align Camel CLI default version pins to 4.22 on camel-4.22.x

### DIFF
--- a/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/dist/CamelJBang.java
@@ -20,9 +20,9 @@
 //JAVA 21+
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
 //JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.3}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.3}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.2}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.22.0}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.22.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.22.0}
 
 package main;
 

--- a/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
+++ b/dsl/camel-jbang/camel-jbang-main/src/main/jbang/main/CamelJBang.java
@@ -20,9 +20,9 @@
 //JAVA 21+
 //REPOS central=https://repo1.maven.org/maven2,apache-snapshot=https://repository.apache.org/content/groups/snapshots/
 //JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
-//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.3}@pom
-//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.3}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.2}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.22.0}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.22.0}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.22.0}
 
 package main;
 


### PR DESCRIPTION
## Problem

Both copies of `CamelJBang.java` on `camel-4.22.x` still default to the **4.18 LTS**:

```java
//DEPS org.apache.camel:camel-bom:${camel.jbang.version:4.18.3}@pom
//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:4.18.3}
//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:4.18.2}
```

This is the script jbang resolves for `jbang app install camel@apache/camel/camel-4.22.x`, so installing the CLI from this branch without an explicit `-Dcamel.jbang.version` gives you a **4.18.3 CLI with the 4.18.2 Kamelets catalog**.

The bumps on `main` — `cd29991cf36d` (CAMEL-24381, 4.18.3 → 4.22.0) and `0b63c867de37` (CAMEL-24547, kamelets → 4.22.0) — both landed after this branch was cut on 14 Aug, so they were never picked up here.

## Why 4.22.0

Every maintenance branch pins its own line's released version:

| Branch | camel-bom / camel-jbang-core | camel-kamelets |
| --- | --- | --- |
| `main` | 4.22.0 | 4.22.0 |
| `camel-4.18.x` | 4.18.2 | 4.18.2 |
| `camel-4.14.x` | 4.14.4 | 4.14.4 |
| `camel-4.22.x` | **4.18.3** :x: | **4.18.2** :x: |

So `camel-4.22.x` should pin `4.22.0`, the released version on this line. Both artifacts and `camel-kamelets:4.22.0` are on Central (verified 200).

Both copies (`dist/` and `src/main/jbang/main/`) are kept in sync, as CAMEL-24547 did on main. After this change they are byte-identical to main's.

## Out of scope

`dsl/camel-jbang/camel-launcher/pom.xml` still has `<camel-kamelets-version>4.20.0</camel-kamelets-version>`, another pin CAMEL-24547 aligned on main. Left alone here to keep this PR to a single concern — happy to fold it in or open a follow-up.

---
_Claude Code on behalf of davsclaus_
