### PR TITLE
CAMEL-24655: add regression test for case-insensitive Camel header filtering in the CoAP consumer

### DIFF
--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPHeaderInjectionTest.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPHeaderInjectionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.coap;
+
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The CoAP consumer maps URI query parameters of an incoming request into Exchange headers. A remote peer must not be
+ * able to use that to set Camel internal headers, whatever casing it uses, as those steer downstream processing (bean
+ * method dispatch, file names, and so on).
+ */
+public class CoAPHeaderInjectionTest extends CoAPTestSupport {
+
+    private static final String[] CAMEL_HEADER_VARIANTS = {
+            "CamelBeanMethodName", "camelBeanMethodName", "caMELBeanMethodName", "CAMELBEANMETHODNAME" };
+
+    @Test
+    void camelHeadersInUriQueryAreFilteredRegardlessOfCase() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:result");
+        mock.expectedMessageCount(CAMEL_HEADER_VARIANTS.length);
+
+        CoapClient client = createClient("/TestResource");
+        for (String variant : CAMEL_HEADER_VARIANTS) {
+            Request request = Request.newPost();
+            request.setURI(client.getURI() + "?" + variant + "=malicious&normalParam=value");
+            request.setPayload("test");
+            request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+            assertNotNull(client.advanced(request), "no CoAP response received for variant " + variant);
+        }
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        List<Exchange> received = mock.getReceivedExchanges();
+        for (int i = 0; i < CAMEL_HEADER_VARIANTS.length; i++) {
+            String variant = CAMEL_HEADER_VARIANTS[i];
+            Message in = received.get(i).getIn();
+            // the Camel header map is case-insensitive, so this lookup also catches the other spellings
+            assertNull(in.getHeader(variant),
+                    "a Camel internal header must not be injectable through a CoAP URI query parameter: " + variant);
+            assertEquals("value", in.getHeader("normalParam", String.class),
+                    "a non-Camel query parameter must still be mapped to a header");
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                fromF("coap://localhost:%d/TestResource", PORT.getPort())
+                        .to("mock:result")
+                        .setBody(constant("ok"));
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Description

The CoAP consumer maps the URI query parameters of an incoming request into Exchange headers (`CamelCoapResource#handleRequest`), running each one through the endpoint `HeaderFilterStrategy` first. `CoAPEndpoint` defaults to `DefaultHeaderFilterStrategy`, whose `inFilterStartsWith` is `{"Camel", "camel"}` with `lowerCase = true`, so names starting with `Camel` are filtered whatever casing the peer uses.

That behaviour is correct today, but it is not covered by any test in `camel-coap`. A refactoring of the consumer could silently drop the filter call, which is exactly the regression the CVE-2025-27636 family was about.

This is a **test-only** change — no production code is modified.

## Changes

- Added `CoAPHeaderInjectionTest`: sends CoAP requests carrying a Camel internal header name as a URI query parameter in four casings (`CamelBeanMethodName`, `camelBeanMethodName`, `caMELBeanMethodName`, `CAMELBEANMETHODNAME`) and asserts the header is never mapped onto the Exchange, while an ordinary query parameter still is.

The assertion relies on the Camel header map being case-insensitive, so a single lookup per request catches any spelling that may have slipped through.

## Testing

- `mvn install -pl components/camel-coap` — 67 tests, all green.
- Verified the test is a real guard, not a vacuous one: with the `applyFilterToExternalHeaders` call in `CamelCoapResource` removed, it fails with `expected: <null> but was: <malicious>`.

_Claude Code on behalf of oscerd_