### PR TITLE
CAMEL-24676: Sync the camel-jgroups 4.22.1 upgrade guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -177,6 +177,32 @@ custom `headerFilterStrategy` is used as-is and is unaffected.
 Routes that relied on one of those headers reaching the wire must set it through the endpoint
 configuration or supply a `headerFilterStrategy` that permits it.
 
+
+=== camel-jgroups - the consumer applies a deserialization filter by default
+
+The consumer maps an incoming cluster message to the exchange body by calling
+`org.jgroups.Message.getObject()`, which Java-deserializes the payload. The class of that body is
+now checked against a JEP-290 `java.io.ObjectInputFilter`, resolved through
+`DeserializationFilterHelper`. Previously no filter was applied at all, and any type a cluster peer
+sent was routed.
+
+When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
+otherwise the shared Camel default allow-list is applied (it permits standard Java and Apache Camel
+types and denies `java.net.**`). Routes that exchange their own classes over the cluster must widen
+it through the new `deserializationFilter` endpoint option, for example:
+
+[source,java]
+----
+from("jgroups:clusterName?deserializationFilter=com.example.model.**;java.**;!*")
+----
+
+Setting `deserializationFilter=*` accepts any type and so restores the previous behavior. A refused
+message is not routed; it is reported to the consumer's `ExceptionHandler`, which logs it at WARN
+level by default.
+
+Note that JGroups deserializes the payload inside its own receive path, so this check is a
+defense-in-depth allow-list on the resulting body type. The JVM-wide `jdk.serialFilter`, together
+with a channel secured with `AUTH` and encryption, remain the primary mitigations.
 == Upgrading Camel 4.21 to 4.22
 
 === camel-tika
@@ -1937,29 +1963,3 @@ When `clientRequestValidation` is enabled and the REST service declares a requir
 message body is no longer replaced with a `String` version of itself. That conversion corrupted binary
 payloads such as `application/octet-stream`. The body is still read to check that it is present, using
 stream caching so it stays re-readable, but it now keeps its original type.
-
-=== camel-jgroups - the consumer applies a deserialization filter by default
-
-The consumer maps an incoming cluster message to the exchange body by calling
-`org.jgroups.Message.getObject()`, which Java-deserializes the payload. The class of that body is
-now checked against a JEP-290 `java.io.ObjectInputFilter`, resolved through
-`DeserializationFilterHelper`. Previously no filter was applied at all, and any type a cluster peer
-sent was routed.
-
-When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
-otherwise the shared Camel default allow-list is applied (it permits standard Java and Apache Camel
-types and denies `java.net.**`). Routes that exchange their own classes over the cluster must widen
-it through the new `deserializationFilter` endpoint option, for example:
-
-[source,java]
-----
-from("jgroups:clusterName?deserializationFilter=com.example.model.**;java.**;!*")
-----
-
-Setting `deserializationFilter=*` accepts any type and so restores the previous behavior. A refused
-message is not routed; it is reported to the consumer's `ExceptionHandler`, which logs it at WARN
-level by default.
-
-Note that JGroups deserializes the payload inside its own receive path, so this check is a
-defense-in-depth allow-list on the resulting body type. The JVM-wide `jdk.serialFilter`, together
-with a channel secured with `AUTH` and encryption, remain the primary mitigations.

--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -1937,3 +1937,29 @@ When `clientRequestValidation` is enabled and the REST service declares a requir
 message body is no longer replaced with a `String` version of itself. That conversion corrupted binary
 payloads such as `application/octet-stream`. The body is still read to check that it is present, using
 stream caching so it stays re-readable, but it now keeps its original type.
+
+=== camel-jgroups - the consumer applies a deserialization filter by default
+
+The consumer maps an incoming cluster message to the exchange body by calling
+`org.jgroups.Message.getObject()`, which Java-deserializes the payload. The class of that body is
+now checked against a JEP-290 `java.io.ObjectInputFilter`, resolved through
+`DeserializationFilterHelper`. Previously no filter was applied at all, and any type a cluster peer
+sent was routed.
+
+When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
+otherwise the shared Camel default allow-list is applied (it permits standard Java and Apache Camel
+types and denies `java.net.**`). Routes that exchange their own classes over the cluster must widen
+it through the new `deserializationFilter` endpoint option, for example:
+
+[source,java]
+----
+from("jgroups:clusterName?deserializationFilter=com.example.model.**;java.**;!*")
+----
+
+Setting `deserializationFilter=*` accepts any type and so restores the previous behavior. A refused
+message is not routed; it is reported to the consumer's `ExceptionHandler`, which logs it at WARN
+level by default.
+
+Note that JGroups deserializes the payload inside its own receive path, so this check is a
+defense-in-depth allow-list on the resulting body type. The JVM-wide `jdk.serialFilter`, together
+with a channel secured with `AUTH` and encryption, remain the primary mitigations.


### PR DESCRIPTION
## Doc sync for the camel-jgroups 4.22.x backport

#26281 backports the camel-jgroups deserialization filter (#26267 / CAMEL-24676) to
`camel-4.22.x`. Because `camel-4x-upgrade-guide-4_23.adoc` does not exist on that branch,
the upgrade-guide entry there was retargeted to the `Upgrading from 4.22.0 to 4.22.1`
section of `camel-4x-upgrade-guide-4_22.adoc`.

The `camel-4x-upgrade-guide-4_XX.adoc` files on `main` are the canonical history across all
release lines, so the same entry belongs here too. Without this, `main`'s 4.22 upgrade guide
drifts out of sync with what actually ships on `camel-4.22.x`.

### What this changes

One file, doc-only: 26 lines appended to
`docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc`.

The text is a **verbatim copy** of the entry on `camel-4.22.x` (verified with `diff`).
No code, no generated files.

Note that `main` keeps its own `camel-4x-upgrade-guide-4_23.adoc` entry from #26267 — that one
covers the 4.23.0 release line and is unaffected.

### Related

- Original PR: #26267
- Backport PR: #26281

---

_Claude Code on behalf of @davsclaus_
