### PR TITLE
CAMEL-24676: Sync the camel-jgroups 4.18.5 upgrade guide entry to main

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_18.adoc
@@ -177,6 +177,33 @@ custom `headerFilterStrategy` is used as-is and is unaffected.
 Routes that relied on one of those headers reaching the wire must set it through the endpoint
 configuration or supply a `headerFilterStrategy` that permits it.
 
+=== camel-jgroups - the consumer applies a deserialization filter by default
+
+The consumer maps an incoming cluster message to the exchange body by calling
+`org.jgroups.Message.getObject()`, which Java-deserializes the payload. The class of that body is
+now checked against a JEP-290 `java.io.ObjectInputFilter`. Previously no filter was applied at all,
+and any type a cluster peer sent was routed.
+
+When no explicit pattern is configured, the JVM-wide `jdk.serialFilter` is honoured if set,
+otherwise a conservative default allow-list is applied
+(`!java.net.**;java.**;javax.**;org.apache.camel.**;!*`), matching the default the other components
+that can receive Java-serialized payloads have applied since 4.18.3. Routes that exchange their own
+classes over the cluster must widen it through the new `deserializationFilter` endpoint option, for
+example:
+
+[source,java]
+----
+from("jgroups:clusterName?deserializationFilter=com.example.model.**;java.**;!*")
+----
+
+Setting `deserializationFilter=*` accepts any type and so restores the previous behavior. A refused
+message is not routed; it is reported to the consumer's `ExceptionHandler`, which logs it at WARN
+level by default.
+
+Note that JGroups deserializes the payload inside its own receive path, so this check is a
+defense-in-depth allow-list on the resulting body type. The JVM-wide `jdk.serialFilter`, together
+with a channel secured with `AUTH` and encryption, remain the primary mitigations.
+
 == Upgrading from 4.18.3 to 4.18.4
 
 === camel-core - Multicast EIP honors UseOriginalAggregationStrategy


### PR DESCRIPTION
Follow-up doc sync for CAMEL-24676.

The camel-jgroups deserialization-filter note shipped on `camel-4.18.x` in #26283, but its entry in `camel-4x-upgrade-guide-4_18.adoc` was never added to `main`. The version-specific upgrade guides for **all** release lines are maintained on `main`, so `main`'s `4_18` guide was missing an entry that is live on the maintenance branch.

This adds the matching **4.18.5** entry to `main`, verbatim from what merged on `camel-4.18.x`, mirroring the 4.22.1 sync done in #26282. Docs-only, no code change.

_Claude Code on behalf of oscerd_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
