### PR TITLE
chore: fix dangling line continuation in the Camel CLI test-infra Dockerfile

### DIFF
--- a/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/Dockerfile
+++ b/test-infra/camel-test-infra-cli/src/main/resources/org/apache/camel/test/infra/cli/services/Dockerfile
@@ -54,7 +54,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java
 RUN echo "Installing JBang..."
 RUN curl -Ls https://sh.jbang.dev | bash -s - app setup \
     && source ~/.bashrc \
-    && jbang trust add https://github.com/$CAMEL_REPO/ \
+    && jbang trust add https://github.com/$CAMEL_REPO/
 
 RUN echo "Using JBang $CAMEL_JBANG_VERSION version from $CAMEL_REPO/$CAMEL_REF"
 RUN source ~/.bashrc \


### PR DESCRIPTION
## Problem

In the Camel CLI test-infra `Dockerfile`, the `jbang trust add` line ends with a backslash followed by a blank line:

```dockerfile
RUN curl -Ls https://sh.jbang.dev | bash -s - app setup \
    && source ~/.bashrc \
    && jbang trust add https://github.com/$CAMEL_REPO/ \

RUN echo "Using JBang $CAMEL_JBANG_VERSION version from $CAMEL_REPO/$CAMEL_REF"
```

Docker skips the blank line, continues the command, and folds the following `RUN echo` instruction into it. jbang then receives the words of that echo as extra arguments and trusts them as if they were URLs:

```
[jbang] Trusting permanently: [https://github.com/apache/camel/, RUN, echo, Using JBang default version from apache/camel/main]
```

Docker flags it as `NoEmptyContinuation: Empty continuation line (line 59)`.

## Change

Drop the trailing backslash. `jbang trust add` now ends where it should, and the `RUN echo` is its own instruction again (the build goes from 17 to 18 steps).

## Verification

Built the container image before and after with the same build args:

**Before**
```
#14 [10/17] RUN curl -Ls https://sh.jbang.dev | bash -s - app setup ... && jbang trust add https://github.com/apache/camel/ RUN echo "Using JBang default version from apache/camel/main"
#14 [jbang] Trusting permanently: [https://github.com/apache/camel/, RUN, echo, Using JBang default version from apache/camel/main]
```

**After**
```
#14 [jbang] Trusting permanently: [https://github.com/apache/camel/]
#15 [11/18] RUN echo "Using JBang default version from apache/camel/main"
#16 [jbang] Command installed: camel
```

Build succeeds and the `NoEmptyContinuation` warning is gone.

## Backport

The same line is present on `camel-4.22.x` and `camel-4.18.x` — worth backporting.

---
_Claude Code on behalf of davsclaus_
