### PR TITLE
CAMEL-24679: Camel TUI: give the MCP server's tool registry the launcher

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-tui.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-tui.adoc
@@ -1109,7 +1109,8 @@ The MCP server exposes tools organized by purpose:
   list the running infra services (brokers, databases) and read their logs
 * *Navigate* -- switch tabs, select integrations, select routes, send keystrokes, apply filters
 * *Act* -- send test messages to endpoints, start/stop/restart routes, change log levels,
-  start/stop/restart infra services, run any entry of the *F2* actions menu by its label
+  list and launch the bundled examples, start/stop/restart infra services, run any entry of
+  the *F2* actions menu by its label
 * *Edit* -- write a source file in the integration's source directory (`tui_write_file`), see below
 * *Annotate* -- locate text and diagram nodes by coordinates, draw shapes (boxes, highlights,
   arrows, underlines, text labels), show captions with typewriter animation

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -365,21 +365,13 @@ class AiPanel {
 
     void setLaunchManager(LaunchManager launchManager) {
         this.launchManager = launchManager;
-        if (toolRegistry != null) {
-            toolRegistry.setLaunchManager(launchManager);
-        }
     }
 
     void setMcpFacade(McpFacade mcpFacade) {
         this.mcpFacade = mcpFacade;
         if (mcpFacade != null) {
             mcpFacade.setWriteMode(writeMode);
-        }
-        if (mcpFacade != null) {
             this.toolRegistry = new TuiToolRegistry(mcpFacade);
-            if (launchManager != null) {
-                toolRegistry.setLaunchManager(launchManager);
-            }
         }
     }
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/AiPanel.java
@@ -243,10 +243,6 @@ class AiPanel {
     private volatile CompletableFuture<AiCliCommandExecutor.Result> activeCliCommand;
     private Runnable exitCallback;
 
-    // Detached launches (/run, /infra run) go through the same LaunchManager the F2 Actions menu uses, so they are
-    // spawned as tracked background processes instead of blocking in-process. Null in tests that construct the panel
-    // directly; the slash context reports an error in that case.
-    private LaunchManager launchManager;
     private volatile List<JsonObject> exampleCatalog;
 
     // Provider switch popup
@@ -363,8 +359,11 @@ class AiPanel {
         this.ctx = ctx;
     }
 
-    void setLaunchManager(LaunchManager launchManager) {
-        this.launchManager = launchManager;
+    // Detached launches (/run, /infra run) go through the same LaunchManager the F2 Actions menu uses, so they are
+    // spawned as tracked background processes instead of blocking in-process. It comes from the facade, the one place
+    // the TUI wires it; null in tests that construct the panel directly, where the slash context reports an error.
+    private LaunchManager launchManager() {
+        return mcpFacade != null ? mcpFacade.getLaunchManager() : null;
     }
 
     void setMcpFacade(McpFacade mcpFacade) {
@@ -3731,6 +3730,7 @@ class AiPanel {
 
         @Override
         public String launchDetached(AiSlashCommandRegistry.LaunchSpec spec) {
+            LaunchManager launchManager = launchManager();
             if (launchManager == null) {
                 throw new IllegalStateException("Launching commands is not available in this session.");
             }
@@ -3764,7 +3764,7 @@ class AiPanel {
      */
     private void launchDetachedQuietly(AiSlashCommandRegistry.LaunchSpec spec) {
         try {
-            launchManager.launchDetached(spec.displayName(), spec.camelArgs());
+            launchManager().launchDetached(spec.displayName(), spec.camelArgs());
         } catch (IOException e) {
             conversation.add(new ConversationEntry(
                     AiRole.ERROR, "Failed to start: " + spec.displayName() + " - " + e.getMessage()));

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -496,7 +496,6 @@ public class CamelMonitor extends CamelCommand {
         actionsPopup.setResetStatsAction(this::resetStats);
         shellPanel.setContext(ctx);
         aiPanel.setContext(ctx);
-        aiPanel.setLaunchManager(actionsPopup.getLaunchManager());
         actionsPopup.setOpenShellAction(shellPanel::open);
         actionsPopup.setOpenAiPromptAction(aiPanel::open);
         actionsPopup.setBrowseFilesAction(this::openFilesPopup);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/CamelMonitor.java
@@ -812,6 +812,7 @@ public class CamelMonitor extends CamelCommand {
                     }
                 });
         mcpFacade.setSourceValidator(tabRegistry.sourceTab().editAssist()::validateSource);
+        mcpFacade.setLaunchManager(actionsPopup.getLaunchManager());
         aiPanel.setMcpFacade(mcpFacade);
         aiPanel.setOtelSpans(dataService.otelSpans());
         mcpFacade.setAiActivityLog(aiPanel::getActivityLog);

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpFacade.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/McpFacade.java
@@ -172,6 +172,9 @@ class McpFacade {
     private volatile StatusFileReader statusFiles = StatusFileReader.defaultReader();
     private volatile Supplier<List<TuiMcpServer.LogEntry>> mcpActivityLog;
     private volatile Supplier<Integer> mcpToolCallCount;
+    // the F2 menu's launcher: starts examples (tui_run_example) and infra services (tui_infra start). It is held
+    // here, not in the tool registry, so the AI panel's registry and the MCP server's registry both see it.
+    private volatile LaunchManager launchManager;
 
     McpFacade(
               MonitorContext ctx,
@@ -209,6 +212,14 @@ class McpFacade {
     void setMcpActivityLog(Supplier<List<TuiMcpServer.LogEntry>> mcpActivityLog, Supplier<Integer> mcpToolCallCount) {
         this.mcpActivityLog = mcpActivityLog;
         this.mcpToolCallCount = mcpToolCallCount;
+    }
+
+    void setLaunchManager(LaunchManager launchManager) {
+        this.launchManager = launchManager;
+    }
+
+    LaunchManager getLaunchManager() {
+        return launchManager;
     }
 
     List<AiPanel.LogEntry> getAiActivityLog() {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistry.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistry.java
@@ -79,6 +79,11 @@ class TuiToolRegistry {
         this.facade = facade;
     }
 
+    /** The launcher the TUI wired into the facade, or null when there is none to launch with. */
+    private LaunchManager launcher() {
+        return facade != null ? facade.getLaunchManager() : null;
+    }
+
     /**
      * The tools needed to answer questions and troubleshoot from the built-in AI panel. The remaining tools drive the
      * screen (drawing, animation, key presses, tape recording, themes) and exist for external MCP agents. Every tool
@@ -1052,7 +1057,7 @@ class TuiToolRegistry {
     }
 
     private String startInfra(String alias) {
-        LaunchManager lm = facade.getLaunchManager();
+        LaunchManager lm = launcher();
         if (lm == null) {
             return "Error: launching is not available";
         }
@@ -2324,7 +2329,7 @@ class TuiToolRegistry {
             return "{\"error\": \"'name' parameter is required\"}";
         }
 
-        LaunchManager lm = facade.getLaunchManager();
+        LaunchManager lm = launcher();
         if (lm == null) {
             return "{\"error\": \"Launching examples is not available in this session\"}";
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistry.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistry.java
@@ -73,15 +73,10 @@ class TuiToolRegistry {
     private volatile AnimationState currentAnimation;
 
     private volatile List<ToolDef> cachedTools;
-    private volatile LaunchManager launchManager;
     private volatile List<JsonObject> exampleCatalog;
 
     TuiToolRegistry(McpFacade facade) {
         this.facade = facade;
-    }
-
-    void setLaunchManager(LaunchManager launchManager) {
-        this.launchManager = launchManager;
     }
 
     /**
@@ -1057,7 +1052,7 @@ class TuiToolRegistry {
     }
 
     private String startInfra(String alias) {
-        LaunchManager lm = launchManager;
+        LaunchManager lm = facade.getLaunchManager();
         if (lm == null) {
             return "Error: launching is not available";
         }
@@ -2329,7 +2324,7 @@ class TuiToolRegistry {
             return "{\"error\": \"'name' parameter is required\"}";
         }
 
-        LaunchManager lm = launchManager;
+        LaunchManager lm = facade.getLaunchManager();
         if (lm == null) {
             return "{\"error\": \"Launching examples is not available in this session\"}";
         }

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistryLaunchTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistryLaunchTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.jbang.core.commands.tui;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.util.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TuiToolRegistryLaunchTest {
+
+    /**
+     * The launcher belongs to the facade, not to the registry: the AI panel and the MCP server each build their own
+     * TuiToolRegistry over the one shared facade, and only the panel's used to be given a LaunchManager, which left
+     * tui_run_example and tui_infra start dead for every external MCP client (CAMEL-24679).
+     */
+    @Test
+    void examplesAreLaunchableAsSoonAsTheFacadeHasTheLauncher() throws Exception {
+        McpFacade facade = new McpFacade(
+                null, null, null, null, null, null, null, null, null, null, null, null, null);
+        TuiToolRegistry registry = new TuiToolRegistry(facade);
+        JsonObject args = new JsonObject(Map.of("name", "no-such/example"));
+
+        String withoutLauncher = registry.execute("tui_run_example", args);
+        assertTrue(withoutLauncher.contains("Launching examples is not available"), withoutLauncher);
+
+        facade.setLaunchManager(new LaunchManager(List::of));
+
+        // the name is unknown, but the catalog is only reached once a launcher is there
+        String withLauncher = registry.execute("tui_run_example", args);
+        assertTrue(withLauncher.contains("Unknown example"), withLauncher);
+    }
+}

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistryLaunchTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/TuiToolRegistryLaunchTest.java
@@ -22,29 +22,70 @@ import java.util.Map;
 import org.apache.camel.util.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * The launcher belongs to the facade, not to the tool registry: the AI panel and the MCP server each build their own
+ * TuiToolRegistry over the one shared facade, and only the panel's used to be given a LaunchManager, which left
+ * tui_run_example and tui_infra start dead for every external MCP client (CAMEL-24679).
+ */
 class TuiToolRegistryLaunchTest {
 
-    /**
-     * The launcher belongs to the facade, not to the registry: the AI panel and the MCP server each build their own
-     * TuiToolRegistry over the one shared facade, and only the panel's used to be given a LaunchManager, which left
-     * tui_run_example and tui_infra start dead for every external MCP client (CAMEL-24679).
-     */
+    private static final JsonObject UNKNOWN_EXAMPLE = new JsonObject(Map.of("name", "no-such/example"));
+    private static final JsonObject START_KAFKA = new JsonObject(Map.of("action", "start", "alias", "kafka"));
+
+    /** Records what it was asked to launch, so the wired path can be asserted without spawning anything. */
+    private static final class RecordingLaunchManager extends LaunchManager {
+
+        private String startedInfra;
+
+        RecordingLaunchManager() {
+            super(List::of);
+        }
+
+        @Override
+        void startInfra(String alias) {
+            this.startedInfra = alias;
+        }
+    }
+
+    private static McpFacade bareFacade() {
+        return new McpFacade(null, null, null, null, null, null, null, null, null, null, null, null, null);
+    }
+
     @Test
-    void examplesAreLaunchableAsSoonAsTheFacadeHasTheLauncher() throws Exception {
-        McpFacade facade = new McpFacade(
-                null, null, null, null, null, null, null, null, null, null, null, null, null);
-        TuiToolRegistry registry = new TuiToolRegistry(facade);
-        JsonObject args = new JsonObject(Map.of("name", "no-such/example"));
+    void launchingToolsSayNothingCanBeLaunchedUntilTheFacadeHasTheLauncher() throws Exception {
+        TuiToolRegistry registry = new TuiToolRegistry(bareFacade());
 
-        String withoutLauncher = registry.execute("tui_run_example", args);
-        assertTrue(withoutLauncher.contains("Launching examples is not available"), withoutLauncher);
+        assertTrue(registry.execute("tui_run_example", UNKNOWN_EXAMPLE).contains("Launching examples is not available"));
+        assertTrue(registry.execute("tui_infra", START_KAFKA).contains("launching is not available"));
+    }
 
-        facade.setLaunchManager(new LaunchManager(List::of));
+    @Test
+    void oneLauncherOnTheFacadeReachesEveryRegistryBuiltOverIt() throws Exception {
+        McpFacade facade = bareFacade();
+        // the AI panel builds its registry in setMcpFacade, the MCP server builds its own one in the constructor
+        TuiToolRegistry panelRegistry = new TuiToolRegistry(facade);
 
-        // the name is unknown, but the catalog is only reached once a launcher is there
-        String withLauncher = registry.execute("tui_run_example", args);
-        assertTrue(withLauncher.contains("Unknown example"), withLauncher);
+        RecordingLaunchManager launcher = new RecordingLaunchManager();
+        facade.setLaunchManager(launcher);
+
+        // built after the wiring, like the MCP server's registry, and never handed the launcher itself
+        TuiToolRegistry mcpServerRegistry = new TuiToolRegistry(facade);
+
+        // the example name is unknown, but the catalog is only reached once there is a launcher
+        assertTrue(panelRegistry.execute("tui_run_example", UNKNOWN_EXAMPLE).contains("Unknown example"));
+        assertTrue(mcpServerRegistry.execute("tui_run_example", UNKNOWN_EXAMPLE).contains("Unknown example"));
+
+        assertTrue(mcpServerRegistry.execute("tui_infra", START_KAFKA).contains("Starting infra service kafka"));
+        assertEquals("kafka", launcher.startedInfra);
+    }
+
+    @Test
+    void aRegistryWithoutAFacadeAnswersInsteadOfFailing() throws Exception {
+        TuiToolRegistry registry = new TuiToolRegistry(null);
+
+        assertTrue(registry.execute("tui_run_example", UNKNOWN_EXAMPLE).contains("Launching examples is not available"));
     }
 }


### PR DESCRIPTION
## Description

Fixes [CAMEL-24679](https://issues.apache.org/jira/browse/CAMEL-24679).

`TuiMcpServer` builds its own `TuiToolRegistry`, but the `LaunchManager` was only ever pushed into the AI panel's registry (`CamelMonitor` -> `AiPanel.setLaunchManager`). Everything else the tools need comes from the single shared `McpFacade`, so this was the one piece of state an external MCP client could not see:

* `tui_run_example` always answered `{"error": "Launching examples is not available in this session"}` — there is no other way for an agent to start a bundled example.
* `tui_infra` with `start`, `run` or `restart` answered `Error: launching is not available`. `list`, `log` and `stop` work, since they go through the facade.

`restart` was the worst case: it stops the service and only then fails to start it, so an agent asked to restart a broker just killed it.

`tui_infra` is part of `CORE_TOOLS` and the documentation advertises "start/stop/restart infra services" under what AI agents can do, so the promise was there but the wiring was not. The ACP coding agent added in CAMEL-24663 drives the TUI through this same MCP server, which is where this surfaced: it could list the bundled examples but never run one.

## Fix

The `LaunchManager` lives on `McpFacade` and is wired once in `CamelMonitor`, next to the other facade collaborators. Every `TuiToolRegistry` built over that facade reads the same instance, whenever it was built, so no registry keeps launch state of its own.

The AI panel reads it from the facade too, dropping its own field and setter, so the launcher has exactly one wiring point instead of being pushed from `CamelMonitor` into two collaborators. Both registry reads go through a small `launcher()` helper that tolerates a null facade, keeping the graceful "launching is not available" answer for a registry built without one.

Net effect is slightly less code than before.

## Testing

`TuiToolRegistryLaunchTest`:

* both launching tools answer "not available" until the facade has a launcher;
* one `setLaunchManager` on the facade reaches a registry built before it *and* one built after it, the way `TuiMcpServer` builds its own — the second is never handed a launcher, so this fails against a per-registry copy;
* `tui_infra {"action": "start", "alias": "kafka"}` reaches the launcher and returns `Starting infra service kafka`. `LaunchManager` is subclassed to record the alias, so the wired path is asserted without spawning a container;
* a registry built with no facade at all still answers instead of throwing.

`mvn test` in `dsl/camel-jbang/camel-jbang-plugin-tui`: 1333 tests, 0 failures, 1 skipped.

Manually verified in a running `camel tui monitor` with an external MCP client: `tui_run_example` and `tui_infra start` now work.

## Documentation

The "What AI Agents Can Do" list in `camel-jbang-tui.adoc` gains the bundled examples, which were never mentioned there.

---

_Claude Code on behalf of luigidemasi_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
