### PR TITLE
[backport camel-4.22.x] Pin com.squareup.wire:wire-runtime to 6.4.7 to remediate CVE-2026-45799

### DIFF
--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -32,6 +32,26 @@
     <name>Camel :: AWS2 Kinesis</name>
     <description>Consuming and Producing data to AWS Kinesis Service</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin com.squareup.wire:wire-runtime transitively brought in by amazon-kinesis-client
+                 via software.amazon.glue:schema-registry-serde (still on Wire 5.2.0, no release with
+                 the fix) to remediate CVE-2026-45799. wire-runtime is an empty Kotlin-Multiplatform
+                 stub and wire-runtime-jvm carries the fix; both are pinned because the advisory lists
+                 both coordinates. -->
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime</artifactId>
+                <version>${squareup-wire-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime-jvm</artifactId>
+                <version>${squareup-wire-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -498,6 +498,7 @@
         <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp5-version>5.4.0</squareup-okhttp5-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>
+        <squareup-wire-version>6.4.7</squareup-wire-version>
         <sshd-version>2.19.0</sshd-version>
         <stompjms-version>1.19</stompjms-version>
         <stripe-java-version>33.2.0</stripe-java-version>


### PR DESCRIPTION
Backport of #26243 to `camel-4.22.x`.

`amazon-kinesis-client` pulls in `software.amazon.glue:schema-registry-serde`, which pins Square Wire
at 5.2.0. `skipGroup()` before Wire 6.3.0 does not reject a negative `LENGTH_DELIMITED` length, so a
crafted 10-byte payload makes `ProtoAdapter.decode(byte[])` throw an unchecked
`ArrayIndexOutOfBoundsException` instead of the documented `IOException` (CVE-2026-45799, CVSS 7.5).
`schema-registry-serde` 1.1.27 is the latest release and is still on Wire 5.2.0, so the version is
managed in the component.

`camel-4.22.x` resolves the same `amazon-kinesis-client` 3.5.1 as `main`, so the dependency graph and
the analysis behind #26243 apply unchanged.

### Only `wire-runtime` is bumped — please don't align the rest

`wire-schema`, `wire-compiler` and the Wire code generators deliberately stay at 5.2.0. The Glue serde
binds to `com.squareup.wire.schema.internal.parser.ProtoFileElement`, whose constructor gained a
parameter in Wire 5.3.0, so aligning every Wire artifact breaks `FileDescriptorUtils` with a
`NoSuchMethodError`. No Wire release has both the 9-arg constructor and the CVE fix.

Both `wire-runtime` and `wire-runtime-jvm` are pinned: `wire-runtime` is an empty
Kotlin-Multiplatform metadata artifact and `wire-runtime-jvm` carries the classes that apply the fix,
but the advisory lists both coordinates.

### Verification on this branch

- Straight cherry-pick — the changeset is byte-identical to the one merged on `main`.
- Dependency tree moves exactly two artifacts; `okio` stays 3.4.0 and `kotlin-stdlib` stays 1.9.25.
- `mvn test -pl components/camel-aws/camel-aws2-kinesis` — 41/41 green.
- PoC over 90 crafted payloads through `ProtoAdapter.decode(byte[])`: 60/90 unchecked
  `ArrayIndexOutOfBoundsException` before the change, 0/90 after (all documented `IOException`).

---
_Claude Code on behalf of James Netherton_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
