### PR TITLE
Pin com.squareup.wire:wire-runtime to 6.4.7 to remediate CVE-2026-45799

### DIFF
--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -32,6 +32,26 @@
     <name>Camel :: AWS2 Kinesis</name>
     <description>Consuming and Producing data to AWS Kinesis Service</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin com.squareup.wire:wire-runtime transitively brought in by amazon-kinesis-client
+                 via software.amazon.glue:schema-registry-serde (still on Wire 5.2.0, no release with
+                 the fix) to remediate CVE-2026-45799. wire-runtime is an empty Kotlin-Multiplatform
+                 stub and wire-runtime-jvm carries the fix; both are pinned because the advisory lists
+                 both coordinates. -->
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime</artifactId>
+                <version>${squareup-wire-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime-jvm</artifactId>
+                <version>${squareup-wire-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -507,6 +507,7 @@
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp5-version>5.5.0</squareup-okhttp5-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>
+        <squareup-wire-version>6.4.7</squareup-wire-version>
         <sshd-version>2.19.0</sshd-version>
         <stompjms-version>1.19</stompjms-version>
         <stripe-java-version>33.4.0</stripe-java-version>


### PR DESCRIPTION
`amazon-kinesis-client` pulls in `software.amazon.glue:schema-registry-serde`, which pins Square Wire
at 5.2.0. `ProtoReader.skipGroup()` and `ByteArrayProtoReader32.skipGroup()` before Wire 6.3.0 do not
reject a negative `LENGTH_DELIMITED` length, so a crafted 10-byte payload makes
`ProtoAdapter.decode(byte[])` throw an unchecked `ArrayIndexOutOfBoundsException` instead of the
documented `IOException` (CVE-2026-45799, CVSS 7.5).

Upstream has not fixed this: `schema-registry-serde` 1.1.27 is the latest release and is still on Wire
5.2.0, so `camel-aws2-kinesis` manages the version itself.

### Only `wire-runtime` is bumped — please don't align the rest

`wire-schema`, `wire-compiler` and the Wire code generators deliberately stay at 5.2.0. The Glue serde
binds to `com.squareup.wire.schema.internal.parser.ProtoFileElement`, whose constructor gained a
parameter in Wire **5.3.0**:

```
5.2.0   (Location, String, Syntax, List, List, List, List, List, List)          9 args
6.3.0+  (Location, String, Syntax, List, List, List, List, List, List, List)   10 args
```

`FileDescriptorUtils` calls the 9-arg form, so aligning every Wire artifact breaks the Glue protobuf
path with a `NoSuchMethodError`. No Wire release has both the 9-arg constructor and the CVE fix — the
constructor changed in 5.3.0, the fix landed in 6.3.0. Splitting the versions is the only combination
that satisfies both.

Both `wire-runtime` and `wire-runtime-jvm` are pinned. `wire-runtime` is an empty Kotlin-Multiplatform
metadata artifact (0 classes); `wire-runtime-jvm` carries all 125 classes and is the entry that
actually applies the fix. The advisory lists both coordinates, so both are pinned to keep scanners
quiet.

### Is Camel exposed?

No. This clears a false positive rather than fixing a reachable vulnerability:

- Scanning all 246 jars on the component's classpath plus Camel's own classes, **only Wire's own jars**
  reference `ProtoAdapter` / `ProtoReader`. `schema-registry-serde` (73 classes),
  `schema-registry-common` (32), `amazon-kinesis-client` (457) and `camel-aws2-kinesis` (39) have zero
  references.
- The Glue serde uses Wire only as a `.proto` **schema-text** parser (`ProtoParser`, `SchemaLoader`).
  Protobuf **message** decoding goes through `com.google.protobuf`, not Wire.
- `KclKinesis2Consumer` builds `ConfigsBuilder` itself and never sets a Glue deserializer, so
  `RetrievalConfig.glueSchemaRegistryDeserializer` stays null and KCL branches over the decode step
  entirely. There is no endpoint option or autowired bean to enable it.
- Camel sets the message body to the raw `ByteBuffer` and performs no deserialization.

It is still worth pinning: it removes a recurring finding for every downstream consumer, and protects
users who put their own Wire-using code on the classpath.

### Verification

- Dependency tree moves exactly two artifacts. `okio` stays 3.4.0 and `kotlin-stdlib` stays 1.9.25 —
  no other version churn.
- `mvn test -pl components/camel-aws/camel-aws2-kinesis` — 41/41 green.
- Linkage check of `wire-schema-jvm` 5.2.0 against `wire-runtime-jvm` 6.4.7: one unresolved reference,
  `RuntimeMessageAdapter.<init>(MessageBinding)`, whose only caller is `SchemaProtoAdapterFactory` —
  reachable solely via `Schema.protoAdapter()`, which the Glue serde never calls (it calls only
  `getType`, `getTypes` and `protoFile`). `wire-runtime` 6.4.7 resolves cleanly against the okio and
  kotlin-stdlib versions already on the classpath.
- PoC over 90 crafted payloads through `ProtoAdapter.decode(byte[])`: 60/90 unchecked
  `ArrayIndexOutOfBoundsException` before the change, 0/90 after (all documented `IOException`).
- Glue protobuf path exercised end to end — `FileDescriptorUtils.protoFileToFileDescriptor` on a real
  `.proto` produces an identical `FileDescriptor` before and after.

### Backports

- **4.22.x** — applies cleanly; dependency resolution is identical to main.
- **4.18.x** — not backported. That branch resolves Wire 4.3.0 via KCL 2.6.0, and `wire-runtime` 6.x
  requires Kotlin >= 1.9 (`kotlin.enums.EnumEntriesKt`) while the branch is on `kotlin-stdlib` 1.7.10,
  so the pin fails there with a `NoClassDefFoundError`. Remediating that branch would also require a
  Kotlin stdlib bump.
- **4.14.x** — EOL.

The underlying issue needs fixing in `aws-glue-schema-registry`, which must move off Wire's
`internal.parser` API before it can take a supported Wire version.

---
_Claude Code on behalf of James Netherton_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
