### PR TITLE
CAMEL-24686: camel-joor - default-value patterns must not span two calls on a line

### DIFF
--- a/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
+++ b/components/camel-joor/src/main/java/org/apache/camel/language/joor/JoorCompiler.java
@@ -38,29 +38,37 @@ import org.slf4j.LoggerFactory;
 
 public class JoorCompiler extends ServiceSupport implements StaticService {
 
+    // quoted name: 'foo' or "foo"
+    private static final String QUOTED_NAME = "(['\"][A-Za-z0-9.$]*['\"])";
+    // default value: anything but parentheses, or a single level of balanced parentheses (eg new Date(), '(none)'),
+    // so a default value can never span from one headerAs/exchangePropertyAs call into the next one on the same line
+    private static final String DEFAULT_VALUE = "((?:[^()]|\\([^()]*\\))+?)";
+    private static final String TYPE_CLASS = "([A-Za-z0-9.$]*\\.class)";
+    private static final String TYPE_NO_CLASS = "([A-Za-z0-9.$]*)";
+
     private static final Pattern BEAN_INJECTION_PATTERN = Pattern.compile("(#bean:)([A-Za-z0-9-_]*)");
-    private static final Pattern BODY_AS_PATTERN = Pattern.compile("(optionalBodyAs|bodyAs)\\(([A-Za-z0-9.$]*)(.class)\\)");
+    private static final Pattern BODY_AS_PATTERN = Pattern.compile("(optionalBodyAs|bodyAs)\\(([A-Za-z0-9.$]*)(\\.class)\\)");
     private static final Pattern BODY_AS_PATTERN_NO_CLASS = Pattern.compile("(optionalBodyAs|bodyAs)\\(([A-Za-z0-9.$]*)\\)");
     private static final Pattern HEADER_AS_PATTERN
-            = Pattern.compile("(optionalHeaderAs|headerAs)\\((['|\"][A-Za-z0-9.$]*['|\"]\\s*),\\s*([A-Za-z0-9.$]*.class)\\)");
+            = Pattern.compile("(optionalHeaderAs|headerAs)\\(" + QUOTED_NAME + "\\s*,\\s*" + TYPE_CLASS + "\\)");
     private static final Pattern HEADER_AS_PATTERN_NO_CLASS
-            = Pattern.compile("(optionalHeaderAs|headerAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,\\s*([A-Za-z0-9.$]*)\\)");
+            = Pattern.compile("(optionalHeaderAs|headerAs)\\(" + QUOTED_NAME + "\\s*,\\s*" + TYPE_NO_CLASS + "\\)");
     private static final Pattern HEADER_AS_DEFAULT_VALUE_PATTERN
-            = Pattern.compile("(headerAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,(.+),\\s*([A-Za-z0-9.$]*.class)\\)");
+            = Pattern.compile("(headerAs)\\(" + QUOTED_NAME + "\\s*," + DEFAULT_VALUE + ",\\s*" + TYPE_CLASS + "\\)");
     private static final Pattern HEADER_AS_DEFAULT_VALUE_PATTERN_NO_CLASS
-            = Pattern.compile("(headerAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,(.+),\\s*([A-Za-z0-9.$]*)\\)");
+            = Pattern.compile("(headerAs)\\(" + QUOTED_NAME + "\\s*," + DEFAULT_VALUE + ",\\s*" + TYPE_NO_CLASS + "\\)");
     private static final Pattern EXCHANGE_PROPERTY_AS_PATTERN
             = Pattern.compile(
-                    "(optionalExchangePropertyAs|exchangePropertyAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,\\s*([A-Za-z0-9.$]*.class)\\)");
+                    "(optionalExchangePropertyAs|exchangePropertyAs)\\(" + QUOTED_NAME + "\\s*,\\s*" + TYPE_CLASS + "\\)");
     private static final Pattern EXCHANGE_PROPERTY_AS_PATTERN_NO_CLASS
             = Pattern.compile(
-                    "(optionalExchangePropertyAs|exchangePropertyAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,\\s*([A-Za-z0-9.$]*)\\)");
+                    "(optionalExchangePropertyAs|exchangePropertyAs)\\(" + QUOTED_NAME + "\\s*,\\s*" + TYPE_NO_CLASS + "\\)");
     private static final Pattern EXCHANGE_PROPERTY_AS_DEFAULT_VALUE_PATTERN
             = Pattern.compile(
-                    "(exchangePropertyAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,(.+),\\s*([A-Za-z0-9.$]*.class)\\)");
+                    "(exchangePropertyAs)\\(" + QUOTED_NAME + "\\s*," + DEFAULT_VALUE + ",\\s*" + TYPE_CLASS + "\\)");
     private static final Pattern EXCHANGE_PROPERTY_AS_DEFAULT_VALUE_PATTERN_NO_CLASS
             = Pattern.compile(
-                    "(exchangePropertyAs)\\((['|\"][A-Za-z0-9.$]*['|\"])\\s*,(.+),\\s*([A-Za-z0-9.$]*)\\)");
+                    "(exchangePropertyAs)\\(" + QUOTED_NAME + "\\s*," + DEFAULT_VALUE + ",\\s*" + TYPE_NO_CLASS + "\\)");
 
     private static final Logger LOG = LoggerFactory.getLogger(JoorCompiler.class);
     private static final AtomicInteger UUID = new AtomicInteger();

--- a/components/camel-joor/src/test/java/org/apache/camel/language/joor/JoorLanguageTest.java
+++ b/components/camel-joor/src/test/java/org/apache/camel/language/joor/JoorLanguageTest.java
@@ -159,6 +159,34 @@ public class JoorLanguageTest extends LanguageTestSupport {
     }
 
     @Test
+    public void testExchangeHeaderAsTwoCallsInOneExpression() {
+        exchange.getIn().setHeader("amount", 42);
+        exchange.getIn().setHeader("vip", true);
+
+        assertExpression("'order-' + headerAs('amount', Integer) + '-' + headerAs('vip', Boolean)", "order-42-true");
+        assertExpression("'order-' + headerAs('amount', Integer.class) + '-' + headerAs('vip', Boolean.class)",
+                "order-42-true");
+        assertExpression("'order-' + headerAs('amount', int) + '-' + headerAs('vip', Boolean.class)", "order-42-true");
+        assertExpression("headerAs('amount', Integer) + headerAs('amount', Integer)", "84");
+    }
+
+    @Test
+    public void testExchangeHeaderAsDefaultValueTwoCallsInOneExpression() {
+        exchange.getIn().setHeader("a", 40);
+
+        assertExpression("headerAs('a', 1, Integer) + headerAs('b', 2, Integer)", "42");
+        assertExpression("headerAs('a', 1, Integer.class) + headerAs('b', 2, Integer.class)", "42");
+        assertExpression("headerAs('a', 1, Integer) + headerAs('b', 2, Integer.class)", "42");
+        assertExpression("headerAs('a', 1, Integer.class) + headerAs('b', 2, Integer)", "42");
+        // two-argument and three-argument forms mixed on the same line
+        assertExpression("headerAs('a', Integer) + headerAs('b', 2, Integer)", "42");
+        assertExpression("headerAs('b', 2, Integer) + headerAs('a', Integer)", "42");
+        // default values containing parentheses and quotes
+        assertExpression("headerAs('x', '(none)', String) + headerAs('y', \"(n/a)\", String)", "(none)(n/a)");
+        assertExpression("headerAs('b', Integer.valueOf(2), Integer) + headerAs('a', Integer)", "42");
+    }
+
+    @Test
     public void testExchangeOptionalHeaderAs() {
         exchange.getIn().setHeader("foo", 22);
 
@@ -177,6 +205,16 @@ public class JoorLanguageTest extends LanguageTestSupport {
         assertExpression("3 * optionalHeaderAs(\"foo\", java.lang.Integer.class).get()", "66");
         assertExpression("3 * optionalHeaderAs(\"foo\", java.lang.Integer).get()", "66");
         assertExpression("var num = optionalHeaderAs(\"foo\", int).get(); return num * 4", "88");
+    }
+
+    @Test
+    public void testExchangePropertyAsTwoCallsInOneExpression() {
+        exchange.setProperty("a", 40);
+
+        assertExpression("exchangePropertyAs('a', Integer) + exchangePropertyAs('a', Integer.class)", "80");
+        assertExpression("exchangePropertyAs('a', 1, Integer) + exchangePropertyAs('b', 2, Integer)", "42");
+        assertExpression("exchangePropertyAs('a', 1, Integer.class) + exchangePropertyAs('b', 2, Integer.class)", "42");
+        assertExpression("exchangePropertyAs('a', Integer) + exchangePropertyAs('b', 2, Integer)", "42");
     }
 
     @Test


### PR DESCRIPTION
The default-value patterns in `JoorCompiler` (`headerAs` / `exchangePropertyAs` with a default) used a greedy `(.+)` for the default value, so two calls on one line were rewritten across each other:

```
'order-' + headerAs('amount', Integer) + '-' + headerAs('vip', Boolean)
```

became `headerAs(message, "amount",  Integer) + "-" + headerAs(message, "vip", Boolean.class)` and failed with `cannot find symbol: variable Integer`. The `.class` dot was unescaped and the quote class accepted a literal `|`.

The default value now matches `((?:[^()]|\([^()]*\))+?)` (no parentheses except one balanced level, so it cannot reach the next call; a plain lazy group still spanned mixed two- and three-argument calls), the dot is escaped and the quote class is `['"]`. Three new tests fail on the old patterns and pass now; all 57 module tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Croway_
