### PR TITLE
[backport camel-4.22.x] CAMEL-24669: camel-groovy - Support Jackson 3 nodes in groovyJson/groovyXml and fix prettyPrint=false

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/groovyJson-dataformat.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/groovyJson-dataformat.adoc
@@ -28,7 +28,7 @@ include::partial$dataformat-options.adoc[]
 This data format supports marshalling from the following Java type to JSon:
 
 - Groovy XML Node object (`groovy.util.Node`) (such as message body is from Groovy XML)
-- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode`)
+- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode` or `tools.jackson.databind.JsonNode`)
 - Camel JSonObject (`org.apache.camel.util.json.JsonObject`)
 - Java Map object ('java.util.Map')
 - Java List object ('java.util.List')

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/groovyXml-dataformat.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/groovyXml-dataformat.adoc
@@ -26,7 +26,7 @@ include::partial$dataformat-options.adoc[]
 This data format supports marshalling from the following Java type to XML:
 
 - Groovy XML Node object (`groovy.util.Node`)
-- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode`)
+- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode` or `tools.jackson.databind.JsonNode`)
 - Camel JSonObject (`org.apache.camel.util.json.JsonObject`)
 - Java Map object ('java.util.Map')
 

--- a/components/camel-groovy/pom.xml
+++ b/components/camel-groovy/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jackson3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/camel-groovy/src/main/docs/groovyJson-dataformat.adoc
+++ b/components/camel-groovy/src/main/docs/groovyJson-dataformat.adoc
@@ -28,7 +28,7 @@ include::partial$dataformat-options.adoc[]
 This data format supports marshalling from the following Java type to JSon:
 
 - Groovy XML Node object (`groovy.util.Node`) (such as message body is from Groovy XML)
-- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode`)
+- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode` or `tools.jackson.databind.JsonNode`)
 - Camel JSonObject (`org.apache.camel.util.json.JsonObject`)
 - Java Map object ('java.util.Map')
 - Java List object ('java.util.List')

--- a/components/camel-groovy/src/main/docs/groovyXml-dataformat.adoc
+++ b/components/camel-groovy/src/main/docs/groovyXml-dataformat.adoc
@@ -26,7 +26,7 @@ include::partial$dataformat-options.adoc[]
 This data format supports marshalling from the following Java type to XML:
 
 - Groovy XML Node object (`groovy.util.Node`)
-- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode`)
+- Jackson Node object (`com.fasterxml.jackson.databind.JsonNode` or `tools.jackson.databind.JsonNode`)
 - Camel JSonObject (`org.apache.camel.util.json.JsonObject`)
 - Java Map object ('java.util.Map')
 

--- a/components/camel-groovy/src/main/java/org/apache/camel/groovy/json/GroovyJSonlDataFormat.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/groovy/json/GroovyJSonlDataFormat.java
@@ -51,8 +51,9 @@ public class GroovyJSonlDataFormat extends ServiceSupport implements DataFormat,
         if (graph instanceof Map map) {
             serialize(map, stream);
         } else {
-            // optional jackson support (TODO: jackson3)
-            if (graph.getClass().getName().startsWith("com.fasterxml.jackson.databind")) {
+            // optional jackson 2.x or 3.x support
+            String type = graph.getClass().getName();
+            if (type.startsWith("com.fasterxml.jackson.databind") || type.startsWith("tools.jackson.databind")) {
                 var map = exchange.getContext().getTypeConverter().convertTo(Map.class, exchange, graph);
                 serialize(map, stream);
             } else {
@@ -75,7 +76,9 @@ public class GroovyJSonlDataFormat extends ServiceSupport implements DataFormat,
 
     private void serialize(Map map, OutputStream stream) throws IOException {
         String out = JsonOutput.toJson(map);
-        out = prettyPrint ? JsonOutput.prettyPrint(out) : JsonOutput.toJson(out);
+        if (prettyPrint) {
+            out = JsonOutput.prettyPrint(out);
+        }
         stream.write(out.getBytes());
     }
 

--- a/components/camel-groovy/src/main/java/org/apache/camel/groovy/xml/GroovyXmlDataFormat.java
+++ b/components/camel-groovy/src/main/java/org/apache/camel/groovy/xml/GroovyXmlDataFormat.java
@@ -64,8 +64,9 @@ public class GroovyXmlDataFormat extends ServiceSupport implements DataFormat, D
         } else if (graph instanceof Map map) {
             serialize(exchange, map, stream);
         } else {
-            // optional jackson support (TODO: jackson3)
-            if (graph.getClass().getName().startsWith("com.fasterxml.jackson.databind")) {
+            // optional jackson 2.x or 3.x support
+            String type = graph.getClass().getName();
+            if (type.startsWith("com.fasterxml.jackson.databind") || type.startsWith("tools.jackson.databind")) {
                 var map = exchange.getContext().getTypeConverter().convertTo(Map.class, exchange, graph);
                 serialize(exchange, map, stream);
             } else {

--- a/components/camel-groovy/src/test/java/org/apache/camel/groovy/GroovyJackson3DataFormatTest.java
+++ b/components/camel-groovy/src/test/java/org/apache/camel/groovy/GroovyJackson3DataFormatTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.groovy;
+
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Jackson 3.x nodes can be marshalled with groovyJson and groovyXml (Jackson 2.x is covered by the other tests).
+ */
+public class GroovyJackson3DataFormatTest extends CamelTestSupport {
+
+    private static final String BOOK_JSON = """
+            {
+                "book": {
+                    "_id": "bk101",
+                    "title": "1984"
+                }
+            }""";
+
+    private static final String BOOK_XML = """
+            <book id="bk101">
+              <title>1984</title>
+            </book>
+            """;
+
+    private final JsonNode book = JsonMapper.builder().build().readTree(BOOK_JSON);
+
+    @Test
+    public void testMarshalGroovyJson() {
+        Assertions.assertEquals(BOOK_JSON, template.requestBody("direct:json", book, String.class));
+    }
+
+    @Test
+    public void testMarshalGroovyXml() {
+        Assertions.assertEquals(BOOK_XML, template.requestBody("direct:xml", book, String.class));
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:json").marshal().groovyJson();
+                from("direct:xml").marshal().groovyXml();
+            }
+        };
+    }
+}

--- a/components/camel-groovy/src/test/java/org/apache/camel/groovy/json/GroovyJSonDataFormatTest.java
+++ b/components/camel-groovy/src/test/java/org/apache/camel/groovy/json/GroovyJSonDataFormatTest.java
@@ -104,7 +104,7 @@ public class GroovyJSonDataFormatTest extends CamelTestSupport {
 
     private static final String BOOKS_NOT_PRETTY
             = """
-                    "{\\"library\\":{\\"book\\":[{\\"title\\":\\"No Title\\",\\"author\\":\\"F. Scott Fitzgerald\\",\\"year\\":\\"1925\\",\\"genre\\":\\"Classic\\",\\"id\\":\\"bk101\\"},{\\"title\\":\\"1984\\",\\"author\\":\\"George Orwell\\",\\"year\\":\\"1949\\",\\"genre\\":\\"Dystopian\\",\\"id\\":\\"bk102\\"}]}}"
+                    {"library":{"book":[{"title":"No Title","author":"F. Scott Fitzgerald","year":"1925","genre":"Classic","id":"bk101"},{"title":"1984","author":"George Orwell","year":"1949","genre":"Dystopian","id":"bk102"}]}}
                     """;
 
     private static final String COUNTRIES


### PR DESCRIPTION
Backport of #26260 to `camel-4.22.x` (fix version 4.22.1).

JIRA: [CAMEL-24669](https://issues.apache.org/jira/browse/CAMEL-24669)

Straight cherry-pick (`git cherry-pick -x b0857cd2fc4d`), with no conflicts. The patch is the same as the original commit; only the `pom.xml` blob index line differs.

## Changes

- `groovyJson` / `groovyXml`: Jackson 3.x nodes (`tools.jackson.databind.JsonNode`) are now converted to a `Map`, the same way Jackson 2.x nodes already were. Before this fix they fell back to raw bytes, so `groovyXml` wrote JSON instead of XML. 4.22.x already ships `camel-jackson3` and its `JsonNode` → `Map` type converter.
- `groovyJson` with `prettyPrint=false` no longer encodes the output twice. Before, it produced a quoted JSON string instead of a JSON object.
- Docs list the Jackson 3 node type. The catalog copy is regenerated.
- New `GroovyJackson3DataFormatTest`. `GroovyJSonDataFormatTest` now expects the corrected non-pretty output.

## Verification

- `mvn test` in `components/camel-groovy` on this branch: 59 tests, 0 failures (1 skipped, as before).
- No uncommitted generated files after the build.

_Claude Code on behalf of Croway_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
