### PR TITLE
CAMEL-24681: camel-jbang export add to pom.xml repos from properties camel.jbang.repos and camel.extra.repos

### DIFF
--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportBaseCommand.java
@@ -98,6 +98,9 @@ public abstract class ExportBaseCommand extends CamelCommand {
     private static final Pattern PACKAGE_PATTERN = Pattern.compile(
             "^\\s*package\\s+([a-zA-Z][.\\w]*)\\s*;.*$", Pattern.MULTILINE);
 
+    private static final String EXTRA_REPOS_PROPERTY = "camel.extra.repos";
+    private static final String EXTRA_REPOS_DEFAULT_VALUE_PROPERTY = "camel.default.extra.repos.default.value";
+
     private static final Set<String> EXCLUDED_GROUP_IDS = Set.of("org.fusesource.jansi", "org.apache.logging.log4j");
 
     protected Path exportBaseDir;
@@ -421,9 +424,17 @@ public abstract class ExportBaseCommand extends CamelCommand {
             int i = 1;
             for (String repo : repos.split(",")) {
                 Map<String, Object> r = new HashMap<>();
-                r.put("id", "custom" + i++);
-                r.put("url", repo);
-                r.put("isSnapshot", repo.contains("snapshots"));
+                // support id=url format (used by camel.extra.repos)
+                int eq = repo.indexOf('=');
+                if (eq > 0 && eq < repo.length() - 1 && !repo.startsWith("http")) {
+                    r.put("id", repo.substring(0, eq));
+                    r.put("url", repo.substring(eq + 1));
+                } else {
+                    r.put("id", "custom" + i++);
+                    r.put("url", repo);
+                }
+                String url = (String) r.get("url");
+                r.put("isSnapshot", url.contains("snapshots"));
                 result.add(r);
             }
         }
@@ -1267,8 +1278,12 @@ public abstract class ExportBaseCommand extends CamelCommand {
         Set<String> answer = new LinkedHashSet<>();
 
         String propRepositories = prop.getProperty(REPOS);
+        if (propRepositories == null) {
+            // fallback to system property
+            propRepositories = System.getProperty(REPOS);
+        }
         if (propRepositories != null) {
-            answer.add(propRepositories);
+            Collections.addAll(answer, propRepositories.split("\\s*,\\s*"));
         }
 
         // include apache snapshot repo if we use SNAPSHOT version of Camel
@@ -1286,7 +1301,18 @@ public abstract class ExportBaseCommand extends CamelCommand {
         }
 
         if (mavenResolver.repos() != null) {
-            Collections.addAll(answer, this.mavenResolver.repos().split(","));
+            Collections.addAll(answer, this.mavenResolver.repos().split("\\s*,\\s*"));
+        }
+
+        // include extra repos from system property
+        String extraRepos = System.getProperty(EXTRA_REPOS_PROPERTY,
+                System.getProperty(EXTRA_REPOS_DEFAULT_VALUE_PROPERTY));
+        if (extraRepos != null && !extraRepos.isBlank()) {
+            for (String r : extraRepos.split("\\s*,\\s*")) {
+                if (!r.isBlank()) {
+                    answer.add(r);
+                }
+            }
         }
 
         return answer.stream()

--- a/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/main/java/org/apache/camel/dsl/jbang/core/commands/ExportSpringBoot.java
@@ -365,14 +365,14 @@ class ExportSpringBoot extends Export {
      * Legacy method for backward compatibility with catalog-provided templates.
      */
     private static String legacyMavenRepositoriesAsPomXml(String repos) {
+        List<Map<String, Object>> repoList = buildRepositoryList(repos);
         StringBuilder sb = new StringBuilder();
-        int i = 1;
         sb.append("    <repositories>\n");
-        for (String repo : repos.split(",")) {
+        for (Map<String, Object> r : repoList) {
             sb.append("        <repository>\n");
-            sb.append("            <id>custom").append(i++).append("</id>\n");
-            sb.append("            <url>").append(repo).append("</url>\n");
-            if (repo.contains("snapshots")) {
+            sb.append("            <id>").append(r.get("id")).append("</id>\n");
+            sb.append("            <url>").append(r.get("url")).append("</url>\n");
+            if (Boolean.TRUE.equals(r.get("isSnapshot"))) {
                 sb.append("            <releases>\n");
                 sb.append("                <enabled>false</enabled>\n");
                 sb.append("            </releases>\n");
@@ -384,11 +384,11 @@ class ExportSpringBoot extends Export {
         }
         sb.append("    </repositories>\n");
         sb.append("    <pluginRepositories>\n");
-        for (String repo : repos.split(",")) {
+        for (Map<String, Object> r : repoList) {
             sb.append("        <pluginRepository>\n");
-            sb.append("            <id>custom").append(i++).append("</id>\n");
-            sb.append("            <url>").append(repo).append("</url>\n");
-            if (repo.contains("snapshots")) {
+            sb.append("            <id>plugin-").append(r.get("id")).append("</id>\n");
+            sb.append("            <url>").append(r.get("url")).append("</url>\n");
+            if (Boolean.TRUE.equals(r.get("isSnapshot"))) {
                 sb.append("            <releases>\n");
                 sb.append("                <enabled>false</enabled>\n");
                 sb.append("            </releases>\n");

--- a/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
+++ b/dsl/camel-jbang/camel-jbang-core/src/test/java/org/apache/camel/dsl/jbang/core/commands/ExportTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.camel.dsl.jbang.core.common.CamelJBangConstants;
@@ -36,6 +37,7 @@ import org.apache.camel.util.IOHelper;
 import org.apache.camel.util.StringHelper;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Repository;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -1306,6 +1308,129 @@ class ExportTest {
         String content = IOHelper.loadText(new FileInputStream(f));
         Assertions.assertTrue(content.contains("<id>jib</id>"),
                 "Jib profile not exported!");
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    @SetSystemProperty(key = "camel.extra.repos", value = "atlassian=https://packages.atlassian.com/maven-external/")
+    public void shouldExportWithExtraReposSystemProperty(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithExtraReposSystemProperty {}", rt);
+        Export command = createCommand(rt, new String[] { "src/test/resources/route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+
+        assertThat(model.getRepositories())
+                .as("Expected extra repos from camel.extra.repos in generated pom.xml")
+                .anySatisfy(repo -> {
+                    assertThat(repo.getId()).isEqualTo("atlassian");
+                    assertThat(repo.getUrl()).isEqualTo("https://packages.atlassian.com/maven-external/");
+                });
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    @SetSystemProperty(key = "camel.extra.repos",
+                       value = "repo1=https://repo1.example.com/maven2,repo2=https://repo2.example.com/releases")
+    public void shouldExportWithMultipleExtraRepos(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithMultipleExtraRepos {}", rt);
+        Export command = createCommand(rt, new String[] { "src/test/resources/route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+
+        assertThat(model.getRepositories())
+                .as("Expected both extra repos in generated pom.xml")
+                .anySatisfy(repo -> {
+                    assertThat(repo.getId()).isEqualTo("repo1");
+                    assertThat(repo.getUrl()).isEqualTo("https://repo1.example.com/maven2");
+                })
+                .anySatisfy(repo -> {
+                    assertThat(repo.getId()).isEqualTo("repo2");
+                    assertThat(repo.getUrl()).isEqualTo("https://repo2.example.com/releases");
+                });
+    }
+
+    @Test
+    public void shouldBuildRepositoryListWithIdUrlFormat() {
+        var repos = ExportBaseCommand.buildRepositoryList(
+                "atlassian=https://packages.atlassian.com/maven-external/,https://other.repo/releases");
+
+        assertThat(repos).hasSize(2);
+        assertThat(repos.get(0))
+                .containsEntry("id", "atlassian")
+                .containsEntry("url", "https://packages.atlassian.com/maven-external/");
+        assertThat(repos.get(1))
+                .containsEntry("id", "custom1")
+                .containsEntry("url", "https://other.repo/releases");
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    @SetSystemProperty(key = "camel.jbang.repos", value = "https://packages.atlassian.com/maven-external/")
+    public void shouldExportWithReposFromSystemProperty(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithReposFromSystemProperty {}", rt);
+        Export command = createCommand(rt, new String[] { "src/test/resources/route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+
+        assertThat(model.getRepositories())
+                .as("Expected camel.jbang.repos from system property in generated pom.xml")
+                .anySatisfy(repo -> assertThat(repo.getUrl()).isEqualTo("https://packages.atlassian.com/maven-external/"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    public void shouldExportWithReposCliHavingUniqueIds(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithReposCliHavingUniqueIds {}", rt);
+        Export command = createCommand(rt, new String[] { "src/test/resources/route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet",
+                "--repos=atlassian=https://packages.atlassian.com/maven-external/,https://repository.apache.org/snapshots/");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+
+        List<String> repoIds = model.getRepositories().stream()
+                .map(Repository::getId)
+                .collect(Collectors.toList());
+        assertThat(repoIds)
+                .as("Repository ids must be unique in generated pom.xml")
+                .doesNotHaveDuplicates();
+
+        assertThat(model.getRepositories())
+                .anySatisfy(repo -> {
+                    assertThat(repo.getId()).isEqualTo("atlassian");
+                    assertThat(repo.getUrl()).isEqualTo("https://packages.atlassian.com/maven-external/");
+                });
+    }
+
+    @ParameterizedTest
+    @MethodSource("runtimeProvider")
+    @SetSystemProperty(key = "camel.default.extra.repos.default.value",
+                       value = "atlassian=https://packages.atlassian.com/maven-external/")
+    public void shouldExportWithExtraReposDefaultValueFallback(RuntimeType rt) throws Exception {
+        LOG.info("shouldExportWithExtraReposDefaultValueFallback {}", rt);
+        Export command = createCommand(rt, new String[] { "src/test/resources/route.yaml" },
+                "--gav=examples:route:1.0.0", "--dir=" + workingDir, "--quiet");
+        int exit = command.doCall();
+
+        Assertions.assertEquals(0, exit);
+        Model model = readMavenModel();
+
+        assertThat(model.getRepositories())
+                .as("Expected extra repos from camel.default.extra.repos.default.value fallback in generated pom.xml")
+                .anySatisfy(repo -> {
+                    assertThat(repo.getId()).isEqualTo("atlassian");
+                    assertThat(repo.getUrl()).isEqualTo("https://packages.atlassian.com/maven-external/");
+                });
     }
 
 }


### PR DESCRIPTION

# Description

Add camel.jbang.repos and camel.extra.repos to generated project POM.
They are needed due to the fact that `camel run --runtime=q|sb` does a hidden spawned export where 3rd party maven repos info need to be carried over.

Needs to be backported to 4.22

_AI-assisted with Claude Code on behalf of @gansheer_

# Target

- [X] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [X] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [X] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [X] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

# AI-assisted contributions

- [X] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

