### PR TITLE
Local E2E tests for camel-openai Audio, Image and Moderation

### DIFF
--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIAudioExternalServiceIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIAudioExternalServiceIT.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnabledIfSystemProperty(named = "openai.live.tests", matches = "true",
+@EnabledIfSystemProperty(named = OpenAIExternalServiceTestSupport.ENABLE_LIVE_TESTS, matches = "true",
                          disabledReason = "Set -Dopenai.live.tests=true and configure an OpenAI-compatible audio service")
 public class OpenAIAudioExternalServiceIT extends OpenAIExternalServiceTestSupport {
 

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIAudioExternalServiceIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIAudioExternalServiceIT.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai.integration;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "openai.live.tests", matches = "true",
+                         disabledReason = "Set -Dopenai.live.tests=true and configure an OpenAI-compatible audio service")
+public class OpenAIAudioExternalServiceIT extends OpenAIExternalServiceTestSupport {
+
+    private static final String AUDIO_MODEL = "openai.live.audio.model";
+    private static final String SPEECH_MODEL = "openai.live.speech.model";
+    private static final String SPEECH_VOICE = "openai.live.speech.voice";
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        String audioModel = requiredProperty(AUDIO_MODEL);
+        String speechModel = requiredProperty(SPEECH_MODEL);
+        String speechVoice = requiredProperty(SPEECH_VOICE);
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:speech").toF("openai:audio-speech?speechModel=%s&speechVoice=%s&speechResponseFormat=wav",
+                        speechModel, speechVoice);
+                from("direct:transcription").toF("openai:audio-transcription?audioModel=%s", audioModel)
+                        .log("${body}");
+                from("direct:translation").toF("openai:audio-translation?audioModel=%s", audioModel)
+                        .log("${body}");
+            }
+        };
+    }
+
+    @Test
+    void speechCanBeTranscribedAndTranslated() throws Exception {
+        Exchange speech = template.request("direct:speech", exchange -> exchange.getIn().setBody("Apache Camel integration"));
+        assertThat(speech.getException()).isNull();
+        byte[] audio = speech.getMessage().getBody(byte[].class);
+        assertThat(audio).isNotEmpty();
+        writeArtifact("speech.wav", audio);
+
+        Exchange transcription = template.request("direct:transcription", exchange -> exchange.getIn().setBody(audio));
+        assertThat(transcription.getException()).isNull();
+        assertThat(transcription.getMessage().getBody(String.class)).isNotBlank();
+
+        Exchange translation = template.request("direct:translation", exchange -> exchange.getIn().setBody(audio));
+        assertThat(translation.getException()).isNull();
+        assertThat(translation.getMessage().getBody(String.class)).isNotBlank();
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIExternalServiceTestSupport.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIExternalServiceTestSupport.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai.integration;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.openai.OpenAIComponent;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.apache.camel.util.ObjectHelper;
+
+abstract class OpenAIExternalServiceTestSupport extends CamelTestSupport {
+
+    static final String ENABLE_LIVE_TESTS = "openai.live.tests";
+    static final String BASE_URL = "openai.live.baseUrl";
+    static final String API_KEY = "openai.live.apiKey";
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        OpenAIComponent component = new OpenAIComponent();
+        component.setBaseUrl(requiredProperty(BASE_URL));
+        component.setApiKey(System.getProperty(API_KEY, "dummy"));
+        context.addComponent("openai", component);
+        return context;
+    }
+
+    protected static String requiredProperty(String name) {
+        String value = System.getProperty(name);
+        if (ObjectHelper.isEmpty(value)) {
+            throw new IllegalStateException("Set the " + name + " system property when enabling live OpenAI tests");
+        }
+        return value;
+    }
+
+    protected static void writeArtifact(String fileName, byte[] contents) throws IOException {
+        Path artifact = Path.of("target", "openai-live", fileName);
+        Files.createDirectories(artifact.getParent());
+        Files.write(artifact, contents);
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIImageExternalServiceIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIImageExternalServiceIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnabledIfSystemProperty(named = "openai.live.tests", matches = "true",
+@EnabledIfSystemProperty(named = OpenAIExternalServiceTestSupport.ENABLE_LIVE_TESTS, matches = "true",
                          disabledReason = "Set -Dopenai.live.tests=true and configure an OpenAI-compatible image service")
 public class OpenAIImageExternalServiceIT extends OpenAIExternalServiceTestSupport {
 

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIImageExternalServiceIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIImageExternalServiceIT.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai.integration;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.openai.OpenAIConstants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "openai.live.tests", matches = "true",
+                         disabledReason = "Set -Dopenai.live.tests=true and configure an OpenAI-compatible image service")
+public class OpenAIImageExternalServiceIT extends OpenAIExternalServiceTestSupport {
+
+    private static final String IMAGE_MODEL = "openai.live.image.model";
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        String imageModel = requiredProperty(IMAGE_MODEL);
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:generate").toF("openai:image-generation?imageModel=%s&imageOutputFormat=png", imageModel);
+                from("direct:edit").toF("openai:image-edit?imageModel=%s&imageOutputFormat=png", imageModel);
+            }
+        };
+    }
+
+    @Test
+    void generatedImageCanBeEdited() throws Exception {
+        Exchange generated = template.request("direct:generate",
+                exchange -> exchange.getIn().setBody("The Apache Camel logo"));
+        assertThat(generated.getException()).isNull();
+        byte[] image = generated.getMessage().getBody(byte[].class);
+        assertThat(image).isNotEmpty();
+        writeArtifact("generated.png", image);
+
+        Exchange edited = template.request("direct:edit", exchange -> {
+            exchange.getIn().setBody(image);
+            exchange.getIn().setHeader(OpenAIConstants.IMAGE_PROMPT, "Change camel color to blue");
+        });
+        assertThat(edited.getException()).isNull();
+        byte[] editedImage = edited.getMessage().getBody(byte[].class);
+        assertThat(editedImage).isNotEmpty();
+        writeArtifact("edited.png", editedImage);
+    }
+}

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIModerationExternalServiceIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIModerationExternalServiceIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnabledIfSystemProperty(named = "openai.live.tests", matches = "true",
+@EnabledIfSystemProperty(named = OpenAIExternalServiceTestSupport.ENABLE_LIVE_TESTS, matches = "true",
                          disabledReason = "Set -Dopenai.live.tests=true and configure an OpenAI moderation endpoint")
 public class OpenAIModerationExternalServiceIT extends OpenAIExternalServiceTestSupport {
 

--- a/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIModerationExternalServiceIT.java
+++ b/components/camel-ai/camel-openai/src/test/java/org/apache/camel/component/openai/integration/OpenAIModerationExternalServiceIT.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.openai.integration;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.openai.OpenAIConstants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "openai.live.tests", matches = "true",
+                         disabledReason = "Set -Dopenai.live.tests=true and configure an OpenAI moderation endpoint")
+public class OpenAIModerationExternalServiceIT extends OpenAIExternalServiceTestSupport {
+
+    private static final String MODERATION_MODEL = "openai.live.moderation.model";
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:moderate").toF("openai:moderation?moderationModel=%s", requiredProperty(MODERATION_MODEL));
+            }
+        };
+    }
+
+    @Test
+    void moderationReturnsAVerdictAndPreservesTheBody() {
+        String input = "Apache Camel is an integration framework.";
+        Exchange result = template.request("direct:moderate", exchange -> exchange.getIn().setBody(input));
+
+        assertThat(result.getException())
+                .as("The configured service must return a valid OpenAI /v1/moderations response")
+                .isNull();
+        assertThat(result.getMessage().getBody(String.class)).isEqualTo(input);
+        assertThat(result.getMessage().getHeader(OpenAIConstants.MODERATION_FLAGGED, Boolean.class)).isNotNull();
+        assertThat(result.getMessage().getHeader(OpenAIConstants.MODERATION_RESPONSE_MODEL, String.class)).isNotBlank();
+    }
+}

--- a/components/camel-ai/camel-openai/test_execution.md
+++ b/components/camel-ai/camel-openai/test_execution.md
@@ -75,3 +75,94 @@ export OPENAI_MODEL=gpt-4o-mini
 export OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
 mvn verify -Dollama.instance.type=openai
 ```
+
+### Opt-in external audio, image, and moderation tests
+
+`OpenAIAudioExternalServiceIT`, `OpenAIImageExternalServiceIT`, and
+`OpenAIModerationExternalServiceIT` are disabled by default. They exercise the real HTTP
+contract of the audio, image, and moderation operations against an endpoint that implements
+the corresponding OpenAI API. Enable an individual test with `-Dopenai.live.tests=true`.
+
+They are also executable examples of the Camel API: configure `openai` once, send the natural
+body to a `direct:` endpoint, and route it to `openai:<operation>`. The audio test feeds the
+speech result directly into transcription and translation; the image test feeds generation
+directly into edit. No OpenAI SDK calls appear in route or test code.
+
+The audio and image tests write returned binary artifacts to `target/openai-live/` (`speech.wav`,
+`generated.png`, and `edited.png`) so they can be inspected after the test completes.
+
+All tests need `openai.live.baseUrl`; `openai.live.apiKey` is optional for local services and
+defaults to `dummy`. These tests intentionally make only structural assertions because model
+output is nondeterministic.
+
+#### macOS Apple Silicon (M4 Max, 32 GB)
+
+Run audio and image services separately: each `rapid-mlx serve` process keeps its model in
+unified memory. Do not use `qwen-image-edit` on a 32 GB machine; use `flux2-klein-4b`, which
+supports both generation and edit.
+
+For audio, install Docker Desktop and `uv` (`brew install uv`), then download the CPU service
+image and the two models used by the test. The models are cached in the Docker volume, so this is
+only needed once. Pin the image to a digest when recording a reproducible result.
+
+```bash
+docker pull ghcr.io/speaches-ai/speaches:latest-cpu
+docker run --rm --detach --publish 8000:8000 --name camel-speaches \
+  --volume camel-speaches-models:/home/ubuntu/.cache/huggingface/hub \
+  ghcr.io/speaches-ai/speaches:latest-cpu
+export SPEACHES_BASE_URL=http://localhost:8000
+uvx speaches-cli model download Systran/faster-distil-whisper-small.en
+uvx speaches-cli model download speaches-ai/Kokoro-82M-v1.0-ONNX
+```
+
+Then run:
+
+```bash
+mvn verify -Dit.test=OpenAIAudioExternalServiceIT -Dopenai.live.tests=true \
+  -Dopenai.live.baseUrl=http://localhost:8000/v1 \
+  -Dopenai.live.audio.model=Systran/faster-distil-whisper-small.en \
+  -Dopenai.live.speech.model=speaches-ai/Kokoro-82M-v1.0-ONNX \
+  -Dopenai.live.speech.voice=af_heart
+```
+
+For images, install the image runtime. Starting the server downloads the `flux2-klein-4b` model
+on its first use; it is the only local image model required by this test.
+
+```bash
+pip install 'rapid-mlx[image]'
+rapid-mlx serve flux2-klein-4b
+mvn verify -Dit.test=OpenAIImageExternalServiceIT -Dopenai.live.tests=true \
+  -Dopenai.live.baseUrl=http://localhost:8000/v1 \
+  -Dopenai.live.image.model=flux2-klein-4b
+```
+
+For local moderation, install the native macOS LocalAI application or CLI (do not use Docker on
+Apple Silicon), then start an instruction model. LocalAI exposes `POST /v1/moderations` and
+constrains the model output to the OpenAI moderation response schema. Install LocalAI's
+documented `qwen3-4b` gallery model as the compatibility baseline for this test. It is a general
+instruction model, not a trained moderation model; this test validates the HTTP contract, not
+safety-classification quality. When using the LocalAI UI, use the exact installed model ID in
+`openai.live.moderation.model`.
+
+Dedicated classifiers such as Llama Guard 3 1B/8B and ShieldGemma are better candidates when
+evaluating local moderation quality, but must first be validated with LocalAI's endpoint. Their
+native safe/unsafe output and hazard taxonomies differ from OpenAI's category schema, so they
+are not drop-in proof that the OpenAI-compatible response is semantically equivalent.
+
+```bash
+# If installed from the UI, start LocalAI and keep it running instead.
+local-ai run qwen3-4b
+mvn verify -Dit.test=OpenAIModerationExternalServiceIT -Dopenai.live.tests=true \
+  -Dopenai.live.baseUrl=http://localhost:8089/v1 \
+  -Dopenai.live.moderation.model=qwen3-4b
+```
+
+Ollama guard models, upstream llama.cpp, vLLM, and MLX servers do not themselves implement the
+OpenAI moderation endpoint. For a provider acceptance check, use OpenAI instead:
+
+```bash
+mvn verify -Dit.test=OpenAIModerationExternalServiceIT -Dopenai.live.tests=true \
+  -Dopenai.live.baseUrl=https://api.openai.com/v1 \
+  -Dopenai.live.apiKey="$OPENAI_API_KEY" \
+  -Dopenai.live.moderation.model=omni-moderation-latest
+```


### PR DESCRIPTION
The tests are successful locally, it is not possible to automate a local execution on the CI (too many resources needed), but the test can be executed pointing to OpenAI (chatGPT) APIs directly.

Fun fact, in the image test I ask the model `flux2-klein-4b` to generate `The Apache Camel logo` and this is what it came up with:
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/2414425c-9974-4169-b3bc-cdc34fc9d15c" />

in the edit image test to change the color to blue
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/7c52d8ae-4e28-4662-b820-b904e6aae61b" />

and it kind of work