### PR TITLE
  CAMEL-24647: Fix flaky JBang IT tests caused by missing cleanup betwen tests

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -87,10 +87,33 @@ public abstract class JBangTestSupport {
     @AfterEach
     protected void afterEach(TestInfo testInfo) {
         logger.debug("ending {}#{} using data folder {}", getClass().getName(), testInfo.getDisplayName(), getDataFolder());
-        assertNoErrors();
-        logger.debug("clean up data folder");
-        if (containerDataFolder != null) {
-            FileUtil.removeDir(new File(containerDataFolder));
+        try {
+            assertNoErrors();
+        } finally {
+            try {
+                execute("stop");
+            } catch (Exception | AssertionError e) {
+                logger.debug("failed to stop running integrations: {}", e.getMessage());
+            }
+            try {
+                Awaitility.await()
+                        .atMost(30, TimeUnit.SECONDS)
+                        .pollInterval(500, TimeUnit.MILLISECONDS)
+                        .until(() -> execute("ps").trim().isEmpty());
+            } catch (Exception | AssertionError e) {
+                logger.warn("integrations did not stop within timeout: {}", e.getMessage());
+            }
+            // Remove non-hidden files/dirs from /home/jbang to prevent cross-test contamination.
+            // The JBang installation baseline is entirely hidden (.jbang/, .bashrc, .camel-jbang/).
+            try {
+                execInContainer("find /home/jbang -maxdepth 1 -mindepth 1 -not -name '.*' -exec rm -rf {} +");
+            } catch (Exception e) {
+                logger.debug("failed to clean up test files from /home/jbang: {}", e.getMessage());
+            }
+            logger.debug("clean up data folder");
+            if (containerDataFolder != null) {
+                FileUtil.removeDir(new File(containerDataFolder));
+            }
         }
     }
 


### PR DESCRIPTION
# Description

  The JBang IT tests share a singleton container, but `afterEach()` never
  stopped background integrations or cleaned up test files. This caused
  two independent failures:

  1. `BindException` (Address already in use): background routes from one test were still bound to port 8080 when the next test tried to start. Fixed by calling "camel stop" and waiting (via Awaitility) until `"camel ps"` reports no running processes before proceeding.

  2. Wrong OpenAPI spec loaded (HTTP 404): tests that call `downloadFile()` or `generateProperties()` leave files in `/home/jbang/` which persist across tests. A stale application.properties with `camel.jbang.open-api `pointing to `petstore-v3.json` caused a subsequent test to load the wrong spec. Fixed by removing all non-hidden files from `/home/jbang/` after each test. The JBang installation baseline is entirely hidden files (`.jbang/, .bashrc, .camel-jbang/`), so this is safe.

  Also wraps `assertNoErrors()` in `try/finally` so cleanup always runs even
  when log assertions fail.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.


# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

