### PR TITLE
CAMEL-24424: sync the vertx-http REST header filter note into the 4.22 and 4.18 upgrade guides

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -145,6 +145,25 @@ default, stop seeing in-progress aggregations re-delivered, and start seeing gen
 now also holds one entry per completed and not yet confirmed exchange; those entries are removed on
 confirmation.
 
+=== camel-vertx-http - the REST producer applies the outbound header filter
+
+`VertxHttpRestHeaderFilterStrategy.applyFilterToCamelHeaders` delegated to
+`applyFilterToExternalHeaders`, so it consulted the inbound filter while implementing the outbound
+direction. The outbound filter that `VertxHttpHeaderFilterStrategy` installs was therefore never
+applied, and the sibling REST strategies in `camel-http-common`, `camel-netty-http` and
+`camel-undertow` all delegate to the matching method.
+
+A REST producer that resolves to `vertx-http` and does not configure its own `headerFilterStrategy`
+now filters the common HTTP headers on the outbound direction, as the other HTTP components already
+did. A message header named `Content-Length`, `Content-Type`, `Host`, `Cache-Control`, `Connection`,
+`Date`, `Pragma`, `Trailer`, `Transfer-Encoding`, `Upgrade`, `Via` or `Warning` is no longer copied
+onto the outgoing request; the `Content-Type` of the request is still taken from the exchange as
+before. Headers consumed by the URI template or the query parameters continue to be filtered, and a
+custom `headerFilterStrategy` is used as-is and is unaffected.
+
+Routes that relied on one of those headers reaching the wire must set it through the endpoint
+configuration or supply a `headerFilterStrategy` that permits it.
+
 == Upgrading from 4.18.3 to 4.18.4
 
 === camel-core - Multicast EIP honors UseOriginalAggregationStrategy

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -145,6 +145,25 @@ default, stop seeing in-progress aggregations re-delivered, and start seeing gen
 now also holds one entry per completed and not yet confirmed exchange; those entries are removed on
 confirmation.
 
+=== camel-vertx-http - the REST producer applies the outbound header filter
+
+`VertxHttpRestHeaderFilterStrategy.applyFilterToCamelHeaders` delegated to
+`applyFilterToExternalHeaders`, so it consulted the inbound filter while implementing the outbound
+direction. The outbound filter that `VertxHttpHeaderFilterStrategy` installs was therefore never
+applied, and the sibling REST strategies in `camel-http-common`, `camel-netty-http` and
+`camel-undertow` all delegate to the matching method.
+
+A REST producer that resolves to `vertx-http` and does not configure its own `headerFilterStrategy`
+now filters the common HTTP headers on the outbound direction, as the other HTTP components already
+did. A message header named `Content-Length`, `Content-Type`, `Host`, `Cache-Control`, `Connection`,
+`Date`, `Pragma`, `Trailer`, `Transfer-Encoding`, `Upgrade`, `Via` or `Warning` is no longer copied
+onto the outgoing request; the `Content-Type` of the request is still taken from the exchange as
+before. Headers consumed by the URI template or the query parameters continue to be filtered, and a
+custom `headerFilterStrategy` is used as-is and is unaffected.
+
+Routes that relied on one of those headers reaching the wire must set it through the endpoint
+configuration or supply a `headerFilterStrategy` that permits it.
+
 == Upgrading Camel 4.21 to 4.22
 
 === camel-tika


### PR DESCRIPTION
Doc-sync follow-up to #26183, #26209 and #26210.

The `camel-vertx-http` REST producer outbound header filter fix shipped on `main` (4.23.0)
and was backported to `camel-4.22.x` (#26209, 4.22.1) and `camel-4.18.x` (#26210, 4.18.5).
The upgrade guide note, however, only existed in `camel-4x-upgrade-guide-4_23.adoc`.

The version-specific upgrade guides for every release line live on `main` and act as the
canonical history across releases, so a change that ships in a maintenance release needs
its note in that line's guide too. This adds the same note to:

* `camel-4x-upgrade-guide-4_22.adoc`, section `Upgrading from 4.22.0 to 4.22.1`
* `camel-4x-upgrade-guide-4_18.adoc`, section `Upgrading from 4.18.4 to 4.18.5`

The wording is identical to the 4.23 entry — a user upgrading along the 4.22 or 4.18 line
now sees the behavior change at the release it actually reaches them in.

Docs only, no code change.

---
_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)