### PR TITLE
CAMEL-24435: camel-as2 - clear the per-request asynchronous MDN state on the connection context

### DIFF
--- a/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
+++ b/components/camel-as2/camel-as2-api/src/main/java/org/apache/camel/component/as2/api/AS2ServerConnection.java
@@ -510,57 +510,17 @@ public class AS2ServerConnection {
 
                     HttpCoreContext coreContext = HttpCoreContext.castOrCreate(context);
 
-                    // Safely retrieve the AS2 consumer configuration and path from ThreadLocal storage.
-                    AS2ConsumerConfiguration config = Optional.ofNullable(CURRENT_CONSUMER_CONFIG.get())
-                            .map(w -> w.config)
-                            .orElse(null);
-
-                    String recipientAddress = coreContext.getAttribute(AS2AsynchronousMDNManager.RECIPIENT_ADDRESS,
-                            String.class);
-
-                    if (recipientAddress != null && config != null) {
-                        // Send the MDN asynchronously.
-
-                        DispositionNotificationMultipartReportEntity multipartReportEntity = coreContext.getAttribute(
-                                AS2AsynchronousMDNManager.ASYNCHRONOUS_MDN,
-                                DispositionNotificationMultipartReportEntity.class);
-                        AS2AsynchronousMDNManager asynchronousMDNManager = new AS2AsynchronousMDNManager(
-                                AS2ServerConnection.this.as2Version,
-                                AS2ServerConnection.this.originServer,
-                                AS2ServerConnection.this.serverFqdn,
-                                config.getSigningCertificateChain(),
-                                config.getSigningPrivateKey(),
-                                AS2ServerConnection.this.userName,
-                                AS2ServerConnection.this.password,
-                                AS2ServerConnection.this.accessToken,
-                                AS2ServerConnection.this.asyncMdnAllowedHosts,
-                                AS2ServerConnection.this.sslContext);
-
-                        HttpRequest request = coreContext.getRequest();
-                        AS2SignedDataGenerator gen = ResponseMDN.createSigningGenerator(
-                                request,
-                                config.getSigningAlgorithm(),
-                                config.getSigningCertificateChain(),
-                                config.getSigningPrivateKey());
-                        if (gen != null) {
-                            // send a signed MDN
-                            MultipartSignedEntity multipartSignedEntity = null;
-                            try {
-                                multipartSignedEntity = ResponseMDN.prepareSignedReceipt(gen, multipartReportEntity);
-                            } catch (Exception e) {
-                                LOG.warn("failed to sign MDN");
-                            }
-                            if (multipartSignedEntity != null) {
-                                asynchronousMDNManager.send(
-                                        multipartSignedEntity, multipartSignedEntity.getContentType(), recipientAddress);
-                            }
-                        } else {
-                            // send an unsigned MDN
-                            asynchronousMDNManager.send(multipartReportEntity,
-                                    multipartReportEntity.getMainMessageContentType(), recipientAddress);
-                        }
+                    try {
+                        handleAsynchronousMDN(coreContext);
+                    } finally {
+                        // The context and the ThreadLocal are reused for every request handled on this
+                        // connection, and nothing else clears them. Without this, a later request that does not
+                        // ask for an asynchronous receipt still finds the earlier request's recipient address and
+                        // report, and dispatches a second MDN to it (CAMEL-24435).
+                        coreContext.removeAttribute(AS2AsynchronousMDNManager.RECIPIENT_ADDRESS);
+                        coreContext.removeAttribute(AS2AsynchronousMDNManager.ASYNCHRONOUS_MDN);
+                        CURRENT_CONSUMER_CONFIG.remove();
                     }
-
                 }
             } catch (final ConnectionClosedException ex) {
                 LOG.info("Client closed connection");
@@ -572,6 +532,59 @@ public class AS2ServerConnection {
                 try {
                     this.serverConnection.close();
                 } catch (final IOException ignore) {
+                }
+            }
+        }
+
+        private void handleAsynchronousMDN(HttpCoreContext coreContext) throws HttpException, IOException {
+            // Safely retrieve the AS2 consumer configuration and path from ThreadLocal storage.
+            AS2ConsumerConfiguration config = Optional.ofNullable(CURRENT_CONSUMER_CONFIG.get())
+                    .map(w -> w.config)
+                    .orElse(null);
+
+            String recipientAddress = coreContext.getAttribute(AS2AsynchronousMDNManager.RECIPIENT_ADDRESS,
+                    String.class);
+
+            if (recipientAddress != null && config != null) {
+                // Send the MDN asynchronously.
+
+                DispositionNotificationMultipartReportEntity multipartReportEntity = coreContext.getAttribute(
+                        AS2AsynchronousMDNManager.ASYNCHRONOUS_MDN,
+                        DispositionNotificationMultipartReportEntity.class);
+                AS2AsynchronousMDNManager asynchronousMDNManager = new AS2AsynchronousMDNManager(
+                        AS2ServerConnection.this.as2Version,
+                        AS2ServerConnection.this.originServer,
+                        AS2ServerConnection.this.serverFqdn,
+                        config.getSigningCertificateChain(),
+                        config.getSigningPrivateKey(),
+                        AS2ServerConnection.this.userName,
+                        AS2ServerConnection.this.password,
+                        AS2ServerConnection.this.accessToken,
+                        AS2ServerConnection.this.asyncMdnAllowedHosts,
+                        AS2ServerConnection.this.sslContext);
+
+                HttpRequest request = coreContext.getRequest();
+                AS2SignedDataGenerator gen = ResponseMDN.createSigningGenerator(
+                        request,
+                        config.getSigningAlgorithm(),
+                        config.getSigningCertificateChain(),
+                        config.getSigningPrivateKey());
+                if (gen != null) {
+                    // send a signed MDN
+                    MultipartSignedEntity multipartSignedEntity = null;
+                    try {
+                        multipartSignedEntity = ResponseMDN.prepareSignedReceipt(gen, multipartReportEntity);
+                    } catch (Exception e) {
+                        LOG.warn("failed to sign MDN");
+                    }
+                    if (multipartSignedEntity != null) {
+                        asynchronousMDNManager.send(
+                                multipartSignedEntity, multipartSignedEntity.getContentType(), recipientAddress);
+                    }
+                } else {
+                    // send an unsigned MDN
+                    asynchronousMDNManager.send(multipartReportEntity,
+                            multipartReportEntity.getMainMessageContentType(), recipientAddress);
                 }
             }
         }

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnContextReuseTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnContextReuseTest.java
@@ -75,9 +75,9 @@ public class AS2AsyncMdnContextReuseTest extends AbstractAS2ITSupport {
 
         // the first message asks for an asynchronous receipt, so exactly one MDN must be delivered
         receipts.expectedMessageCount(1);
+        receipts.setResultWaitTime(TimeUnit.SECONDS.toMillis(10));
         requestBodyAndHeaders("direct://SEND", EDI_MESSAGE,
                 as2Headers("http://localhost:" + jettyPort.getPort() + "/handle-receipts"));
-        receipts.setResultWaitTime(TimeUnit.SECONDS.toMillis(10));
         receipts.assertIsSatisfied();
 
         // the second message does not, and it travels over the same pooled connection. The recipient address left

--- a/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnContextReuseTest.java
+++ b/components/camel-as2/camel-as2-component/src/test/java/org/apache/camel/component/as2/AS2AsyncMdnContextReuseTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.as2;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.as2.api.AS2MediaType;
+import org.apache.camel.component.as2.api.AS2MessageStructure;
+import org.apache.camel.component.as2.api.AS2ServerConnection;
+import org.apache.camel.component.as2.api.AS2SignatureAlgorithm;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.AvailablePortFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * The AS2 request handler creates its {@code HttpContext} once per connection and reuses it for every request handled
+ * on that connection. A request that asks for an asynchronous MDN leaves the recipient address and the report on that
+ * context; a later request on the same connection that does not ask for one must not inherit them and trigger a second
+ * delivery (CAMEL-24435).
+ */
+public class AS2AsyncMdnContextReuseTest extends AbstractAS2ITSupport {
+
+    @RegisterExtension
+    AvailablePortFinder.Port jettyPort = AvailablePortFinder.find();
+
+    private static final String EDI_MESSAGE = """
+            UNB+UNOA:1+005435656:1+006415160:1+060515:1434+00000000000778'
+            UNH+00000000000117+INVOIC:D:97B:UN'
+            BGM+380+342459+9'
+            UNT+23+00000000000117'
+            UNZ+1+00000000000778'
+            """;
+
+    private AS2ServerConnection serverConnection;
+    private int targetPort;
+
+    @Override
+    public void setupResources() throws Exception {
+        serverConnection = new AS2ServerConnection(
+                "1.1", "AS2AsyncMdnContextReuseTest Server", "server.example.com", 0,
+                AS2SignatureAlgorithm.SHA256WITHRSA, null, null, null, "TBD", null, null,
+                null, null, null, "localhost");
+        targetPort = serverConnection.getLocalPort();
+        serverConnection.listen("/", new AS2AsyncMDNServerManagerIT.RequestHandler());
+    }
+
+    @Override
+    public void cleanupResources() {
+        if (serverConnection != null) {
+            serverConnection.close();
+        }
+    }
+
+    @Test
+    public void asyncMdnStateDoesNotLeakToTheNextRequestOnTheSameConnection() throws Exception {
+        MockEndpoint receipts = getMockEndpoint("mock:receipts");
+
+        // the first message asks for an asynchronous receipt, so exactly one MDN must be delivered
+        receipts.expectedMessageCount(1);
+        requestBodyAndHeaders("direct://SEND", EDI_MESSAGE,
+                as2Headers("http://localhost:" + jettyPort.getPort() + "/handle-receipts"));
+        receipts.setResultWaitTime(TimeUnit.SECONDS.toMillis(10));
+        receipts.assertIsSatisfied();
+
+        // the second message does not, and it travels over the same pooled connection. The recipient address left
+        // on that connection's context must not be reused to deliver a second MDN.
+        receipts.reset();
+        receipts.expectedMessageCount(0);
+        // keep asserting for a while after the send, so a leaked delivery has time to show up
+        receipts.setAssertPeriod(TimeUnit.SECONDS.toMillis(5));
+        requestBodyAndHeaders("direct://SEND", EDI_MESSAGE, as2Headers(null));
+        receipts.assertIsSatisfied();
+    }
+
+    private Map<String, Object> as2Headers(String asyncMdnDeliveryAddress) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelAs2.requestUri", "/");
+        headers.put("CamelAs2.subject", "Test Case");
+        headers.put("CamelAs2.from", "mrAS@example.org");
+        headers.put("CamelAs2.as2From", "878051556");
+        headers.put("CamelAs2.as2To", "878051556");
+        headers.put("CamelAs2.as2MessageStructure", AS2MessageStructure.PLAIN);
+        headers.put("CamelAs2.ediMessageContentType", AS2MediaType.APPLICATION_EDIFACT);
+        headers.put("CamelAs2.ediMessageTransferEncoding", "7bit");
+        headers.put("CamelAs2.dispositionNotificationTo", "mrAS2@example.com");
+        if (asyncMdnDeliveryAddress != null) {
+            headers.put("CamelAs2.receiptDeliveryOption", asyncMdnDeliveryAddress);
+        }
+        return headers;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct://SEND")
+                        .to("as2://client/send?inBody=ediMessage&httpSocketTimeout=5m&httpConnectionTimeout=5m");
+
+                from("jetty:http://localhost:" + jettyPort.getPort() + "/handle-receipts")
+                        .to("mock:receipts");
+            }
+        };
+    }
+
+    @Override
+    protected void customizeConfiguration(AS2Configuration configuration) {
+        configuration.setTargetPortNumber(targetPort);
+    }
+}


### PR DESCRIPTION
## Issue

[CAMEL-24435](https://issues.apache.org/jira/browse/CAMEL-24435)

## Problem

`AS2ServerConnection.RequestHandlerThread.run()` creates its `HttpContext` once, **outside** the
request loop, and reuses it for every request handled on that connection:

```java
final HttpContext context = HttpCoreContext.create();
while (!Thread.interrupted()) {
    this.httpService.handleRequest(this.serverConnection, context);
    ...
    String recipientAddress = coreContext.getAttribute(AS2AsynchronousMDNManager.RECIPIENT_ADDRESS, String.class);
    if (recipientAddress != null && config != null) {
        // Send the MDN asynchronously.
```

`ResponseMDN` sets `RECIPIENT_ADDRESS` and `ASYNCHRONOUS_MDN` on that context while handling a request
that carried `Receipt-Delivery-Option`, and nothing removed them afterwards. A later request on the
same connection that did **not** ask for an asynchronous receipt therefore still found a non-null
recipient address, and the handler dispatched a second asynchronous MDN — carrying whatever report was
still stored under `ASYNCHRONOUS_MDN` — to the address supplied by the *earlier* request.

## Fix

Both attributes are removed in a `finally` after every request. Using `finally` rather than clearing
at the end of the send block also covers the paths that skip the send — in particular a request URI
with no registered consumer configuration, where `config` is null and the old code left the address
behind untouched.

### Also clears `CURRENT_CONSUMER_CONFIG`

The same `finally` clears the `CURRENT_CONSUMER_CONFIG` ThreadLocal, which is not in the issue text
but has the identical defect. `setupConfigurationForRequest` returns early **without** setting it when
a path has no registered configuration:

```java
if (config == null) {
    LOG.warn("No AS2 consumer configuration found for canonical path: {} ...", requestUriPath);
    return null;
}
...
CURRENT_CONSUMER_CONFIG.set(wrapper);
```

so the thread kept the previous request's wrapper. On its own that cannot trigger a send, but paired
with a *new* legitimate recipient address it would have signed the MDN with the previous path's key.
Clearing only the context attributes would have left that half of the leak in place.

The post-processing block is extracted into `handleAsynchronousMDN` so the `finally` reads clearly;
the logic inside is unchanged.

## Test

`AS2AsyncMdnContextReuseTest` sends two messages through one `as2://client/send` route, so both travel
over the same pooled connection to the server:

1. the first carries `receiptDeliveryOption` → exactly one MDN must reach the receipt endpoint;
2. the second does not → the receipt endpoint must see **no** further MDN.

The second assertion uses `setAssertPeriod(5s)` so a leaked delivery has time to arrive rather than
the test passing simply by being quick.

Verified both ways: against the unfixed `camel-as2-api` the test fails with
`mock://receipts Received message count. Expected: <0> but was: <1>`, and it passes with the fix.

`components/camel-as2` suite green (API + Component). Full reactor build clean.

## Documentation

No upgrade-guide entry: the previous behaviour was sending an MDN nobody asked for, to an address from
an unrelated earlier request. There is nothing for a user to migrate.

## Review follow-up

- `setResultWaitTime` on the receipt mock is now configured **before** the `requestBodyAndHeaders`
  call that triggers the first MDN, instead of after it (@gnodet). It could not cause a false pass —
  `expectedMessageCount(1)` was already satisfied at that point — but the endpoint should be fully
  configured before the action that feeds it.
- The `Test` suffix (surefire) rather than `IT` (failsafe) is intentional: the test stands up its own
  `AS2ServerConnection` in `setupResources` and needs no failsafe lifecycle, matching the other
  self-contained tests in the package (`AS2AsyncMdnBasicAuthHeaderTest`, `AS2BasicAuthHeaderTest`,
  `AS2ServerBasicAuthHeaderTest`, `AS2TokenAuthHeaderTest`), which also extend `AbstractAS2ITSupport`.

---
_Claude Code on behalf of oscerd; review follow-up by Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
