### PR TITLE
camel-vertx-websocket: Fix flaky peer count assertions in VertxWebsocketTest

### DIFF
--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebSocketTestSupport.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebSocketTestSupport.java
@@ -26,6 +26,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.impl.VertxInternal;
@@ -36,6 +37,9 @@ import io.vertx.ext.web.RoutingContext;
 import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit6.CamelTestSupport;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VertxWebSocketTestSupport extends CamelTestSupport {
 
@@ -67,6 +71,19 @@ public class VertxWebSocketTestSupport extends CamelTestSupport {
         WebSocket webSocket = future.get(5, TimeUnit.SECONDS);
         webSocket.textMessageHandler(handler::accept);
         return webSocket;
+    }
+
+    /**
+     * Waits for the given endpoint to have registered the expected number of connected peers.
+     * <p>
+     * {@link #openWebSocketConnection(String, int, String, Consumer)} returns as soon as the client side of the
+     * handshake completes, which can happen before the server side consumer has registered the peer. Asserting the peer
+     * count immediately after opening the connections is therefore racy.
+     */
+    public Map<String, ServerWebSocket> awaitConnectedPeers(VertxWebsocketEndpoint endpoint, int expectedPeerCount) {
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(expectedPeerCount, endpoint.findPeersForHostPort().size()));
+        return endpoint.findPeersForHostPort();
     }
 
     public Router createRouter(String path, CountDownLatch latch) {

--- a/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketTest.java
+++ b/components/camel-vertx/camel-vertx-websocket/src/test/java/org/apache/camel/component/vertx/websocket/VertxWebsocketTest.java
@@ -105,8 +105,7 @@ public class VertxWebsocketTest extends VertxWebSocketTestSupport {
 
         VertxWebsocketEndpoint endpoint
                 = context.getEndpoint("vertx-websocket:localhost:" + port + "/test", VertxWebsocketEndpoint.class);
-        Map<String, ServerWebSocket> connectedPeers = endpoint.findPeersForHostPort();
-        assertEquals(2, connectedPeers.size());
+        Map<String, ServerWebSocket> connectedPeers = awaitConnectedPeers(endpoint, 2);
 
         String connectionKey = connectedPeers.keySet().iterator().next();
 
@@ -136,8 +135,7 @@ public class VertxWebsocketTest extends VertxWebSocketTestSupport {
         VertxWebsocketEndpoint endpoint
                 = context.getEndpoint("vertx-websocket:localhost:" + port + "/test/paramA/other/paramB",
                         VertxWebsocketEndpoint.class);
-        Map<String, ServerWebSocket> connectedPeers = endpoint.findPeersForHostPort();
-        assertEquals(2, connectedPeers.size());
+        Map<String, ServerWebSocket> connectedPeers = awaitConnectedPeers(endpoint, 2);
 
         String connectionKey = connectedPeers.keySet().iterator().next();
 
@@ -168,8 +166,7 @@ public class VertxWebsocketTest extends VertxWebSocketTestSupport {
         VertxWebsocketEndpoint endpoint
                 = context.getEndpoint("vertx-websocket:localhost:" + port + "/test/paramA/other/paramB",
                         VertxWebsocketEndpoint.class);
-        Map<String, ServerWebSocket> connectedPeers = endpoint.findPeersForHostPort();
-        assertEquals(2, connectedPeers.size());
+        Map<String, ServerWebSocket> connectedPeers = awaitConnectedPeers(endpoint, 2);
 
         String connectionKey = connectedPeers.keySet().iterator().next();
 
@@ -207,8 +204,7 @@ public class VertxWebsocketTest extends VertxWebSocketTestSupport {
         VertxWebsocketEndpoint endpoint
                 = context.getEndpoint("vertx-websocket:localhost:" + port + "/test/wildcarded/path",
                         VertxWebsocketEndpoint.class);
-        Map<String, ServerWebSocket> connectedPeers = endpoint.findPeersForHostPort();
-        assertEquals(2, connectedPeers.size());
+        Map<String, ServerWebSocket> connectedPeers = awaitConnectedPeers(endpoint, 2);
 
         String connectionKey = connectedPeers.keySet().iterator().next();
 
@@ -245,8 +241,7 @@ public class VertxWebsocketTest extends VertxWebSocketTestSupport {
         VertxWebsocketEndpoint endpoint
                 = context.getEndpoint("vertx-websocket:localhost:" + port + "/test/wildcarded/path",
                         VertxWebsocketEndpoint.class);
-        Map<String, ServerWebSocket> connectedPeers = endpoint.findPeersForHostPort();
-        assertEquals(2, connectedPeers.size());
+        Map<String, ServerWebSocket> connectedPeers = awaitConnectedPeers(endpoint, 2);
 
         String connectionKey = connectedPeers.keySet().iterator().next();
 
@@ -287,8 +282,7 @@ public class VertxWebsocketTest extends VertxWebSocketTestSupport {
 
         VertxWebsocketEndpoint endpoint
                 = context.getEndpoint("vertx-websocket:localhost:" + port + "/test", VertxWebsocketEndpoint.class);
-        Map<String, ServerWebSocket> connectedPeers = endpoint.findPeersForHostPort();
-        assertEquals(5, connectedPeers.size());
+        Map<String, ServerWebSocket> connectedPeers = awaitConnectedPeers(endpoint, 5);
 
         StringJoiner joiner = new StringJoiner(",");
         Iterator<String> iterator = connectedPeers.keySet().iterator();


### PR DESCRIPTION
## Motivation

`VertxWebsocketTest.testSendWithMultipleConnectionKeys` failed in CI on #26257 with:

```
org.opentest4j.AssertionFailedError: expected: <5> but was: <4>
	at VertxWebsocketTest.testSendWithMultipleConnectionKeys(VertxWebsocketTest.java:291)
```

(all three surefire reruns failed, and the failure had nothing to do with that PR)

`openWebSocketConnection()` returns as soon as the **client** side of the WebSocket handshake completes, which can happen before the **server** side consumer has registered the peer. Asserting `endpoint.findPeersForHostPort().size()` on the very next line is therefore racy — under CI load one peer can still be missing.

Six test methods in `VertxWebsocketTest` share this exact pattern (open N connections, immediately assert the peer map has N entries), so all six are potentially flaky, not just the one that failed.

## Modifications

- Add `awaitConnectedPeers(VertxWebsocketEndpoint, int)` to `VertxWebSocketTestSupport`, which waits with Awaitility (already a test dependency of the module) until the endpoint has registered the expected number of peers, then returns the peer map. It uses `untilAsserted(...)` so a genuine mismatch still reports the familiar `expected: <5> but was: <4>` message instead of an opaque timeout.
- Replace the six racy `findPeersForHostPort()` + `assertEquals(n, ...)` pairs in `VertxWebsocketTest` with a call to the helper.

Test-only change — no production code touched.

## Result

`mvn test` in `components/camel-vertx/camel-vertx-websocket`: 85 tests, 0 failures, 0 errors.

---
_Claude Code on behalf of davsclaus_