### PR TITLE
CAMEL-24667: camel-http - exclude Brotli from Accept-Encoding when native JNI library is unavailable

### DIFF
--- a/components/camel-http/pom.xml
+++ b/components/camel-http/pom.xml
@@ -137,6 +137,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+            <version>${brotli4j-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
+++ b/components/camel-http/src/main/java/org/apache/camel/component/http/HttpComponent.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -58,6 +59,9 @@ import org.apache.camel.util.UnsafeUriCharactersEncoder;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.entity.InputStreamFactory;
+import org.apache.hc.client5.http.entity.compress.ContentCodecRegistry;
+import org.apache.hc.client5.http.entity.compress.ContentCoding;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -68,6 +72,7 @@ import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.ssl.SSLContexts;
@@ -85,6 +90,7 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpComponent.class);
     private static final String TARGET_URI_PARAMETER = HttpComponent.class.getName() + ".targetUri";
+    private static final boolean BROTLI4J_AVAILABLE = isBrotli4jAvailable();
 
     @Metadata(label = "advanced",
               description = "To use the custom HttpClientConfigurer to perform configuration of the HttpClient that will be used.")
@@ -644,6 +650,13 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
         }
         if (contentCompressionDisabled) {
             clientBuilder.disableContentCompression();
+        } else if (!BROTLI4J_AVAILABLE) {
+            // Brotli4j API jar may be on the classpath (e.g. via quarkus-vertx-http) without
+            // the platform-native JNI library. HttpClient's Brotli4jRuntime.available() only
+            // checks class presence, not JNI loadability, so it would advertise "br" in
+            // Accept-Encoding and then fail at decompression time with UnsatisfiedLinkError.
+            // Re-register all available decoders except brotli.
+            clientBuilder.setContentDecoderRegistry(buildDecodersWithoutBrotli());
         }
         if (cookieManagementDisabled) {
             clientBuilder.disableCookieManagement();
@@ -662,6 +675,35 @@ public class HttpComponent extends HttpCommonComponent implements RestProducerFa
         }
 
         return clientBuilder;
+    }
+
+    static boolean isBrotli4jAvailable() {
+        try {
+            Class<?> loader = Class.forName("com.aayushatharva.brotli4j.Brotli4jLoader", true,
+                    HttpComponent.class.getClassLoader());
+            return (boolean) loader.getMethod("isAvailable").invoke(null);
+        } catch (Exception | LinkageError e) {
+            return false;
+        }
+    }
+
+    /**
+     * Builds a content decoder registry containing all HttpClient-supported decoders except Brotli. Called when the
+     * Brotli4j API jar is on the classpath but the platform-native JNI library is missing.
+     */
+    static LinkedHashMap<String, InputStreamFactory> buildDecodersWithoutBrotli() {
+        LinkedHashMap<String, InputStreamFactory> decoders = new LinkedHashMap<>();
+        for (ContentCoding cc : ContentCoding.values()) {
+            if (cc == ContentCoding.BROTLI) {
+                continue;
+            }
+            if (ContentCodecRegistry.decoder(cc) != null) {
+                final ContentCoding coding = cc;
+                decoders.put(cc.token(), in -> ContentCodecRegistry.unwrap(coding,
+                        new BasicHttpEntity(in, null)).getContent());
+            }
+        }
+        return decoders;
     }
 
     protected TlsSocketStrategy createTlsStrategy(

--- a/components/camel-http/src/test/java/org/apache/camel/component/http/HttpBrotli4jAvailabilityTest.java
+++ b/components/camel-http/src/test/java/org/apache/camel/component/http/HttpBrotli4jAvailabilityTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.http;
+
+import java.util.LinkedHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.aayushatharva.brotli4j.Brotli4jLoader;
+import org.apache.hc.client5.http.entity.InputStreamFactory;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.impl.bootstrap.HttpServer;
+import org.apache.hc.core5.http.impl.bootstrap.ServerBootstrap;
+import org.apache.hc.core5.http.io.HttpRequestHandler;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpBrotli4jAvailabilityTest extends BaseHttpTest {
+
+    private HttpServer localServer;
+    private final AtomicReference<String> capturedAcceptEncoding = new AtomicReference<>();
+
+    @Override
+    public void setupResources() throws Exception {
+        HttpRequestHandler handler = (request, response, context) -> {
+            capturedAcceptEncoding.set(
+                    request.getFirstHeader("Accept-Encoding") != null
+                            ? request.getFirstHeader("Accept-Encoding").getValue()
+                            : null);
+            response.setCode(HttpStatus.SC_OK);
+            response.setEntity(new StringEntity(getExpectedContent()));
+        };
+
+        localServer = ServerBootstrap.bootstrap()
+                .setCanonicalHostName("localhost")
+                .register("/", handler)
+                .create();
+        localServer.start();
+    }
+
+    @Override
+    public void cleanupResources() throws Exception {
+        if (localServer != null) {
+            localServer.stop();
+        }
+    }
+
+    @Test
+    void brotli4jAvailabilityShouldMatchLoaderState() {
+        // The brotli4j API jar is on the test classpath (test-scope dependency).
+        // Whether the native library loads depends on the test machine (e.g. Homebrew
+        // brotli on macOS). What matters is that our reflective check returns the same
+        // result as calling Brotli4jLoader.isAvailable() directly.
+        assertThat(HttpComponent.isBrotli4jAvailable())
+                .as("isBrotli4jAvailable() must agree with Brotli4jLoader.isAvailable()")
+                .isEqualTo(Brotli4jLoader.isAvailable());
+    }
+
+    @Test
+    void brotli4jLoaderClassShouldBeOnClasspath() {
+        // Verify the API jar is actually on the test classpath, so the test above
+        // is validating native-lib detection, not just a missing class.
+        try {
+            Class.forName("com.aayushatharva.brotli4j.Brotli4jLoader");
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("brotli4j API jar should be on the test classpath as a test-scope dependency", e);
+        }
+    }
+
+    @Test
+    void buildDecodersWithoutBrotliShouldExcludeBr() {
+        LinkedHashMap<String, InputStreamFactory> decoders = HttpComponent.buildDecodersWithoutBrotli();
+        assertThat(decoders).doesNotContainKey("br");
+        assertThat(decoders).containsKey("gzip");
+        assertThat(decoders).containsKey("deflate");
+    }
+
+    @Test
+    void acceptEncodingShouldReflectBrotli4jAvailability() {
+        template.request("http://localhost:" + localServer.getLocalPort() + "/",
+                exchange -> exchange.getIn().setBody("test"));
+
+        String acceptEncoding = capturedAcceptEncoding.get();
+        assertThat(acceptEncoding).as("Accept-Encoding header").isNotNull();
+        assertThat(acceptEncoding).contains("gzip", "deflate");
+
+        if (Brotli4jLoader.isAvailable()) {
+            assertThat(acceptEncoding).as("brotli4j is available, Accept-Encoding should include br").contains("br");
+        } else {
+            assertThat(acceptEncoding).as("brotli4j is unavailable, Accept-Encoding must not include br")
+                    .doesNotContain("br");
+        }
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,6 +97,7 @@
         <bouncycastle-version>1.85</bouncycastle-version>
         <box-java-sdk-version>4.16.4</box-java-sdk-version>
         <braintree-gateway-version>3.53.0</braintree-gateway-version>
+        <brotli4j-version>1.23.0</brotli4j-version>
         <build-helper-maven-plugin-version>3.6.1</build-helper-maven-plugin-version>
         <bytebuddy-version>1.18.12</bytebuddy-version>
         <c3p0-version>0.14.1</c3p0-version>


### PR DESCRIPTION
# Description

  When the Brotli4j API jar is on the classpath (e.g. pulled transitively via
  `quarkus-vertx-http`) without the platform-native JNI library, HttpClient 5's
  `Brotli4jRuntime.available()` only checks class presence, not JNI loadability.
  This causes it to advertise "br" in Accept-Encoding and then fail with
  `UnsatisfiedLinkError` at decompression time.

  Fix: at class-load time, reflectively call `Brotli4jLoader.isAvailable()` which
  verifies the native library actually loads. When it reports unavailable,
  re-register all HttpClient content decoders except Brotli via
  `setContentDecoderRegistry()`, preserving `gzip`, `deflate`, `zstd` and any other
  codec whose native library is present.

  ## Test plan

  - `brotli4jAvailabilityShouldMatchLoaderState` — verifies the reflective
    `isBrotli4jAvailable()` check agrees with calling `Brotli4jLoader.isAvailable()`
    directly (passes on both native-available and native-unavailable machines)
  - `brotli4jLoaderClassShouldBeOnClasspath` — confirms the API jar is on the test
    classpath so the test above is validating native-lib detection, not a missing class
  - `acceptEncodingShouldReflectBrotli4jAvailability` — starts a local HTTP server,
    sends a request, and asserts that the `Accept-Encoding` header includes `br` only
    when the native library is actually loadable

  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

