### PR TITLE
CAMEL-24651: Fix NPE in ExceptionHelper.stackTraceToString() when exception is null

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/language/simple/SimpleTest.java
@@ -642,6 +642,14 @@ public class SimpleTest extends LanguageTestSupport {
     }
 
     @Test
+    public void testExceptionStacktraceNoException() {
+        // CAMEL-24651
+        String out = context.resolveLanguage("simple").createExpression("${exception.stacktrace}").evaluate(exchange,
+                String.class);
+        assertNull(out);
+    }
+
+    @Test
     public void testException() {
         exchange.setException(new IllegalArgumentException("Just testing"));
 

--- a/core/camel-support/src/main/java/org/apache/camel/support/ExceptionHelper.java
+++ b/core/camel-support/src/main/java/org/apache/camel/support/ExceptionHelper.java
@@ -33,9 +33,12 @@ public class ExceptionHelper {
      * Dumps the stack trace from the given exception to a String
      *
      * @param  e the exception to print the stack trace
-     * @return   A string instance with the stack trace for the given exception
+     * @return   A string instance with the stack trace for the given exception, or null if the exception is null
      */
     public static String stackTraceToString(Throwable e) {
+        if (e == null) {
+            return null;
+        }
         final StringWriter writer = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(writer, true);
         e.printStackTrace(printWriter);


### PR DESCRIPTION
Fixes [CAMEL-24651](https://issues.apache.org/jira/browse/CAMEL-24651): regression introduced by commit f9048eb0a822 ("consolidate duplicated code for printing the stack traces").

## Problem

When `${exception.stacktrace}` is evaluated on an exchange that has no exception:

1. `LanguageHelper.exceptionStacktrace()` calls `exception(exchange)` which returns `null`
2. That `null` is passed to `ExceptionHelper.stackTraceToString(null)`
3. `stackTraceToString()` calls `e.printStackTrace(printWriter)` → **NPE**

Prior to the refactoring, the call site had an explicit null check that was lost during consolidation. `LanguageHelper.exceptionMessage()` still has its null guard and is unaffected.

## Fix

Add a null guard at the top of `ExceptionHelper.stackTraceToString()` so it returns `null` when the supplied `Throwable` is `null`. This is the defensive approach: it protects all callers rather than just the one in `LanguageHelper`.

## Test

Added `SimpleTest#testExceptionStacktraceNoException` to cover the regression: evaluating `${exception.stacktrace}` on an exchange with no exception must return `null` (not throw NPE).