### PR TITLE
CAMEL-23376: Add completionGoals to regenerate src/generated/ after release

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/release-guide.adoc
+++ b/docs/user-manual/modules/ROOT/pages/release-guide.adoc
@@ -249,7 +249,17 @@ Complete the following steps to create a new Camel release:
   $ ./mvnw release:prepare -Prelease
 
 
-*  This command will create the tag and update all pom files with the given version number.
+*  This command will:
+.. Set the release version, build and tag it.
+.. Bump all POMs to the next development SNAPSHOT version.
+.. Run an additional `install` pass (the `completionGoals`) to regenerate all
+   `src/generated/` metadata files (JSON descriptors, configurer sources,
+   endpoint-dsl, etc.) that embed the project version.
+.. Commit the regenerated files together with the SNAPSHOT version POMs in a
+   single "prepare for next development iteration" commit.
++
+The regeneration step eliminates the manual "refresh PR" that was previously
+required after every release to bring `src/generated/` up to date (CAMEL-23376).
 
 . Perform the release and publish to the Apache staging repository:
 

--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,21 @@
                             build produces no native Windows executables and no WinGet payload.
                         -->
                         <arguments>-Prelease -Dcamel.exe.build=true</arguments>
+                        <!--
+                            After the development SNAPSHOT version is set, rebuild to regenerate
+                            all files in src/generated/ directories that embed the project version.
+                            Without this step, those generated metadata files (JSON descriptors,
+                            configurer sources, endpoint-dsl, etc.) would still carry the just-
+                            released version instead of the new SNAPSHOT, requiring a manual
+                            "refresh" PR after every release (see CAMEL-23376).
+
+                            The same <arguments> above apply here, so tests are skipped and the
+                            release profile is active — but no artifacts are deployed; the rebuilt
+                            jars are installed locally only, and the regenerated src/generated/
+                            files are folded into the "prepare for next development iteration" SCM
+                            commit by the release plugin.
+                        -->
+                        <completionGoals>install</completionGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Summary

Adds a `<completionGoals>install</completionGoals>` to the `maven-release-plugin` configuration in the root `pom.xml`, so that the release process automatically regenerates all `src/generated/` files after bumping to the next development SNAPSHOT version.

## Root Cause

The `release:prepare` goal runs `preparationGoals` (`clean install`) against the release version, then bumps all POMs to the next SNAPSHOT. At that point, the `src/generated/` directories still contain files that embed the old (just-released) version string, because no build has run against the new SNAPSHOT yet. A manual "refresh PR" was needed after every release to fix this.

## Fix

Add `<completionGoals>install</completionGoals>` to the `maven-release-plugin` configuration. After the development version is set, the plugin now:

1. Runs `install` (with the same `<arguments>` — tests already skipped by `-Prelease`).
2. The `camel-package-maven-plugin` regenerates every `src/generated/` file (JSON descriptors, configurer sources, endpoint-dsl, catalog entries, etc.) with the new SNAPSHOT version.
3. The regenerated files are folded into the "prepare for next development iteration" SCM commit automatically.

The `FileUtil.updateFile()` helper used by the generator always rewrites files whose content has changed, so a version bump guarantees all version-bearing generated files are updated even without a prior `git clean`.

## Documentation

`docs/user-manual/modules/ROOT/pages/release-guide.adoc` is updated to describe the new behaviour of `release:prepare`.

## Test

This is a build-system change that takes effect during the next `release:prepare` run. The logic relies on existing, well-tested infrastructure (maven-release-plugin `completionGoals` + camel-package-maven-plugin generators).

---
_Hermes Agent (Claude Sonnet 4.6) on behalf of Guillaume Nodet_
