### PR TITLE
CAMEL-24666: camel-catalog suggests option names by default with edit distance

### DIFF
--- a/catalog/camel-catalog-suggest/pom.xml
+++ b/catalog/camel-catalog-suggest/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>camel-catalog-suggest</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: Catalog :: Suggest</name>
+    <name>Camel :: Catalog :: Suggest (deprecated)</name>
     <description>Camel Catalog Suggest</description>
 
     <properties>
@@ -41,10 +41,6 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-catalog</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
         </dependency>
 
         <!-- test -->

--- a/catalog/camel-catalog-suggest/src/main/java/org/apache/camel/catalog/suggest/CatalogSuggestionStrategy.java
+++ b/catalog/camel-catalog-suggest/src/main/java/org/apache/camel/catalog/suggest/CatalogSuggestionStrategy.java
@@ -16,19 +16,19 @@
  */
 package org.apache.camel.catalog.suggest;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 import org.apache.camel.catalog.SuggestionStrategy;
-import org.apache.commons.codec.language.Soundex;
+import org.apache.camel.catalog.impl.EditDistanceSuggestionStrategy;
 
 /**
- * Phonetic soundex based {@link SuggestionStrategy}.
+ * Edit distance based {@link SuggestionStrategy}.
+ *
+ * @deprecated since 4.23 the catalog suggests option names by default with {@link EditDistanceSuggestionStrategy} from
+ *             camel-core-catalog; this module is no longer needed.
  */
+@Deprecated(since = "4.23.0")
 public class CatalogSuggestionStrategy implements SuggestionStrategy {
 
     private static final int MAX_SUGGESTIONS = 5;
@@ -39,45 +39,6 @@ public class CatalogSuggestionStrategy implements SuggestionStrategy {
     }
 
     public static String[] suggestEndpointOptions(Collection<String> names, String unknownOption, int maxSuggestions) {
-        List<String> answer = new ArrayList<>();
-        Soundex soundex = Soundex.US_ENGLISH_SIMPLIFIED;
-
-        List<String> sort = new ArrayList<>(names);
-        Collections.sort(sort);
-
-        try {
-            // try highest match first
-            for (String name : sort) {
-                int value = soundex.difference(unknownOption, name);
-                if (value == 4 && answer.size() < maxSuggestions) {
-                    answer.add(name);
-                }
-            }
-            // then the 2nd-best
-            for (String name : sort) {
-                int value = soundex.difference(unknownOption, name);
-                if (value == 3 && answer.size() < maxSuggestions) {
-                    if (!answer.contains(name)) {
-                        answer.add(name);
-                    }
-                }
-            }
-            // then options starting with the same
-            if (answer.size() < maxSuggestions && unknownOption.length() >= 4) {
-                unknownOption = unknownOption.toLowerCase(Locale.ROOT);
-                for (String name : sort) {
-                    String lower = name.toLowerCase(Locale.ROOT);
-                    if (answer.size() < maxSuggestions && lower.startsWith(unknownOption)) {
-                        if (!answer.contains(name)) {
-                            answer.add(name);
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // ignore
-        }
-
-        return answer.toArray(new String[0]);
+        return EditDistanceSuggestionStrategy.suggest(names, unknownOption, maxSuggestions);
     }
 }

--- a/catalog/camel-catalog-suggest/src/test/java/org/apache/camel/catalog/suggest/CamelCatalogSuggestTest.java
+++ b/catalog/camel-catalog-suggest/src/test/java/org/apache/camel/catalog/suggest/CamelCatalogSuggestTest.java
@@ -54,11 +54,10 @@ public class CamelCatalogSuggestTest {
         EndpointValidationResult result = catalog.validateEndpointProperties("log:mylog?showE=true");
         assertFalse(result.isSuccess());
         assertTrue(result.getUnknown().contains("showE"));
-        assertEquals(4, result.getUnknownSuggestions().get("showE").length);
-        assertEquals("showAll", result.getUnknownSuggestions().get("showE")[0]);
-        assertEquals("showException", result.getUnknownSuggestions().get("showE")[1]);
-        assertEquals("showExchangeId", result.getUnknownSuggestions().get("showE")[2]);
-        assertEquals("showExchangePattern", result.getUnknownSuggestions().get("showE")[3]);
+        assertEquals(3, result.getUnknownSuggestions().get("showE").length);
+        assertEquals("showException", result.getUnknownSuggestions().get("showE")[0]);
+        assertEquals("showExchangeId", result.getUnknownSuggestions().get("showE")[1]);
+        assertEquals("showExchangePattern", result.getUnknownSuggestions().get("showE")[2]);
         assertEquals(1, result.getNumberOfErrors());
     }
 }

--- a/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/CamelCatalog.java
+++ b/catalog/camel-catalog/src/main/java/org/apache/camel/catalog/CamelCatalog.java
@@ -82,7 +82,8 @@ public interface CamelCatalog {
     boolean isCaching();
 
     /**
-     * To plugin a custom {@link SuggestionStrategy} to provide suggestion for unknown options
+     * To plugin a custom {@link SuggestionStrategy} to provide suggestion for unknown options. An edit-distance based
+     * strategy is used by default (since 4.23); set null to turn suggestions off.
      */
     void setSuggestionStrategy(SuggestionStrategy suggestionStrategy);
 

--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogSuggestionTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogSuggestionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.catalog;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.camel.catalog.impl.EditDistanceSuggestionStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The catalog suggests the closest option names and enum values out of the box (edit distance based).
+ */
+public class CamelCatalogSuggestionTest {
+
+    private final CamelCatalog catalog = new DefaultCamelCatalog();
+
+    @Test
+    public void suggestsByDefault() {
+        assertNotNull(catalog.getSuggestionStrategy());
+        assertTrue(catalog.getSuggestionStrategy() instanceof EditDistanceSuggestionStrategy);
+    }
+
+    @Test
+    public void typoInOptionName() {
+        EndpointValidationResult result = catalog.validateEndpointProperties("log:mylog?levl=WARN");
+        assertFalse(result.isSuccess());
+        assertTrue(result.getUnknown().contains("levl"));
+        assertEquals("level", result.getUnknownSuggestions().get("levl")[0]);
+        assertTrue(result.summaryErrorMessage(false).contains("Did you mean: [level]"));
+    }
+
+    @Test
+    public void wrongCaseAndSwappedLetters() {
+        EndpointValidationResult result = catalog.validateEndpointProperties("kafka:orders?groupid=demo&brokres=x");
+        assertEquals("groupId", result.getUnknownSuggestions().get("groupid")[0]);
+        assertEquals("brokers", result.getUnknownSuggestions().get("brokres")[0]);
+    }
+
+    @Test
+    public void partlyTypedNameListsTheNamesStartingWithIt() {
+        EndpointValidationResult result = catalog.validateEndpointProperties("log:mylog?showE=true");
+        assertArrayEquals(new String[] { "showException", "showExchangeId", "showExchangePattern" },
+                result.getUnknownSuggestions().get("showE"));
+    }
+
+    @Test
+    public void nothingCloseGivesNoSuggestion() {
+        EndpointValidationResult result = catalog.validateEndpointProperties("log:mylog?xyzzyqwerty=true");
+        assertEquals(0, result.getUnknownSuggestions().get("xyzzyqwerty").length);
+        assertTrue(result.summaryErrorMessage(false).contains("Unknown option"));
+        assertFalse(result.summaryErrorMessage(false).contains("Did you mean"));
+    }
+
+    @Test
+    public void invalidEnumValueSuggestsTheClosestChoice() {
+        EndpointValidationResult result = catalog.validateEndpointProperties("log:mylog?level=WARM");
+        assertFalse(result.isSuccess());
+        assertEquals("WARM", result.getInvalidEnum().get("level"));
+        assertEquals("WARN", result.getInvalidEnumSuggestions().get("level")[0]);
+    }
+
+    @Test
+    public void suggestionsCanBeTurnedOff() {
+        CamelCatalog silent = new DefaultCamelCatalog();
+        silent.setSuggestionStrategy(null);
+        EndpointValidationResult result = silent.validateEndpointProperties("log:mylog?levl=WARN");
+        assertTrue(result.getUnknown().contains("levl"));
+        assertNull(result.getUnknownSuggestions());
+    }
+
+    @Test
+    public void strategyRanksExactThenPrefixThenDistance() {
+        List<String> names = Arrays.asList("period", "fixedRate", "delay", "repeatCount", "timerName", "time");
+        assertArrayEquals(new String[] { "fixedRate" }, EditDistanceSuggestionStrategy.suggest(names, "fixedRte", 5));
+        assertArrayEquals(new String[] { "period" }, EditDistanceSuggestionStrategy.suggest(names, "PERIOD", 5));
+        // "tim" is a prefix of both; the shorter name sorts first alphabetically
+        assertArrayEquals(new String[] { "time", "timerName" }, EditDistanceSuggestionStrategy.suggest(names, "tim", 5));
+        assertArrayEquals(new String[] { "delay" }, EditDistanceSuggestionStrategy.suggest(names, "dealy", 5));
+        assertEquals(0, EditDistanceSuggestionStrategy.suggest(names, "brokers", 5).length);
+        assertEquals(0, EditDistanceSuggestionStrategy.suggest(names, "", 5).length);
+        assertEquals(0, EditDistanceSuggestionStrategy.suggest(null, "period", 5).length);
+        assertEquals(1, EditDistanceSuggestionStrategy.suggest(names, "tim", 1).length);
+        assertEquals(1, new EditDistanceSuggestionStrategy().suggestEndpointOptions(Set.of("period"), "perod").length);
+    }
+}

--- a/catalog/camel-report-maven-plugin/pom.xml
+++ b/catalog/camel-report-maven-plugin/pom.xml
@@ -69,11 +69,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-catalog-suggest</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
             <artifactId>camel-catalog-maven</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/ValidateMojo.java
+++ b/catalog/camel-report-maven-plugin/src/main/java/org/apache/camel/maven/ValidateMojo.java
@@ -34,7 +34,6 @@ import org.apache.camel.catalog.EndpointValidationResult;
 import org.apache.camel.catalog.LanguageValidationResult;
 import org.apache.camel.catalog.common.FileUtil;
 import org.apache.camel.catalog.maven.MavenVersionManager;
-import org.apache.camel.catalog.suggest.CatalogSuggestionStrategy;
 import org.apache.camel.parser.RouteBuilderParser;
 import org.apache.camel.parser.XmlRouteParser;
 import org.apache.camel.parser.model.CamelEndpointDetails;
@@ -247,8 +246,6 @@ public class ValidateMojo extends AbstractMojo {
         CamelCatalog catalog = new DefaultCamelCatalog();
         // add activemq as a known component
         catalog.addComponent("activemq", "org.apache.activemq.camel.component.ActiveMQComponent");
-        // enable did you mean
-        catalog.setSuggestionStrategy(new CatalogSuggestionStrategy());
         // enable loading other catalog versions dynamically
         catalog.setVersionManager(
                 new MavenVersionManager(repositorySystem, repositorySystemSession, session.getSettings()));

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
@@ -77,7 +77,7 @@ public abstract class AbstractCamelCatalog {
     private static final Pattern SYNTAX_DASH_PATTERN = Pattern.compile("([\\w.-]+)");
     private static final Pattern COMPONENT_SYNTAX_PARSER = Pattern.compile("([^\\w-]*)([\\w-]+)");
 
-    private SuggestionStrategy suggestionStrategy;
+    private SuggestionStrategy suggestionStrategy = new EditDistanceSuggestionStrategy();
     private JSonSchemaResolver jsonSchemaResolver;
 
     public String componentJSonSchema(String name) {

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/EditDistanceSuggestionStrategy.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/EditDistanceSuggestionStrategy.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.catalog.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.camel.catalog.SuggestionStrategy;
+
+/**
+ * A {@link SuggestionStrategy} based on edit distance, for the "did you mean" of unknown option names and invalid enum
+ * values. Option names are camelCase identifiers, so a mistake is a typo, a slip of case, a missing or swapped letter,
+ * or a name typed only partly; the strategy ranks the known names by how many such edits separate them from the unknown
+ * one and returns the closest, at most {@link #DEFAULT_MAX_SUGGESTIONS} of them.
+ * <p>
+ * A name that matches ignoring case comes first, then names the unknown one is a prefix of (or that are a prefix of
+ * it), then names within a small Damerau-Levenshtein distance (transpositions count as one edit). The distance allowed
+ * grows with the length of the name, so a long name may be a few letters off while a short one must be close. This is
+ * the default strategy of the catalog.
+ */
+public class EditDistanceSuggestionStrategy implements SuggestionStrategy {
+
+    public static final int DEFAULT_MAX_SUGGESTIONS = 5;
+
+    private static final int MIN_PREFIX_LENGTH = 3;
+
+    private final int maxSuggestions;
+
+    public EditDistanceSuggestionStrategy() {
+        this(DEFAULT_MAX_SUGGESTIONS);
+    }
+
+    public EditDistanceSuggestionStrategy(int maxSuggestions) {
+        this.maxSuggestions = maxSuggestions;
+    }
+
+    @Override
+    public String[] suggestEndpointOptions(Set<String> names, String unknownOption) {
+        return suggest(names, unknownOption, maxSuggestions);
+    }
+
+    /**
+     * The known names closest to the unknown one, best first; empty when none is close enough.
+     *
+     * @param  names          the valid names
+     * @param  unknown        the name that was not recognised
+     * @param  maxSuggestions how many names to return at most
+     * @return                the suggestions, never null
+     */
+    public static String[] suggest(Collection<String> names, String unknown, int maxSuggestions) {
+        if (names == null || unknown == null || unknown.isBlank() || maxSuggestions <= 0) {
+            return new String[0];
+        }
+        String key = unknown.trim().toLowerCase(Locale.ROOT);
+        int allowed = allowedDistance(key);
+        List<Match> matches = new ArrayList<>();
+        for (String name : names) {
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            String candidate = name.toLowerCase(Locale.ROOT);
+            int score;
+            if (candidate.equals(key)) {
+                score = 0;
+            } else if (isPrefix(candidate, key)) {
+                score = 1;
+            } else {
+                int distance = distance(candidate, key);
+                if (distance > allowed) {
+                    continue;
+                }
+                // a real edit is never as good as a name that only lacks its tail
+                score = distance + 1;
+            }
+            matches.add(new Match(name, score));
+        }
+        matches.sort(Comparator.comparingInt(Match::score).thenComparing(Match::name));
+        List<String> answer = new ArrayList<>();
+        for (Match match : matches) {
+            if (answer.size() >= maxSuggestions) {
+                break;
+            }
+            answer.add(match.name());
+        }
+        return answer.toArray(new String[0]);
+    }
+
+    /** How many edits a name may be off: two for short names, a quarter of the length for longer ones. */
+    static int allowedDistance(String key) {
+        return Math.max(2, key.length() / 4);
+    }
+
+    private static boolean isPrefix(String candidate, String key) {
+        if (key.length() >= MIN_PREFIX_LENGTH && candidate.startsWith(key)) {
+            return true;
+        }
+        return candidate.length() >= MIN_PREFIX_LENGTH && key.startsWith(candidate);
+    }
+
+    /**
+     * The Damerau-Levenshtein distance (optimal string alignment): insertions, deletions, substitutions and
+     * transpositions of adjacent characters each count as one edit.
+     */
+    static int distance(String a, String b) {
+        int n = a.length();
+        int m = b.length();
+        if (n == 0) {
+            return m;
+        }
+        if (m == 0) {
+            return n;
+        }
+        int[][] d = new int[n + 1][m + 1];
+        for (int i = 0; i <= n; i++) {
+            d[i][0] = i;
+        }
+        for (int j = 0; j <= m; j++) {
+            d[0][j] = j;
+        }
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+                int value = Math.min(Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1), d[i - 1][j - 1] + cost);
+                if (i > 1 && j > 1 && a.charAt(i - 1) == b.charAt(j - 2) && a.charAt(i - 2) == b.charAt(j - 1)) {
+                    value = Math.min(value, d[i - 2][j - 2] + 1);
+                }
+                d[i][j] = value;
+            }
+        }
+        return d[n][m];
+    }
+
+    private record Match(String name, int score) {
+    }
+}

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_23.adoc
@@ -162,7 +162,23 @@ The Maven archetype `camel-archetype-spring` was deprecated in 4.17. Use spring 
 
 ==== camel-catalog-lucene
 
-The maven plugin was deprecated in 4.12. `camel-catalog-suggest` is replacing it.
+The maven plugin was deprecated in 4.12. The catalog now has built-in suggestions (see `camel-catalog` below).
+
+=== camel-catalog - did-you-mean suggestions by default, camel-catalog-suggest deprecated
+
+`CamelCatalog` now suggests the closest option names (and enum values) by default when validation finds an
+unknown one, using the new edit-distance based `org.apache.camel.catalog.impl.EditDistanceSuggestionStrategy`
+from `camel-core-catalog`. Before, suggestions were only produced when a `SuggestionStrategy` had been set
+explicitly, which meant the CLI and the TUI validators never gave any. Code that never wants suggestions can call
+`setSuggestionStrategy(null)`.
+
+The `camel-catalog-suggest` module with its phonetic (Soundex, commons-codec based) `CatalogSuggestionStrategy`
+is deprecated: the class now delegates to the edit-distance strategy and the module no longer depends on
+commons-codec. Remove the dependency and the `setSuggestionStrategy` call; the default gives the same or better
+suggestions. Edit distance also changes what is suggested: a partly typed name lists the names starting with it,
+and a name with a typo lists the names a few edits away, whereas Soundex matched by the sound of the consonants
+(for `showE` the `log` component now suggests `showException`, `showExchangeId` and `showExchangePattern`, no
+longer `showAll`).
 
 ==== camel-digitalocean
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistry.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistry.java
@@ -1571,13 +1571,7 @@ class TuiToolRegistry {
             result.put("problems", new JsonArray(List.of("Cannot parse the URI: " + e.getMessage())));
             return Jsoner.serialize(result);
         }
-        List<String> known = new ArrayList<>();
-        if (cm.getEndpointOptions() != null) {
-            for (BaseOptionModel opt : cm.getEndpointOptions()) {
-                known.add(opt.getName());
-            }
-        }
-        List<String> problems = endpointProblems(validation, scheme, known);
+        List<String> problems = endpointProblems(validation);
         List<String> warnings = new ArrayList<>();
         if (validation.getDeprecated() != null) {
             for (String name : validation.getDeprecated()) {
@@ -1618,7 +1612,7 @@ class TuiToolRegistry {
         return Jsoner.serialize(result);
     }
 
-    static List<String> endpointProblems(EndpointValidationResult r, String scheme, List<String> knownOptions) {
+    static List<String> endpointProblems(EndpointValidationResult r) {
         List<String> problems = new ArrayList<>();
         if (r.getSyntaxError() != null) {
             problems.add("Syntax error: " + r.getSyntaxError());
@@ -1632,11 +1626,10 @@ class TuiToolRegistry {
         if (r.getUnknown() != null) {
             for (String name : r.getUnknown()) {
                 StringBuilder sb = new StringBuilder("Unknown option '").append(name).append("'");
+                // the catalog suggests the closest names itself (edit distance, CAMEL-24666)
                 String[] suggestions = r.getUnknownSuggestions() != null ? r.getUnknownSuggestions().get(name) : null;
-                List<String> similar = suggestions != null && suggestions.length > 0
-                        ? Arrays.asList(suggestions) : similarNames(knownOptions, name, 3);
-                if (!similar.isEmpty()) {
-                    sb.append(". Did you mean: ").append(similar);
+                if (suggestions != null && suggestions.length > 0) {
+                    sb.append(". Did you mean: ").append(Arrays.asList(suggestions));
                 }
                 problems.add(sb.toString());
             }
@@ -1675,50 +1668,6 @@ class TuiToolRegistry {
             }
         }
         return problems;
-    }
-
-    /**
-     * The known names closest to a misspelled one (a typo, a case slip or a missing letter), by edit distance; the
-     * catalog's own suggestion strategy is an optional module that is not on the TUI's classpath.
-     */
-    static List<String> similarNames(List<String> known, String name, int max) {
-        String lower = name.toLowerCase(Locale.ROOT);
-        int allowed = Math.max(2, lower.length() / 4);
-        List<Map.Entry<String, Integer>> ranked = new ArrayList<>();
-        for (String candidate : known) {
-            String c = candidate.toLowerCase(Locale.ROOT);
-            int distance = c.contains(lower) || lower.contains(c) ? 1 : editDistance(c, lower);
-            if (distance <= allowed) {
-                ranked.add(Map.entry(candidate, distance));
-            }
-        }
-        ranked.sort(Map.Entry.comparingByValue());
-        List<String> answer = new ArrayList<>();
-        for (Map.Entry<String, Integer> entry : ranked) {
-            if (answer.size() < max) {
-                answer.add(entry.getKey());
-            }
-        }
-        return answer;
-    }
-
-    private static int editDistance(String a, String b) {
-        int[] prev = new int[b.length() + 1];
-        int[] cur = new int[b.length() + 1];
-        for (int j = 0; j <= b.length(); j++) {
-            prev[j] = j;
-        }
-        for (int i = 1; i <= a.length(); i++) {
-            cur[0] = i;
-            for (int j = 1; j <= b.length(); j++) {
-                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
-                cur[j] = Math.min(Math.min(cur[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
-            }
-            int[] swap = prev;
-            prev = cur;
-            cur = swap;
-        }
-        return prev[b.length()];
     }
 
     private static void addInvalid(List<String> problems, Map<String, String> invalid, String type) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistryCatalogDocTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistryCatalogDocTest.java
@@ -111,11 +111,6 @@ class TuiToolRegistryCatalogDocTest {
         assertFalse(scheme.getCollection("suggestions").isEmpty());
         assertTrue(catalogDoc(Map.of("endpoint", "no-scheme-here")).getString("error").contains("Not an endpoint URI"));
         assertTrue(catalogDoc(Map.of()).getString("error").contains("required"));
-
-        assertEquals(List.of("fixedRate"), TuiToolRegistry.similarNames(List.of("fixedRate", "period", "delay"),
-                "fixedRte", 3));
-        assertEquals(List.of("groupId"), TuiToolRegistry.similarNames(List.of("groupId", "brokers"), "groupid", 3));
-        assertTrue(TuiToolRegistry.similarNames(List.of("period"), "brokers", 3).isEmpty());
     }
 
     @Test

--- a/dsl/camel-kamelet-main/pom.xml
+++ b/dsl/camel-kamelet-main/pom.xml
@@ -140,10 +140,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-catalog-suggest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
             <artifactId>camel-catalog-console</artifactId>
         </dependency>
 

--- a/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/SuggestSimilarHelper.java
+++ b/dsl/camel-kamelet-main/src/main/java/org/apache/camel/main/util/SuggestSimilarHelper.java
@@ -19,7 +19,7 @@ package org.apache.camel.main.util;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.camel.catalog.suggest.CatalogSuggestionStrategy;
+import org.apache.camel.catalog.impl.EditDistanceSuggestionStrategy;
 
 public final class SuggestSimilarHelper {
 
@@ -29,7 +29,7 @@ public final class SuggestSimilarHelper {
     }
 
     public static List<String> didYouMean(List<String> names, String unknown) {
-        String[] suggestions = CatalogSuggestionStrategy.suggestEndpointOptions(names, unknown, MAX_SUGGESTIONS);
+        String[] suggestions = EditDistanceSuggestionStrategy.suggest(names, unknown, MAX_SUGGESTIONS);
         if (suggestions != null) {
             return Arrays.asList(suggestions);
         }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-24666

## What

The catalog's "did you mean" for unknown option names and invalid enum values is now built in and on by default.

- **`EditDistanceSuggestionStrategy`** in `camel-core-catalog`: a case-insensitive exact match ranks first, then names the unknown one is a prefix of (a partly typed name), then names within a small Damerau-Levenshtein distance that grows with the name length. At most 5 suggestions, ranked by closeness then name. No third-party dependency.
- **`AbstractCamelCatalog`** uses it as the default `SuggestionStrategy`, so `camel validate`, the TUI validators, the MCP server and every other catalog user get suggestions without wiring. `setSuggestionStrategy(null)` turns them off.
- **`camel-catalog-suggest`** is deprecated: `CatalogSuggestionStrategy` delegates to the new strategy and the module no longer depends on commons-codec (Soundex was its only use). `camel-report-maven-plugin` and `camel-kamelet-main` use the core strategy directly and drop the dependency.
- Upgrade guide entry for 4.23 (default behaviour change, module deprecation, and what changes in the suggestions).
- **`camel-jbang-plugin-tui`** drops the edit-distance fallback its endpoint check carried for the same reason; the catalog's suggestions are used as they are.

## Why

The only strategy was phonetic: Soundex matches by the sound of the consonants, which is fine for surnames and wrong for camelCase identifiers, where a mistake is a typo, a case slip, a swapped letter or a missing tail. And it was installed in only two places, so most users never saw a suggestion at all. AI assistants (the TUI's built-in AI with local models, MCP clients) correct themselves from the validation messages; a message that names the right option turns a retry into a fix.

Example, `log:mylog?levl=WARN` now reports `Unknown option. Did you mean: [level]` out of the box; `kafka:orders?groupid=demo&brokres=x` suggests `groupId` and `brokers`; `log:mylog?level=WARM` suggests `WARN`.

## Testing

- New `CamelCatalogSuggestionTest` in camel-catalog (typo, case, swapped letters, prefix, nothing close, enum value, turning it off, ranking).
- `CamelCatalogSuggestTest` in the deprecated module updated to the edit-distance results.
- Full camel-catalog suite (1034 tests) green, camel-jbang-core and camel-jbang-plugin-tui validation tests green, camel-report-maven-plugin and camel-kamelet-main compile.

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJi142oSKk3QhHNw25QhEo
