### PR TITLE
Fix CamelConfigITCase.testCamelListConfig

### DIFF
--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelConfigITCase.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/CamelConfigITCase.java
@@ -37,9 +37,10 @@ public class CamelConfigITCase extends JBangTestSupport {
         execute("config set runtime=quarkus");
         execute("config set directory=" + mountPoint());
         checkCommandOutputs("config list",
-                "gav = com.foo:acme:1.0-SNAPSHOT\n" +
-                                           "runtime = quarkus\n" +
-                                           "directory = " + mountPoint());
+                new String[] {
+                        "gav = com.foo:acme:1.0-SNAPSHOT",
+                        "runtime = quarkus",
+                        "directory = " + mountPoint() });
     }
 
     @Test

--- a/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
+++ b/dsl/camel-jbang/camel-jbang-it/src/test/java/org/apache/camel/dsl/jbang/it/support/JBangTestSupport.java
@@ -215,6 +215,12 @@ public abstract class JBangTestSupport {
                 .contains(contains);
     }
 
+    protected void checkCommandOutputs(String command, String... contains) {
+        Assertions.assertThat(execute(command))
+                .as("command  " + getMainCommand() + " " + command + " should output each of these lines " + contains)
+                .contains(contains);
+    }
+
     protected void checkCommandFailsWithError(String command, String error) {
         Assertions.assertThat(execute(command, true, true))
                 .as("command " + getMainCommand() + " " + command + " should fail with error " + error)


### PR DESCRIPTION
The order of config in the output is not important, check only if they are all there

it avoids this error:
```
[command  camel config list should output gav =
com.foo:acme:1.0-SNAPSHOT
runtime = quarkus
directory = /deployments/data/84965e9286b07]
Expecting actual:
  "----- Global -----
gav = com.foo:acme:1.0-SNAPSHOT
directory = /deployments/data/84965e9286b07
runtime = quarkus
"
to contain:
  "gav = com.foo:acme:1.0-SNAPSHOT
runtime = quarkus
directory = /deployments/data/84965e9286b07"
```

# Description

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [ ] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [ ] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [ ] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [ ] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

