### PR TITLE
CAMEL-24597: Fix MailConverters double getContent() causing flaky POP3 test

### DIFF
--- a/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConverters.java
+++ b/components/camel-mail/src/main/java/org/apache/camel/component/mail/MailConverters.java
@@ -85,17 +85,17 @@ public final class MailConverters {
             for (int i = 0; i < size; i++) {
                 BodyPart part = multipart.getBodyPart(i);
                 Object content = part.getContent();
-                while (content instanceof MimeMultipart) {
-                    if (multipart.getCount() < 1) {
+                while (content instanceof MimeMultipart mimeMultipart) {
+                    if (mimeMultipart.getCount() < 1) {
                         break;
                     }
-                    part = ((MimeMultipart) content).getBodyPart(0);
+                    part = mimeMultipart.getBodyPart(0);
                     content = part.getContent();
                 }
                 // Perform a case-insensitive "startsWith" check that works for different locales
                 String prefix = "text";
                 if (part.getContentType().regionMatches(true, 0, prefix, 0, prefix.length())) {
-                    return part.getContent().toString();
+                    return content.toString();
                 }
             }
         } catch (MessagingException e) {


### PR DESCRIPTION
## Summary

Fixes CAMEL-24597: `MailAttachmentDuplicateNamesTest.testSendAndReceiveMailWithAttachmentsWithDuplicateNames` is flaky when reading mail via POP3.

## Root Cause

In `MailConverters.toString(Multipart)`, `part.getContent()` was called **twice**:

1. Line 87: `Object content = part.getContent();` — fetches the content (consuming the POP3 stream)
2. Line 98: `return part.getContent().toString();` — re-fetches, but the stream is already consumed

With POP3, the underlying `InputStream` from the data source is exhausted after the first read. The second `getContent()` call either:
- Returns the raw `MimeMultipart` object (so `.toString()` gives `jakarta.mail.internet.MimeMultipart@...` instead of `"Hello World"`), or
- Throws `MessagingException: No inputstream from datasource` (which is swallowed by the catch block that ignores folder-closed errors)

There was also a bug in the inner `while` loop guard: `multipart.getCount() < 1` checked the **outer** method parameter (always ≥ 1 when reached) instead of the inner `MimeMultipart`'s count, making the guard dead code.

## Fix

- Use the already-fetched `content` variable at the return site instead of calling `part.getContent()` again
- Fix the inner loop guard to check the inner `MimeMultipart`'s count using `instanceof` pattern matching
- Migrate test assertions from JUnit to AssertJ; drop unnecessary `public` from class/method declarations per CLAUDE.md conventions

## Test

`MailAttachmentDuplicateNamesTest.testSendAndReceiveMailWithAttachmentsWithDuplicateNames` now reliably passes. The test sends a multipart mail (text body + 2 duplicate-named attachments) via SMTP and reads it back via POP3, asserting `getBody(String.class)` returns `"Hello World"` — which is the assertion that was failing.

_Hermes Agent (Claude Sonnet 4.6) on behalf of Guillaume Nodet_