### PR TITLE
[backport camel-4.18.x] CAMEL-24424: camel-vertx-http - apply the outbound header filter on the REST producer

### DIFF
--- a/components/camel-vertx/camel-vertx-http/pom.xml
+++ b/components/camel-vertx/camel-vertx-http/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-rest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-undertow</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/camel-vertx/camel-vertx-http/src/main/java/org/apache/camel/component/vertx/http/VertxHttpRestHeaderFilterStrategy.java
+++ b/components/camel-vertx/camel-vertx-http/src/main/java/org/apache/camel/component/vertx/http/VertxHttpRestHeaderFilterStrategy.java
@@ -32,7 +32,7 @@ public class VertxHttpRestHeaderFilterStrategy extends VertxHttpHeaderFilterStra
 
     @Override
     public boolean applyFilterToCamelHeaders(String headerName, Object headerValue, Exchange exchange) {
-        boolean answer = super.applyFilterToExternalHeaders(headerName, headerValue, exchange);
+        boolean answer = super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
 
         return filterCheck(templateUri, queryParameters, headerName, answer);
     }

--- a/components/camel-vertx/camel-vertx-http/src/test/java/org/apache/camel/component/vertx/http/VertxHttpRestProducerHeaderFilterTest.java
+++ b/components/camel-vertx/camel-vertx-http/src/test/java/org/apache/camel/component/vertx/http/VertxHttpRestProducerHeaderFilterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.vertx.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.Message;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class VertxHttpRestProducerHeaderFilterTest extends VertxHttpTestSupport {
+
+    @Test
+    public void testRestProducerAppliesTheOutboundFilter() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:input");
+        mock.expectedMessageCount(1);
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("id", "123");
+        headers.put("Via", "1.1 rogue-proxy");
+        headers.put("Cache-Control", "no-cache");
+        headers.put("Content-Type", "application/json");
+        headers.put("X-Custom", "custom-value");
+
+        String out = template.requestBodyAndHeaders("direct:start", null, headers, String.class);
+        assertEquals("Hello World", out);
+
+        MockEndpoint.assertIsSatisfied(context);
+
+        Message received = mock.getReceivedExchanges().get(0).getMessage();
+        // excluded on the outbound direction by the common HTTP filter set, so they must not reach the wire
+        assertNull(received.getHeader("Via"));
+        assertNull(received.getHeader("Cache-Control"));
+        // already consumed by the uri template, so it must not be sent as an HTTP header as well
+        assertNull(received.getHeader("id"));
+        // not filtered on either direction
+        assertEquals("custom-value", received.getHeader("X-Custom"));
+        // Content-Type is in the common HTTP filter set, but the producer sets it explicitly from the exchange
+        // content type before the filter loop runs, so it must still reach the server
+        assertEquals("application/json", received.getHeader("Content-Type"));
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                restConfiguration()
+                        .producerComponent("vertx-http")
+                        .host("localhost").port(getPort());
+
+                from("direct:start")
+                        .to("rest:get:foo/{id}");
+
+                from(getTestServerUri() + "/foo/123")
+                        .to("mock:input")
+                        .setBody(constant("Hello World"));
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Backport of #26183

Cherry-pick of #26183 onto `camel-4.18.x`.

**Original PR:** #26183 - CAMEL-24424: camel-vertx-http - apply the outbound header filter on the REST producer
**Original author:** @oscerd
**Target branch:** `camel-4.18.x`

Straight cherry-pick — the code, the test and the pom change applied with no conflicts and no changes.
The `camel-4x-upgrade-guide-4_23.adoc` hunk is dropped because that file does not exist on this
branch; the upgrade guides for every line live on `main`. Full reactor sanity build on the target
branch is clean.

Note on the test: `VertxHttpTestSupport` on this branch extends the JUnit 5 `CamelTestSupport` rather
than the JUnit 6 one on `main`, but the new test extends `VertxHttpTestSupport` rather than importing
`CamelTestSupport` directly, so it needed no adaptation. It uses JUnit assertions, so it also needs no
AssertJ dependency here.

### Why this is worth backporting

`VertxHttpHeaderFilterStrategy` installs the common HTTP out filter, and the REST strategy never
applied it, so a message header named `Content-Length`, `Transfer-Encoding`, `Host` or `Connection`
was copied verbatim onto the outgoing request. Forwarding a stale framing header onto a new request
is the kind of thing that desynchronises a downstream parser, which is why this is going to the
maintenance lines rather than main only.

### Original description

`VertxHttpRestHeaderFilterStrategy.applyFilterToCamelHeaders()` delegated to
`super.applyFilterToExternalHeaders()` — the inbound rules — while implementing the outbound
direction, so the out filter was never applied on a REST producer. The sibling REST strategies in
`camel-http-common`, `camel-netty-http` and `camel-undertow` all delegate to the matching super
method; vertx-http was the only one left with the mismatch, which has been there since the component
was added in CAMEL-15283.

---
_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)