### PR TITLE
CAMEL-24216: Wrap setAttribute in try-catch in XsltEndpoint like XsltSaxonEndpoint

### DIFF
--- a/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XsltEndpoint.java
+++ b/components/camel-xslt/src/main/java/org/apache/camel/component/xslt/XsltEndpoint.java
@@ -477,8 +477,12 @@ public class XsltEndpoint extends ProcessorEndpoint {
             }
 
             if (effectiveXpathTotalOpLimit > 0) {
-                LOG.debug("Setting jdk.xml.xpathTotalOpLimit={} on TransformerFactory", effectiveXpathTotalOpLimit);
-                factory.setAttribute("jdk.xml.xpathTotalOpLimit", effectiveXpathTotalOpLimit);
+                try {
+                    LOG.debug("Setting jdk.xml.xpathTotalOpLimit={} on TransformerFactory", effectiveXpathTotalOpLimit);
+                    factory.setAttribute("jdk.xml.xpathTotalOpLimit", effectiveXpathTotalOpLimit);
+                } catch (IllegalArgumentException e) {
+                    LOG.debug("TransformerFactory does not support jdk.xml.xpathTotalOpLimit");
+                }
             }
 
             LOG.debug("Using TransformerFactory {}", factory);


### PR DESCRIPTION
Follow-up to #25165, as pointed out by @graben.

When a custom `TransformerFactory` class is configured via `transformerFactoryClass`, it may not support the JDK-specific `jdk.xml.xpathTotalOpLimit` attribute and will throw `IllegalArgumentException`. `XsltSaxonEndpoint` already wraps the `setAttribute` call in a try-catch for exactly this reason — this PR applies the same defensive pattern to `XsltEndpoint`.