### PR TITLE
CAMEL-24680: camel-jpa - Field access for KeyValueEntry, cover all shipped entities in the mapping test

### DIFF
--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -143,8 +143,11 @@
                 </property>
             </activation>
             <properties>
-                <!-- the OpenJPA enhancer agent must only be attached when the OpenJPA provider is in use;
-                     with -Dhibernate the agent jar is not copied and the forked JVM would fail to start -->
+                <!-- the OpenJPA enhancer agent must only be attached when the OpenJPA provider is in use.
+                     The agent jar itself is copied to target/ by the "full" profile regardless of -Dhibernate,
+                     but PCEnhancerAgent.premain needs the OpenJPA runtime classes (and their xbean-asm
+                     transitives), which only this profile puts on the classpath - so with -Dhibernate the
+                     agent would die in premain and the forked test JVM would fail to start -->
                 <camel.surefire.fork.additional-vmargs>-javaagent:${project.basedir}/target/openjpa-${openjpa-version}.jar -Xmx3G</camel.surefire.fork.additional-vmargs>
             </properties>
             <build>

--- a/components/camel-jpa/src/main/java/org/apache/camel/processor/keyvalue/jpa/KeyValueEntry.java
+++ b/components/camel-jpa/src/main/java/org/apache/camel/processor/keyvalue/jpa/KeyValueEntry.java
@@ -24,7 +24,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 
 /**
  * JPA entity representing a single key-value entry in the {@code CAMEL_KEYVALUE} table.
@@ -41,8 +40,15 @@ public class KeyValueEntry implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    @Id
+    @Column(name = "ITEM_KEY", length = 512)
     private String itemKey;
+
+    @Lob
+    @Column(name = "ITEM_VALUE", nullable = false)
     private byte[] itemValue;
+
+    @Column(name = "EXPIRES_AT", nullable = false)
     private long expiresAt;
 
     /**
@@ -64,8 +70,6 @@ public class KeyValueEntry implements Serializable {
         this.expiresAt = expiresAt;
     }
 
-    @Id
-    @Column(name = "ITEM_KEY", length = 512)
     public String getItemKey() {
         return itemKey;
     }
@@ -74,8 +78,6 @@ public class KeyValueEntry implements Serializable {
         this.itemKey = itemKey;
     }
 
-    @Lob
-    @Column(name = "ITEM_VALUE", nullable = false)
     public byte[] getItemValue() {
         return itemValue;
     }
@@ -84,7 +86,6 @@ public class KeyValueEntry implements Serializable {
         this.itemValue = itemValue;
     }
 
-    @Column(name = "EXPIRES_AT", nullable = false)
     public long getExpiresAt() {
         return expiresAt;
     }
@@ -98,7 +99,6 @@ public class KeyValueEntry implements Serializable {
      *
      * @return whether the entry is expired
      */
-    @Transient
     public boolean isExpired() {
         return expiresAt > 0 && System.currentTimeMillis() >= expiresAt;
     }

--- a/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/ShippedEntitiesHibernateMappingTest.java
+++ b/components/camel-jpa/src/test/java/org/apache/camel/processor/jpa/ShippedEntitiesHibernateMappingTest.java
@@ -14,8 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.processor.keyvalue.jpa;
+package org.apache.camel.processor.jpa;
 
+import org.apache.camel.processor.idempotent.jpa.MessageProcessed;
+import org.apache.camel.processor.keyvalue.jpa.KeyValueEntry;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -24,29 +26,32 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
- * Verifies in every build (not only with -Dhibernate) that Hibernate can map {@link KeyValueEntry}. The entity is
- * shipped in the camel-jpa jar and e.g. Quarkus auto-discovers it from the classpath and always maps it with Hibernate,
- * so a mapping problem breaks applications that never use the KeyValueRepository (CAMEL-24604: a derived getter
- * without @Transient made Hibernate fail with "Could not locate setter method for property 'expired'").
+ * Verifies in every build (not only with -Dhibernate) that Hibernate can map every {@code @Entity} shipped in the
+ * camel-jpa jar. Runtimes such as Quarkus auto-discover these entities from the classpath and map them all with
+ * Hibernate in a single persistence unit, so a mapping problem in any one of them breaks applications that merely have
+ * camel-jpa on the classpath and never use the entity themselves (CAMEL-24604: a derived getter without a setter made
+ * Hibernate fail with "Could not locate setter method for property 'expired'").
  * <p>
- * Uses the native Hibernate bootstrap on purpose: it does not go through jakarta.persistence provider resolution, so
- * the rest of the test suite keeps using the provider selected by the active maven profile.
+ * All shipped entities are mapped together, the way an auto-discovering runtime does it. Uses the native Hibernate
+ * bootstrap on purpose: it does not go through jakarta.persistence provider resolution, so the rest of the test suite
+ * keeps using the provider selected by the active maven profile.
  */
-class KeyValueEntryHibernateMappingTest {
+class ShippedEntitiesHibernateMappingTest {
 
     @Test
-    void hibernateMustBeAbleToMapKeyValueEntry() {
+    void hibernateMustBeAbleToMapAllShippedEntities() {
         StandardServiceRegistry registry = new StandardServiceRegistryBuilder()
                 .applySetting("hibernate.connection.driver_class", "org.h2.Driver")
-                .applySetting("hibernate.connection.url", "jdbc:h2:mem:camel24604")
+                .applySetting("hibernate.connection.url", "jdbc:h2:mem:camelJpaEntityMapping")
                 .build();
         try {
             assertDoesNotThrow(() -> new MetadataSources(registry)
                     .addAnnotatedClass(KeyValueEntry.class)
+                    .addAnnotatedClass(MessageProcessed.class)
                     .buildMetadata()
                     .buildSessionFactory()
                     .close(),
-                    "Hibernate should be able to build a SessionFactory for KeyValueEntry");
+                    "Hibernate should be able to build a SessionFactory for the entities shipped in camel-jpa");
         } finally {
             StandardServiceRegistryBuilder.destroy(registry);
         }

--- a/components/camel-jpa/src/test/resources/META-INF/persistence.xml
+++ b/components/camel-jpa/src/test/resources/META-INF/persistence.xml
@@ -24,10 +24,11 @@
 
   <persistence-unit name="camel" transaction-type="RESOURCE_LOCAL">
     <!--
-        The default provider can be OpenJPA, or some other product.
-        This element is optional if OpenJPA is the only JPA provider
-        in the current classloading environment, but can be specified
-        in cases where there are multiple JPA implementations available.
+        <provider> is required in every unit of this file: hibernate-core is
+        unconditionally on the test classpath (so that the shipped entities are
+        mapping-checked with Hibernate in every build), which makes it the first
+        JPA provider discovered. Without an explicit provider Hibernate would
+        claim these units, which are configured for OpenJPA.
     -->
     <provider>
       org.apache.openjpa.persistence.PersistenceProviderImpl


### PR DESCRIPTION
Fixes [CAMEL-24680](https://issues.apache.org/jira/browse/CAMEL-24680)

Follow-up to CAMEL-24604 / CAMEL-24615. @Croway left four suggestions on #26068, but that PR was superseded by #26074 before they were applied, so none of them landed on `main`. This picks them up.

### 1. `KeyValueEntry` uses field access instead of `@Transient`

The entity annotated its **getters** while the constructor, `isExpired()` and `toString()` read the **fields** directly. That mismatch is the root cause CAMEL-24604 papered over with `@Transient` on `isExpired()`, and OpenJPA warned about it on every run:

```
"KeyValueEntry" uses property access, but its field "expiresAt" is accessed directly in method "isExpired"
"KeyValueEntry" uses property access, but its field "expiresAt" is accessed directly in method "toString"
"KeyValueEntry" uses property access, but its field "itemKey" is accessed directly in method "toString"
```

Moving `@Id` / `@Column` / `@Lob` onto the fields — as `Customer`, `VersionedItem` and `Address` already do — makes any future helper getter safe by construction, lets `@Transient` go, and silences all three warnings (verified: 3 before, 0 after).

The entity is `@since 4.23` and unreleased, so the access type can still change with no upgrade note. Column mapping is unchanged, and the JPQL in `JpaKeyValueRepository` (`e.itemKey`, `e.expiresAt`) resolves identically since the field names already match the property names.

### 2. The mapping test now covers every shipped entity

`KeyValueEntryHibernateMappingTest` only mapped `KeyValueEntry`. `MessageProcessed` is the other property-access `@Entity` shipped in the jar, is auto-discovered by Quarkus exactly the same way, and no CI job ever mapped it with Hibernate.

Renamed to `ShippedEntitiesHibernateMappingTest`; it now maps **all** shipped entities in one `SessionFactory`, the way an auto-discovering runtime does.

I confirmed it actually guards `MessageProcessed` rather than just naming it — temporarily adding a derived getter reproduces the CAMEL-24604 failure mode:

```
org.hibernate.PropertyNotFoundException: Could not locate setter method for
property 'stale' of class 'org.apache.camel.processor.idempotent.jpa.MessageProcessed'
```

`MessageProcessed` itself is left on property access — unlike `KeyValueEntry` it has shipped for many releases, so changing its access type is not free.

### 3. `persistence.xml` header comment corrected

It still claimed `<provider>` is *"optional if OpenJPA is the only JPA provider"*, which stopped being true once `hibernate-core` moved onto the test classpath unconditionally — Hibernate is now the first provider discovered and would claim any unpinned unit. Reworded to say why every unit needs the explicit provider.

### 4. The `openjpa` profile comment stated the wrong cause

It blamed the javaagent move on the agent jar not being copied under `-Dhibernate`. It **is** copied — by the `full` profile, independently of `-Dhibernate`. Verified:

```
$ mvn -pl components/camel-jpa -Dhibernate validate && ls target/openjpa-*.jar
target/openjpa-4.1.1.jar
```

The real reason is that `PCEnhancerAgent.premain` needs the OpenJPA runtime classes and their `xbean-asm` transitives, which only the `openjpa` profile puts on the classpath. Comment corrected.

## Testing

No schema or behaviour change.

- `mvn verify` (default OpenJPA profile) — **119 tests, 0 failures**, and zero `uses property access` warnings
- `mvn -Dhibernate verify` — **119 tests, 0 failures**
- `mvn install -Psourcecheck` — clean, no uncommitted generated changes

---

🤖 AI-assisted: written with Claude Code (Opus 5) on behalf of @davsclaus. Commit carries a `Co-authored-by` trailer.