### PR TITLE
[backport camel-4.18.x] Upgrade netty to 4.2.17.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -423,7 +423,7 @@
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>6.0.2</neo4j-version>
-        <netty-version>4.1.137.Final</netty-version>
+        <netty-version>4.2.17.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.9</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.7</nimbus-jose-jwt>


### PR DESCRIPTION
## Backport of #26176

Cherry-pick of 582ed4d999c34eff45d728ee2ded7a9e0ef7ff07 to camel-4.18.x.
Conflicts resolved automatically by backport bot agent.