### PR TITLE
CAMEL-23318: fix /component-test for fork PRs by using refs/pull/N/head

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -22,7 +22,7 @@ on:
     branches:
       - main
     # CI-only changes don't need a full build. Use workflow_dispatch to
-    # test CI changes: gh workflow run "Build and test" -f pr_number=XXXX -f pr_ref=branch-name
+    # test CI changes: gh workflow run "Build and test" -f pr_number=XXXX -f pr_ref=refs/pull/XXXX/head
     paths-ignore:
       - .claude-plugin/**
       - .idea/**
@@ -41,7 +41,7 @@ on:
         required: true
         type: string
       pr_ref:
-        description: 'Git ref of the pull request branch'
+        description: 'Git ref of the pull request (e.g. refs/pull/XXXX/head)'
         required: true
         type: string
       extra_modules:

--- a/.github/workflows/pr-manual-component-test.yml
+++ b/.github/workflows/pr-manual-component-test.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           pr="$(gh api /repos/${GH_REPO}/pulls/${PR_NUMBER})"
           head_sha="$(echo "$pr" | jq -r .head.sha)"
-          head_ref="$(echo "$pr" | jq -r .head.ref)"
           # Check that the PR branch was not pushed to after the comment was created.
           commit="$(gh api /repos/${GH_REPO}/commits/${head_sha})"
           committed_at="$(echo "$commit" | jq -r .commit.committer.date)"
@@ -58,7 +57,10 @@ jobs:
               exit 1
           fi
           echo "pr_sha=$head_sha" >> $GITHUB_OUTPUT
-          echo "pr_ref=$head_ref" >> $GITHUB_OUTPUT
+          # Use refs/pull/<N>/head so the ref is resolvable in apache/camel for both
+          # same-repo and fork PRs (head.ref is the branch name in the fork, which
+          # does not exist in the base repository).
+          echo "pr_ref=refs/pull/${PR_NUMBER}/head" >> $GITHUB_OUTPUT
       - name: React to comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the `/component-test` command on fork PRs, broken since #22247.

## Root Cause

`pr-manual-component-test.yml` extracts `head.ref` from the PR API response
and passes it as `pr_ref` to the `"Build and test"` workflow. For fork PRs,
`head.ref` is the branch name **in the contributor's fork** (e.g.
`fix/my-feature`). That branch does not exist in `apache/camel`, so the
`actions/checkout` step in `pr-build-main.yml` fails to resolve the ref and
the dispatched run fails immediately.

Same-repo PRs were unaffected because their `head.ref` is a branch that exists
in `apache/camel`.

## Fix

Emit `refs/pull/${PR_NUMBER}/head` instead of `head.ref`. GitHub always
exposes this pseudo-ref for every open PR, regardless of whether the source
branch lives in a fork or the base repo. The `actions/checkout` step can
resolve it in both cases.

Also updated the `pr_ref` input description and the inline manual-dispatch
comment in `pr-build-main.yml` to document the expected format.

## Test

CI-only change — no unit tests applicable. The fix can be verified by posting
a `/component-test camel-core` comment on any fork PR and confirming the
dispatched workflow reaches the checkout step without failing.

---

_Hermes Agent (Claude Sonnet 4.6) on behalf of Guillaume Nodet_
