### PR TITLE
CAMEL-23677: Fix SjmsConnectionRecoveryTest to run on s390x

### DIFF
--- a/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
+++ b/components/camel-sjms/src/test/java/org/apache/camel/component/sjms/SjmsConnectionRecoveryTest.java
@@ -30,12 +30,11 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.test.infra.artemis.services.ArtemisContainer;
+import org.apache.camel.test.infra.artemis.services.ArtemisService;
+import org.apache.camel.test.infra.artemis.services.ArtemisServiceFactory;
 import org.apache.camel.test.junit6.CamelTestSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,40 +50,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * {@code initConsumers()} skips re-creation (because {@code consumers != null}), leaving consumers attached to closed
  * sessions.
  * <p>
- * Uses a real Artemis broker over TCP (via Testcontainers) so that connection close truly kills sessions and consumers,
- * matching the behavior of Oracle AQ and other remote JMS providers.
+ * Uses an embedded Artemis broker with a real TCP acceptor (via
+ * {@link ArtemisServiceFactory#createTCPAllProtocolsService()}) so that connection close truly kills sessions and
+ * consumers, matching the behavior of Oracle AQ and other remote JMS providers. This approach works on all
+ * architectures including s390x, unlike the previous container-based approach which required a platform-specific Docker
+ * image.
  */
-@DisabledOnOs(architectures = { "s390x" },
-              disabledReason = "The container image cannot be started for this test. Maybe because it is using the ArtemisContainer instead fo the service.")
-public class SjmsConnectionRecoveryTest extends CamelTestSupport {
+class SjmsConnectionRecoveryTest extends CamelTestSupport {
 
     private static final String SJMS_QUEUE_NAME = "sjms:queue:SjmsConnectionRecoveryTest";
     private static final String MOCK_RESULT = "mock:result";
     private static final int RECOVERY_INTERVAL_MS = 1000;
 
-    private static ArtemisContainer broker;
+    @RegisterExtension
+    static ArtemisService service = ArtemisServiceFactory.createTCPAllProtocolsService();
+
     private CountingConnectionFactory countingFactory;
-
-    @BeforeAll
-    static void startBroker() {
-        broker = new ArtemisContainer();
-        broker.start();
-    }
-
-    @AfterAll
-    static void stopBroker() {
-        if (broker != null) {
-            broker.stop();
-        }
-    }
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
 
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(
-                "tcp://" + broker.getHost() + ":" + broker.defaultAcceptorPort(),
-                broker.username(), broker.password());
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(service.serviceAddress());
         connectionFactory.setReconnectAttempts(0);
 
         countingFactory = new CountingConnectionFactory(connectionFactory);
@@ -127,7 +114,7 @@ public class SjmsConnectionRecoveryTest extends CamelTestSupport {
      * are consumed normally.
      */
     @Test
-    public void testRecoveryStopsAfterSuccessfulReconnection() throws Exception {
+    void testRecoveryStopsAfterSuccessfulReconnection() throws Exception {
         MockEndpoint mock = getMockEndpoint(MOCK_RESULT);
 
         // Phase 1: verify normal consumption (also confirms consumer is fully started).


### PR DESCRIPTION
## Summary

Fix `SjmsConnectionRecoveryTest` so it runs on **all architectures including s390x**, by replacing the Testcontainers-based `ArtemisContainer` with an embedded Artemis broker that opens a real TCP acceptor.

## Root Cause

The test was previously annotated with `@DisabledOnOs(architectures = {"s390x"})` because `ArtemisContainer` pulls the Docker image `icr.io/s390x-oss/activemq-artemis-broker-s390x:2.0.2`, which cannot be fetched in CI on s390x (container registry access issue). An earlier fix attempt (PR #25266 / commit `670620c04a0d`) was reverted (commit `4b99a3660d50`) for this reason.

## Fix

Replace `ArtemisContainer` (Testcontainers) with `ArtemisServiceFactory.createTCPAllProtocolsService()`, which starts an **embedded** Artemis broker that listens on a real TCP port — no Docker image needed, no registry access required.

Key changes:
- Drop `@DisabledOnOs(architectures = {"s390x"})` 
- Replace `private static ArtemisContainer broker` + `@BeforeAll`/`@AfterAll` lifecycle with `@RegisterExtension static ArtemisService service`
- Derive connection URL from `service.serviceAddress()` instead of the container's host/port

The test semantics are preserved: a real TCP connection is used, so `connection.close()` genuinely kills sessions and consumer subscriptions, exercising the recovery path under test — matching the Oracle AQ customer scenario.

## Test

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.694 s
```

Run locally with: `mvn test -Dtest=SjmsConnectionRecoveryTest -pl components/camel-sjms -Dlicense.skip`

---
_Hermes Agent (Claude Sonnet 4.6) on behalf of Guillaume Nodet_
