### PR TITLE
chore: fix misleading javadoc and document camel.extra.repos

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-running.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-running.adoc
@@ -201,12 +201,22 @@ You can also configure repositories in `application.properties`:
 camel.jbang.repos=https://packages.atlassian.com/maven-external
 ----
 
-Or set a global default via environment variable:
+Or set a global default with the `camel.extra.repos` JVM system property, which applies to every
+Camel CLI command without having to repeat `--repos`:
 
 [source,bash]
 ----
 export JAVA_TOOL_OPTIONS="-Dcamel.extra.repos=repo1=https://repo1.example.com/maven2,repo2=https://repo2.example.com/releases"
 ----
+
+The value is a comma-separated list of repositories, where each entry is either a plain URL or an
+`id=url` pair. Prefer the `id=url` form when the repository requires authentication, as the id is
+what Camel matches against the `<server>` entries in `~/.m2/settings.xml`.
+
+NOTE: A custom Camel distribution can provide a baseline for this via the
+`camel.default.extra.repos.default.value` system property. It is only consulted when
+`camel.extra.repos` is not set, so setting `camel.extra.repos` replaces that baseline rather than
+adding to it. Apache Camel itself sets neither property.
 
 == Downloading JARs over the internet
 

--- a/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloaderImpl.java
+++ b/tooling/camel-tooling-maven/src/main/java/org/apache/camel/tooling/maven/MavenDownloaderImpl.java
@@ -85,8 +85,10 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
     public static final String MAVEN_CENTRAL_REPO = "https://repo1.maven.org/maven2";
     public static final String APACHE_SNAPSHOT_REPO = "https://repository.apache.org/snapshots";
 
-    private static final String EXTRA_DEFAULT_REPOS_DEFAULT_VALUE = "camel.default.extra.repos.default.value";
+    // extra default Maven repositories, as a comma-separated list of id=url pairs
     private static final String EXTRA_DEFAULT_REPOS_PROPERTY = "camel.extra.repos";
+    // fallback for the above, consulted only when camel.extra.repos is not set
+    private static final String EXTRA_DEFAULT_REPOS_DEFAULT_VALUE = "camel.default.extra.repos.default.value";
 
     private static final RepositoryPolicy POLICY_DEFAULT = new RepositoryPolicy(
             true, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_WARN);
@@ -503,18 +505,24 @@ public class MavenDownloaderImpl extends ServiceSupport implements MavenDownload
     }
 
     /**
-     * Loads extra default Maven repositories from classpath properties files and system property.
+     * Loads extra default Maven repositories from a system property, so they are used in addition to Maven Central and
+     * the repositories from {@code settings.xml} without having to pass {@code --repos} on every command.
      * <p>
-     * Two complementary mechanisms:
-     * <ul>
-     * <li>System property: {@value #EXTRA_DEFAULT_REPOS_PROPERTY or EXTRA_DEFAULT_REPOS_DEFAULT_VALUE} (comma-separated
-     * id=url pairs)</li>
-     * </ul>
-     * Both are additive and merged. Upstream ships no properties file (no-op). Product builds can add the file or use
-     * the system property.
+     * The value is a comma-separated list of repositories, where each entry is either a plain URL or an {@code id=url}
+     * pair, for example {@code repo1=https://repo1.example.com/maven2,repo2=https://repo2.example.com/releases}. See
+     * {@link #configureRepositories(List, Set)} for why the {@code id=url} form is preferable.
+     * <p>
+     * Two system properties are consulted, in order:
+     * <ol>
+     * <li>{@value #EXTRA_DEFAULT_REPOS_PROPERTY} &ndash; intended for end users</li>
+     * <li>{@value #EXTRA_DEFAULT_REPOS_DEFAULT_VALUE} &ndash; a fallback used only when the former is not set, so that
+     * a custom Camel distribution can bake in a baseline that end users are still able to override</li>
+     * </ol>
+     * They are not merged: the first one that is set wins. Apache Camel does not set either of them, so this is a no-op
+     * unless configured.
      */
     private void loadExtraDefaultRepositories(List<RemoteRepository> repositories) {
-        // Load from system property (comma-separated id=url pairs)
+        // user-provided value first, then any baseline a custom distribution provided
         String sysProp
                 = System.getProperty(EXTRA_DEFAULT_REPOS_PROPERTY, System.getProperty(EXTRA_DEFAULT_REPOS_DEFAULT_VALUE));
         if (sysProp != null && !sysProp.isBlank()) {


### PR DESCRIPTION
Follow-up cleanup on [CAMEL-23353](https://issues.apache.org/jira/browse/CAMEL-23353) / #22709. Comments and documentation only — **no functional change**.

## Javadoc fix

The javadoc on `MavenDownloaderImpl.loadExtraDefaultRepositories` did not match the code that was merged:

- It described loading "from classpath properties files" (`camel-extra-default-repos.properties`). That mechanism was announced in the #22709 description but never landed in the merged diff.
- It announced "Two complementary mechanisms" under a `<ul>` containing only one bullet.
- It claimed "Both are additive and merged". They are not: `camel.default.extra.repos.default.value` is only the *fallback* default of `System.getProperty("camel.extra.repos", ...)`, so whichever is set first wins and the two are never merged.
- The `{@value #EXTRA_DEFAULT_REPOS_PROPERTY or EXTRA_DEFAULT_REPOS_DEFAULT_VALUE}` tag was malformed — `{@value}` takes a single field reference.

It also understated the accepted value format: `configureRepositories` accepts a plain URL as well as an `id=url` pair, and the `id=url` form exists specifically so the id can be matched against `<server>` entries in `settings.xml` for authentication.

The two constants are also reordered so the primary property (`camel.extra.repos`) comes first, each with a one-line comment saying which is which.

## Documentation

`camel.extra.repos` was previously only present in `camel-jbang-running.adoc` as a bare `export JAVA_TOOL_OPTIONS=...` line labelled "a global default via environment variable", with no explanation of the value format. Now documented properly:

- named as a JVM system property that applies to every Camel CLI command without repeating `--repos`
- the comma-separated plain-URL-or-`id=url` value format, and why `id=url` is preferable for authenticated repositories
- a NOTE covering `camel.default.extra.repos.default.value`: it is a baseline for custom Camel distributions, is consulted only when `camel.extra.repos` is unset, and is therefore *replaced* rather than extended when a user sets `camel.extra.repos`

That last point is the easiest thing to get wrong about the current behaviour, so it is worth having written down.

## Testing

`mvn -DskipTests install` in `tooling/camel-tooling-maven` is clean, and the formatter produced no changes. No tests were run, as the change touches only comments and AsciiDoc.

---
_Claude Code on behalf of davsclaus_