### PR TITLE
CAMEL-24685: camel-joor - compile inline scripts once when preCompile=false

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/java-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/java-language.adoc
@@ -304,7 +304,8 @@ from("seda:orders")
 
 === Hot re-load
 
-You can turn off pre-compilation for the Java language and then Camel will recompile the script for each message.
+You can turn off pre-compilation for the Java language and then Camel will recompile an external script resource for each message
+(an inline script is still only compiled once, on first use, as its text cannot change).
 You can externalize the code into a resource file, which will be reloaded on each message as shown:
 
 ._Java-only: programmatic hot-reload configuration with Java DSL_

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/joor-language.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/joor-language.adoc
@@ -309,7 +309,8 @@ from("seda:orders")
 
 === Hot re-load
 
-You can turn off pre-compilation for the jOOR language and then Camel will recompile the script for each message.
+You can turn off pre-compilation for the jOOR language and then Camel will recompile an external script resource for each message
+(an inline script is still only compiled once, on first use, as its text cannot change).
 You can externalize the code into a resource file, which will be reloaded on each message as shown:
 
 [tabs]

--- a/components/camel-joor/src/main/docs/java-language.adoc
+++ b/components/camel-joor/src/main/docs/java-language.adoc
@@ -304,7 +304,8 @@ from("seda:orders")
 
 === Hot re-load
 
-You can turn off pre-compilation for the Java language and then Camel will recompile the script for each message.
+You can turn off pre-compilation for the Java language and then Camel will recompile an external script resource for each message
+(an inline script is still only compiled once, on first use, as its text cannot change).
 You can externalize the code into a resource file, which will be reloaded on each message as shown:
 
 ._Java-only: programmatic hot-reload configuration with Java DSL_

--- a/components/camel-joor/src/main/docs/joor-language.adoc
+++ b/components/camel-joor/src/main/docs/joor-language.adoc
@@ -309,7 +309,8 @@ from("seda:orders")
 
 === Hot re-load
 
-You can turn off pre-compilation for the jOOR language and then Camel will recompile the script for each message.
+You can turn off pre-compilation for the jOOR language and then Camel will recompile an external script resource for each message
+(an inline script is still only compiled once, on first use, as its text cannot change).
 You can externalize the code into a resource file, which will be reloaded on each message as shown:
 
 [tabs]

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
@@ -81,6 +81,13 @@ public class JoorCompiler extends ServiceSupport implements StaticService {
         return aliases;
     }
 
+    /**
+     * Number of scripts this compiler has compiled so far.
+     */
+    public int getCounter() {
+        return counter;
+    }
+
     public void setAliases(Map<String, String> aliases) {
         this.aliases = aliases;
     }

--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorExpression.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorExpression.java
@@ -22,12 +22,13 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExpressionEvaluationException;
 import org.apache.camel.support.ExpressionAdapter;
+import org.apache.camel.support.ScriptHelper;
 
 public class JoorExpression extends ExpressionAdapter {
 
     private final String text;
     private JoorCompiler compiler;
-    private JoorMethod method;
+    private volatile JoorMethod method;
 
     private Class<?> resultType;
     private boolean preCompile = true;
@@ -78,7 +79,13 @@ public class JoorExpression extends ExpressionAdapter {
     public Object evaluate(Exchange exchange) {
         JoorMethod target = this.method;
         if (target == null) {
-            target = compiler.compile(exchange.getContext(), text, singleQuotes);
+            if (ScriptHelper.hasExternalScript(text)) {
+                // preCompile=false with an external resource means hot re-load: recompile on every message
+                target = compiler.compile(exchange.getContext(), text, singleQuotes);
+            } else {
+                // inline script text cannot change, so compile it once lazily and keep it
+                target = compileOnce(exchange.getContext());
+            }
         }
         // optimize as we call the same method all the time so we dont want to find the method every time as joor would do
         // if you use its call method
@@ -96,6 +103,20 @@ public class JoorExpression extends ExpressionAdapter {
         } else {
             return out;
         }
+    }
+
+    private JoorMethod compileOnce(CamelContext context) {
+        JoorMethod target = this.method;
+        if (target == null) {
+            synchronized (this) {
+                target = this.method;
+                if (target == null) {
+                    target = compiler.compile(context, text, singleQuotes);
+                    this.method = target;
+                }
+            }
+        }
+        return target;
     }
 
     @Override

--- a/components/camel-joor/src/test/java/org/apache/camel/language/joor/JoorPreCompileFalseInlineTest.java
+++ b/components/camel-joor/src/test/java/org/apache/camel/language/joor/JoorPreCompileFalseInlineTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.joor;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit6.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * With preCompile=false an inline script (not an external resource) must still only be compiled once.
+ */
+public class JoorPreCompileFalseInlineTest extends CamelTestSupport {
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                JoorLanguage joor = (JoorLanguage) context.resolveLanguage("joor");
+                joor.setPreCompile(false);
+
+                from("direct:start")
+                        .transform().joor("'Hello ' + body")
+                        .to("mock:result");
+            }
+        };
+    }
+
+    @Test
+    public void testInlineScriptCompiledOnce() throws Exception {
+        JoorCompiler compiler = ((JoorLanguage) context.resolveLanguage("joor")).getCompiler();
+        // not pre-compiled, so nothing has been compiled before the first message
+        assertEquals(0, compiler.getCounter());
+
+        getMockEndpoint("mock:result").expectedBodiesReceived("Hello World", "Hello Camel");
+        template.sendBody("direct:start", "World");
+        template.sendBody("direct:start", "Camel");
+        MockEndpoint.assertIsSatisfied(context);
+
+        assertEquals(1, compiler.getCounter());
+    }
+
+}


### PR DESCRIPTION
`JoorExpression.evaluate` compiled into a local variable when `method` was null and never stored it, so with `preCompile=false` every exchange ran javac and defined a new class.

`preCompile=false` with a `resource:` script is the documented hot re-load mode (`JoorPreCompileFalseTest` rewrites the file mid-test), so that path keeps recompiling. Inline scripts are now compiled once lazily into a volatile field. The joor and java language docs (and their catalog mirrors) say which is which. A new test sends two messages through a `preCompile=false` inline expression and asserts one compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Croway_
