### PR TITLE
[backport camel-4.22.x] chore(docs): use backtick formatting for property names in option tables

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/main.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/main.adoc
@@ -24,136 +24,136 @@ The camel.main supports 130 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.main.additionalSensitiveKeywords* | Camel comes with a default set of sensitive keywords which are automatically masked. This option allows to add additional custom keywords to be masked as well. Multiple keywords can be separated by comma. |  | String
-| *camel.main.allowUseOriginalMessage* | Sets whether to allow access to the original message from Camel's error handler, or from org.apache.camel.spi.UnitOfWork.getOriginalInMessage(). Turning this off can optimize performance, as defensive copy of the original message is not needed. Default is false. | false | boolean
-| *camel.main.autoConfigurationEnabled* | Whether auto configuration of components, dataformats, languages is enabled or not. When enabled the configuration parameters are loaded from the properties component. You can prefix the parameters in the properties file with: - camel.component.name.option1=value1 - camel.component.name.option2=value2 - camel.dataformat.name.option1=value1 - camel.dataformat.name.option2=value2 - camel.language.name.option1=value1 - camel.language.name.option2=value2 Where name is the name of the component, dataformat or language such as seda,direct,jaxb. The auto configuration also works for any options on components that is a complex type (not standard Java type) and there has been an explicit single bean instance registered to the Camel registry via the org.apache.camel.spi.Registry#bind(String,Object) method or by using the org.apache.camel.BindToRegistry annotation style. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationEnvironmentVariablesEnabled* | Whether auto configuration should include OS environment variables as well. When enabled this allows to overrule any configuration using an OS environment variable. For example to set a shutdown timeout of 5 seconds: CAMEL_MAIN_SHUTDOWNTIMEOUT=5. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationFailFast* | Whether auto configuration should fail fast when configuring one ore more properties fails for whatever reason such as a invalid property name, etc. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationLogSummary* | Whether auto configuration should log a summary with the configured properties. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationSystemPropertiesEnabled* | Whether auto configuration should include JVM system properties as well. When enabled this allows to overrule any configuration using a JVM system property. For example to set a shutdown timeout of 5 seconds: -D camel.main.shutdown-timeout=5. Note that JVM system properties take precedence over OS environment variables. This option is default enabled. | true | boolean
-| *camel.main.autoStartup* | Sets whether the object should automatically start when Camel starts. Important: Currently only routes can be disabled, as CamelContext's are always started. Note: When setting auto startup false on CamelContext then that takes precedence and no routes are started. You would need to start CamelContext explicit using the org.apache.camel.CamelContext.start() method, to start the context, and then you would need to start the routes manually using CamelContext.getRouteController().startRoute(String). Default is true to always start up. | true | boolean
-| *camel.main.autoStartupExcludePattern* | Used for exclusive filtering of routes to not automatically start with Camel starts. The pattern support matching by route id or endpoint urls. Multiple patterns can be specified separated by comma, as example, to exclude all the routes starting from kafka or jms use: kafka,jms. |  | String
-| *camel.main.autowiredEnabled* | Whether autowiring is enabled. This is used for automatic autowiring options (the option must be marked as autowired) by looking up in the registry to find if there is a single instance of matching type, which then gets configured on the component. This can be used for automatic configuring JDBC data sources, JMS connection factories, AWS Clients, etc. Default is true. | true | boolean
-| *camel.main.basePackageScan* | Package name to use as base (offset) for classpath scanning of RouteBuilder , org.apache.camel.TypeConverter , CamelConfiguration classes, and also classes annotated with org.apache.camel.Converter , or org.apache.camel.BindToRegistry . If you are using Spring Boot then it is instead recommended to use Spring Boots component scanning and annotate your route builder classes with Component. In other words only use this for Camel Main in standalone mode. |  | String
-| *camel.main.basePackageScanEnabled* | Whether base package scan is enabled. | true | boolean
-| *camel.main.beanIntrospectionExtendedStatistics* | Sets whether bean introspection uses extended statistics. The default is false. | false | boolean
-| *camel.main.beanIntrospectionLoggingLevel* | Sets the logging level used by bean introspection, logging activity of its usage. The default is TRACE. |  | LoggingLevel
-| *camel.main.beanPostProcessorEnabled* | Can be used to turn off bean post processing. Be careful to turn this off, as this means that beans that use Camel annotations such as org.apache.camel.EndpointInject , org.apache.camel.ProducerTemplate , org.apache.camel.Produce , org.apache.camel.Consume etc will not be injected and in use. Turning this off should only be done if you are sure you do not use any of these Camel features. Not all runtimes allow turning this off. The default value is true (enabled). | true | boolean
-| *camel.main.camelEventsTimestampEnabled* | Whether to include timestamps for all emitted Camel Events. Enabling this allows to know fine-grained at what time each event was emitted, which can be used for reporting to report exactly the time of the events. This is by default false to avoid the overhead of including this information. | false | boolean
-| *camel.main.caseInsensitiveHeaders* | Whether to use case sensitive or insensitive headers. Important: When using case sensitive (this is set to false). Then the map is case sensitive which means headers such as content-type and Content-Type are two different keys which can be a problem for some protocols such as HTTP based, which rely on case insensitive headers. However case sensitive implementations can yield faster performance. Therefore use case sensitive implementation with care. Default is true. | true | boolean
-| *camel.main.cloudPropertiesLocation* | Sets the locations (comma separated values) where to find properties configuration as defined for cloud native environments such as Kubernetes. You should only scan text based mounted configuration. |  | String
-| *camel.main.compileWorkDir* | Work directory for compiler. Can be used to write compiled classes or other resources. |  | String
-| *camel.main.configurationClasses* | Sets classes names that will be used to configure the camel context as example by providing custom beans through org.apache.camel.BindToRegistry annotation. |  | String
-| *camel.main.configurations* | Sets the configuration objects used to configure the camel context. |  | List
-| *camel.main.consumerTemplateCacheSize* | Consumer template endpoints cache size. | 1000 | int
-| *camel.main.contextReloadEnabled* | Used for enabling context reloading. If enabled then Camel allow external systems such as security vaults (AWS secrets manager, etc.) to trigger refreshing Camel by updating property placeholders and reload all existing routes to take changes into effect. | false | boolean
-| *camel.main.description* | Sets the description (intended for humans) of the Camel application. |  | String
-| *camel.main.devConsoleEnabled* | Whether to enable developer console (requires camel-console on classpath). The developer console is only for assisting during development. This is NOT for production usage. | false | boolean
-| *camel.main.dumpRoutes* | If dumping is enabled then Camel will during startup dump all loaded routes (incl rests and route templates) represented as XML, YAML, or Java DSL into the log. This is intended for trouble shooting or to assist during development. Sensitive information that may be configured in the route endpoints could potentially be included in the dump output and is therefore not recommended being used for production usage. This requires to have camel-xml-io/camel-yaml-io/camel-java-io on the classpath to be able to dump the routes as XML/YAML/Java. You can also use JSon which dumps the route structure in JSon. The JSon does not represent Camel DSL but it useful for tooling to understand the structure of the routes and how EIPs are nested together. You can also use png to save route diagrams as PNG image files either all combined in a single file (default camel-route-diagrams.png) or to a given folder, where routes are grouped by source file name(s) and saved as corresponding .png files. This requires to have camel-diagram on the classpath to be able to render PNG diagrams. |  | String
-| *camel.main.dumpRoutesGeneratedIds* | Whether to include auto generated IDs in the dumped output. Default is false. | false | boolean
-| *camel.main.dumpRoutesInclude* | Controls what to include in output for route dumping. Possible values: all, routes, rests, routeConfigurations, routeTemplates, beans, dataFormats. Multiple values can be separated by comma. Default is routes. | routes | String
-| *camel.main.dumpRoutesLog* | Whether to log route dumps to Logger | true | boolean
-| *camel.main.dumpRoutesOutput* | Whether to save route dumps to an output file. If the output is a filename, then all content is saved to this file. If the output is a directory name, then one or more files are saved to the directory, where the names are based on the original source file names, or auto generated names. |  | String
-| *camel.main.dumpRoutesResolvePlaceholders* | Whether to resolve property placeholders in the dumped output. Default is true. | true | boolean
-| *camel.main.dumpRoutesUriAsParameters* | When dumping routes to YAML format, then this option controls whether endpoint URIs should be expanded into a key/value parameters. | false | boolean
-| *camel.main.durationHitExitCode* | Sets the exit code for the application if duration was hit |  | int
-| *camel.main.durationMaxAction* | Controls whether the Camel application should shutdown the JVM, or stop all routes, when duration max is triggered. | shutdown | String
-| *camel.main.durationMaxIdleSeconds* | To specify for how long time in seconds Camel can be idle before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
-| *camel.main.durationMaxMessages* | To specify how many messages to process by Camel before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
-| *camel.main.durationMaxSeconds* | To specify for how long time in seconds to keep running the JVM before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
-| *camel.main.endpointBridgeErrorHandler* | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN/ERROR level and ignored. The default value is false. | false | boolean
-| *camel.main.endpointLazyStartProducer* | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. The default value is false. | false | boolean
-| *camel.main.endpointRuntimeStatisticsEnabled* | Sets whether endpoint runtime statistics is enabled (gathers runtime usage of each incoming and outgoing endpoints). The default value is false. | false | boolean
-| *camel.main.exchangeFactory* | Controls whether to pool (reuse) exchanges or create new exchanges (prototype). Using pooled will reduce JVM garbage collection overhead by avoiding to re-create Exchange instances per message each consumer receives. The default is prototype mode. | default | String
-| *camel.main.exchangeFactoryCapacity* | The capacity the pool (for each consumer) uses for storing exchanges. The default capacity is 100. | 100 | int
-| *camel.main.exchangeFactoryStatisticsEnabled* | Configures whether statistics is enabled on exchange factory. | false | boolean
-| *camel.main.extraShutdownTimeout* | Extra timeout in seconds to graceful shutdown Camel. When Camel is shutting down then Camel first shutdown all the routes (shutdownTimeout). Then additional services is shutdown (extraShutdownTimeout). | 15 | int
-| *camel.main.fileConfigurations* | Directory to load additional properties files that contains configurations that takes precedence (except for camel.main.xxx configurations). This can be used to refer to files that may have secret configuration that has been mounted on the file system for containers. You can specify a pattern to load from file-system (not classpath) and a name pattern such as /var/app/secret/.properties, multiple directories can be separated by comma. |  | String
-| *camel.main.globalOptions* | Sets global options that can be referenced in the camel context Important: This has nothing to do with property placeholders, and is just a plain set of key/value pairs which are used to configure global options on CamelContext, such as a maximum debug logging length etc. |  | Map
-| *camel.main.groovyPreloadCompiled* | Whether to preload existing compiled Groovy sources from the compileWorkDir option on startup. This can be enabled to avoid compiling sources that already has been compiled during a build phase. | false | boolean
-| *camel.main.groovyScriptPattern* | Directories to scan for groovy source to be pre-compiled. For example: scripts/.groovy will scan inside the classpath folder scripts for all groovy source files. By default, sources are scanned from the classpath, but you can prefix with file: to use file system. The directories are using Ant-path style pattern, and multiple directories can be specified separated by comma. This requires having camel-groovy JAR on the classpath. | classpath:camel-groovy/*,classpath:camel-groovy-compiled/* | String
-| *camel.main.inflightRepositoryBrowseEnabled* | Sets whether the inflight repository should allow browsing each inflight exchange. This is by default disabled as there is a very slight performance overhead when enabled. | false | boolean
-| *camel.main.javaRoutesExcludePattern* | Used for exclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. For example to exclude all classes starting with Bar use: &#42;&#42;/Bar&#42; To exclude all routes form a specific package use: com/mycompany/bar/&#42; To exclude all routes form a specific package and its sub-packages use double wildcards: com/mycompany/bar/&#42;&#42; And to exclude all routes from two specific packages use: com/mycompany/bar/&#42;,com/mycompany/stuff/&#42; |  | String
-| *camel.main.javaRoutesIncludePattern* | Used for inclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. Multiple patterns can be specified separated by comma. For example to include all classes starting with Foo use: &#42;&#42;/Foo To include all routes form a specific package use: com/mycompany/foo/&#42; To include all routes form a specific package and its sub-packages use double wildcards: com/mycompany/foo/&#42;&#42; And to include all routes from two specific packages use: com/mycompany/foo/&#42;,com/mycompany/stuff/&#42; |  | String
-| *camel.main.jmxEnabled* | Enable JMX in your Camel application. | true | boolean
-| *camel.main.jmxManagementMBeansLevel* | Sets the mbeans registration level. The default value is Default. | Default | ManagementMBeansLevel
-| *camel.main.jmxManagementNamePattern* | The naming pattern for creating the CamelContext JMX management name. The default pattern is #name# | #name# | String
-| *camel.main.jmxManagementRegisterRoutesCreateByKamelet* | Whether routes created by Kamelets should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via Kamelets. This is default disabled as a Kamelet is intended as a component (black-box) and its implementation details as Camel route makes the overall management and monitoring of Camel applications more verbose. During development of Kamelets then enabling this will make it possible for developers to do fine-grained performance inspection and identify potential bottlenecks in the Kamelet routes. However, for production usage then keeping this disabled is recommended. | false | boolean
-| *camel.main.jmxManagementRegisterRoutesCreateByTemplate* | Whether routes created by route templates (not Kamelets) should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via route templates. This is default enabled (unlike Kamelets) as routes created via templates is regarded as standard routes, and should be available for management and monitoring. | true | boolean
-| *camel.main.jmxManagementStatisticsLevel* | Sets the JMX statistics level, the level can be set to Extended to gather additional information The default value is Default. | Default | ManagementStatisticsLevel
-| *camel.main.jmxUpdateRouteEnabled* | Whether to allow updating routes at runtime via JMX using the ManagedRouteMBean. This is disabled by default, but can be enabled for development and troubleshooting purposes, such as updating routes in an existing running Camel via JMX and other tools. | false | boolean
-| *camel.main.loadHealthChecks* | Whether to load custom health checks by scanning classpath. | false | boolean
-| *camel.main.loadStatisticsEnabled* | Sets whether Camel load (inflight messages, not cpu) statistics is enabled (something like the unix load average). The statistics requires to have camel-management on the classpath as JMX is required. The default value is false. | false | boolean
-| *camel.main.loadTypeConverters* | Whether to load custom type converters by scanning classpath. This is used for backwards compatibility with Camel 2.x. Its recommended to migrate to use fast type converter loading by setting Converter(loader = true) on your custom type converter classes. | false | boolean
-| *camel.main.logDebugMaxChars* | Is used to limit the maximum length of the logging Camel message bodies. If the message body is longer than the limit, the log message is clipped. Use -1 to have unlimited length. Use for example 1000 to log at most 1000 characters. |  | int
-| *camel.main.logExhaustedMessageBody* | Sets whether to log exhausted message body with message history. Default is false. | false | boolean
-| *camel.main.logLanguage* | To configure the language to use for Log EIP. By default, the simple language is used. However, Camel also supports other languages such as groovy. |  | String
-| *camel.main.logMask* | Sets whether log mask is enabled or not. Default is false. | false | boolean
-| *camel.main.logName* | The global name to use for Log EIP The name is default the routeId or the source:line if source location is enabled. You can also specify the name using tokens: $\{class} - the logger class name (org.apache.camel.processor.LogProcessor) $\{contextId} - the camel context id $\{routeId} - the route id $\{groupId} - the route group id $\{nodeId} - the node id $\{nodePrefixId} - the node prefix id $\{source} - the source:line (source location must be enabled) ${source.name} - the source filename (source location must be enabled) ${source.line} - the source line number (source location must be enabled) For example to use the route and node id you can specify the name as: $\{routeId}/$\{nodeId} |  | String
-| *camel.main.mainListenerClasses* | Sets classes names that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | String
-| *camel.main.mainListeners* | Sets main listener objects that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | List
-| *camel.main.mdcLoggingKeysPattern* | Sets the pattern used for determine which custom MDC keys to propagate during message routing when the routing engine continues routing asynchronously for the given message. Setting this pattern to will propagate all custom keys. Or setting the pattern to foo,bar will propagate any keys starting with either foo or bar. Notice that a set of standard Camel MDC keys are always propagated which starts with camel. as key name. The match rules are applied in this order (case insensitive): 1. exact match, returns true 2. wildcard match (pattern ends with a and the name starts with the pattern), returns true 3. regular expression match, returns true 4. otherwise returns false Deprecated, use camel-mdc component instead |  | String
-| *camel.main.messageHistory* | Sets whether message history is enabled or not. Default is false. | false | boolean
-| *camel.main.messageSizeEnabled* | Sets whether message size observation is enabled (default is false). When enabled, Camel will compute the size of message body and headers (in bytes) per endpoint (for both IN and OUT directions) and make this available via JMX MBeans (min/max/mean body size and headers size). | false | boolean
-| *camel.main.modeline* | Whether to support JBang style //DEPS to specify additional dependencies when running Camel CLI | false | boolean
-| *camel.main.name* | Sets the name of the CamelContext. |  | String
-| *camel.main.producerTemplateCacheSize* | Producer template endpoints cache size. | 1000 | int
-| *camel.main.profile* | Camel profile to use when running. The dev profile is for development, which enables a set of additional developer focus functionality, tracing, debugging, and gathering additional runtime statistics that are useful during development. However, those additional features has a slight overhead cost, and are not enabled for production profile. The default profile is prod. |  | String
-| *camel.main.routeFilterExcludePattern* | Used for filtering routes routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
-| *camel.main.routeFilterIncludePattern* | Used for filtering routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
-| *camel.main.routesBuilderClasses* | Sets classes names that implement RoutesBuilder . |  | String
-| *camel.main.routesBuilders* | Sets the RoutesBuilder instances. |  | List
-| *camel.main.routesCollectorEnabled* | Whether the routes collector is enabled or not. When enabled Camel will auto-discover routes (RouteBuilder instances from the registry and also load additional routes from the file system). The routes collector is default enabled. | true | boolean
-| *camel.main.routesCollectorIgnoreLoadingError* | Whether the routes collector should ignore any errors during loading and compiling routes. This is only intended for development or tooling. | false | boolean
-| *camel.main.routesExcludePattern* | Used for exclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to exclude all the routes from a directory whose name contains foo use: &#42;&#42;/foo. |  | String
-| *camel.main.routesIncludePattern* | Used for inclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to include all the routes from a directory whose name contains foo use: &#42;&#42;/foo. | classpath:camel/*,classpath:camel-template/*,classpath:camel-rest/* | String
-| *camel.main.routesReloadDirectory* | Directory to scan for route changes. Camel cannot scan the classpath, so this must be configured to a file directory. Development with Maven as build tool, you can configure the directory to be src/main/resources to scan for Camel routes in XML or YAML files. | src/main/resources/camel | String
-| *camel.main.routesReloadDirectoryRecursive* | Whether the directory to scan should include sub directories. Depending on the number of sub directories, then this can cause the JVM to startup slower as Camel uses the JDK file-watch service to scan for file changes. | false | boolean
-| *camel.main.routesReloadEnabled* | Used for enabling automatic routes reloading. If enabled then Camel will watch for file changes in the given reload directory, and trigger reloading routes if files are changed. | false | boolean
-| *camel.main.routesReloadPattern* | Used for inclusive filtering of routes from directories. Typical used for specifying to accept routes in XML or YAML files, such as .yaml,.xml. Multiple patterns can be specified separated by comma. |  | String
-| *camel.main.routesReloadRemoveAllRoutes* | When reloading routes should all existing routes be stopped and removed. By default, Camel will stop and remove all existing routes before reloading routes. This ensures that only the reloaded routes will be active. If disabled then only routes with the same route id is updated, and any existing routes are continued to run. | true | boolean
-| *camel.main.routesReloadRestartDuration* | Whether to restart max duration when routes are reloaded. For example if max duration is 60 seconds, and a route is reloaded after 25 seconds, then this will restart the count and wait 60 seconds again. | false | boolean
-| *camel.main.shutdownLogInflightExchangesOnTimeout* | Sets whether to log information about the inflight Exchanges which are still running during a shutdown which didn't complete without the given timeout. This requires to enable the option inflightRepositoryBrowseEnabled. | true | boolean
-| *camel.main.shutdownNowOnTimeout* | Sets whether to force shutdown of all consumers when a timeout occurred and thus not all consumers was shutdown within that period. You should have good reasons to set this option to false as it means that the routes keep running and is halted abruptly when CamelContext has been shutdown. | true | boolean
-| *camel.main.shutdownRoutesInReverseOrder* | Sets whether routes should be shutdown in reverse or the same order as they were started. | true | boolean
-| *camel.main.shutdownSuppressLoggingOnTimeout* | Whether Camel should try to suppress logging during shutdown and timeout was triggered, meaning forced shutdown is happening. And during forced shutdown we want to avoid logging errors/warnings et all in the logs as a side-effect of the forced timeout. Notice the suppress is a best effort as there may still be some logs coming from 3rd party libraries and whatnot, which Camel cannot control. This option is default false. | false | boolean
-| *camel.main.shutdownTimeout* | Timeout in seconds to graceful shutdown all the Camel routes. | 45 | int
-| *camel.main.sourceLocationEnabled* | Whether to capture precise source location:line-number for all EIPs in Camel routes. Enabling this will impact parsing Java based routes (also Groovy etc.) on startup as this uses JDK StackTraceElement to calculate the location from the Camel route, which comes with a performance cost. This only impact startup, not the performance of the routes at runtime. | false | boolean
-| *camel.main.startupRecorder* | To use startup recorder for capturing execution time during starting Camel. The recorder can be one of: false (or off), logging, backlog, java-flight-recorder (or jfr). |  | String
-| *camel.main.startupRecorderDir* | Directory to store the recording. By default the current directory will be used. Use false to turn off saving recording to disk. |  | String
-| *camel.main.startupRecorderDuration* | How long time to run the startup recorder. Use 0 (default) to keep the recorder running until the JVM is exited. Use -1 to stop the recorder right after Camel has been started (to only focus on potential Camel startup performance bottlenecks) Use a positive value to keep recording for N seconds. When the recorder is stopped then the recording is auto saved to disk (note: save to disk can be disabled by setting startupRecorderDir to false) |  | long
-| *camel.main.startupRecorderMaxDepth* | To filter our sub steps at a maximum depth. Use -1 for no maximum. Use 0 for no sub steps. Use 1 for max 1 sub step, and so forth. The default is -1. | -1 | int
-| *camel.main.startupRecorderProfile* | To use a specific Java Flight Recorder profile configuration, such as default or profile. The default is default. | default | String
-| *camel.main.startupRecorderRecording* | To enable Java Flight Recorder to start a recording and automatic dump the recording to disk after startup is complete. This requires that camel-jfr is on the classpath, and to enable this option. | false | boolean
-| *camel.main.startupRecorderRuntimeEnabled* | To also instrument the running Camel application, and not only its startup, by emitting Java Flight Recorder events for every exchange, route and processor. This requires that camel-jfr is on the classpath, and to enable this option. The runtime events are only captured while a recording is active. As they are emitted per message they add overhead, so this is turned off by default. | false | boolean
-| *camel.main.startupSummaryLevel* | Controls the level of information logged during startup (and shutdown) of CamelContext. | Default | StartupSummaryLevel
-| *camel.main.streamCachingAllowClasses* | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
-| *camel.main.streamCachingAnySpoolRules* | Sets whether if just any of the org.apache.camel.spi.StreamCachingStrategy.SpoolRule rules returns true then shouldSpoolCache(long) returns true, to allow spooling to disk. If this option is false, then all the org.apache.camel.spi.StreamCachingStrategy.SpoolRule must return true. The default value is false which means that all the rules must return true. | false | boolean
-| *camel.main.streamCachingBufferSize* | Sets the stream caching buffer size to use when allocating in-memory buffers used for in-memory stream caches. The default size is 4096. |  | int
-| *camel.main.streamCachingDenyClasses* | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
-| *camel.main.streamCachingEnabled* | Sets whether stream caching is enabled or not. While stream types (like StreamSource, InputStream and Reader) are commonly used in messaging for performance reasons, they also have an important drawback: they can only be read once. In order to be able to work with message content multiple times, the stream needs to be cached. Streams are cached in memory only (by default). If streamCachingSpoolEnabled=true, then, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is true. | true | boolean
-| *camel.main.streamCachingRemoveSpoolDirectoryWhenStopping* | Whether to remove stream caching temporary directory when stopping. This option is default true. | true | boolean
-| *camel.main.streamCachingSpoolCipher* | Sets a stream caching cipher name to use when spooling to disk to write with encryption. By default the data is not encrypted. |  | String
-| *camel.main.streamCachingSpoolDirectory* | Sets the stream caching spool (temporary) directory to use for overflow and spooling to disk. If no spool directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
-| *camel.main.streamCachingSpoolEnabled* | To enable stream caching spooling to disk. This means, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is false. | false | boolean
-| *camel.main.streamCachingSpoolRules* | Sets custom rules (org.apache.camel.spi.StreamCachingStrategy.SpoolRule) for deciding when to spool to disk. Multiple rules can be separated by comma. |  | String
-| *camel.main.streamCachingSpoolThreshold* | Stream caching threshold in bytes when overflow to disk is activated. The default threshold is 128kb. Use -1 to disable overflow to disk. |  | long
-| *camel.main.streamCachingSpoolUsedHeapMemoryLimit* | Sets what the upper bounds should be when streamCachingSpoolUsedHeapMemoryThreshold is in use. | Max | String
-| *camel.main.streamCachingSpoolUsedHeapMemoryThreshold* | Sets a percentage (1-99) of used heap memory threshold to activate stream caching spooling to disk. |  | int
-| *camel.main.streamCachingStatisticsEnabled* | Sets whether stream caching statistics is enabled. | false | boolean
-| *camel.main.threadNamePattern* | Sets the thread name pattern used for creating the full thread name. The default pattern is: Camel (#camelId#) thread ##counter# - #name# Where #camelId# is the name of the CamelContext. and #counter# is a unique incrementing counter. and #name# is the regular thread name. You can also use #longName# which is the long thread name which can includes endpoint parameters etc. |  | String
-| *camel.main.tracing* | Sets whether tracing is enabled or not. Default is false. | false | boolean
-| *camel.main.tracingLoggingFormat* | To use a custom tracing logging format. The default format (arrow, routeId, label) is: %-4.4s %-12.12s %-33.33s | %-4.4s [%-12.12s] [%-33.33s] | String
-| *camel.main.tracingPattern* | Tracing pattern to match which node EIPs to trace. For example to match all To EIP nodes, use to. The pattern matches by node and route id's Multiple patterns can be separated by comma. |  | String
-| *camel.main.tracingStandby* | Whether to set tracing on standby. If on standby then the tracer is installed and made available. Then the tracer can be enabled later at runtime via JMX or via Tracer#setEnabled(boolean) . | false | boolean
-| *camel.main.tracingTemplates* | Whether tracing should trace inner details from route templates (or kamelets). Turning this on increases the verbosity of tracing by including events from internal routes in the templates or kamelets. Default is false. | false | boolean
-| *camel.main.typeConverterStatisticsEnabled* | Sets whether type converter statistics is enabled. By default the type converter utilization statistics is disabled. Notice: If enabled then there is a slight performance impact under very heavy load. | false | boolean
-| *camel.main.useBreadcrumb* | Set whether breadcrumb is enabled. The default value is false. | false | boolean
-| *camel.main.useDataType* | Whether to enable using data type on Camel messages. Data type are automatic turned on if one ore more routes has been explicit configured with input and output types. Otherwise data type is default off. | false | boolean
-| *camel.main.useMdcLogging* | To turn on MDC logging (deprecated, use camel-mdc component instead) | false | boolean
-| *camel.main.uuidGenerator* | UUID generator to use. default (32 bytes), short (16 bytes), classic (32 bytes or longer), simple (long incrementing counter), off (turned off for exchanges - only intended for performance profiling) | default | String
-| *camel.main.virtualThreadsEnabled* | Whether to enable virtual threads when creating thread pools. When enabled, Camel will use virtual threads instead of platform threads for its thread pools. This can also be enabled via the JVM system property {code camel.threads.virtual.enabled=true} . This option must be read early during bootstrap, so it is set as a system property before thread pools are created. | false | boolean
-| *camel.main.yamlDslCompactNotationWarn* | Whether to log a WARN when YAML DSL routes use compact (shorthand) notation instead of the canonical (explicit/normalized) form. The canonical style is recommended as it is more tooling and AI friendly. Use Camel CLI to normalize existing routes: camel validate normalize &lt;file&gt; | true | boolean
+| `camel.main.additionalSensitiveKeywords` | Camel comes with a default set of sensitive keywords which are automatically masked. This option allows to add additional custom keywords to be masked as well. Multiple keywords can be separated by comma. |  | String
+| `camel.main.allowUseOriginalMessage` | Sets whether to allow access to the original message from Camel's error handler, or from org.apache.camel.spi.UnitOfWork.getOriginalInMessage(). Turning this off can optimize performance, as defensive copy of the original message is not needed. Default is false. | false | boolean
+| `camel.main.autoConfigurationEnabled` | Whether auto configuration of components, dataformats, languages is enabled or not. When enabled the configuration parameters are loaded from the properties component. You can prefix the parameters in the properties file with: - camel.component.name.option1=value1 - camel.component.name.option2=value2 - camel.dataformat.name.option1=value1 - camel.dataformat.name.option2=value2 - camel.language.name.option1=value1 - camel.language.name.option2=value2 Where name is the name of the component, dataformat or language such as seda,direct,jaxb. The auto configuration also works for any options on components that is a complex type (not standard Java type) and there has been an explicit single bean instance registered to the Camel registry via the org.apache.camel.spi.Registry#bind(String,Object) method or by using the org.apache.camel.BindToRegistry annotation style. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationEnvironmentVariablesEnabled` | Whether auto configuration should include OS environment variables as well. When enabled this allows to overrule any configuration using an OS environment variable. For example to set a shutdown timeout of 5 seconds: CAMEL_MAIN_SHUTDOWNTIMEOUT=5. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationFailFast` | Whether auto configuration should fail fast when configuring one ore more properties fails for whatever reason such as a invalid property name, etc. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationLogSummary` | Whether auto configuration should log a summary with the configured properties. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationSystemPropertiesEnabled` | Whether auto configuration should include JVM system properties as well. When enabled this allows to overrule any configuration using a JVM system property. For example to set a shutdown timeout of 5 seconds: -D camel.main.shutdown-timeout=5. Note that JVM system properties take precedence over OS environment variables. This option is default enabled. | true | boolean
+| `camel.main.autoStartup` | Sets whether the object should automatically start when Camel starts. Important: Currently only routes can be disabled, as CamelContext's are always started. Note: When setting auto startup false on CamelContext then that takes precedence and no routes are started. You would need to start CamelContext explicit using the org.apache.camel.CamelContext.start() method, to start the context, and then you would need to start the routes manually using CamelContext.getRouteController().startRoute(String). Default is true to always start up. | true | boolean
+| `camel.main.autoStartupExcludePattern` | Used for exclusive filtering of routes to not automatically start with Camel starts. The pattern support matching by route id or endpoint urls. Multiple patterns can be specified separated by comma, as example, to exclude all the routes starting from kafka or jms use: kafka,jms. |  | String
+| `camel.main.autowiredEnabled` | Whether autowiring is enabled. This is used for automatic autowiring options (the option must be marked as autowired) by looking up in the registry to find if there is a single instance of matching type, which then gets configured on the component. This can be used for automatic configuring JDBC data sources, JMS connection factories, AWS Clients, etc. Default is true. | true | boolean
+| `camel.main.basePackageScan` | Package name to use as base (offset) for classpath scanning of RouteBuilder , org.apache.camel.TypeConverter , CamelConfiguration classes, and also classes annotated with org.apache.camel.Converter , or org.apache.camel.BindToRegistry . If you are using Spring Boot then it is instead recommended to use Spring Boots component scanning and annotate your route builder classes with Component. In other words only use this for Camel Main in standalone mode. |  | String
+| `camel.main.basePackageScanEnabled` | Whether base package scan is enabled. | true | boolean
+| `camel.main.beanIntrospectionExtendedStatistics` | Sets whether bean introspection uses extended statistics. The default is false. | false | boolean
+| `camel.main.beanIntrospectionLoggingLevel` | Sets the logging level used by bean introspection, logging activity of its usage. The default is TRACE. |  | LoggingLevel
+| `camel.main.beanPostProcessorEnabled` | Can be used to turn off bean post processing. Be careful to turn this off, as this means that beans that use Camel annotations such as org.apache.camel.EndpointInject , org.apache.camel.ProducerTemplate , org.apache.camel.Produce , org.apache.camel.Consume etc will not be injected and in use. Turning this off should only be done if you are sure you do not use any of these Camel features. Not all runtimes allow turning this off. The default value is true (enabled). | true | boolean
+| `camel.main.camelEventsTimestampEnabled` | Whether to include timestamps for all emitted Camel Events. Enabling this allows to know fine-grained at what time each event was emitted, which can be used for reporting to report exactly the time of the events. This is by default false to avoid the overhead of including this information. | false | boolean
+| `camel.main.caseInsensitiveHeaders` | Whether to use case sensitive or insensitive headers. Important: When using case sensitive (this is set to false). Then the map is case sensitive which means headers such as content-type and Content-Type are two different keys which can be a problem for some protocols such as HTTP based, which rely on case insensitive headers. However case sensitive implementations can yield faster performance. Therefore use case sensitive implementation with care. Default is true. | true | boolean
+| `camel.main.cloudPropertiesLocation` | Sets the locations (comma separated values) where to find properties configuration as defined for cloud native environments such as Kubernetes. You should only scan text based mounted configuration. |  | String
+| `camel.main.compileWorkDir` | Work directory for compiler. Can be used to write compiled classes or other resources. |  | String
+| `camel.main.configurationClasses` | Sets classes names that will be used to configure the camel context as example by providing custom beans through org.apache.camel.BindToRegistry annotation. |  | String
+| `camel.main.configurations` | Sets the configuration objects used to configure the camel context. |  | List
+| `camel.main.consumerTemplateCacheSize` | Consumer template endpoints cache size. | 1000 | int
+| `camel.main.contextReloadEnabled` | Used for enabling context reloading. If enabled then Camel allow external systems such as security vaults (AWS secrets manager, etc.) to trigger refreshing Camel by updating property placeholders and reload all existing routes to take changes into effect. | false | boolean
+| `camel.main.description` | Sets the description (intended for humans) of the Camel application. |  | String
+| `camel.main.devConsoleEnabled` | Whether to enable developer console (requires camel-console on classpath). The developer console is only for assisting during development. This is NOT for production usage. | false | boolean
+| `camel.main.dumpRoutes` | If dumping is enabled then Camel will during startup dump all loaded routes (incl rests and route templates) represented as XML, YAML, or Java DSL into the log. This is intended for trouble shooting or to assist during development. Sensitive information that may be configured in the route endpoints could potentially be included in the dump output and is therefore not recommended being used for production usage. This requires to have camel-xml-io/camel-yaml-io/camel-java-io on the classpath to be able to dump the routes as XML/YAML/Java. You can also use JSon which dumps the route structure in JSon. The JSon does not represent Camel DSL but it useful for tooling to understand the structure of the routes and how EIPs are nested together. You can also use png to save route diagrams as PNG image files either all combined in a single file (default camel-route-diagrams.png) or to a given folder, where routes are grouped by source file name(s) and saved as corresponding .png files. This requires to have camel-diagram on the classpath to be able to render PNG diagrams. |  | String
+| `camel.main.dumpRoutesGeneratedIds` | Whether to include auto generated IDs in the dumped output. Default is false. | false | boolean
+| `camel.main.dumpRoutesInclude` | Controls what to include in output for route dumping. Possible values: all, routes, rests, routeConfigurations, routeTemplates, beans, dataFormats. Multiple values can be separated by comma. Default is routes. | routes | String
+| `camel.main.dumpRoutesLog` | Whether to log route dumps to Logger | true | boolean
+| `camel.main.dumpRoutesOutput` | Whether to save route dumps to an output file. If the output is a filename, then all content is saved to this file. If the output is a directory name, then one or more files are saved to the directory, where the names are based on the original source file names, or auto generated names. |  | String
+| `camel.main.dumpRoutesResolvePlaceholders` | Whether to resolve property placeholders in the dumped output. Default is true. | true | boolean
+| `camel.main.dumpRoutesUriAsParameters` | When dumping routes to YAML format, then this option controls whether endpoint URIs should be expanded into a key/value parameters. | false | boolean
+| `camel.main.durationHitExitCode` | Sets the exit code for the application if duration was hit |  | int
+| `camel.main.durationMaxAction` | Controls whether the Camel application should shutdown the JVM, or stop all routes, when duration max is triggered. | shutdown | String
+| `camel.main.durationMaxIdleSeconds` | To specify for how long time in seconds Camel can be idle before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
+| `camel.main.durationMaxMessages` | To specify how many messages to process by Camel before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
+| `camel.main.durationMaxSeconds` | To specify for how long time in seconds to keep running the JVM before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
+| `camel.main.endpointBridgeErrorHandler` | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN/ERROR level and ignored. The default value is false. | false | boolean
+| `camel.main.endpointLazyStartProducer` | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. The default value is false. | false | boolean
+| `camel.main.endpointRuntimeStatisticsEnabled` | Sets whether endpoint runtime statistics is enabled (gathers runtime usage of each incoming and outgoing endpoints). The default value is false. | false | boolean
+| `camel.main.exchangeFactory` | Controls whether to pool (reuse) exchanges or create new exchanges (prototype). Using pooled will reduce JVM garbage collection overhead by avoiding to re-create Exchange instances per message each consumer receives. The default is prototype mode. | default | String
+| `camel.main.exchangeFactoryCapacity` | The capacity the pool (for each consumer) uses for storing exchanges. The default capacity is 100. | 100 | int
+| `camel.main.exchangeFactoryStatisticsEnabled` | Configures whether statistics is enabled on exchange factory. | false | boolean
+| `camel.main.extraShutdownTimeout` | Extra timeout in seconds to graceful shutdown Camel. When Camel is shutting down then Camel first shutdown all the routes (shutdownTimeout). Then additional services is shutdown (extraShutdownTimeout). | 15 | int
+| `camel.main.fileConfigurations` | Directory to load additional properties files that contains configurations that takes precedence (except for camel.main.xxx configurations). This can be used to refer to files that may have secret configuration that has been mounted on the file system for containers. You can specify a pattern to load from file-system (not classpath) and a name pattern such as /var/app/secret/.properties, multiple directories can be separated by comma. |  | String
+| `camel.main.globalOptions` | Sets global options that can be referenced in the camel context Important: This has nothing to do with property placeholders, and is just a plain set of key/value pairs which are used to configure global options on CamelContext, such as a maximum debug logging length etc. |  | Map
+| `camel.main.groovyPreloadCompiled` | Whether to preload existing compiled Groovy sources from the compileWorkDir option on startup. This can be enabled to avoid compiling sources that already has been compiled during a build phase. | false | boolean
+| `camel.main.groovyScriptPattern` | Directories to scan for groovy source to be pre-compiled. For example: scripts/.groovy will scan inside the classpath folder scripts for all groovy source files. By default, sources are scanned from the classpath, but you can prefix with file: to use file system. The directories are using Ant-path style pattern, and multiple directories can be specified separated by comma. This requires having camel-groovy JAR on the classpath. | classpath:camel-groovy/*,classpath:camel-groovy-compiled/* | String
+| `camel.main.inflightRepositoryBrowseEnabled` | Sets whether the inflight repository should allow browsing each inflight exchange. This is by default disabled as there is a very slight performance overhead when enabled. | false | boolean
+| `camel.main.javaRoutesExcludePattern` | Used for exclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. For example to exclude all classes starting with Bar use: &#42;&#42;/Bar&#42; To exclude all routes form a specific package use: com/mycompany/bar/&#42; To exclude all routes form a specific package and its sub-packages use double wildcards: com/mycompany/bar/&#42;&#42; And to exclude all routes from two specific packages use: com/mycompany/bar/&#42;,com/mycompany/stuff/&#42; |  | String
+| `camel.main.javaRoutesIncludePattern` | Used for inclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. Multiple patterns can be specified separated by comma. For example to include all classes starting with Foo use: &#42;&#42;/Foo To include all routes form a specific package use: com/mycompany/foo/&#42; To include all routes form a specific package and its sub-packages use double wildcards: com/mycompany/foo/&#42;&#42; And to include all routes from two specific packages use: com/mycompany/foo/&#42;,com/mycompany/stuff/&#42; |  | String
+| `camel.main.jmxEnabled` | Enable JMX in your Camel application. | true | boolean
+| `camel.main.jmxManagementMBeansLevel` | Sets the mbeans registration level. The default value is Default. | Default | ManagementMBeansLevel
+| `camel.main.jmxManagementNamePattern` | The naming pattern for creating the CamelContext JMX management name. The default pattern is #name# | #name# | String
+| `camel.main.jmxManagementRegisterRoutesCreateByKamelet` | Whether routes created by Kamelets should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via Kamelets. This is default disabled as a Kamelet is intended as a component (black-box) and its implementation details as Camel route makes the overall management and monitoring of Camel applications more verbose. During development of Kamelets then enabling this will make it possible for developers to do fine-grained performance inspection and identify potential bottlenecks in the Kamelet routes. However, for production usage then keeping this disabled is recommended. | false | boolean
+| `camel.main.jmxManagementRegisterRoutesCreateByTemplate` | Whether routes created by route templates (not Kamelets) should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via route templates. This is default enabled (unlike Kamelets) as routes created via templates is regarded as standard routes, and should be available for management and monitoring. | true | boolean
+| `camel.main.jmxManagementStatisticsLevel` | Sets the JMX statistics level, the level can be set to Extended to gather additional information The default value is Default. | Default | ManagementStatisticsLevel
+| `camel.main.jmxUpdateRouteEnabled` | Whether to allow updating routes at runtime via JMX using the ManagedRouteMBean. This is disabled by default, but can be enabled for development and troubleshooting purposes, such as updating routes in an existing running Camel via JMX and other tools. | false | boolean
+| `camel.main.loadHealthChecks` | Whether to load custom health checks by scanning classpath. | false | boolean
+| `camel.main.loadStatisticsEnabled` | Sets whether Camel load (inflight messages, not cpu) statistics is enabled (something like the unix load average). The statistics requires to have camel-management on the classpath as JMX is required. The default value is false. | false | boolean
+| `camel.main.loadTypeConverters` | Whether to load custom type converters by scanning classpath. This is used for backwards compatibility with Camel 2.x. Its recommended to migrate to use fast type converter loading by setting Converter(loader = true) on your custom type converter classes. | false | boolean
+| `camel.main.logDebugMaxChars` | Is used to limit the maximum length of the logging Camel message bodies. If the message body is longer than the limit, the log message is clipped. Use -1 to have unlimited length. Use for example 1000 to log at most 1000 characters. |  | int
+| `camel.main.logExhaustedMessageBody` | Sets whether to log exhausted message body with message history. Default is false. | false | boolean
+| `camel.main.logLanguage` | To configure the language to use for Log EIP. By default, the simple language is used. However, Camel also supports other languages such as groovy. |  | String
+| `camel.main.logMask` | Sets whether log mask is enabled or not. Default is false. | false | boolean
+| `camel.main.logName` | The global name to use for Log EIP The name is default the routeId or the source:line if source location is enabled. You can also specify the name using tokens: $\{class} - the logger class name (org.apache.camel.processor.LogProcessor) $\{contextId} - the camel context id $\{routeId} - the route id $\{groupId} - the route group id $\{nodeId} - the node id $\{nodePrefixId} - the node prefix id $\{source} - the source:line (source location must be enabled) ${source.name} - the source filename (source location must be enabled) ${source.line} - the source line number (source location must be enabled) For example to use the route and node id you can specify the name as: $\{routeId}/$\{nodeId} |  | String
+| `camel.main.mainListenerClasses` | Sets classes names that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | String
+| `camel.main.mainListeners` | Sets main listener objects that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | List
+| `camel.main.mdcLoggingKeysPattern` | Sets the pattern used for determine which custom MDC keys to propagate during message routing when the routing engine continues routing asynchronously for the given message. Setting this pattern to will propagate all custom keys. Or setting the pattern to foo,bar will propagate any keys starting with either foo or bar. Notice that a set of standard Camel MDC keys are always propagated which starts with camel. as key name. The match rules are applied in this order (case insensitive): 1. exact match, returns true 2. wildcard match (pattern ends with a and the name starts with the pattern), returns true 3. regular expression match, returns true 4. otherwise returns false Deprecated, use camel-mdc component instead |  | String
+| `camel.main.messageHistory` | Sets whether message history is enabled or not. Default is false. | false | boolean
+| `camel.main.messageSizeEnabled` | Sets whether message size observation is enabled (default is false). When enabled, Camel will compute the size of message body and headers (in bytes) per endpoint (for both IN and OUT directions) and make this available via JMX MBeans (min/max/mean body size and headers size). | false | boolean
+| `camel.main.modeline` | Whether to support JBang style //DEPS to specify additional dependencies when running Camel CLI | false | boolean
+| `camel.main.name` | Sets the name of the CamelContext. |  | String
+| `camel.main.producerTemplateCacheSize` | Producer template endpoints cache size. | 1000 | int
+| `camel.main.profile` | Camel profile to use when running. The dev profile is for development, which enables a set of additional developer focus functionality, tracing, debugging, and gathering additional runtime statistics that are useful during development. However, those additional features has a slight overhead cost, and are not enabled for production profile. The default profile is prod. |  | String
+| `camel.main.routeFilterExcludePattern` | Used for filtering routes routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
+| `camel.main.routeFilterIncludePattern` | Used for filtering routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
+| `camel.main.routesBuilderClasses` | Sets classes names that implement RoutesBuilder . |  | String
+| `camel.main.routesBuilders` | Sets the RoutesBuilder instances. |  | List
+| `camel.main.routesCollectorEnabled` | Whether the routes collector is enabled or not. When enabled Camel will auto-discover routes (RouteBuilder instances from the registry and also load additional routes from the file system). The routes collector is default enabled. | true | boolean
+| `camel.main.routesCollectorIgnoreLoadingError` | Whether the routes collector should ignore any errors during loading and compiling routes. This is only intended for development or tooling. | false | boolean
+| `camel.main.routesExcludePattern` | Used for exclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to exclude all the routes from a directory whose name contains foo use: &#42;&#42;/foo. |  | String
+| `camel.main.routesIncludePattern` | Used for inclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to include all the routes from a directory whose name contains foo use: &#42;&#42;/foo. | classpath:camel/*,classpath:camel-template/*,classpath:camel-rest/* | String
+| `camel.main.routesReloadDirectory` | Directory to scan for route changes. Camel cannot scan the classpath, so this must be configured to a file directory. Development with Maven as build tool, you can configure the directory to be src/main/resources to scan for Camel routes in XML or YAML files. | src/main/resources/camel | String
+| `camel.main.routesReloadDirectoryRecursive` | Whether the directory to scan should include sub directories. Depending on the number of sub directories, then this can cause the JVM to startup slower as Camel uses the JDK file-watch service to scan for file changes. | false | boolean
+| `camel.main.routesReloadEnabled` | Used for enabling automatic routes reloading. If enabled then Camel will watch for file changes in the given reload directory, and trigger reloading routes if files are changed. | false | boolean
+| `camel.main.routesReloadPattern` | Used for inclusive filtering of routes from directories. Typical used for specifying to accept routes in XML or YAML files, such as .yaml,.xml. Multiple patterns can be specified separated by comma. |  | String
+| `camel.main.routesReloadRemoveAllRoutes` | When reloading routes should all existing routes be stopped and removed. By default, Camel will stop and remove all existing routes before reloading routes. This ensures that only the reloaded routes will be active. If disabled then only routes with the same route id is updated, and any existing routes are continued to run. | true | boolean
+| `camel.main.routesReloadRestartDuration` | Whether to restart max duration when routes are reloaded. For example if max duration is 60 seconds, and a route is reloaded after 25 seconds, then this will restart the count and wait 60 seconds again. | false | boolean
+| `camel.main.shutdownLogInflightExchangesOnTimeout` | Sets whether to log information about the inflight Exchanges which are still running during a shutdown which didn't complete without the given timeout. This requires to enable the option inflightRepositoryBrowseEnabled. | true | boolean
+| `camel.main.shutdownNowOnTimeout` | Sets whether to force shutdown of all consumers when a timeout occurred and thus not all consumers was shutdown within that period. You should have good reasons to set this option to false as it means that the routes keep running and is halted abruptly when CamelContext has been shutdown. | true | boolean
+| `camel.main.shutdownRoutesInReverseOrder` | Sets whether routes should be shutdown in reverse or the same order as they were started. | true | boolean
+| `camel.main.shutdownSuppressLoggingOnTimeout` | Whether Camel should try to suppress logging during shutdown and timeout was triggered, meaning forced shutdown is happening. And during forced shutdown we want to avoid logging errors/warnings et all in the logs as a side-effect of the forced timeout. Notice the suppress is a best effort as there may still be some logs coming from 3rd party libraries and whatnot, which Camel cannot control. This option is default false. | false | boolean
+| `camel.main.shutdownTimeout` | Timeout in seconds to graceful shutdown all the Camel routes. | 45 | int
+| `camel.main.sourceLocationEnabled` | Whether to capture precise source location:line-number for all EIPs in Camel routes. Enabling this will impact parsing Java based routes (also Groovy etc.) on startup as this uses JDK StackTraceElement to calculate the location from the Camel route, which comes with a performance cost. This only impact startup, not the performance of the routes at runtime. | false | boolean
+| `camel.main.startupRecorder` | To use startup recorder for capturing execution time during starting Camel. The recorder can be one of: false (or off), logging, backlog, java-flight-recorder (or jfr). |  | String
+| `camel.main.startupRecorderDir` | Directory to store the recording. By default the current directory will be used. Use false to turn off saving recording to disk. |  | String
+| `camel.main.startupRecorderDuration` | How long time to run the startup recorder. Use 0 (default) to keep the recorder running until the JVM is exited. Use -1 to stop the recorder right after Camel has been started (to only focus on potential Camel startup performance bottlenecks) Use a positive value to keep recording for N seconds. When the recorder is stopped then the recording is auto saved to disk (note: save to disk can be disabled by setting startupRecorderDir to false) |  | long
+| `camel.main.startupRecorderMaxDepth` | To filter our sub steps at a maximum depth. Use -1 for no maximum. Use 0 for no sub steps. Use 1 for max 1 sub step, and so forth. The default is -1. | -1 | int
+| `camel.main.startupRecorderProfile` | To use a specific Java Flight Recorder profile configuration, such as default or profile. The default is default. | default | String
+| `camel.main.startupRecorderRecording` | To enable Java Flight Recorder to start a recording and automatic dump the recording to disk after startup is complete. This requires that camel-jfr is on the classpath, and to enable this option. | false | boolean
+| `camel.main.startupRecorderRuntimeEnabled` | To also instrument the running Camel application, and not only its startup, by emitting Java Flight Recorder events for every exchange, route and processor. This requires that camel-jfr is on the classpath, and to enable this option. The runtime events are only captured while a recording is active. As they are emitted per message they add overhead, so this is turned off by default. | false | boolean
+| `camel.main.startupSummaryLevel` | Controls the level of information logged during startup (and shutdown) of CamelContext. | Default | StartupSummaryLevel
+| `camel.main.streamCachingAllowClasses` | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
+| `camel.main.streamCachingAnySpoolRules` | Sets whether if just any of the org.apache.camel.spi.StreamCachingStrategy.SpoolRule rules returns true then shouldSpoolCache(long) returns true, to allow spooling to disk. If this option is false, then all the org.apache.camel.spi.StreamCachingStrategy.SpoolRule must return true. The default value is false which means that all the rules must return true. | false | boolean
+| `camel.main.streamCachingBufferSize` | Sets the stream caching buffer size to use when allocating in-memory buffers used for in-memory stream caches. The default size is 4096. |  | int
+| `camel.main.streamCachingDenyClasses` | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
+| `camel.main.streamCachingEnabled` | Sets whether stream caching is enabled or not. While stream types (like StreamSource, InputStream and Reader) are commonly used in messaging for performance reasons, they also have an important drawback: they can only be read once. In order to be able to work with message content multiple times, the stream needs to be cached. Streams are cached in memory only (by default). If streamCachingSpoolEnabled=true, then, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is true. | true | boolean
+| `camel.main.streamCachingRemoveSpoolDirectoryWhenStopping` | Whether to remove stream caching temporary directory when stopping. This option is default true. | true | boolean
+| `camel.main.streamCachingSpoolCipher` | Sets a stream caching cipher name to use when spooling to disk to write with encryption. By default the data is not encrypted. |  | String
+| `camel.main.streamCachingSpoolDirectory` | Sets the stream caching spool (temporary) directory to use for overflow and spooling to disk. If no spool directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
+| `camel.main.streamCachingSpoolEnabled` | To enable stream caching spooling to disk. This means, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is false. | false | boolean
+| `camel.main.streamCachingSpoolRules` | Sets custom rules (org.apache.camel.spi.StreamCachingStrategy.SpoolRule) for deciding when to spool to disk. Multiple rules can be separated by comma. |  | String
+| `camel.main.streamCachingSpoolThreshold` | Stream caching threshold in bytes when overflow to disk is activated. The default threshold is 128kb. Use -1 to disable overflow to disk. |  | long
+| `camel.main.streamCachingSpoolUsedHeapMemoryLimit` | Sets what the upper bounds should be when streamCachingSpoolUsedHeapMemoryThreshold is in use. | Max | String
+| `camel.main.streamCachingSpoolUsedHeapMemoryThreshold` | Sets a percentage (1-99) of used heap memory threshold to activate stream caching spooling to disk. |  | int
+| `camel.main.streamCachingStatisticsEnabled` | Sets whether stream caching statistics is enabled. | false | boolean
+| `camel.main.threadNamePattern` | Sets the thread name pattern used for creating the full thread name. The default pattern is: Camel (#camelId#) thread ##counter# - #name# Where #camelId# is the name of the CamelContext. and #counter# is a unique incrementing counter. and #name# is the regular thread name. You can also use #longName# which is the long thread name which can includes endpoint parameters etc. |  | String
+| `camel.main.tracing` | Sets whether tracing is enabled or not. Default is false. | false | boolean
+| `camel.main.tracingLoggingFormat` | To use a custom tracing logging format. The default format (arrow, routeId, label) is: %-4.4s %-12.12s %-33.33s | %-4.4s [%-12.12s] [%-33.33s] | String
+| `camel.main.tracingPattern` | Tracing pattern to match which node EIPs to trace. For example to match all To EIP nodes, use to. The pattern matches by node and route id's Multiple patterns can be separated by comma. |  | String
+| `camel.main.tracingStandby` | Whether to set tracing on standby. If on standby then the tracer is installed and made available. Then the tracer can be enabled later at runtime via JMX or via Tracer#setEnabled(boolean) . | false | boolean
+| `camel.main.tracingTemplates` | Whether tracing should trace inner details from route templates (or kamelets). Turning this on increases the verbosity of tracing by including events from internal routes in the templates or kamelets. Default is false. | false | boolean
+| `camel.main.typeConverterStatisticsEnabled` | Sets whether type converter statistics is enabled. By default the type converter utilization statistics is disabled. Notice: If enabled then there is a slight performance impact under very heavy load. | false | boolean
+| `camel.main.useBreadcrumb` | Set whether breadcrumb is enabled. The default value is false. | false | boolean
+| `camel.main.useDataType` | Whether to enable using data type on Camel messages. Data type are automatic turned on if one ore more routes has been explicit configured with input and output types. Otherwise data type is default off. | false | boolean
+| `camel.main.useMdcLogging` | To turn on MDC logging (deprecated, use camel-mdc component instead) | false | boolean
+| `camel.main.uuidGenerator` | UUID generator to use. default (32 bytes), short (16 bytes), classic (32 bytes or longer), simple (long incrementing counter), off (turned off for exchanges - only intended for performance profiling) | default | String
+| `camel.main.virtualThreadsEnabled` | Whether to enable virtual threads when creating thread pools. When enabled, Camel will use virtual threads instead of platform threads for its thread pools. This can also be enabled via the JVM system property {code camel.threads.virtual.enabled=true} . This option must be read early during bootstrap, so it is set as a system property before thread pools are created. | false | boolean
+| `camel.main.yamlDslCompactNotationWarn` | Whether to log a WARN when YAML DSL routes use compact (shorthand) notation instead of the canonical (explicit/normalized) form. The canonical style is recommended as it is more tooling and AI friendly. Use Camel CLI to normalize existing routes: camel validate normalize &lt;file&gt; | true | boolean
 |===
 
 
@@ -163,13 +163,13 @@ The camel.startupcondition supports 7 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.startupcondition.customClassNames* | A list of custom class names (FQN). Multiple classes can be separated by comma. |  | String
-| *camel.startupcondition.enabled* | To enable using startup conditions | false | boolean
-| *camel.startupcondition.environmentVariableExists* | Wait for an environment variable with the given name to exists before continuing |  | String
-| *camel.startupcondition.fileExists* | Wait for a file with the given name to exists before continuing |  | String
-| *camel.startupcondition.interval* | Interval in millis between checking conditions. | 500 | int
-| *camel.startupcondition.onTimeout* | What action, to do on timeout. fail = do not startup, and throw an exception causing camel to fail stop = do not startup, and stop camel ignore = log a WARN and continue to startup | stop | String
-| *camel.startupcondition.timeout* | Total timeout (in millis) for all startup conditions. | 20000 | int
+| `camel.startupcondition.customClassNames` | A list of custom class names (FQN). Multiple classes can be separated by comma. |  | String
+| `camel.startupcondition.enabled` | To enable using startup conditions | false | boolean
+| `camel.startupcondition.environmentVariableExists` | Wait for an environment variable with the given name to exists before continuing |  | String
+| `camel.startupcondition.fileExists` | Wait for a file with the given name to exists before continuing |  | String
+| `camel.startupcondition.interval` | Interval in millis between checking conditions. | 500 | int
+| `camel.startupcondition.onTimeout` | What action, to do on timeout. fail = do not startup, and throw an exception causing camel to fail stop = do not startup, and stop camel ignore = log a WARN and continue to startup | stop | String
+| `camel.startupcondition.timeout` | Total timeout (in millis) for all startup conditions. | 20000 | int
 |===
 
 
@@ -179,18 +179,18 @@ The camel.routecontroller supports 12 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.routecontroller.backOffDelay* | Backoff delay in millis when restarting a route that failed to startup. | 2000 | long
-| *camel.routecontroller.backOffMaxAttempts* | Backoff maximum number of attempts to restart a route that failed to startup. When this threshold has been exceeded then the controller will give up attempting to restart the route, and the route will remain as stopped. |  | long
-| *camel.routecontroller.backOffMaxDelay* | Backoff maximum delay in millis when restarting a route that failed to startup. |  | long
-| *camel.routecontroller.backOffMaxElapsedTime* | Backoff maximum elapsed time in millis, after which the backoff should be considered exhausted and no more attempts should be made. |  | long
-| *camel.routecontroller.backOffMultiplier* | Backoff multiplier to use for exponential backoff. This is used to extend the delay between restart attempts. |  | double
-| *camel.routecontroller.enabled* | To enable using supervising route controller which allows Camel to start up and then, the controller takes care of starting the routes in a safe manner. This can be used when you want to start up Camel despite a route may otherwise fail fast during startup and cause Camel to fail to start up as well. By delegating the route startup to the supervising route controller, then it manages the startup using a background thread. The controller allows to be configured with various settings to attempt to restart failing routes. | false | boolean
-| *camel.routecontroller.excludeRoutes* | Pattern for filtering routes to be excluded as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to exclude all JMS routes, you can say jms:. And to exclude routes with specific route ids mySpecialRoute,myOtherSpecialRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
-| *camel.routecontroller.includeRoutes* | Pattern for filtering routes to be included as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to include all kafka routes, you can say kafka:. And to include routes with specific route ids myRoute,myOtherRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
-| *camel.routecontroller.initialDelay* | Initial delay in milli seconds before the route controller starts, after CamelContext has been started. |  | long
-| *camel.routecontroller.threadPoolSize* | The number of threads used by the route controller scheduled thread pool that are used for restarting routes. The pool uses 1 thread by default, but you can increase this to allow the controller to concurrently attempt to restart multiple routes in case more than one route has problems starting. | 1 | int
-| *camel.routecontroller.unhealthyOnExhausted* | Whether to mark the route as unhealthy (down) when all restarting attempts (backoff) have failed and the route is not successfully started and the route manager is giving up. If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
-| *camel.routecontroller.unhealthyOnRestarting* | Whether to mark the route as unhealthy (down) when the route failed to initially start, and is being controlled for restarting (backoff). If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
+| `camel.routecontroller.backOffDelay` | Backoff delay in millis when restarting a route that failed to startup. | 2000 | long
+| `camel.routecontroller.backOffMaxAttempts` | Backoff maximum number of attempts to restart a route that failed to startup. When this threshold has been exceeded then the controller will give up attempting to restart the route, and the route will remain as stopped. |  | long
+| `camel.routecontroller.backOffMaxDelay` | Backoff maximum delay in millis when restarting a route that failed to startup. |  | long
+| `camel.routecontroller.backOffMaxElapsedTime` | Backoff maximum elapsed time in millis, after which the backoff should be considered exhausted and no more attempts should be made. |  | long
+| `camel.routecontroller.backOffMultiplier` | Backoff multiplier to use for exponential backoff. This is used to extend the delay between restart attempts. |  | double
+| `camel.routecontroller.enabled` | To enable using supervising route controller which allows Camel to start up and then, the controller takes care of starting the routes in a safe manner. This can be used when you want to start up Camel despite a route may otherwise fail fast during startup and cause Camel to fail to start up as well. By delegating the route startup to the supervising route controller, then it manages the startup using a background thread. The controller allows to be configured with various settings to attempt to restart failing routes. | false | boolean
+| `camel.routecontroller.excludeRoutes` | Pattern for filtering routes to be excluded as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to exclude all JMS routes, you can say jms:. And to exclude routes with specific route ids mySpecialRoute,myOtherSpecialRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
+| `camel.routecontroller.includeRoutes` | Pattern for filtering routes to be included as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to include all kafka routes, you can say kafka:. And to include routes with specific route ids myRoute,myOtherRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
+| `camel.routecontroller.initialDelay` | Initial delay in milli seconds before the route controller starts, after CamelContext has been started. |  | long
+| `camel.routecontroller.threadPoolSize` | The number of threads used by the route controller scheduled thread pool that are used for restarting routes. The pool uses 1 thread by default, but you can increase this to allow the controller to concurrently attempt to restart multiple routes in case more than one route has problems starting. | 1 | int
+| `camel.routecontroller.unhealthyOnExhausted` | Whether to mark the route as unhealthy (down) when all restarting attempts (backoff) have failed and the route is not successfully started and the route manager is giving up. If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
+| `camel.routecontroller.unhealthyOnRestarting` | Whether to mark the route as unhealthy (down) when the route failed to initially start, and is being controlled for restarting (backoff). If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
 |===
 
 
@@ -200,34 +200,34 @@ The camel.server supports 28 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.server.authenticationEnabled* | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
-| *camel.server.authenticationPath* | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
-| *camel.server.authenticationRealm* | Sets the authentication realm |  | String
-| *camel.server.basicPropertiesFile* | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
-| *camel.server.enabled* | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
-| *camel.server.fileUploadDirectory* | Directory to temporary store file uploads while Camel routes the incoming request. If no directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
-| *camel.server.fileUploadEnabled* | Whether to enable file uploads being supported (such as POST multipart/form-data) and stored into a temporary directory. | true | boolean
-| *camel.server.host* | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
-| *camel.server.jwtAllowMissingIssuerAndAudience* | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the embedded server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
-| *camel.server.jwtAudience* | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
-| *camel.server.jwtIssuer* | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
-| *camel.server.jwtKeystorePassword* | Password from the keystore used for JWT tokens validation. |  | String
-| *camel.server.jwtKeystorePath* | Path to the keystore file used for JWT tokens validation. |  | String
-| *camel.server.jwtKeystoreType* | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
-| *camel.server.maxBodySize* | Maximum HTTP body size the embedded HTTP server can accept. |  | Long
-| *camel.server.mcpEnabled* | Whether to expose ai-tool routes as MCP tools over streamable HTTP. Requires camel-mcp-server on the classpath. By default, the MCP server is not enabled. | false | boolean
-| *camel.server.mcpPath* | HTTP path where the MCP endpoint is served. | /mcp | String
-| *camel.server.mcpServerName* | MCP server name advertised to clients. Defaults to the CamelContext name. |  | String
-| *camel.server.mcpSessionIdleTtl* | Idle TTL in milliseconds for MCP sessions on the Vert.x streamable transport. Sessions with no activity for longer than this interval are evicted. 0 disables idle eviction. | 300000 | long
-| *camel.server.mcpSessionKeepAliveInterval* | Keep-alive ping interval in milliseconds for MCP sessions on the Vert.x streamable transport. Dead sessions are evicted after consecutive ping failures. 0 disables keep-alive pings. | 30000 | long
-| *camel.server.mcpTags* | Comma-separated list of ai-tool tag patterns to expose as MCP tools. Matching is case-insensitive and supports exact match, wildcard prefix ( {code foo} ), and {code } to match all tags. Only tools registered under a matching tag are exposed; the untagged default pool is never exposed. When not set, no tools are exposed. |  | String
-| *camel.server.mcpToolTimeout* | Per-call MCP tool execution timeout in milliseconds. A call exceeding the timeout returns an error result to the MCP client; the underlying route keeps running until it completes on its own. | 20000 | long
-| *camel.server.path* | Context-path to use for embedded HTTP server | / | String
-| *camel.server.port* | Port to use for binding embedded HTTP server. Use 0 to dynamic assign a free random port number. | 8080 | int
-| *camel.server.staticContextPath* | The context-path to use for serving static content. By default, the root path is used. And if there is an index.html page then this is automatically loaded. | / | String
-| *camel.server.staticEnabled* | Whether serving static files is enabled. If enabled then Camel can host html/js and other web files that makes it possible to include small web applications. | false | boolean
-| *camel.server.staticSourceDir* | Additional directory that holds static content when static is enabled. |  | String
-| *camel.server.useGlobalSslContextParameters* | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
+| `camel.server.authenticationEnabled` | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
+| `camel.server.authenticationPath` | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
+| `camel.server.authenticationRealm` | Sets the authentication realm |  | String
+| `camel.server.basicPropertiesFile` | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
+| `camel.server.enabled` | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
+| `camel.server.fileUploadDirectory` | Directory to temporary store file uploads while Camel routes the incoming request. If no directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
+| `camel.server.fileUploadEnabled` | Whether to enable file uploads being supported (such as POST multipart/form-data) and stored into a temporary directory. | true | boolean
+| `camel.server.host` | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
+| `camel.server.jwtAllowMissingIssuerAndAudience` | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the embedded server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
+| `camel.server.jwtAudience` | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
+| `camel.server.jwtIssuer` | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
+| `camel.server.jwtKeystorePassword` | Password from the keystore used for JWT tokens validation. |  | String
+| `camel.server.jwtKeystorePath` | Path to the keystore file used for JWT tokens validation. |  | String
+| `camel.server.jwtKeystoreType` | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
+| `camel.server.maxBodySize` | Maximum HTTP body size the embedded HTTP server can accept. |  | Long
+| `camel.server.mcpEnabled` | Whether to expose ai-tool routes as MCP tools over streamable HTTP. Requires camel-mcp-server on the classpath. By default, the MCP server is not enabled. | false | boolean
+| `camel.server.mcpPath` | HTTP path where the MCP endpoint is served. | /mcp | String
+| `camel.server.mcpServerName` | MCP server name advertised to clients. Defaults to the CamelContext name. |  | String
+| `camel.server.mcpSessionIdleTtl` | Idle TTL in milliseconds for MCP sessions on the Vert.x streamable transport. Sessions with no activity for longer than this interval are evicted. 0 disables idle eviction. | 300000 | long
+| `camel.server.mcpSessionKeepAliveInterval` | Keep-alive ping interval in milliseconds for MCP sessions on the Vert.x streamable transport. Dead sessions are evicted after consecutive ping failures. 0 disables keep-alive pings. | 30000 | long
+| `camel.server.mcpTags` | Comma-separated list of ai-tool tag patterns to expose as MCP tools. Matching is case-insensitive and supports exact match, wildcard prefix ( {code foo} ), and {code } to match all tags. Only tools registered under a matching tag are exposed; the untagged default pool is never exposed. When not set, no tools are exposed. |  | String
+| `camel.server.mcpToolTimeout` | Per-call MCP tool execution timeout in milliseconds. A call exceeding the timeout returns an error result to the MCP client; the underlying route keeps running until it completes on its own. | 20000 | long
+| `camel.server.path` | Context-path to use for embedded HTTP server | / | String
+| `camel.server.port` | Port to use for binding embedded HTTP server. Use 0 to dynamic assign a free random port number. | 8080 | int
+| `camel.server.staticContextPath` | The context-path to use for serving static content. By default, the root path is used. And if there is an index.html page then this is automatically loaded. | / | String
+| `camel.server.staticEnabled` | Whether serving static files is enabled. If enabled then Camel can host html/js and other web files that makes it possible to include small web applications. | false | boolean
+| `camel.server.staticSourceDir` | Additional directory that holds static content when static is enabled. |  | String
+| `camel.server.useGlobalSslContextParameters` | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
 |===
 
 
@@ -237,37 +237,37 @@ The camel.management supports 31 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.management.authenticationEnabled* | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
-| *camel.management.authenticationPath* | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
-| *camel.management.authenticationRealm* | Sets the authentication realm |  | String
-| *camel.management.basicPropertiesFile* | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
-| *camel.management.devConsoleEnabled* | Whether to enable developer console (not intended for production use). Dev console must also be enabled on CamelContext. For example by setting camel.context.dev-console=true in application.properties, or via code camelContext.setDevConsole(true); If enabled then you can access a basic developer console on context-path: /q/dev. | false | boolean
-| *camel.management.downloadEnabled* | Whether to enable file download via HTTP. This makes it possible to browse and download resource source files such as Camel XML or YAML routes. Only enable this for development, troubleshooting or special situations for management and monitoring. | false | boolean
-| *camel.management.enabled* | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
-| *camel.management.healthCheckEnabled* | Whether to enable health-check console. If enabled then you can access health-check status on context-path: /observe/health | false | boolean
-| *camel.management.healthPath* | The path endpoint used to expose the health status | /observe/health | String
-| *camel.management.host* | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
-| *camel.management.infoEnabled* | Whether to enable info console. If enabled then you can see some basic Camel information at /observe/info | false | boolean
-| *camel.management.infoPath* | The path endpoint used to expose the info status | /observe/info | String
-| *camel.management.jolokiaEnabled* | Whether to enable jolokia. If enabled then you can access jolokia api on context-path: /observe/jolokia | false | boolean
-| *camel.management.jolokiaPath* | The path endpoint used to expose the jolokia data. | /observe/jolokia | String
-| *camel.management.jwtAllowMissingIssuerAndAudience* | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the management server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
-| *camel.management.jwtAudience* | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
-| *camel.management.jwtIssuer* | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
-| *camel.management.jwtKeystorePassword* | Password from the keystore used for JWT tokens validation. |  | String
-| *camel.management.jwtKeystorePath* | Path to the keystore file used for JWT tokens validation. |  | String
-| *camel.management.jwtKeystoreType* | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
-| *camel.management.mcpEnabled* | Whether to expose dev/diagnostics MCP tools on this management server (requires camel-mcp-server on the classpath). Currently honored only when Camel JBang registers JbangDevMcpMainListener (for example camel run --mcp). For route-based MCP on the main HTTP server in plain camel-main, configure camel.server.mcpEnabled instead. Not intended for production use. | false | boolean
-| *camel.management.mcpPath* | HTTP path where the management MCP endpoint is served. | /mcp | String
-| *camel.management.metricsEnabled* | Whether to enable metrics. If enabled then you can access metrics on context-path: /observe/metrics | false | boolean
-| *camel.management.openapiUiEnabled* | Whether to enable Swagger UI for REST DSL OpenAPI documents. If enabled then you can browse the API at context-path: /q/openapi. The OpenAPI document is expected at openapiUiSpecPath (by default /q/openapi.json from REST DSL apiContextPath ). | false | boolean
-| *camel.management.openapiUiSpecPath* | Path or URL of the OpenAPI document loaded by Swagger UI at /q/openapi. | /q/openapi.json | String
-| *camel.management.path* | Context-path to use for embedded HTTP server | / | String
-| *camel.management.port* | Port to use for binding embedded HTTP management server. Use 0 to dynamic assign a free random port number. | 8080 | int
-| *camel.management.sendEnabled* | Whether to enable sending messages to Camel via HTTP. This makes it possible to use Camel to send messages to Camel endpoint URIs via HTTP. | false | boolean
-| *camel.management.uploadEnabled* | Whether to enable file upload via HTTP (not intended for production use). This functionality is for development to be able to reload Camel routes and code with source changes (if reload is enabled). If enabled then you can upload/delete files via HTTP PUT/DELETE on context-path: /q/upload/\{name}. You must also configure the uploadSourceDir option. | false | boolean
-| *camel.management.uploadSourceDir* | Source directory when upload is enabled. |  | String
-| *camel.management.useGlobalSslContextParameters* | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
+| `camel.management.authenticationEnabled` | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
+| `camel.management.authenticationPath` | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
+| `camel.management.authenticationRealm` | Sets the authentication realm |  | String
+| `camel.management.basicPropertiesFile` | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
+| `camel.management.devConsoleEnabled` | Whether to enable developer console (not intended for production use). Dev console must also be enabled on CamelContext. For example by setting camel.context.dev-console=true in application.properties, or via code camelContext.setDevConsole(true); If enabled then you can access a basic developer console on context-path: /q/dev. | false | boolean
+| `camel.management.downloadEnabled` | Whether to enable file download via HTTP. This makes it possible to browse and download resource source files such as Camel XML or YAML routes. Only enable this for development, troubleshooting or special situations for management and monitoring. | false | boolean
+| `camel.management.enabled` | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
+| `camel.management.healthCheckEnabled` | Whether to enable health-check console. If enabled then you can access health-check status on context-path: /observe/health | false | boolean
+| `camel.management.healthPath` | The path endpoint used to expose the health status | /observe/health | String
+| `camel.management.host` | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
+| `camel.management.infoEnabled` | Whether to enable info console. If enabled then you can see some basic Camel information at /observe/info | false | boolean
+| `camel.management.infoPath` | The path endpoint used to expose the info status | /observe/info | String
+| `camel.management.jolokiaEnabled` | Whether to enable jolokia. If enabled then you can access jolokia api on context-path: /observe/jolokia | false | boolean
+| `camel.management.jolokiaPath` | The path endpoint used to expose the jolokia data. | /observe/jolokia | String
+| `camel.management.jwtAllowMissingIssuerAndAudience` | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the management server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
+| `camel.management.jwtAudience` | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
+| `camel.management.jwtIssuer` | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
+| `camel.management.jwtKeystorePassword` | Password from the keystore used for JWT tokens validation. |  | String
+| `camel.management.jwtKeystorePath` | Path to the keystore file used for JWT tokens validation. |  | String
+| `camel.management.jwtKeystoreType` | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
+| `camel.management.mcpEnabled` | Whether to expose dev/diagnostics MCP tools on this management server (requires camel-mcp-server on the classpath). Currently honored only when Camel JBang registers JbangDevMcpMainListener (for example camel run --mcp). For route-based MCP on the main HTTP server in plain camel-main, configure camel.server.mcpEnabled instead. Not intended for production use. | false | boolean
+| `camel.management.mcpPath` | HTTP path where the management MCP endpoint is served. | /mcp | String
+| `camel.management.metricsEnabled` | Whether to enable metrics. If enabled then you can access metrics on context-path: /observe/metrics | false | boolean
+| `camel.management.openapiUiEnabled` | Whether to enable Swagger UI for REST DSL OpenAPI documents. If enabled then you can browse the API at context-path: /q/openapi. The OpenAPI document is expected at openapiUiSpecPath (by default /q/openapi.json from REST DSL apiContextPath ). | false | boolean
+| `camel.management.openapiUiSpecPath` | Path or URL of the OpenAPI document loaded by Swagger UI at /q/openapi. | /q/openapi.json | String
+| `camel.management.path` | Context-path to use for embedded HTTP server | / | String
+| `camel.management.port` | Port to use for binding embedded HTTP management server. Use 0 to dynamic assign a free random port number. | 8080 | int
+| `camel.management.sendEnabled` | Whether to enable sending messages to Camel via HTTP. This makes it possible to use Camel to send messages to Camel endpoint URIs via HTTP. | false | boolean
+| `camel.management.uploadEnabled` | Whether to enable file upload via HTTP (not intended for production use). This functionality is for development to be able to reload Camel routes and code with source changes (if reload is enabled). If enabled then you can upload/delete files via HTTP PUT/DELETE on context-path: /q/upload/\{name}. You must also configure the uploadSourceDir option. | false | boolean
+| `camel.management.uploadSourceDir` | Source directory when upload is enabled. |  | String
+| `camel.management.useGlobalSslContextParameters` | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
 |===
 
 
@@ -277,21 +277,21 @@ The camel.debug supports 15 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.debug.bodyIncludeFiles* | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
-| *camel.debug.bodyIncludeStreams* | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
-| *camel.debug.bodyMaxChars* | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
-| *camel.debug.breakpoints* | Allows to pre-configure breakpoints (node ids) to use with debugger on startup. Multiple ids can be separated by comma. Use special value _all_routes_ to add a breakpoint for the first node for every route, in other words this makes it easy to debug from the beginning of every route without knowing the exact node ids. |  | String
-| *camel.debug.enabled* | Enables Debugger in your Camel application. | false | boolean
-| *camel.debug.fallbackTimeout* | Fallback Timeout in seconds (300 seconds as default) when block the message processing in Camel. A timeout used for waiting for a message to arrive at a given breakpoint. | 300 | long
-| *camel.debug.includeException* | Trace messages to include exception if the message failed | true | boolean
-| *camel.debug.includeExchangeProperties* | Whether to include the exchange properties in the traced message | true | boolean
-| *camel.debug.includeExchangeVariables* | Whether to include the exchange variables in the traced message | true | boolean
-| *camel.debug.jmxConnectorEnabled* | Whether to create JMX connector that allows tooling to control the Camel debugger. This is what the IDEA and VSCode tooling is using. | true | boolean
-| *camel.debug.jmxConnectorPort* | Port number to expose a JMX RMI connector for tooling that needs to control the debugger. | 1099 | int
-| *camel.debug.loggingLevel* | The debugger logging level to use when logging activity. | INFO | LoggingLevel
-| *camel.debug.singleStepIncludeStartEnd* | In single step mode, then when the exchange is created and completed, then simulate a breakpoint at start and end, that allows to suspend and watch the incoming/complete exchange at the route (you can see message body as response, failed exception etc). | false | boolean
-| *camel.debug.standby* | To set the debugger in standby mode, where the debugger will be installed by not automatic enabled. The debugger can then later be enabled explicit from Java, JMX or tooling. | false | boolean
-| *camel.debug.waitForAttach* | Whether the debugger should suspend on startup, and wait for a remote debugger to attach. This is what the IDEA and VSCode tooling is using. | false | boolean
+| `camel.debug.bodyIncludeFiles` | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
+| `camel.debug.bodyIncludeStreams` | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
+| `camel.debug.bodyMaxChars` | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
+| `camel.debug.breakpoints` | Allows to pre-configure breakpoints (node ids) to use with debugger on startup. Multiple ids can be separated by comma. Use special value _all_routes_ to add a breakpoint for the first node for every route, in other words this makes it easy to debug from the beginning of every route without knowing the exact node ids. |  | String
+| `camel.debug.enabled` | Enables Debugger in your Camel application. | false | boolean
+| `camel.debug.fallbackTimeout` | Fallback Timeout in seconds (300 seconds as default) when block the message processing in Camel. A timeout used for waiting for a message to arrive at a given breakpoint. | 300 | long
+| `camel.debug.includeException` | Trace messages to include exception if the message failed | true | boolean
+| `camel.debug.includeExchangeProperties` | Whether to include the exchange properties in the traced message | true | boolean
+| `camel.debug.includeExchangeVariables` | Whether to include the exchange variables in the traced message | true | boolean
+| `camel.debug.jmxConnectorEnabled` | Whether to create JMX connector that allows tooling to control the Camel debugger. This is what the IDEA and VSCode tooling is using. | true | boolean
+| `camel.debug.jmxConnectorPort` | Port number to expose a JMX RMI connector for tooling that needs to control the debugger. | 1099 | int
+| `camel.debug.loggingLevel` | The debugger logging level to use when logging activity. | INFO | LoggingLevel
+| `camel.debug.singleStepIncludeStartEnd` | In single step mode, then when the exchange is created and completed, then simulate a breakpoint at start and end, that allows to suspend and watch the incoming/complete exchange at the route (you can see message body as response, failed exception etc). | false | boolean
+| `camel.debug.standby` | To set the debugger in standby mode, where the debugger will be installed by not automatic enabled. The debugger can then later be enabled explicit from Java, JMX or tooling. | false | boolean
+| `camel.debug.waitForAttach` | Whether the debugger should suspend on startup, and wait for a remote debugger to attach. This is what the IDEA and VSCode tooling is using. | false | boolean
 |===
 
 
@@ -301,22 +301,22 @@ The camel.trace supports 16 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.trace.activityEnabled* | Whether activity tracking is enabled. When enabled, the backlog tracer will capture activity data that can be enriched with additional details from tracing (such as span decorator attributes). | false | boolean
-| *camel.trace.activitySize* | Defines how many completed exchange summaries to keep in the activity queue (should be between 1 - 1000). The activity queue captures lightweight metadata (no body or headers) each time an exchange completes a route, providing a rolling window of recent exchange activity. | 100 | int
-| *camel.trace.backlogSize* | Defines how many of the last messages to keep in the tracer (should be between 1 - 1000). | 100 | int
-| *camel.trace.bodyIncludeFiles* | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
-| *camel.trace.bodyIncludeStreams* | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
-| *camel.trace.bodyMaxChars* | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
-| *camel.trace.enabled* | Enables tracer in your Camel application. | false | boolean
-| *camel.trace.includeException* | Trace messages to include exception if the message failed | true | boolean
-| *camel.trace.includeExchangeProperties* | Whether to include the exchange properties in the traced message | true | boolean
-| *camel.trace.includeExchangeVariables* | Whether to include the exchange variables in the traced message | true | boolean
-| *camel.trace.removeOnDump* | Whether all traced messages should be removed when the tracer is dumping. By default, the messages are removed, which means that dumping will not contain previous dumped messages. | true | boolean
-| *camel.trace.standby* | To set the tracer in standby mode, where the tracer will be installed by not automatic enabled. The tracer can then later be enabled explicit from Java, JMX or tooling. | false | boolean
-| *camel.trace.traceFilter* | Filter for tracing messages |  | String
-| *camel.trace.tracePattern* | Filter for tracing by route or node id |  | String
-| *camel.trace.traceRests* | Whether to trace routes that is created from Rest DSL. | true | boolean
-| *camel.trace.traceTemplates* | Whether to trace routes that is created from route templates or kamelets. | false | boolean
+| `camel.trace.activityEnabled` | Whether activity tracking is enabled. When enabled, the backlog tracer will capture activity data that can be enriched with additional details from tracing (such as span decorator attributes). | false | boolean
+| `camel.trace.activitySize` | Defines how many completed exchange summaries to keep in the activity queue (should be between 1 - 1000). The activity queue captures lightweight metadata (no body or headers) each time an exchange completes a route, providing a rolling window of recent exchange activity. | 100 | int
+| `camel.trace.backlogSize` | Defines how many of the last messages to keep in the tracer (should be between 1 - 1000). | 100 | int
+| `camel.trace.bodyIncludeFiles` | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
+| `camel.trace.bodyIncludeStreams` | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
+| `camel.trace.bodyMaxChars` | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
+| `camel.trace.enabled` | Enables tracer in your Camel application. | false | boolean
+| `camel.trace.includeException` | Trace messages to include exception if the message failed | true | boolean
+| `camel.trace.includeExchangeProperties` | Whether to include the exchange properties in the traced message | true | boolean
+| `camel.trace.includeExchangeVariables` | Whether to include the exchange variables in the traced message | true | boolean
+| `camel.trace.removeOnDump` | Whether all traced messages should be removed when the tracer is dumping. By default, the messages are removed, which means that dumping will not contain previous dumped messages. | true | boolean
+| `camel.trace.standby` | To set the tracer in standby mode, where the tracer will be installed by not automatic enabled. The tracer can then later be enabled explicit from Java, JMX or tooling. | false | boolean
+| `camel.trace.traceFilter` | Filter for tracing messages |  | String
+| `camel.trace.tracePattern` | Filter for tracing by route or node id |  | String
+| `camel.trace.traceRests` | Whether to trace routes that is created from Rest DSL. | true | boolean
+| `camel.trace.traceTemplates` | Whether to trace routes that is created from route templates or kamelets. | false | boolean
 |===
 
 
@@ -326,12 +326,12 @@ The camel.security supports 6 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.security.allowedProperties* | Comma-separated list of property keys to exclude from security policy checks. Use full property paths to allow specific properties regardless of the configured policy. |  | String
-| *camel.security.insecureDevPolicy* | Security policy for development-only features. When set, overrides the global policy for options intended only for development environments. |  | String
-| *camel.security.insecureSerializationPolicy* | Security policy for insecure deserialization configuration. When set, overrides the global policy for options that enable dangerous deserialization of untrusted data. |  | String
-| *camel.security.insecureSslPolicy* | Security policy for insecure SSL/TLS configuration. When set, overrides the global policy for options that disable certificate validation or hostname verification. |  | String
-| *camel.security.policy* | Global security policy applied to all categories unless overridden. Controls how Camel reacts when insecure configuration is detected at startup. | warn | String
-| *camel.security.secretPolicy* | Security policy for plain-text secrets. When set, overrides the global policy for properties that contain sensitive values configured as plain text. |  | String
+| `camel.security.allowedProperties` | Comma-separated list of property keys to exclude from security policy checks. Use full property paths to allow specific properties regardless of the configured policy. |  | String
+| `camel.security.insecureDevPolicy` | Security policy for development-only features. When set, overrides the global policy for options intended only for development environments. |  | String
+| `camel.security.insecureSerializationPolicy` | Security policy for insecure deserialization configuration. When set, overrides the global policy for options that enable dangerous deserialization of untrusted data. |  | String
+| `camel.security.insecureSslPolicy` | Security policy for insecure SSL/TLS configuration. When set, overrides the global policy for options that disable certificate validation or hostname verification. |  | String
+| `camel.security.policy` | Global security policy applied to all categories unless overridden. Controls how Camel reacts when insecure configuration is detected at startup. | warn | String
+| `camel.security.secretPolicy` | Security policy for plain-text secrets. When set, overrides the global policy for properties that contain sensitive values configured as plain text. |  | String
 |===
 
 
@@ -341,34 +341,34 @@ The camel.ssl supports 28 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.ssl.certAlias* | An optional certificate alias to use. This is useful when the keystore has multiple certificates. |  | String
-| *camel.ssl.cipherSuites* | List of TLS/SSL cipher suite algorithm names. Multiple names can be separated by comma. |  | String
-| *camel.ssl.cipherSuitesExclude* | Filters TLS/SSL cipher suites algorithms names. This filter is used for excluding algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.cipherSuitesInclude* | Filters TLS/SSL cipher suites algorithms names. This filter is used for including algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.clientAuthentication* | Sets the configuration for server-side client-authentication requirements | NONE | String
-| *camel.ssl.enabled* | Enables SSL in your Camel application. | false | boolean
-| *camel.ssl.keyManagerAlgorithm* | Algorithm name used for creating the KeyManagerFactory. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
-| *camel.ssl.keyManagerProvider* | To use a specific provider for creating KeyManagerFactory. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.keyStore* | The key store to load. The key store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
-| *camel.ssl.keystorePassword* | Sets the SSL Keystore password. |  | String
-| *camel.ssl.keyStoreProvider* | To use a specific provider for creating KeyStore. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.keyStoreType* | The type of the key store to load. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
-| *camel.ssl.namedGroups* | List of TLS/SSL named groups (key exchange groups). Multiple names can be separated by comma. Named groups control which key exchange algorithms are available during the TLS handshake, including post-quantum hybrid groups such as X25519MLKEM768. |  | String
-| *camel.ssl.namedGroupsExclude* | Filters TLS/SSL named groups. This filter is used for excluding named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.namedGroupsInclude* | Filters TLS/SSL named groups. This filter is used for including named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.provider* | To use a specific provider for creating SSLContext. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.secureRandomAlgorithm* | Algorithm name used for creating the SecureRandom. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
-| *camel.ssl.secureRandomProvider* | To use a specific provider for creating SecureRandom. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.secureSocketProtocol* | The protocol for the secure sockets created by the SSLContext. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html | TLSv1.3 | String
-| *camel.ssl.selfSigned* | Whether to generate a self-signed certificate for development use when no keystore is configured. This can be used in development environment to easily enable HTTPS without providing a keystore. Do NOT use this in production as the certificate is not trusted and is regenerated on each restart. | false | boolean
-| *camel.ssl.selfSignedKeyType* | The key algorithm to use when generating the self-signed certificate for development use (requires selfSigned to be enabled). Supported values are EC (default, NIST P-256) and RSA (2048-bit). | EC | String
-| *camel.ssl.sessionTimeout* | Timeout in seconds to use for SSLContext. The default is 24 hours. | 86400 | int
-| *camel.ssl.signatureSchemes* | List of TLS/SSL signature schemes. Multiple names can be separated by comma. Signature schemes control which signature algorithms are available during the TLS handshake, including post-quantum signature algorithms such as ML-DSA. |  | String
-| *camel.ssl.signatureSchemesExclude* | Filters TLS/SSL signature schemes. This filter is used for excluding signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.signatureSchemesInclude* | Filters TLS/SSL signature schemes. This filter is used for including signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.trustAllCertificates* | Allows to trust all SSL certificates without performing certificate validation. This can be used in development environment but may expose the system to security risks. Notice that if the trustAllCertificates option is set to true then the trustStore/trustStorePassword options are not in use. | false | boolean
-| *camel.ssl.trustStore* | The trust store to load. The trust store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
-| *camel.ssl.trustStorePassword* | Sets the SSL Truststore password. |  | String
+| `camel.ssl.certAlias` | An optional certificate alias to use. This is useful when the keystore has multiple certificates. |  | String
+| `camel.ssl.cipherSuites` | List of TLS/SSL cipher suite algorithm names. Multiple names can be separated by comma. |  | String
+| `camel.ssl.cipherSuitesExclude` | Filters TLS/SSL cipher suites algorithms names. This filter is used for excluding algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.cipherSuitesInclude` | Filters TLS/SSL cipher suites algorithms names. This filter is used for including algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.clientAuthentication` | Sets the configuration for server-side client-authentication requirements | NONE | String
+| `camel.ssl.enabled` | Enables SSL in your Camel application. | false | boolean
+| `camel.ssl.keyManagerAlgorithm` | Algorithm name used for creating the KeyManagerFactory. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
+| `camel.ssl.keyManagerProvider` | To use a specific provider for creating KeyManagerFactory. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.keyStore` | The key store to load. The key store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
+| `camel.ssl.keystorePassword` | Sets the SSL Keystore password. |  | String
+| `camel.ssl.keyStoreProvider` | To use a specific provider for creating KeyStore. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.keyStoreType` | The type of the key store to load. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
+| `camel.ssl.namedGroups` | List of TLS/SSL named groups (key exchange groups). Multiple names can be separated by comma. Named groups control which key exchange algorithms are available during the TLS handshake, including post-quantum hybrid groups such as X25519MLKEM768. |  | String
+| `camel.ssl.namedGroupsExclude` | Filters TLS/SSL named groups. This filter is used for excluding named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.namedGroupsInclude` | Filters TLS/SSL named groups. This filter is used for including named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.provider` | To use a specific provider for creating SSLContext. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.secureRandomAlgorithm` | Algorithm name used for creating the SecureRandom. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
+| `camel.ssl.secureRandomProvider` | To use a specific provider for creating SecureRandom. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.secureSocketProtocol` | The protocol for the secure sockets created by the SSLContext. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html | TLSv1.3 | String
+| `camel.ssl.selfSigned` | Whether to generate a self-signed certificate for development use when no keystore is configured. This can be used in development environment to easily enable HTTPS without providing a keystore. Do NOT use this in production as the certificate is not trusted and is regenerated on each restart. | false | boolean
+| `camel.ssl.selfSignedKeyType` | The key algorithm to use when generating the self-signed certificate for development use (requires selfSigned to be enabled). Supported values are EC (default, NIST P-256) and RSA (2048-bit). | EC | String
+| `camel.ssl.sessionTimeout` | Timeout in seconds to use for SSLContext. The default is 24 hours. | 86400 | int
+| `camel.ssl.signatureSchemes` | List of TLS/SSL signature schemes. Multiple names can be separated by comma. Signature schemes control which signature algorithms are available during the TLS handshake, including post-quantum signature algorithms such as ML-DSA. |  | String
+| `camel.ssl.signatureSchemesExclude` | Filters TLS/SSL signature schemes. This filter is used for excluding signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.signatureSchemesInclude` | Filters TLS/SSL signature schemes. This filter is used for including signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.trustAllCertificates` | Allows to trust all SSL certificates without performing certificate validation. This can be used in development environment but may expose the system to security risks. Notice that if the trustAllCertificates option is set to true then the trustStore/trustStorePassword options are not in use. | false | boolean
+| `camel.ssl.trustStore` | The trust store to load. The trust store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
+| `camel.ssl.trustStorePassword` | Sets the SSL Truststore password. |  | String
 |===
 
 
@@ -378,14 +378,14 @@ The camel.threadpool supports 8 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.threadpool.allowCoreThreadTimeOut* | Sets default whether to allow core threads to timeout | false | Boolean
-| *camel.threadpool.config* | Adds a configuration for a specific thread pool profile (inherits default values) |  | Map
-| *camel.threadpool.keepAliveTime* | Sets the default keep alive time for inactive threads |  | Long
-| *camel.threadpool.maxPoolSize* | Sets the default maximum pool size |  | Integer
-| *camel.threadpool.maxQueueSize* | Sets the default maximum number of tasks in the work queue. Use -1 or an unbounded queue |  | Integer
-| *camel.threadpool.poolSize* | Sets the default core pool size (threads to keep minimum in pool) |  | Integer
-| *camel.threadpool.rejectedPolicy* | Sets the default handler for tasks which cannot be executed by the thread pool. |  | ThreadPoolRejectedPolicy
-| *camel.threadpool.timeUnit* | Sets the default time unit used for keep alive time |  | TimeUnit
+| `camel.threadpool.allowCoreThreadTimeOut` | Sets default whether to allow core threads to timeout | false | Boolean
+| `camel.threadpool.config` | Adds a configuration for a specific thread pool profile (inherits default values) |  | Map
+| `camel.threadpool.keepAliveTime` | Sets the default keep alive time for inactive threads |  | Long
+| `camel.threadpool.maxPoolSize` | Sets the default maximum pool size |  | Integer
+| `camel.threadpool.maxQueueSize` | Sets the default maximum number of tasks in the work queue. Use -1 or an unbounded queue |  | Integer
+| `camel.threadpool.poolSize` | Sets the default core pool size (threads to keep minimum in pool) |  | Integer
+| `camel.threadpool.rejectedPolicy` | Sets the default handler for tasks which cannot be executed by the thread pool. |  | ThreadPoolRejectedPolicy
+| `camel.threadpool.timeUnit` | Sets the default time unit used for keep alive time |  | TimeUnit
 |===
 
 
@@ -395,14 +395,14 @@ The camel.health supports 8 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.health.consumersEnabled* | Whether consumers health check is enabled | true | Boolean
-| *camel.health.enabled* | Whether health check is enabled globally | true | Boolean
-| *camel.health.excludePattern* | Pattern to exclude health checks from being invoked by Camel when checking healths. Multiple patterns can be separated by comma. |  | String
-| *camel.health.exposureLevel* | Sets the level of details to exposure as result of invoking health checks. There are the following levels: full, default, oneline The full level will include all details and status from all the invoked health checks. The default level will report UP if everything is okay, and only include detailed information for health checks that was DOWN. The oneline level will only report either UP or DOWN. | default | String
-| *camel.health.initialState* | The initial state of health-checks (readiness). There are the following states: UP, DOWN, UNKNOWN. By default, the state is DOWN, is regarded as being pessimistic/careful. This means that the overall health checks may report as DOWN during startup and then only if everything is up and running flip to being UP. Setting the initial state to UP, is regarded as being optimistic. This means that the overall health checks may report as UP during startup and then if a consumer or other service is in fact un-healthy, then the health-checks can flip being DOWN. Setting the state to UNKNOWN means that some health-check would be reported in unknown state, especially during early bootstrap where a consumer may not be fully initialized or validated a connection to a remote system. This option allows to pre-configure the state for different modes. | down | String
-| *camel.health.producersEnabled* | Whether producers health check is enabled | false | Boolean
-| *camel.health.registryEnabled* | Whether registry health check is enabled | true | Boolean
-| *camel.health.routesEnabled* | Whether routes health check is enabled | true | Boolean
+| `camel.health.consumersEnabled` | Whether consumers health check is enabled | true | Boolean
+| `camel.health.enabled` | Whether health check is enabled globally | true | Boolean
+| `camel.health.excludePattern` | Pattern to exclude health checks from being invoked by Camel when checking healths. Multiple patterns can be separated by comma. |  | String
+| `camel.health.exposureLevel` | Sets the level of details to exposure as result of invoking health checks. There are the following levels: full, default, oneline The full level will include all details and status from all the invoked health checks. The default level will report UP if everything is okay, and only include detailed information for health checks that was DOWN. The oneline level will only report either UP or DOWN. | default | String
+| `camel.health.initialState` | The initial state of health-checks (readiness). There are the following states: UP, DOWN, UNKNOWN. By default, the state is DOWN, is regarded as being pessimistic/careful. This means that the overall health checks may report as DOWN during startup and then only if everything is up and running flip to being UP. Setting the initial state to UP, is regarded as being optimistic. This means that the overall health checks may report as UP during startup and then if a consumer or other service is in fact un-healthy, then the health-checks can flip being DOWN. Setting the state to UNKNOWN means that some health-check would be reported in unknown state, especially during early bootstrap where a consumer may not be fully initialized or validated a connection to a remote system. This option allows to pre-configure the state for different modes. | down | String
+| `camel.health.producersEnabled` | Whether producers health check is enabled | false | Boolean
+| `camel.health.registryEnabled` | Whether registry health check is enabled | true | Boolean
+| `camel.health.routesEnabled` | Whether routes health check is enabled | true | Boolean
 |===
 
 
@@ -412,37 +412,37 @@ The camel.rest supports 31 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.rest.apiComponent* | Sets the name of the Camel component to use as the REST API (such as swagger or openapi) |  | String
-| *camel.rest.apiContextPath* | Sets a leading API context-path the REST API services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. |  | String
-| *camel.rest.apiContextRouteId* | Sets the route id to use for the route that services the REST API. The route will by default use an auto assigned route id. |  | String
-| *camel.rest.apiHost* | To use a specific hostname for the API documentation (such as swagger or openapi) This can be used to override the generated host with this configured hostname |  | String
-| *camel.rest.apiProperties* | Sets additional options on api level |  | Map
-| *camel.rest.apiVendorExtension* | Whether vendor extension is enabled in the Rest APIs. If enabled then Camel will include additional information as vendor extension (eg keys starting with x-) such as route ids, class names etc. Not all 3rd party API gateways and tools supports vendor-extensions when importing your API docs. | false | boolean
-| *camel.rest.bindingMode* | Sets the binding mode to be used by the REST consumer | RestBindingMode.off | RestBindingMode
-| *camel.rest.bindingPackageScan* | Package name to use as base (offset) for classpath scanning of POJO classes are located when using binding mode is enabled for JSon or XML. Multiple package names can be separated by comma. |  | String
-| *camel.rest.clientRequestValidation* | Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error. | false | boolean
-| *camel.rest.clientResponseValidation* | Whether to check what Camel is returning as response to the client: 1) Status-code and Content-Type matches Rest DSL response messages. 2) Check whether expected headers is included according to the Rest DSL repose message headers. 3) If the response body is JSon then check whether its valid JSon. Returns 500 if validation error detected. | false | boolean
-| *camel.rest.component* | Sets the name of the Camel component to use as the REST consumer |  | String
-| *camel.rest.componentProperties* | Sets additional options on component level |  | Map
-| *camel.rest.consumerProperties* | Sets additional options on consumer level |  | Map
-| *camel.rest.contextPath* | Sets a leading context-path the REST services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. Or for components such as camel-jetty or camel-netty-http that includes a HTTP server. |  | String
-| *camel.rest.corsHeaders* | Sets the CORS headers to use if CORS has been enabled. |  | Map
-| *camel.rest.dataFormatProperties* | Sets additional options on data format level |  | Map
-| *camel.rest.enableCORS* | To specify whether to enable CORS which means Camel will automatic include CORS in the HTTP headers in the response. This option is default false | false | boolean
-| *camel.rest.enableNoContentResponse* | Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false. | false | boolean
-| *camel.rest.endpointProperties* | Sets additional options on endpoint level |  | Map
-| *camel.rest.host* | Sets the hostname to use by the REST consumer |  | String
-| *camel.rest.hostNameResolver* | Sets the resolver to use for resolving hostname | RestHostNameResolver.allLocalIp | RestHostNameResolver
-| *camel.rest.inlineRoutes* | Inline routes in rest-dsl which are linked using direct endpoints. Each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). By inlining (default) allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. If a route is not using direct endpoint then the rest-dsl is not inlined, and will become an individual route. This option is default true. | true | boolean
-| *camel.rest.jsonDataFormat* | Sets a custom json data format to be used Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
-| *camel.rest.port* | Sets the port to use by the REST consumer |  | int
-| *camel.rest.producerApiDoc* | Sets the location of the api document (swagger api) the REST producer will use to validate the REST uri and query parameters are valid accordingly to the api document. This requires adding camel-openapi-java to the classpath, and any miss configuration will let Camel fail on startup and report the error(s). The location of the api document is loaded from classpath by default, but you can use file: or http: to refer to resources to load from file or http url. |  | String
-| *camel.rest.producerComponent* | Sets the name of the Camel component to use as the REST producer |  | String
-| *camel.rest.scheme* | Sets the scheme to use by the REST consumer |  | String
-| *camel.rest.skipBindingOnErrorCode* | Whether to skip binding output if there is a custom HTTP error code, and instead use the response body as-is. This option is default true. | true | boolean
-| *camel.rest.useXForwardHeaders* | Whether to use X-Forward headers to set host etc. for OpenApi. This may be needed in special cases involving reverse-proxy and networking going from HTTP to HTTPS etc. Then the proxy can send X-Forward headers (X-Forwarded-Proto) that influences the host names in the OpenAPI schema that camel-openapi-java generates from Rest DSL routes. | false | boolean
-| *camel.rest.validationLevels* | Sets the client request validation levels when using camel-openapi-validator. |  | Map
-| *camel.rest.xmlDataFormat* | Sets a custom xml data format to be used. Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
+| `camel.rest.apiComponent` | Sets the name of the Camel component to use as the REST API (such as swagger or openapi) |  | String
+| `camel.rest.apiContextPath` | Sets a leading API context-path the REST API services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. |  | String
+| `camel.rest.apiContextRouteId` | Sets the route id to use for the route that services the REST API. The route will by default use an auto assigned route id. |  | String
+| `camel.rest.apiHost` | To use a specific hostname for the API documentation (such as swagger or openapi) This can be used to override the generated host with this configured hostname |  | String
+| `camel.rest.apiProperties` | Sets additional options on api level |  | Map
+| `camel.rest.apiVendorExtension` | Whether vendor extension is enabled in the Rest APIs. If enabled then Camel will include additional information as vendor extension (eg keys starting with x-) such as route ids, class names etc. Not all 3rd party API gateways and tools supports vendor-extensions when importing your API docs. | false | boolean
+| `camel.rest.bindingMode` | Sets the binding mode to be used by the REST consumer | RestBindingMode.off | RestBindingMode
+| `camel.rest.bindingPackageScan` | Package name to use as base (offset) for classpath scanning of POJO classes are located when using binding mode is enabled for JSon or XML. Multiple package names can be separated by comma. |  | String
+| `camel.rest.clientRequestValidation` | Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error. | false | boolean
+| `camel.rest.clientResponseValidation` | Whether to check what Camel is returning as response to the client: 1) Status-code and Content-Type matches Rest DSL response messages. 2) Check whether expected headers is included according to the Rest DSL repose message headers. 3) If the response body is JSon then check whether its valid JSon. Returns 500 if validation error detected. | false | boolean
+| `camel.rest.component` | Sets the name of the Camel component to use as the REST consumer |  | String
+| `camel.rest.componentProperties` | Sets additional options on component level |  | Map
+| `camel.rest.consumerProperties` | Sets additional options on consumer level |  | Map
+| `camel.rest.contextPath` | Sets a leading context-path the REST services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. Or for components such as camel-jetty or camel-netty-http that includes a HTTP server. |  | String
+| `camel.rest.corsHeaders` | Sets the CORS headers to use if CORS has been enabled. |  | Map
+| `camel.rest.dataFormatProperties` | Sets additional options on data format level |  | Map
+| `camel.rest.enableCORS` | To specify whether to enable CORS which means Camel will automatic include CORS in the HTTP headers in the response. This option is default false | false | boolean
+| `camel.rest.enableNoContentResponse` | Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false. | false | boolean
+| `camel.rest.endpointProperties` | Sets additional options on endpoint level |  | Map
+| `camel.rest.host` | Sets the hostname to use by the REST consumer |  | String
+| `camel.rest.hostNameResolver` | Sets the resolver to use for resolving hostname | RestHostNameResolver.allLocalIp | RestHostNameResolver
+| `camel.rest.inlineRoutes` | Inline routes in rest-dsl which are linked using direct endpoints. Each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). By inlining (default) allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. If a route is not using direct endpoint then the rest-dsl is not inlined, and will become an individual route. This option is default true. | true | boolean
+| `camel.rest.jsonDataFormat` | Sets a custom json data format to be used Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
+| `camel.rest.port` | Sets the port to use by the REST consumer |  | int
+| `camel.rest.producerApiDoc` | Sets the location of the api document (swagger api) the REST producer will use to validate the REST uri and query parameters are valid accordingly to the api document. This requires adding camel-openapi-java to the classpath, and any miss configuration will let Camel fail on startup and report the error(s). The location of the api document is loaded from classpath by default, but you can use file: or http: to refer to resources to load from file or http url. |  | String
+| `camel.rest.producerComponent` | Sets the name of the Camel component to use as the REST producer |  | String
+| `camel.rest.scheme` | Sets the scheme to use by the REST consumer |  | String
+| `camel.rest.skipBindingOnErrorCode` | Whether to skip binding output if there is a custom HTTP error code, and instead use the response body as-is. This option is default true. | true | boolean
+| `camel.rest.useXForwardHeaders` | Whether to use X-Forward headers to set host etc. for OpenApi. This may be needed in special cases involving reverse-proxy and networking going from HTTP to HTTPS etc. Then the proxy can send X-Forward headers (X-Forwarded-Proto) that influences the host names in the OpenAPI schema that camel-openapi-java generates from Rest DSL routes. | false | boolean
+| `camel.rest.validationLevels` | Sets the client request validation levels when using camel-openapi-validator. |  | Map
+| `camel.rest.xmlDataFormat` | Sets a custom xml data format to be used. Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
 |===
 
 
@@ -452,19 +452,19 @@ The camel.vault.aws supports 13 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.aws.accessKey* | The AWS access key |  | String
-| *camel.vault.aws.defaultCredentialsProvider* | Define if we want to use the AWS Default Credentials Provider or not | false | boolean
-| *camel.vault.aws.overrideEndpoint* | Set the need for overriding the endpoint. This option needs to be used in combination with the uriEndpointOverride option | false | boolean
-| *camel.vault.aws.profileCredentialsProvider* | Define if we want to use the AWS Profile Credentials Provider or not | false | boolean
-| *camel.vault.aws.profileName* | Define the profile name to use if Profile Credentials Provider is selected |  | String
-| *camel.vault.aws.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in AWS. | false | boolean
-| *camel.vault.aws.refreshPeriod* | The period (millis) between checking AWS for updated secrets. | 30000 | long
-| *camel.vault.aws.region* | The AWS region |  | String
-| *camel.vault.aws.secretKey* | The AWS secret key |  | String
-| *camel.vault.aws.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.aws.sqsQueueUrl* | In case of usage of SQS notification this field will specified the Queue URL to use |  | String
-| *camel.vault.aws.uriEndpointOverride* | Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option |  | String
-| *camel.vault.aws.useSqsNotification* | Whether to use AWS SQS for secrets updates notification, this will require setting up Eventbridge/Cloudtrail/SQS communication | false | boolean
+| `camel.vault.aws.accessKey` | The AWS access key |  | String
+| `camel.vault.aws.defaultCredentialsProvider` | Define if we want to use the AWS Default Credentials Provider or not | false | boolean
+| `camel.vault.aws.overrideEndpoint` | Set the need for overriding the endpoint. This option needs to be used in combination with the uriEndpointOverride option | false | boolean
+| `camel.vault.aws.profileCredentialsProvider` | Define if we want to use the AWS Profile Credentials Provider or not | false | boolean
+| `camel.vault.aws.profileName` | Define the profile name to use if Profile Credentials Provider is selected |  | String
+| `camel.vault.aws.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in AWS. | false | boolean
+| `camel.vault.aws.refreshPeriod` | The period (millis) between checking AWS for updated secrets. | 30000 | long
+| `camel.vault.aws.region` | The AWS region |  | String
+| `camel.vault.aws.secretKey` | The AWS secret key |  | String
+| `camel.vault.aws.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.aws.sqsQueueUrl` | In case of usage of SQS notification this field will specified the Queue URL to use |  | String
+| `camel.vault.aws.uriEndpointOverride` | Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option |  | String
+| `camel.vault.aws.useSqsNotification` | Whether to use AWS SQS for secrets updates notification, this will require setting up Eventbridge/Cloudtrail/SQS communication | false | boolean
 |===
 
 
@@ -474,13 +474,13 @@ The camel.vault.gcp supports 7 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.gcp.projectId* | The GCP Project ID |  | String
-| *camel.vault.gcp.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in GCP. | false | boolean
-| *camel.vault.gcp.refreshPeriod* | The period (millis) between checking Google for updated secrets. | 30000 | long
-| *camel.vault.gcp.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.gcp.serviceAccountKey* | The Service Account Key location |  | String
-| *camel.vault.gcp.subscriptionName* | Define the Google Pubsub subscription Name to be used when checking for updates |  | String
-| *camel.vault.gcp.useDefaultInstance* | Define if we want to use the GCP Client Default Instance or not | false | boolean
+| `camel.vault.gcp.projectId` | The GCP Project ID |  | String
+| `camel.vault.gcp.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in GCP. | false | boolean
+| `camel.vault.gcp.refreshPeriod` | The period (millis) between checking Google for updated secrets. | 30000 | long
+| `camel.vault.gcp.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.gcp.serviceAccountKey` | The Service Account Key location |  | String
+| `camel.vault.gcp.subscriptionName` | Define the Google Pubsub subscription Name to be used when checking for updates |  | String
+| `camel.vault.gcp.useDefaultInstance` | Define if we want to use the GCP Client Default Instance or not | false | boolean
 |===
 
 
@@ -490,18 +490,18 @@ The camel.vault.azure supports 12 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.azure.azureIdentityEnabled* | Whether the Azure Identity Authentication should be used or not. | false | boolean
-| *camel.vault.azure.blobAccessKey* | The Eventhubs Blob Access Key for CheckpointStore purpose |  | String
-| *camel.vault.azure.blobAccountName* | The Eventhubs Blob Account Name for CheckpointStore purpose |  | String
-| *camel.vault.azure.blobContainerName* | The Eventhubs Blob Container Name for CheckpointStore purpose |  | String
-| *camel.vault.azure.clientId* | The client Id for accessing Azure Key Vault |  | String
-| *camel.vault.azure.clientSecret* | The client Secret for accessing Azure Key Vault |  | String
-| *camel.vault.azure.eventhubConnectionString* | The Eventhubs connection String for Key Vault Secret events notifications |  | String
-| *camel.vault.azure.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in Azure. | false | boolean
-| *camel.vault.azure.refreshPeriod* | The period (millis) between checking Azure for updated secrets. | 30000 | long
-| *camel.vault.azure.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.azure.tenantId* | The Tenant Id for accessing Azure Key Vault |  | String
-| *camel.vault.azure.vaultName* | The vault Name in Azure Key Vault |  | String
+| `camel.vault.azure.azureIdentityEnabled` | Whether the Azure Identity Authentication should be used or not. | false | boolean
+| `camel.vault.azure.blobAccessKey` | The Eventhubs Blob Access Key for CheckpointStore purpose |  | String
+| `camel.vault.azure.blobAccountName` | The Eventhubs Blob Account Name for CheckpointStore purpose |  | String
+| `camel.vault.azure.blobContainerName` | The Eventhubs Blob Container Name for CheckpointStore purpose |  | String
+| `camel.vault.azure.clientId` | The client Id for accessing Azure Key Vault |  | String
+| `camel.vault.azure.clientSecret` | The client Secret for accessing Azure Key Vault |  | String
+| `camel.vault.azure.eventhubConnectionString` | The Eventhubs connection String for Key Vault Secret events notifications |  | String
+| `camel.vault.azure.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in Azure. | false | boolean
+| `camel.vault.azure.refreshPeriod` | The period (millis) between checking Azure for updated secrets. | 30000 | long
+| `camel.vault.azure.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.azure.tenantId` | The Tenant Id for accessing Azure Key Vault |  | String
+| `camel.vault.azure.vaultName` | The vault Name in Azure Key Vault |  | String
 |===
 
 
@@ -511,10 +511,10 @@ The camel.vault.kubernetes supports 4 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.kubernetes.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in Kubernetes Cluster. | false | boolean
-| *camel.vault.kubernetes.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.kubernetescm.configmaps* | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
-| *camel.vault.kubernetescm.refreshEnabled* | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
+| `camel.vault.kubernetes.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in Kubernetes Cluster. | false | boolean
+| `camel.vault.kubernetes.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.kubernetescm.configmaps` | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
+| `camel.vault.kubernetescm.refreshEnabled` | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
 |===
 
 
@@ -524,8 +524,8 @@ The camel.vault.kubernetescm supports 2 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.kubernetescm.configmaps* | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
-| *camel.vault.kubernetescm.refreshEnabled* | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
+| `camel.vault.kubernetescm.configmaps` | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
+| `camel.vault.kubernetescm.refreshEnabled` | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
 |===
 
 
@@ -535,15 +535,15 @@ The camel.vault.hashicorp supports 9 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.hashicorp.cloud* | Determine if the Hashicorp Vault is deployed on Hashicorp Cloud or not | false | boolean
-| *camel.vault.hashicorp.host* | Host to access hashicorp vault |  | String
-| *camel.vault.hashicorp.namespace* | If the Hashicorp Vault instance is deployed on Hashicorp Cloud, this field will determine the namespace |  | String
-| *camel.vault.hashicorp.port* | Port to access hashicorp vault |  | String
-| *camel.vault.hashicorp.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in Hashicorp Vault. | false | boolean
-| *camel.vault.hashicorp.refreshPeriod* | The period (millis) between checking Hashicorp Vault for updated secrets. | 60000 | long
-| *camel.vault.hashicorp.scheme* | Scheme to access hashicorp vault |  | String
-| *camel.vault.hashicorp.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.hashicorp.token* | Token to access hashicorp vault |  | String
+| `camel.vault.hashicorp.cloud` | Determine if the Hashicorp Vault is deployed on Hashicorp Cloud or not | false | boolean
+| `camel.vault.hashicorp.host` | Host to access hashicorp vault |  | String
+| `camel.vault.hashicorp.namespace` | If the Hashicorp Vault instance is deployed on Hashicorp Cloud, this field will determine the namespace |  | String
+| `camel.vault.hashicorp.port` | Port to access hashicorp vault |  | String
+| `camel.vault.hashicorp.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in Hashicorp Vault. | false | boolean
+| `camel.vault.hashicorp.refreshPeriod` | The period (millis) between checking Hashicorp Vault for updated secrets. | 60000 | long
+| `camel.vault.hashicorp.scheme` | Scheme to access hashicorp vault |  | String
+| `camel.vault.hashicorp.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.hashicorp.token` | Token to access hashicorp vault |  | String
 |===
 
 
@@ -553,16 +553,16 @@ The camel.vault.ibm supports 10 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.ibm.eventStreamBootstrapServers* | Specify the Bootstrap servers for consuming notification on IBM Event Stream. Multiple servers can be separated by comma. |  | String
-| *camel.vault.ibm.eventStreamConsumerPollTimeout* | Specify the Consumer Poll Timeout while consuming from IBM Event Stream Topic | 3000 | long
-| *camel.vault.ibm.eventStreamGroupId* | Specify the Consumer Group ID to access IBM Event Stream |  | String
-| *camel.vault.ibm.eventStreamPassword* | Specify the password to access IBM Event Stream |  | String
-| *camel.vault.ibm.eventStreamTopic* | Specify the topic name for consuming notification on IBM Event Stream |  | String
-| *camel.vault.ibm.eventStreamUsername* | Specify the username to access IBM Event Stream |  | String
-| *camel.vault.ibm.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in IBM. | false | boolean
-| *camel.vault.ibm.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.ibm.serviceUrl* | Service URL to access IBM Secrets Manager vault |  | String
-| *camel.vault.ibm.token* | Token to access IBM Secrets Manager vault |  | String
+| `camel.vault.ibm.eventStreamBootstrapServers` | Specify the Bootstrap servers for consuming notification on IBM Event Stream. Multiple servers can be separated by comma. |  | String
+| `camel.vault.ibm.eventStreamConsumerPollTimeout` | Specify the Consumer Poll Timeout while consuming from IBM Event Stream Topic | 3000 | long
+| `camel.vault.ibm.eventStreamGroupId` | Specify the Consumer Group ID to access IBM Event Stream |  | String
+| `camel.vault.ibm.eventStreamPassword` | Specify the password to access IBM Event Stream |  | String
+| `camel.vault.ibm.eventStreamTopic` | Specify the topic name for consuming notification on IBM Event Stream |  | String
+| `camel.vault.ibm.eventStreamUsername` | Specify the username to access IBM Event Stream |  | String
+| `camel.vault.ibm.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in IBM. | false | boolean
+| `camel.vault.ibm.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.ibm.serviceUrl` | Service URL to access IBM Secrets Manager vault |  | String
+| `camel.vault.ibm.token` | Token to access IBM Secrets Manager vault |  | String
 |===
 
 
@@ -572,15 +572,15 @@ The camel.vault.cyberark supports 9 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.cyberark.account* | The CyberArk Conjur account name |  | String
-| *camel.vault.cyberark.apiKey* | The API key for authentication |  | String
-| *camel.vault.cyberark.authToken* | Pre-authenticated token to use |  | String
-| *camel.vault.cyberark.certificatePath* | Path to the SSL certificate for verification |  | String
-| *camel.vault.cyberark.password* | The password for authentication |  | String
-| *camel.vault.cyberark.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.cyberark.url* | The CyberArk Conjur instance URL |  | String
-| *camel.vault.cyberark.username* | The username for authentication |  | String
-| *camel.vault.cyberark.verifySsl* | Whether to verify SSL certificates | false | boolean
+| `camel.vault.cyberark.account` | The CyberArk Conjur account name |  | String
+| `camel.vault.cyberark.apiKey` | The API key for authentication |  | String
+| `camel.vault.cyberark.authToken` | Pre-authenticated token to use |  | String
+| `camel.vault.cyberark.certificatePath` | Path to the SSL certificate for verification |  | String
+| `camel.vault.cyberark.password` | The password for authentication |  | String
+| `camel.vault.cyberark.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.cyberark.url` | The CyberArk Conjur instance URL |  | String
+| `camel.vault.cyberark.username` | The username for authentication |  | String
+| `camel.vault.cyberark.verifySsl` | Whether to verify SSL certificates | false | boolean
 |===
 
 
@@ -590,17 +590,17 @@ The camel.opentelemetry supports 11 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.opentelemetry.enabled* | To enable OpenTelemetry | false | boolean
-| *camel.opentelemetry.encoding* | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
-| *camel.opentelemetry.excludePatterns* | Adds an exclude pattern that will disable tracing for Camel messages that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.opentelemetry.instrumentationName* | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
-| *camel.opentelemetry.traceProcessors* | Setting this to true will create new OpenTelemetry Spans for each Camel Processors. Use the excludePattern property to filter out Processors. | false | boolean
-| *camel.opentelemetry2.enabled* | To enable OpenTelemetry 2 | false | boolean
-| *camel.opentelemetry2.encoding* | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
-| *camel.opentelemetry2.excludePatterns* | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.opentelemetry2.includePatterns* | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
-| *camel.opentelemetry2.instrumentationName* | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
-| *camel.opentelemetry2.traceProcessors* | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.opentelemetry.enabled` | To enable OpenTelemetry | false | boolean
+| `camel.opentelemetry.encoding` | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
+| `camel.opentelemetry.excludePatterns` | Adds an exclude pattern that will disable tracing for Camel messages that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.opentelemetry.instrumentationName` | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
+| `camel.opentelemetry.traceProcessors` | Setting this to true will create new OpenTelemetry Spans for each Camel Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.opentelemetry2.enabled` | To enable OpenTelemetry 2 | false | boolean
+| `camel.opentelemetry2.encoding` | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
+| `camel.opentelemetry2.excludePatterns` | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.opentelemetry2.includePatterns` | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
+| `camel.opentelemetry2.instrumentationName` | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
+| `camel.opentelemetry2.traceProcessors` | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
 |===
 
 
@@ -610,12 +610,12 @@ The camel.opentelemetry2 supports 6 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.opentelemetry2.enabled* | To enable OpenTelemetry 2 | false | boolean
-| *camel.opentelemetry2.encoding* | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
-| *camel.opentelemetry2.excludePatterns* | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.opentelemetry2.includePatterns* | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
-| *camel.opentelemetry2.instrumentationName* | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
-| *camel.opentelemetry2.traceProcessors* | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.opentelemetry2.enabled` | To enable OpenTelemetry 2 | false | boolean
+| `camel.opentelemetry2.encoding` | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
+| `camel.opentelemetry2.excludePatterns` | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.opentelemetry2.includePatterns` | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
+| `camel.opentelemetry2.instrumentationName` | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
+| `camel.opentelemetry2.traceProcessors` | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
 |===
 
 
@@ -625,11 +625,11 @@ The camel.telemetryDev supports 5 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.telemetryDev.enabled* | To enable TelemetryDev | false | boolean
-| *camel.telemetryDev.excludePatterns* | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.telemetryDev.includePatterns* | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
-| *camel.telemetryDev.traceFormat* | The output format for traces. |  | String
-| *camel.telemetryDev.traceProcessors* | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.telemetryDev.enabled` | To enable TelemetryDev | false | boolean
+| `camel.telemetryDev.excludePatterns` | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.telemetryDev.includePatterns` | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
+| `camel.telemetryDev.traceFormat` | The output format for traces. |  | String
+| `camel.telemetryDev.traceProcessors` | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
 |===
 
 
@@ -639,9 +639,9 @@ The camel.mdc supports 3 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.mdc.customExchangeHeaders* | Provide the headers you would like to use in the logging. Use &#42; value to include all available headers |  | String
-| *camel.mdc.customExchangeProperties* | Provide the properties you would like to use in the logging. Use &#42; value to include all available properties |  | String
-| *camel.mdc.enabled* | To enable MDC service | false | boolean
+| `camel.mdc.customExchangeHeaders` | Provide the headers you would like to use in the logging. Use &#42; value to include all available headers |  | String
+| `camel.mdc.customExchangeProperties` | Provide the properties you would like to use in the logging. Use &#42; value to include all available properties |  | String
+| `camel.mdc.enabled` | To enable MDC service | false | boolean
 |===
 
 
@@ -651,22 +651,22 @@ The camel.metrics supports 16 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.metrics.baseEndpointURIExchangeEventNotifier* | Whether to use static or dynamic values for Endpoint Name tags in captured metrics. By default, static values are used. When using dynamic tags, then a dynamic to (toD) can compute many different endpoint URIs that, can lead to many tags as the URI is dynamic, so use this with care if setting this option to false. | true | boolean
-| *camel.metrics.binders* | Additional Micrometer binders to include such as jvm-memory, processor, jvm-thread, and so forth. Multiple binders can be separated by comma. The following binders currently is available from Micrometer: class-loader, commons-object-pool2, file-descriptor, hystrix-metrics-binder, jvm-compilation, jvm-gc, jvm-heap-pressure, jvm-info, jvm-memory, jvm-thread, log4j2, logback, processor, uptime |  | String
-| *camel.metrics.clearOnReload* | Clear the captured metrics data when Camel is reloading routes such as when using Camel CLI. | true | boolean
-| *camel.metrics.enabled* | To enable Micrometer metrics. | false | boolean
-| *camel.metrics.enableExchangeEventNotifier* | Set whether to enable the MicrometerExchangeEventNotifier for capturing metrics on exchange processing times. | true | boolean
-| *camel.metrics.enableInstrumentedThreadPoolFactory* | Set whether to gather performance information about Camel Thread Pools by injecting an InstrumentedThreadPoolFactory. | false | boolean
-| *camel.metrics.enableMessageHistory* | Set whether to enable the MicrometerMessageHistoryFactory for capturing metrics on individual route node processing times. Depending on the number of configured route nodes, there is the potential to create a large volume of metrics. Therefore, this option is disabled by default. | false | boolean
-| *camel.metrics.enableRouteEventNotifier* | Set whether to enable the MicrometerRouteEventNotifier for capturing metrics on the total number of routes and total number of routes running. | true | boolean
-| *camel.metrics.enableRoutePolicy* | Set whether to enable the MicrometerRoutePolicyFactory for capturing metrics on route processing times. | true | boolean
-| *camel.metrics.logMetricsOnShutdown* | Log metrics when application is shutting down. (default, false). | false | boolean
-| *camel.metrics.logMetricsOnShutdownFilters* | List of metrics (comma separated) to log when application is shutting down. You can use character to log any metrics containing the wildcard, for example camel.exchanges. (default to all metrics available). |  | String
-| *camel.metrics.namingStrategy* | Controls the name style to use for metrics. Default = uses micrometer naming convention. Legacy = uses the classic naming style (camelCase) | default | String
-| *camel.metrics.path* | The path endpoint used to expose the metrics. | /observe/metrics | String
-| *camel.metrics.routePolicyLevel* | Sets the level of information to capture. all = both context and routes. | all | String
-| *camel.metrics.skipCamelInfo* | Skip the evaluation of app.info metric which contains runtime provider information (default, false). | false | boolean
-| *camel.metrics.textFormatVersion* | The text-format version to use with Prometheus scraping. 0.0.4 = text/plain; version=0.0.4; charset=utf-8 1.0.0 = application/openmetrics-text; version=1.0.0; charset=utf-8 | 0.0.4 | String
+| `camel.metrics.baseEndpointURIExchangeEventNotifier` | Whether to use static or dynamic values for Endpoint Name tags in captured metrics. By default, static values are used. When using dynamic tags, then a dynamic to (toD) can compute many different endpoint URIs that, can lead to many tags as the URI is dynamic, so use this with care if setting this option to false. | true | boolean
+| `camel.metrics.binders` | Additional Micrometer binders to include such as jvm-memory, processor, jvm-thread, and so forth. Multiple binders can be separated by comma. The following binders currently is available from Micrometer: class-loader, commons-object-pool2, file-descriptor, hystrix-metrics-binder, jvm-compilation, jvm-gc, jvm-heap-pressure, jvm-info, jvm-memory, jvm-thread, log4j2, logback, processor, uptime |  | String
+| `camel.metrics.clearOnReload` | Clear the captured metrics data when Camel is reloading routes such as when using Camel CLI. | true | boolean
+| `camel.metrics.enabled` | To enable Micrometer metrics. | false | boolean
+| `camel.metrics.enableExchangeEventNotifier` | Set whether to enable the MicrometerExchangeEventNotifier for capturing metrics on exchange processing times. | true | boolean
+| `camel.metrics.enableInstrumentedThreadPoolFactory` | Set whether to gather performance information about Camel Thread Pools by injecting an InstrumentedThreadPoolFactory. | false | boolean
+| `camel.metrics.enableMessageHistory` | Set whether to enable the MicrometerMessageHistoryFactory for capturing metrics on individual route node processing times. Depending on the number of configured route nodes, there is the potential to create a large volume of metrics. Therefore, this option is disabled by default. | false | boolean
+| `camel.metrics.enableRouteEventNotifier` | Set whether to enable the MicrometerRouteEventNotifier for capturing metrics on the total number of routes and total number of routes running. | true | boolean
+| `camel.metrics.enableRoutePolicy` | Set whether to enable the MicrometerRoutePolicyFactory for capturing metrics on route processing times. | true | boolean
+| `camel.metrics.logMetricsOnShutdown` | Log metrics when application is shutting down. (default, false). | false | boolean
+| `camel.metrics.logMetricsOnShutdownFilters` | List of metrics (comma separated) to log when application is shutting down. You can use character to log any metrics containing the wildcard, for example camel.exchanges. (default to all metrics available). |  | String
+| `camel.metrics.namingStrategy` | Controls the name style to use for metrics. Default = uses micrometer naming convention. Legacy = uses the classic naming style (camelCase) | default | String
+| `camel.metrics.path` | The path endpoint used to expose the metrics. | /observe/metrics | String
+| `camel.metrics.routePolicyLevel` | Sets the level of information to capture. all = both context and routes. | all | String
+| `camel.metrics.skipCamelInfo` | Skip the evaluation of app.info metric which contains runtime provider information (default, false). | false | boolean
+| `camel.metrics.textFormatVersion` | The text-format version to use with Prometheus scraping. 0.0.4 = text/plain; version=0.0.4; charset=utf-8 1.0.0 = application/openmetrics-text; version=1.0.0; charset=utf-8 | 0.0.4 | String
 |===
 
 
@@ -676,17 +676,17 @@ The camel.faulttolerance supports 11 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.faulttolerance.bulkheadEnabled* | Whether bulkhead is enabled or not on the circuit breaker. Default is false. | false | Boolean
-| *camel.faulttolerance.bulkheadMaxConcurrentCalls* | Configures the max amount of concurrent calls the bulkhead will support. Default value is 10. | 10 | Integer
-| *camel.faulttolerance.bulkheadWaitingTaskQueue* | Configures the task queue size for holding waiting tasks to be processed by the bulkhead. Default value is 10. | 10 | Integer
-| *camel.faulttolerance.delay* | Control how long the circuit breaker stays open. The default is 5 seconds. | 5000 | Long
-| *camel.faulttolerance.failureRatio* | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Integer
-| *camel.faulttolerance.requestVolumeThreshold* | Controls the size of the rolling window used when the circuit breaker is closed Default value is 20. | 20 | Integer
-| *camel.faulttolerance.successThreshold* | Controls the number of trial calls which are allowed when the circuit breaker is half-open Default value is 1. | 1 | Integer
-| *camel.faulttolerance.threadOffloadExecutorService* | References a custom thread pool to use when offloading a guarded action to another thread. |  | String
-| *camel.faulttolerance.timeoutDuration* | Configures the thread execution timeout. Default value is 1000 milliseconds. | 1000 | Long
-| *camel.faulttolerance.timeoutEnabled* | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
-| *camel.faulttolerance.typedGuard* | Refers to an existing io.smallrye.faulttolerance.api.TypedGuard instance to lookup and use from the registry. When using this, then any other TypedGuard circuit breaker options are not in use. |  | String
+| `camel.faulttolerance.bulkheadEnabled` | Whether bulkhead is enabled or not on the circuit breaker. Default is false. | false | Boolean
+| `camel.faulttolerance.bulkheadMaxConcurrentCalls` | Configures the max amount of concurrent calls the bulkhead will support. Default value is 10. | 10 | Integer
+| `camel.faulttolerance.bulkheadWaitingTaskQueue` | Configures the task queue size for holding waiting tasks to be processed by the bulkhead. Default value is 10. | 10 | Integer
+| `camel.faulttolerance.delay` | Control how long the circuit breaker stays open. The default is 5 seconds. | 5000 | Long
+| `camel.faulttolerance.failureRatio` | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Integer
+| `camel.faulttolerance.requestVolumeThreshold` | Controls the size of the rolling window used when the circuit breaker is closed Default value is 20. | 20 | Integer
+| `camel.faulttolerance.successThreshold` | Controls the number of trial calls which are allowed when the circuit breaker is half-open Default value is 1. | 1 | Integer
+| `camel.faulttolerance.threadOffloadExecutorService` | References a custom thread pool to use when offloading a guarded action to another thread. |  | String
+| `camel.faulttolerance.timeoutDuration` | Configures the thread execution timeout. Default value is 1000 milliseconds. | 1000 | Long
+| `camel.faulttolerance.timeoutEnabled` | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
+| `camel.faulttolerance.typedGuard` | Refers to an existing io.smallrye.faulttolerance.api.TypedGuard instance to lookup and use from the registry. When using this, then any other TypedGuard circuit breaker options are not in use. |  | String
 |===
 
 
@@ -696,31 +696,31 @@ The camel.resilience4j supports 25 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.resilience4j.asynchronous* | Whether to use asynchronous (non-blocking) processing using Resilience4j's CompletionStage-based decorators. When enabled, the caller thread is released immediately and processing completes asynchronously. | false | Boolean
-| *camel.resilience4j.automaticTransitionFromOpenToHalfOpenEnabled* | Enables automatic transition from OPEN to HALF_OPEN state once the waitDurationInOpenState has passed. | false | Boolean
-| *camel.resilience4j.bulkheadEnabled* | Whether bulkhead is enabled or not on the circuit breaker. | false | Boolean
-| *camel.resilience4j.bulkheadFairCallHandlingEnabled* | Configures whether the bulkhead uses a fair calling strategy. When enabled (default), a fair strategy guarantees the order of incoming requests (FIFO). When disabled, no ordering is guaranteed and may improve throughput. | true | Boolean
-| *camel.resilience4j.bulkheadMaxConcurrentCalls* | Configures the max amount of concurrent calls the bulkhead will support. |  | Integer
-| *camel.resilience4j.bulkheadMaxWaitDuration* | Configures a maximum amount of time which the calling thread will wait to enter the bulkhead. Accepts Camel duration expressions (e.g. 500ms, 1s) or millisecond values. Default is 0 (no waiting). |  | String
-| *camel.resilience4j.circuitBreaker* | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreaker instance to lookup and use from the registry. When using this, then any other circuit breaker options are not in use. |  | String
-| *camel.resilience4j.config* | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreakerConfig instance to lookup and use from the registry. |  | String
-| *camel.resilience4j.failureRateThreshold* | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Float
-| *camel.resilience4j.maxWaitDurationInHalfOpenState* | Configures the maximum wait duration which controls how long the CircuitBreaker should stay in Half Open state, before it switches to open. Value 0 means circuit breaker will wait in half open state until all permitted calls have been completed. Accepts Camel duration expressions (e.g. 10s, 1m) or millisecond values. | 0 | String
-| *camel.resilience4j.micrometerEnabled* | Whether to enable collecting statistics using Micrometer. This requires adding camel-resilience4j-micrometer JAR to the classpath. | false | Boolean
-| *camel.resilience4j.minimumNumberOfCalls* | Configures configures the minimum number of calls which are required (per sliding window period) before the CircuitBreaker can calculate the error rate. For example, if minimumNumberOfCalls is 10, then at least 10 calls must be recorded, before the failure rate can be calculated. If only 9 calls have been recorded the CircuitBreaker will not transition to open even if all 9 calls have failed. Default minimumNumberOfCalls is 100 | 100 | Integer
-| *camel.resilience4j.permittedNumberOfCallsInHalfOpenState* | Configures the number of permitted calls when the CircuitBreaker is half open. The size must be greater than 0. Default size is 10. | 10 | Integer
-| *camel.resilience4j.slidingWindowSize* | Configures the size of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. slidingWindowSize configures the size of the sliding window. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. The slidingWindowSize must be greater than 0. The minimumNumberOfCalls must be greater than 0. If the slidingWindowType is COUNT_BASED, the minimumNumberOfCalls cannot be greater than slidingWindowSize . If the slidingWindowType is TIME_BASED, you can pick whatever you want. Default slidingWindowSize is 100. | 100 | Integer
-| *camel.resilience4j.slidingWindowSynchronizationStrategy* | Configures the synchronization strategy for the sliding window. LOCK_FREE uses a CAS-based lock-free algorithm for better performance under high concurrency. SYNCHRONIZED uses blocking locks with lower memory allocation. | SYNCHRONIZED | String
-| *camel.resilience4j.slidingWindowType* | Configures the type of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. Default slidingWindowType is COUNT_BASED. | COUNT_BASED | String
-| *camel.resilience4j.slowCallDurationThreshold* | Configures the duration threshold above which calls are considered as slow and increase the slow calls percentage. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
-| *camel.resilience4j.slowCallRateThreshold* | Configures a threshold in percentage. The CircuitBreaker considers a call as slow when the call duration is greater than slowCallDurationThreshold(Duration. When the percentage of slow calls is equal or greater the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 100 percentage which means that all recorded calls must be slower than slowCallDurationThreshold. | 100 | Float
-| *camel.resilience4j.throwExceptionWhenHalfOpenOrOpenState* | Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open or open. | false | Boolean
-| *camel.resilience4j.timeoutCancelRunningFuture* | Configures whether cancel is called on the running future. Defaults to true. | true | Boolean
-| *camel.resilience4j.timeoutDuration* | Configures the thread execution timeout. Accepts Camel duration expressions (e.g. 1s, 500ms) or millisecond values. Default value is 1000 millis (1 second). | 1000 | String
-| *camel.resilience4j.timeoutEnabled* | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
-| *camel.resilience4j.timeoutExecutorService* | References to a custom thread pool to use when timeout is enabled (uses ForkJoinPool#commonPool() by default) |  | String
-| *camel.resilience4j.waitDurationInOpenState* | Configures the wait duration which specifies how long the CircuitBreaker should stay open, before it switches to half open. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
-| *camel.resilience4j.writableStackTraceEnabled* | Enables writable stack traces. When set to false, Exception.getStackTrace returns a zero length array. This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls). | false | Boolean
+| `camel.resilience4j.asynchronous` | Whether to use asynchronous (non-blocking) processing using Resilience4j's CompletionStage-based decorators. When enabled, the caller thread is released immediately and processing completes asynchronously. | false | Boolean
+| `camel.resilience4j.automaticTransitionFromOpenToHalfOpenEnabled` | Enables automatic transition from OPEN to HALF_OPEN state once the waitDurationInOpenState has passed. | false | Boolean
+| `camel.resilience4j.bulkheadEnabled` | Whether bulkhead is enabled or not on the circuit breaker. | false | Boolean
+| `camel.resilience4j.bulkheadFairCallHandlingEnabled` | Configures whether the bulkhead uses a fair calling strategy. When enabled (default), a fair strategy guarantees the order of incoming requests (FIFO). When disabled, no ordering is guaranteed and may improve throughput. | true | Boolean
+| `camel.resilience4j.bulkheadMaxConcurrentCalls` | Configures the max amount of concurrent calls the bulkhead will support. |  | Integer
+| `camel.resilience4j.bulkheadMaxWaitDuration` | Configures a maximum amount of time which the calling thread will wait to enter the bulkhead. Accepts Camel duration expressions (e.g. 500ms, 1s) or millisecond values. Default is 0 (no waiting). |  | String
+| `camel.resilience4j.circuitBreaker` | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreaker instance to lookup and use from the registry. When using this, then any other circuit breaker options are not in use. |  | String
+| `camel.resilience4j.config` | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreakerConfig instance to lookup and use from the registry. |  | String
+| `camel.resilience4j.failureRateThreshold` | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Float
+| `camel.resilience4j.maxWaitDurationInHalfOpenState` | Configures the maximum wait duration which controls how long the CircuitBreaker should stay in Half Open state, before it switches to open. Value 0 means circuit breaker will wait in half open state until all permitted calls have been completed. Accepts Camel duration expressions (e.g. 10s, 1m) or millisecond values. | 0 | String
+| `camel.resilience4j.micrometerEnabled` | Whether to enable collecting statistics using Micrometer. This requires adding camel-resilience4j-micrometer JAR to the classpath. | false | Boolean
+| `camel.resilience4j.minimumNumberOfCalls` | Configures configures the minimum number of calls which are required (per sliding window period) before the CircuitBreaker can calculate the error rate. For example, if minimumNumberOfCalls is 10, then at least 10 calls must be recorded, before the failure rate can be calculated. If only 9 calls have been recorded the CircuitBreaker will not transition to open even if all 9 calls have failed. Default minimumNumberOfCalls is 100 | 100 | Integer
+| `camel.resilience4j.permittedNumberOfCallsInHalfOpenState` | Configures the number of permitted calls when the CircuitBreaker is half open. The size must be greater than 0. Default size is 10. | 10 | Integer
+| `camel.resilience4j.slidingWindowSize` | Configures the size of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. slidingWindowSize configures the size of the sliding window. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. The slidingWindowSize must be greater than 0. The minimumNumberOfCalls must be greater than 0. If the slidingWindowType is COUNT_BASED, the minimumNumberOfCalls cannot be greater than slidingWindowSize . If the slidingWindowType is TIME_BASED, you can pick whatever you want. Default slidingWindowSize is 100. | 100 | Integer
+| `camel.resilience4j.slidingWindowSynchronizationStrategy` | Configures the synchronization strategy for the sliding window. LOCK_FREE uses a CAS-based lock-free algorithm for better performance under high concurrency. SYNCHRONIZED uses blocking locks with lower memory allocation. | SYNCHRONIZED | String
+| `camel.resilience4j.slidingWindowType` | Configures the type of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. Default slidingWindowType is COUNT_BASED. | COUNT_BASED | String
+| `camel.resilience4j.slowCallDurationThreshold` | Configures the duration threshold above which calls are considered as slow and increase the slow calls percentage. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
+| `camel.resilience4j.slowCallRateThreshold` | Configures a threshold in percentage. The CircuitBreaker considers a call as slow when the call duration is greater than slowCallDurationThreshold(Duration. When the percentage of slow calls is equal or greater the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 100 percentage which means that all recorded calls must be slower than slowCallDurationThreshold. | 100 | Float
+| `camel.resilience4j.throwExceptionWhenHalfOpenOrOpenState` | Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open or open. | false | Boolean
+| `camel.resilience4j.timeoutCancelRunningFuture` | Configures whether cancel is called on the running future. Defaults to true. | true | Boolean
+| `camel.resilience4j.timeoutDuration` | Configures the thread execution timeout. Accepts Camel duration expressions (e.g. 1s, 500ms) or millisecond values. Default value is 1000 millis (1 second). | 1000 | String
+| `camel.resilience4j.timeoutEnabled` | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
+| `camel.resilience4j.timeoutExecutorService` | References to a custom thread pool to use when timeout is enabled (uses ForkJoinPool#commonPool() by default) |  | String
+| `camel.resilience4j.waitDurationInOpenState` | Configures the wait duration which specifies how long the CircuitBreaker should stay open, before it switches to half open. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
+| `camel.resilience4j.writableStackTraceEnabled` | Enables writable stack traces. When set to false, Exception.getStackTrace returns a zero length array. This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls). | false | Boolean
 |===
 
 
@@ -730,11 +730,11 @@ The camel.lra supports 5 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.lra.coordinatorContextPath* | The context-path for the LRA coordinator. Is default /lra-coordinator | /lra-coordinator | String
-| *camel.lra.coordinatorUrl* | The URL for the LRA coordinator service that orchestrates the transactions |  | String
-| *camel.lra.enabled* | To enable Saga LRA | false | boolean
-| *camel.lra.localParticipantContextPath* | The context-path for the local participant. Is default /lra-participant | /lra-participant | String
-| *camel.lra.localParticipantUrl* | The URL for the local participant |  | String
+| `camel.lra.coordinatorContextPath` | The context-path for the LRA coordinator. Is default /lra-coordinator | /lra-coordinator | String
+| `camel.lra.coordinatorUrl` | The URL for the LRA coordinator service that orchestrates the transactions |  | String
+| `camel.lra.enabled` | To enable Saga LRA | false | boolean
+| `camel.lra.localParticipantContextPath` | The context-path for the local participant. Is default /lra-participant | /lra-participant | String
+| `camel.lra.localParticipantUrl` | The URL for the local participant |  | String
 |===
 
 
@@ -744,14 +744,14 @@ The camel.errorRegistry supports 8 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.errorRegistry.bodyIncludeFiles* | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
-| *camel.errorRegistry.bodyIncludeStreams* | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
-| *camel.errorRegistry.bodyMaxChars* | To limit the message body to a maximum size in the captured error data. Use 0 or negative value to use unlimited size. | 32768 | int
-| *camel.errorRegistry.enabled* | Whether the error registry is enabled to capture errors during message routing. | false | boolean
-| *camel.errorRegistry.includeExchangeProperties* | Whether to include the exchange properties in the captured error data. | true | boolean
-| *camel.errorRegistry.includeExchangeVariables* | Whether to include the exchange variables in the captured error data. | true | boolean
-| *camel.errorRegistry.maximumEntries* | The maximum number of error entries to keep in the registry. When the limit is exceeded, the oldest entries are evicted. | 100 | int
-| *camel.errorRegistry.timeToLiveSeconds* | The time-to-live in seconds for error entries. Entries older than this are evicted. The default value is 0 (disabled). | 0 | int
+| `camel.errorRegistry.bodyIncludeFiles` | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
+| `camel.errorRegistry.bodyIncludeStreams` | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
+| `camel.errorRegistry.bodyMaxChars` | To limit the message body to a maximum size in the captured error data. Use 0 or negative value to use unlimited size. | 32768 | int
+| `camel.errorRegistry.enabled` | Whether the error registry is enabled to capture errors during message routing. | false | boolean
+| `camel.errorRegistry.includeExchangeProperties` | Whether to include the exchange properties in the captured error data. | true | boolean
+| `camel.errorRegistry.includeExchangeVariables` | Whether to include the exchange variables in the captured error data. | true | boolean
+| `camel.errorRegistry.maximumEntries` | The maximum number of error entries to keep in the registry. When the limit is exceeded, the oldest entries are evicted. | 100 | int
+| `camel.errorRegistry.timeToLiveSeconds` | The time-to-live in seconds for error entries. Entries older than this are evicted. The default value is 0 (disabled). | 0 | int
 |===
 
 
@@ -761,16 +761,16 @@ The camel.cluster.file supports 10 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.file.acquireLockDelay* | The time to wait before starting to try to acquire the cluster lock. Note that if FileLockClusterService determines no cluster members are running or cannot reliably determine the cluster state, the initial delay is computed from the acquireLockInterval. | 1 | long
-| *camel.cluster.file.acquireLockDelayUnit* | The time unit for the acquireLockDelay | SECONDS | TimeUnit
-| *camel.cluster.file.acquireLockInterval* | The time to wait between attempts to try to acquire the cluster lock evaluated using wall-clock time. All cluster members must use the same value so leadership checks and leader liveness detection remain consistent. | 10 | long
-| *camel.cluster.file.acquireLockIntervalUnit* | The time unit for the acquireLockInterval | SECONDS | TimeUnit
-| *camel.cluster.file.clusterDataTaskMaxAttempts* | Sets how many times a cluster data task will run, counting both the first execution and subsequent retries in case of failure or timeout. The default is 5 attempts. This can be useful when the cluster data root is on network based file storage, where I/O operations may occasionally block for long or unpredictable periods. | 5 | int
-| *camel.cluster.file.clusterDataTaskTimeout* | Sets the timeout for a cluster data task (reading or writing cluster data). The default is 10 seconds. Timeouts are useful when the cluster data root is on network storage, where I/O operations may occasionally block for long or unpredictable periods. | 10 | long
-| *camel.cluster.file.clusterDataTaskTimeoutUnit* | The time unit for the clusterDataTaskTimeoutUnit | SECONDS | TimeUnit
-| *camel.cluster.file.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.file.heartbeatTimeoutMultiplier* | Multiplier applied to the cluster leader acquireLockInterval to determine how long followers should wait before considering the leader stale. For example, if the leader updates its heartbeat every 2 seconds and the heartbeatTimeoutMultiplier is 3, followers will tolerate up to 2s * 3 = 6s of silence before declaring the leader unavailable. | 5 | int
-| *camel.cluster.file.root* | The root file path |  | String
+| `camel.cluster.file.acquireLockDelay` | The time to wait before starting to try to acquire the cluster lock. Note that if FileLockClusterService determines no cluster members are running or cannot reliably determine the cluster state, the initial delay is computed from the acquireLockInterval. | 1 | long
+| `camel.cluster.file.acquireLockDelayUnit` | The time unit for the acquireLockDelay | SECONDS | TimeUnit
+| `camel.cluster.file.acquireLockInterval` | The time to wait between attempts to try to acquire the cluster lock evaluated using wall-clock time. All cluster members must use the same value so leadership checks and leader liveness detection remain consistent. | 10 | long
+| `camel.cluster.file.acquireLockIntervalUnit` | The time unit for the acquireLockInterval | SECONDS | TimeUnit
+| `camel.cluster.file.clusterDataTaskMaxAttempts` | Sets how many times a cluster data task will run, counting both the first execution and subsequent retries in case of failure or timeout. The default is 5 attempts. This can be useful when the cluster data root is on network based file storage, where I/O operations may occasionally block for long or unpredictable periods. | 5 | int
+| `camel.cluster.file.clusterDataTaskTimeout` | Sets the timeout for a cluster data task (reading or writing cluster data). The default is 10 seconds. Timeouts are useful when the cluster data root is on network storage, where I/O operations may occasionally block for long or unpredictable periods. | 10 | long
+| `camel.cluster.file.clusterDataTaskTimeoutUnit` | The time unit for the clusterDataTaskTimeoutUnit | SECONDS | TimeUnit
+| `camel.cluster.file.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.file.heartbeatTimeoutMultiplier` | Multiplier applied to the cluster leader acquireLockInterval to determine how long followers should wait before considering the leader stale. For example, if the leader updates its heartbeat every 2 seconds and the heartbeatTimeoutMultiplier is 3, followers will tolerate up to 2s * 3 = 6s of silence before declaring the leader unavailable. | 5 | int
+| `camel.cluster.file.root` | The root file path |  | String
 |===
 
 
@@ -780,21 +780,21 @@ The camel.cluster.kubernetes supports 15 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.kubernetes.clusterLabels* | Labels used to identify the members of the cluster. |  | Map
-| *camel.cluster.kubernetes.configuration* | To use an existing configuration for Kubernetes |  | KubernetesConfiguration
-| *camel.cluster.kubernetes.connectionTimeout* | Connection timeout in milliseconds to use when making requests to the Kubernetes API server. |  | Integer
-| *camel.cluster.kubernetes.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.kubernetes.groupName* | Name of the lock group (or namespace according to the Camel cluster convention) within the chosen ConfigMap. |  | String
-| *camel.cluster.kubernetes.jitterFactor* | A jitter factor to apply in order to prevent all pods to call Kubernetes APIs in the same instant. | 1.2 | double
-| *camel.cluster.kubernetes.kubernetesResourceName* | Name of the resource used for locking (or prefix, in case multiple ones are used). | leaders | String
-| *camel.cluster.kubernetes.kubernetesResourcesNamespace* | Kubernetes namespace containing the pods and the ConfigMap used for locking. |  | String
-| *camel.cluster.kubernetes.leaseDurationMillis* | The default duration of the lease for the current leader. | 15000 | long
-| *camel.cluster.kubernetes.leaseResourceType* | Kubernetes resource type used to hold the leases. | Lease | LeaseResourceType
-| *camel.cluster.kubernetes.masterUrl* | URL to a remote Kubernetes API server. This should only be used when your Camel application is connecting from outside Kubernetes. If you run your Camel application inside Kubernetes, then you can use local or client as the URL to tell Camel to run in local mode. If you connect remotely to Kubernetes, then you may also need some of the many other configuration options for secured connection with certificates, etc. |  | String
-| *camel.cluster.kubernetes.namespace* | Kubernetes namespace |  | String
-| *camel.cluster.kubernetes.podName* | Name of the current pod (defaults to host name). |  | String
-| *camel.cluster.kubernetes.renewDeadlineMillis* | The deadline after which the leader must stop its services because it may have lost the leadership. | 10000 | long
-| *camel.cluster.kubernetes.retryPeriodMillis* | The time between two subsequent attempts to check and acquire the leadership. It is randomized using the jitter factor. | 2000 | long
+| `camel.cluster.kubernetes.clusterLabels` | Labels used to identify the members of the cluster. |  | Map
+| `camel.cluster.kubernetes.configuration` | To use an existing configuration for Kubernetes |  | KubernetesConfiguration
+| `camel.cluster.kubernetes.connectionTimeout` | Connection timeout in milliseconds to use when making requests to the Kubernetes API server. |  | Integer
+| `camel.cluster.kubernetes.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.kubernetes.groupName` | Name of the lock group (or namespace according to the Camel cluster convention) within the chosen ConfigMap. |  | String
+| `camel.cluster.kubernetes.jitterFactor` | A jitter factor to apply in order to prevent all pods to call Kubernetes APIs in the same instant. | 1.2 | double
+| `camel.cluster.kubernetes.kubernetesResourceName` | Name of the resource used for locking (or prefix, in case multiple ones are used). | leaders | String
+| `camel.cluster.kubernetes.kubernetesResourcesNamespace` | Kubernetes namespace containing the pods and the ConfigMap used for locking. |  | String
+| `camel.cluster.kubernetes.leaseDurationMillis` | The default duration of the lease for the current leader. | 15000 | long
+| `camel.cluster.kubernetes.leaseResourceType` | Kubernetes resource type used to hold the leases. | Lease | LeaseResourceType
+| `camel.cluster.kubernetes.masterUrl` | URL to a remote Kubernetes API server. This should only be used when your Camel application is connecting from outside Kubernetes. If you run your Camel application inside Kubernetes, then you can use local or client as the URL to tell Camel to run in local mode. If you connect remotely to Kubernetes, then you may also need some of the many other configuration options for secured connection with certificates, etc. |  | String
+| `camel.cluster.kubernetes.namespace` | Kubernetes namespace |  | String
+| `camel.cluster.kubernetes.podName` | Name of the current pod (defaults to host name). |  | String
+| `camel.cluster.kubernetes.renewDeadlineMillis` | The deadline after which the leader must stop its services because it may have lost the leadership. | 10000 | long
+| `camel.cluster.kubernetes.retryPeriodMillis` | The time between two subsequent attempts to check and acquire the leadership. It is randomized using the jitter factor. | 2000 | long
 |===
 
 
@@ -804,18 +804,18 @@ The camel.cluster.zookeeper supports 12 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.zookeeper.basePath* | The base path to store in ZooKeeper |  | String
-| *camel.cluster.zookeeper.connectTimeout* | Connect timeout (millis) | 15000 | long
-| *camel.cluster.zookeeper.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.zookeeper.id* | Node id |  | String
-| *camel.cluster.zookeeper.maxCloseWait* | Time to wait (millis) during close to join background threads | 1000 | long
-| *camel.cluster.zookeeper.namespace* | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace |  | String
-| *camel.cluster.zookeeper.nodes* | The Zookeeper server hosts (multiple servers can be separated by comma) |  | String
-| *camel.cluster.zookeeper.reconnectBaseSleepTime* | Initial amount of time (millis) to wait between retries | 1000 | long
-| *camel.cluster.zookeeper.reconnectMaxRetries* | Max number of times to retry | 3 | int
-| *camel.cluster.zookeeper.reconnectMaxSleepTime* | Max time (millis) to sleep on each retry |  | long
-| *camel.cluster.zookeeper.retryPolicy* | To use a custom retry policy implementation |  | RetryPolicy
-| *camel.cluster.zookeeper.sessionTimeout* | Session timeout (millis) | 60000 | long
+| `camel.cluster.zookeeper.basePath` | The base path to store in ZooKeeper |  | String
+| `camel.cluster.zookeeper.connectTimeout` | Connect timeout (millis) | 15000 | long
+| `camel.cluster.zookeeper.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.zookeeper.id` | Node id |  | String
+| `camel.cluster.zookeeper.maxCloseWait` | Time to wait (millis) during close to join background threads | 1000 | long
+| `camel.cluster.zookeeper.namespace` | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace |  | String
+| `camel.cluster.zookeeper.nodes` | The Zookeeper server hosts (multiple servers can be separated by comma) |  | String
+| `camel.cluster.zookeeper.reconnectBaseSleepTime` | Initial amount of time (millis) to wait between retries | 1000 | long
+| `camel.cluster.zookeeper.reconnectMaxRetries` | Max number of times to retry | 3 | int
+| `camel.cluster.zookeeper.reconnectMaxSleepTime` | Max time (millis) to sleep on each retry |  | long
+| `camel.cluster.zookeeper.retryPolicy` | To use a custom retry policy implementation |  | RetryPolicy
+| `camel.cluster.zookeeper.sessionTimeout` | Session timeout (millis) | 60000 | long
 |===
 
 
@@ -825,23 +825,23 @@ The camel.cluster.consul supports 17 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.consul.aclToken* | Sets the ACL token to be used with Consul |  | String
-| *camel.cluster.consul.blockSeconds* | The second to wait for a watch event, default 10 seconds | 10 | int
-| *camel.cluster.consul.configuration* | To use an existing configuration |  | ConsulClusterConfiguration
-| *camel.cluster.consul.connectTimeout* | Connect timeout in millis |  | int
-| *camel.cluster.consul.datacenter* | The data center |  | String
-| *camel.cluster.consul.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.consul.id* | Client id registered as _consul.service.registry.id |  | String
-| *camel.cluster.consul.password* | Sets the password to be used for basic authentication |  | String
-| *camel.cluster.consul.readTimeout* | Read timeout in millis |  | int
-| *camel.cluster.consul.rootPath* | The Consul cluster root directory path | /camel | String
-| *camel.cluster.consul.sessionLockDelay* | Session lock delay in seconds | 5 | int
-| *camel.cluster.consul.sessionRefreshInterval* | Session refresh interval in seconds | 5 | int
-| *camel.cluster.consul.sessionTtl* | Session time to live in seconds | 60 | int
-| *camel.cluster.consul.sslContextParameters* | SSL configuration for advanced security configuration |  | SSLContextParameters
-| *camel.cluster.consul.url* | The Consul agent URL |  | String
-| *camel.cluster.consul.userName* | Sets the username to be used for basic authentication |  | String
-| *camel.cluster.consul.writeTimeout* | Write timeout in mills |  | int
+| `camel.cluster.consul.aclToken` | Sets the ACL token to be used with Consul |  | String
+| `camel.cluster.consul.blockSeconds` | The second to wait for a watch event, default 10 seconds | 10 | int
+| `camel.cluster.consul.configuration` | To use an existing configuration |  | ConsulClusterConfiguration
+| `camel.cluster.consul.connectTimeout` | Connect timeout in millis |  | int
+| `camel.cluster.consul.datacenter` | The data center |  | String
+| `camel.cluster.consul.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.consul.id` | Client id registered as _consul.service.registry.id |  | String
+| `camel.cluster.consul.password` | Sets the password to be used for basic authentication |  | String
+| `camel.cluster.consul.readTimeout` | Read timeout in millis |  | int
+| `camel.cluster.consul.rootPath` | The Consul cluster root directory path | /camel | String
+| `camel.cluster.consul.sessionLockDelay` | Session lock delay in seconds | 5 | int
+| `camel.cluster.consul.sessionRefreshInterval` | Session refresh interval in seconds | 5 | int
+| `camel.cluster.consul.sessionTtl` | Session time to live in seconds | 60 | int
+| `camel.cluster.consul.sslContextParameters` | SSL configuration for advanced security configuration |  | SSLContextParameters
+| `camel.cluster.consul.url` | The Consul agent URL |  | String
+| `camel.cluster.consul.userName` | Sets the username to be used for basic authentication |  | String
+| `camel.cluster.consul.writeTimeout` | Write timeout in mills |  | int
 |===
 
 
@@ -851,11 +851,11 @@ The camel.cluster.jgroups-raft supports 5 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.jgroups-raft.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.jgroups-raft.id* | Unique Raft id |  | String
-| *camel.cluster.jgroups-raft.jgroupsClusterName* | The name of the cluster | jgroupsraft-master | String
-| *camel.cluster.jgroups-raft.jgroupsConfig* | The path to the JGroups Raft configuration | raft.xml | String
-| *camel.cluster.jgroups-raft.raftHandle* | To use a custom RaftHandler |  | RaftHandle
+| `camel.cluster.jgroups-raft.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.jgroups-raft.id` | Unique Raft id |  | String
+| `camel.cluster.jgroups-raft.jgroupsClusterName` | The name of the cluster | jgroupsraft-master | String
+| `camel.cluster.jgroups-raft.jgroupsConfig` | The path to the JGroups Raft configuration | raft.xml | String
+| `camel.cluster.jgroups-raft.raftHandle` | To use a custom RaftHandler |  | RaftHandle
 |===
 
 
@@ -865,22 +865,22 @@ The camel.cluster.infinispan supports 16 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.infinispan.cacheContainer* | Specifies the cache Container to connect |  | RemoteCacheManager
-| *camel.cluster.infinispan.cacheContainerConfiguration* | The CacheContainer configuration. Used if the cacheContainer is not defined. |  | Configuration
-| *camel.cluster.infinispan.configuration* | To use an existing configuration |  | InfinispanRemoteClusterConfiguration
-| *camel.cluster.infinispan.configurationProperties* | Implementation specific properties for the CacheManager |  | Map
-| *camel.cluster.infinispan.configurationUri* | An implementation specific URI for the CacheManager |  | String
-| *camel.cluster.infinispan.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.infinispan.hosts* | Specifies the host of the cache on Infinispan instance. Multiple hosts can be separated by semicolon. |  | String
-| *camel.cluster.infinispan.id* | Node id |  | String
-| *camel.cluster.infinispan.lifespan* | The lifespan of the cache entry for the local cluster member registered to the inventory | 30 | long
-| *camel.cluster.infinispan.lifespanTimeUnit* | The TimeUnit of the lifespan | SECONDS | TimeUnit
-| *camel.cluster.infinispan.password* | Define the password to access the infinispan instance |  | String
-| *camel.cluster.infinispan.saslMechanism* | Define the SASL Mechanism to access the infinispan instance |  | String
-| *camel.cluster.infinispan.secure* | Define if we are connecting to a secured Infinispan instance | false | boolean
-| *camel.cluster.infinispan.securityRealm* | Define the security realm to access the infinispan instance |  | String
-| *camel.cluster.infinispan.securityServerName* | Define the security server name to access the infinispan instance |  | String
-| *camel.cluster.infinispan.username* | Define the username to access the infinispan instance |  | String
+| `camel.cluster.infinispan.cacheContainer` | Specifies the cache Container to connect |  | RemoteCacheManager
+| `camel.cluster.infinispan.cacheContainerConfiguration` | The CacheContainer configuration. Used if the cacheContainer is not defined. |  | Configuration
+| `camel.cluster.infinispan.configuration` | To use an existing configuration |  | InfinispanRemoteClusterConfiguration
+| `camel.cluster.infinispan.configurationProperties` | Implementation specific properties for the CacheManager |  | Map
+| `camel.cluster.infinispan.configurationUri` | An implementation specific URI for the CacheManager |  | String
+| `camel.cluster.infinispan.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.infinispan.hosts` | Specifies the host of the cache on Infinispan instance. Multiple hosts can be separated by semicolon. |  | String
+| `camel.cluster.infinispan.id` | Node id |  | String
+| `camel.cluster.infinispan.lifespan` | The lifespan of the cache entry for the local cluster member registered to the inventory | 30 | long
+| `camel.cluster.infinispan.lifespanTimeUnit` | The TimeUnit of the lifespan | SECONDS | TimeUnit
+| `camel.cluster.infinispan.password` | Define the password to access the infinispan instance |  | String
+| `camel.cluster.infinispan.saslMechanism` | Define the SASL Mechanism to access the infinispan instance |  | String
+| `camel.cluster.infinispan.secure` | Define if we are connecting to a secured Infinispan instance | false | boolean
+| `camel.cluster.infinispan.securityRealm` | Define the security realm to access the infinispan instance |  | String
+| `camel.cluster.infinispan.securityServerName` | Define the security server name to access the infinispan instance |  | String
+| `camel.cluster.infinispan.username` | Define the username to access the infinispan instance |  | String
 |===
 // main options: END
 

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/properties-component.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/properties-component.adoc
@@ -123,25 +123,25 @@ The component supports the following options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.component.properties.auto-discover-properties-sources* | Whether to automatically discovery instances of PropertiesSource from registry and service factory. | true | Boolean
-| *camel.component.properties.default-fallback-enabled* | If false, the component does not attempt to find a default for the key by looking after the colon separator. | true | Boolean
-| *camel.component.properties.encoding* | Encoding to use when loading properties file from the file system or classpath.
+| `camel.component.properties.auto-discover-properties-sources` | Whether to automatically discovery instances of PropertiesSource from registry and service factory. | true | Boolean
+| `camel.component.properties.default-fallback-enabled` | If false, the component does not attempt to find a default for the key by looking after the colon separator. | true | Boolean
+| `camel.component.properties.encoding` | Encoding to use when loading properties file from the file system or classpath.
 If no encoding has been set, then the properties files is loaded using ISO-8859-1 encoding (latin-1) as documented by java.util.Properties#load(java.io.InputStream) |  | String
-| *camel.component.properties.environment-variable-mode* | Sets the OS environment variables mode (0 = never, 1 = fallback, 2 = override).
+| `camel.component.properties.environment-variable-mode` | Sets the OS environment variables mode (0 = never, 1 = fallback, 2 = override).
 The default mode (override) is to use OS environment variables if present, and override any existing properties.
 OS environment variable mode is checked before JVM system property mode | 2 | Integer
-| *camel.component.properties.ignore-missing-location* | Whether to silently ignore if a location cannot be located, such as a properties file not found. | false | Boolean
-| *camel.component.properties.initial-properties* | Sets initial properties which will be used before any locations are resolved.
+| `camel.component.properties.ignore-missing-location` | Whether to silently ignore if a location cannot be located, such as a properties file not found. | false | Boolean
+| `camel.component.properties.initial-properties` | Sets initial properties which will be used before any locations are resolved.
 The option is a java.util.Properties type. |  | String
-| *camel.component.properties.location* | A list of locations to load properties.
+| `camel.component.properties.location` | A list of locations to load properties.
 You can use comma to separate multiple locations.
 This option will override any default locations and only use the locations from this option. |  | String
-| *camel.component.properties.nested-placeholder* | Whether to support nested property placeholders. A nested placeholder, means that a placeholder, has also a placeholder, that should be resolved (recursively). | true | Boolean
-| *camel.component.properties.override-properties* | Sets a special list of override properties that take precedence and will use first, if a property exist.
+| `camel.component.properties.nested-placeholder` | Whether to support nested property placeholders. A nested placeholder, means that a placeholder, has also a placeholder, that should be resolved (recursively). | true | Boolean
+| `camel.component.properties.override-properties` | Sets a special list of override properties that take precedence and will use first, if a property exist.
 The option is a java.util.Properties type. |  | String
-| *camel.component.properties.properties-parser* | To use a custom PropertiesParser.
+| `camel.component.properties.properties-parser` | To use a custom PropertiesParser.
 The option is a org.apache.camel.component.properties.PropertiesParser type. |  | String
-| *camel.component.properties.system-properties-mode* | Sets the JVM system property mode (0 = never, 1 = fallback, 2 = override).
+| `camel.component.properties.system-properties-mode` | Sets the JVM system property mode (0 = never, 1 = fallback, 2 = override).
 The default mode (override) is to use system properties if present, and override any existing properties.
 OS environment variable mode is checked before JVM system property mode | 2 | Integer
 |===

--- a/core/camel-base/src/main/docs/properties-component.adoc
+++ b/core/camel-base/src/main/docs/properties-component.adoc
@@ -123,25 +123,25 @@ The component supports the following options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.component.properties.auto-discover-properties-sources* | Whether to automatically discovery instances of PropertiesSource from registry and service factory. | true | Boolean
-| *camel.component.properties.default-fallback-enabled* | If false, the component does not attempt to find a default for the key by looking after the colon separator. | true | Boolean
-| *camel.component.properties.encoding* | Encoding to use when loading properties file from the file system or classpath.
+| `camel.component.properties.auto-discover-properties-sources` | Whether to automatically discovery instances of PropertiesSource from registry and service factory. | true | Boolean
+| `camel.component.properties.default-fallback-enabled` | If false, the component does not attempt to find a default for the key by looking after the colon separator. | true | Boolean
+| `camel.component.properties.encoding` | Encoding to use when loading properties file from the file system or classpath.
 If no encoding has been set, then the properties files is loaded using ISO-8859-1 encoding (latin-1) as documented by java.util.Properties#load(java.io.InputStream) |  | String
-| *camel.component.properties.environment-variable-mode* | Sets the OS environment variables mode (0 = never, 1 = fallback, 2 = override).
+| `camel.component.properties.environment-variable-mode` | Sets the OS environment variables mode (0 = never, 1 = fallback, 2 = override).
 The default mode (override) is to use OS environment variables if present, and override any existing properties.
 OS environment variable mode is checked before JVM system property mode | 2 | Integer
-| *camel.component.properties.ignore-missing-location* | Whether to silently ignore if a location cannot be located, such as a properties file not found. | false | Boolean
-| *camel.component.properties.initial-properties* | Sets initial properties which will be used before any locations are resolved.
+| `camel.component.properties.ignore-missing-location` | Whether to silently ignore if a location cannot be located, such as a properties file not found. | false | Boolean
+| `camel.component.properties.initial-properties` | Sets initial properties which will be used before any locations are resolved.
 The option is a java.util.Properties type. |  | String
-| *camel.component.properties.location* | A list of locations to load properties.
+| `camel.component.properties.location` | A list of locations to load properties.
 You can use comma to separate multiple locations.
 This option will override any default locations and only use the locations from this option. |  | String
-| *camel.component.properties.nested-placeholder* | Whether to support nested property placeholders. A nested placeholder, means that a placeholder, has also a placeholder, that should be resolved (recursively). | true | Boolean
-| *camel.component.properties.override-properties* | Sets a special list of override properties that take precedence and will use first, if a property exist.
+| `camel.component.properties.nested-placeholder` | Whether to support nested property placeholders. A nested placeholder, means that a placeholder, has also a placeholder, that should be resolved (recursively). | true | Boolean
+| `camel.component.properties.override-properties` | Sets a special list of override properties that take precedence and will use first, if a property exist.
 The option is a java.util.Properties type. |  | String
-| *camel.component.properties.properties-parser* | To use a custom PropertiesParser.
+| `camel.component.properties.properties-parser` | To use a custom PropertiesParser.
 The option is a org.apache.camel.component.properties.PropertiesParser type. |  | String
-| *camel.component.properties.system-properties-mode* | Sets the JVM system property mode (0 = never, 1 = fallback, 2 = override).
+| `camel.component.properties.system-properties-mode` | Sets the JVM system property mode (0 = never, 1 = fallback, 2 = override).
 The default mode (override) is to use system properties if present, and override any existing properties.
 OS environment variable mode is checked before JVM system property mode | 2 | Integer
 |===

--- a/core/camel-main/src/main/docs/main.adoc
+++ b/core/camel-main/src/main/docs/main.adoc
@@ -24,136 +24,136 @@ The camel.main supports 130 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.main.additionalSensitiveKeywords* | Camel comes with a default set of sensitive keywords which are automatically masked. This option allows to add additional custom keywords to be masked as well. Multiple keywords can be separated by comma. |  | String
-| *camel.main.allowUseOriginalMessage* | Sets whether to allow access to the original message from Camel's error handler, or from org.apache.camel.spi.UnitOfWork.getOriginalInMessage(). Turning this off can optimize performance, as defensive copy of the original message is not needed. Default is false. | false | boolean
-| *camel.main.autoConfigurationEnabled* | Whether auto configuration of components, dataformats, languages is enabled or not. When enabled the configuration parameters are loaded from the properties component. You can prefix the parameters in the properties file with: - camel.component.name.option1=value1 - camel.component.name.option2=value2 - camel.dataformat.name.option1=value1 - camel.dataformat.name.option2=value2 - camel.language.name.option1=value1 - camel.language.name.option2=value2 Where name is the name of the component, dataformat or language such as seda,direct,jaxb. The auto configuration also works for any options on components that is a complex type (not standard Java type) and there has been an explicit single bean instance registered to the Camel registry via the org.apache.camel.spi.Registry#bind(String,Object) method or by using the org.apache.camel.BindToRegistry annotation style. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationEnvironmentVariablesEnabled* | Whether auto configuration should include OS environment variables as well. When enabled this allows to overrule any configuration using an OS environment variable. For example to set a shutdown timeout of 5 seconds: CAMEL_MAIN_SHUTDOWNTIMEOUT=5. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationFailFast* | Whether auto configuration should fail fast when configuring one ore more properties fails for whatever reason such as a invalid property name, etc. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationLogSummary* | Whether auto configuration should log a summary with the configured properties. This option is default enabled. | true | boolean
-| *camel.main.autoConfigurationSystemPropertiesEnabled* | Whether auto configuration should include JVM system properties as well. When enabled this allows to overrule any configuration using a JVM system property. For example to set a shutdown timeout of 5 seconds: -D camel.main.shutdown-timeout=5. Note that JVM system properties take precedence over OS environment variables. This option is default enabled. | true | boolean
-| *camel.main.autoStartup* | Sets whether the object should automatically start when Camel starts. Important: Currently only routes can be disabled, as CamelContext's are always started. Note: When setting auto startup false on CamelContext then that takes precedence and no routes are started. You would need to start CamelContext explicit using the org.apache.camel.CamelContext.start() method, to start the context, and then you would need to start the routes manually using CamelContext.getRouteController().startRoute(String). Default is true to always start up. | true | boolean
-| *camel.main.autoStartupExcludePattern* | Used for exclusive filtering of routes to not automatically start with Camel starts. The pattern support matching by route id or endpoint urls. Multiple patterns can be specified separated by comma, as example, to exclude all the routes starting from kafka or jms use: kafka,jms. |  | String
-| *camel.main.autowiredEnabled* | Whether autowiring is enabled. This is used for automatic autowiring options (the option must be marked as autowired) by looking up in the registry to find if there is a single instance of matching type, which then gets configured on the component. This can be used for automatic configuring JDBC data sources, JMS connection factories, AWS Clients, etc. Default is true. | true | boolean
-| *camel.main.basePackageScan* | Package name to use as base (offset) for classpath scanning of RouteBuilder , org.apache.camel.TypeConverter , CamelConfiguration classes, and also classes annotated with org.apache.camel.Converter , or org.apache.camel.BindToRegistry . If you are using Spring Boot then it is instead recommended to use Spring Boots component scanning and annotate your route builder classes with Component. In other words only use this for Camel Main in standalone mode. |  | String
-| *camel.main.basePackageScanEnabled* | Whether base package scan is enabled. | true | boolean
-| *camel.main.beanIntrospectionExtendedStatistics* | Sets whether bean introspection uses extended statistics. The default is false. | false | boolean
-| *camel.main.beanIntrospectionLoggingLevel* | Sets the logging level used by bean introspection, logging activity of its usage. The default is TRACE. |  | LoggingLevel
-| *camel.main.beanPostProcessorEnabled* | Can be used to turn off bean post processing. Be careful to turn this off, as this means that beans that use Camel annotations such as org.apache.camel.EndpointInject , org.apache.camel.ProducerTemplate , org.apache.camel.Produce , org.apache.camel.Consume etc will not be injected and in use. Turning this off should only be done if you are sure you do not use any of these Camel features. Not all runtimes allow turning this off. The default value is true (enabled). | true | boolean
-| *camel.main.camelEventsTimestampEnabled* | Whether to include timestamps for all emitted Camel Events. Enabling this allows to know fine-grained at what time each event was emitted, which can be used for reporting to report exactly the time of the events. This is by default false to avoid the overhead of including this information. | false | boolean
-| *camel.main.caseInsensitiveHeaders* | Whether to use case sensitive or insensitive headers. Important: When using case sensitive (this is set to false). Then the map is case sensitive which means headers such as content-type and Content-Type are two different keys which can be a problem for some protocols such as HTTP based, which rely on case insensitive headers. However case sensitive implementations can yield faster performance. Therefore use case sensitive implementation with care. Default is true. | true | boolean
-| *camel.main.cloudPropertiesLocation* | Sets the locations (comma separated values) where to find properties configuration as defined for cloud native environments such as Kubernetes. You should only scan text based mounted configuration. |  | String
-| *camel.main.compileWorkDir* | Work directory for compiler. Can be used to write compiled classes or other resources. |  | String
-| *camel.main.configurationClasses* | Sets classes names that will be used to configure the camel context as example by providing custom beans through org.apache.camel.BindToRegistry annotation. |  | String
-| *camel.main.configurations* | Sets the configuration objects used to configure the camel context. |  | List
-| *camel.main.consumerTemplateCacheSize* | Consumer template endpoints cache size. | 1000 | int
-| *camel.main.contextReloadEnabled* | Used for enabling context reloading. If enabled then Camel allow external systems such as security vaults (AWS secrets manager, etc.) to trigger refreshing Camel by updating property placeholders and reload all existing routes to take changes into effect. | false | boolean
-| *camel.main.description* | Sets the description (intended for humans) of the Camel application. |  | String
-| *camel.main.devConsoleEnabled* | Whether to enable developer console (requires camel-console on classpath). The developer console is only for assisting during development. This is NOT for production usage. | false | boolean
-| *camel.main.dumpRoutes* | If dumping is enabled then Camel will during startup dump all loaded routes (incl rests and route templates) represented as XML, YAML, or Java DSL into the log. This is intended for trouble shooting or to assist during development. Sensitive information that may be configured in the route endpoints could potentially be included in the dump output and is therefore not recommended being used for production usage. This requires to have camel-xml-io/camel-yaml-io/camel-java-io on the classpath to be able to dump the routes as XML/YAML/Java. You can also use JSon which dumps the route structure in JSon. The JSon does not represent Camel DSL but it useful for tooling to understand the structure of the routes and how EIPs are nested together. You can also use png to save route diagrams as PNG image files either all combined in a single file (default camel-route-diagrams.png) or to a given folder, where routes are grouped by source file name(s) and saved as corresponding .png files. This requires to have camel-diagram on the classpath to be able to render PNG diagrams. |  | String
-| *camel.main.dumpRoutesGeneratedIds* | Whether to include auto generated IDs in the dumped output. Default is false. | false | boolean
-| *camel.main.dumpRoutesInclude* | Controls what to include in output for route dumping. Possible values: all, routes, rests, routeConfigurations, routeTemplates, beans, dataFormats. Multiple values can be separated by comma. Default is routes. | routes | String
-| *camel.main.dumpRoutesLog* | Whether to log route dumps to Logger | true | boolean
-| *camel.main.dumpRoutesOutput* | Whether to save route dumps to an output file. If the output is a filename, then all content is saved to this file. If the output is a directory name, then one or more files are saved to the directory, where the names are based on the original source file names, or auto generated names. |  | String
-| *camel.main.dumpRoutesResolvePlaceholders* | Whether to resolve property placeholders in the dumped output. Default is true. | true | boolean
-| *camel.main.dumpRoutesUriAsParameters* | When dumping routes to YAML format, then this option controls whether endpoint URIs should be expanded into a key/value parameters. | false | boolean
-| *camel.main.durationHitExitCode* | Sets the exit code for the application if duration was hit |  | int
-| *camel.main.durationMaxAction* | Controls whether the Camel application should shutdown the JVM, or stop all routes, when duration max is triggered. | shutdown | String
-| *camel.main.durationMaxIdleSeconds* | To specify for how long time in seconds Camel can be idle before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
-| *camel.main.durationMaxMessages* | To specify how many messages to process by Camel before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
-| *camel.main.durationMaxSeconds* | To specify for how long time in seconds to keep running the JVM before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
-| *camel.main.endpointBridgeErrorHandler* | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN/ERROR level and ignored. The default value is false. | false | boolean
-| *camel.main.endpointLazyStartProducer* | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. The default value is false. | false | boolean
-| *camel.main.endpointRuntimeStatisticsEnabled* | Sets whether endpoint runtime statistics is enabled (gathers runtime usage of each incoming and outgoing endpoints). The default value is false. | false | boolean
-| *camel.main.exchangeFactory* | Controls whether to pool (reuse) exchanges or create new exchanges (prototype). Using pooled will reduce JVM garbage collection overhead by avoiding to re-create Exchange instances per message each consumer receives. The default is prototype mode. | default | String
-| *camel.main.exchangeFactoryCapacity* | The capacity the pool (for each consumer) uses for storing exchanges. The default capacity is 100. | 100 | int
-| *camel.main.exchangeFactoryStatisticsEnabled* | Configures whether statistics is enabled on exchange factory. | false | boolean
-| *camel.main.extraShutdownTimeout* | Extra timeout in seconds to graceful shutdown Camel. When Camel is shutting down then Camel first shutdown all the routes (shutdownTimeout). Then additional services is shutdown (extraShutdownTimeout). | 15 | int
-| *camel.main.fileConfigurations* | Directory to load additional properties files that contains configurations that takes precedence (except for camel.main.xxx configurations). This can be used to refer to files that may have secret configuration that has been mounted on the file system for containers. You can specify a pattern to load from file-system (not classpath) and a name pattern such as /var/app/secret/.properties, multiple directories can be separated by comma. |  | String
-| *camel.main.globalOptions* | Sets global options that can be referenced in the camel context Important: This has nothing to do with property placeholders, and is just a plain set of key/value pairs which are used to configure global options on CamelContext, such as a maximum debug logging length etc. |  | Map
-| *camel.main.groovyPreloadCompiled* | Whether to preload existing compiled Groovy sources from the compileWorkDir option on startup. This can be enabled to avoid compiling sources that already has been compiled during a build phase. | false | boolean
-| *camel.main.groovyScriptPattern* | Directories to scan for groovy source to be pre-compiled. For example: scripts/.groovy will scan inside the classpath folder scripts for all groovy source files. By default, sources are scanned from the classpath, but you can prefix with file: to use file system. The directories are using Ant-path style pattern, and multiple directories can be specified separated by comma. This requires having camel-groovy JAR on the classpath. | classpath:camel-groovy/*,classpath:camel-groovy-compiled/* | String
-| *camel.main.inflightRepositoryBrowseEnabled* | Sets whether the inflight repository should allow browsing each inflight exchange. This is by default disabled as there is a very slight performance overhead when enabled. | false | boolean
-| *camel.main.javaRoutesExcludePattern* | Used for exclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. For example to exclude all classes starting with Bar use: &#42;&#42;/Bar&#42; To exclude all routes form a specific package use: com/mycompany/bar/&#42; To exclude all routes form a specific package and its sub-packages use double wildcards: com/mycompany/bar/&#42;&#42; And to exclude all routes from two specific packages use: com/mycompany/bar/&#42;,com/mycompany/stuff/&#42; |  | String
-| *camel.main.javaRoutesIncludePattern* | Used for inclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. Multiple patterns can be specified separated by comma. For example to include all classes starting with Foo use: &#42;&#42;/Foo To include all routes form a specific package use: com/mycompany/foo/&#42; To include all routes form a specific package and its sub-packages use double wildcards: com/mycompany/foo/&#42;&#42; And to include all routes from two specific packages use: com/mycompany/foo/&#42;,com/mycompany/stuff/&#42; |  | String
-| *camel.main.jmxEnabled* | Enable JMX in your Camel application. | true | boolean
-| *camel.main.jmxManagementMBeansLevel* | Sets the mbeans registration level. The default value is Default. | Default | ManagementMBeansLevel
-| *camel.main.jmxManagementNamePattern* | The naming pattern for creating the CamelContext JMX management name. The default pattern is #name# | #name# | String
-| *camel.main.jmxManagementRegisterRoutesCreateByKamelet* | Whether routes created by Kamelets should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via Kamelets. This is default disabled as a Kamelet is intended as a component (black-box) and its implementation details as Camel route makes the overall management and monitoring of Camel applications more verbose. During development of Kamelets then enabling this will make it possible for developers to do fine-grained performance inspection and identify potential bottlenecks in the Kamelet routes. However, for production usage then keeping this disabled is recommended. | false | boolean
-| *camel.main.jmxManagementRegisterRoutesCreateByTemplate* | Whether routes created by route templates (not Kamelets) should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via route templates. This is default enabled (unlike Kamelets) as routes created via templates is regarded as standard routes, and should be available for management and monitoring. | true | boolean
-| *camel.main.jmxManagementStatisticsLevel* | Sets the JMX statistics level, the level can be set to Extended to gather additional information The default value is Default. | Default | ManagementStatisticsLevel
-| *camel.main.jmxUpdateRouteEnabled* | Whether to allow updating routes at runtime via JMX using the ManagedRouteMBean. This is disabled by default, but can be enabled for development and troubleshooting purposes, such as updating routes in an existing running Camel via JMX and other tools. | false | boolean
-| *camel.main.loadHealthChecks* | Whether to load custom health checks by scanning classpath. | false | boolean
-| *camel.main.loadStatisticsEnabled* | Sets whether Camel load (inflight messages, not cpu) statistics is enabled (something like the unix load average). The statistics requires to have camel-management on the classpath as JMX is required. The default value is false. | false | boolean
-| *camel.main.loadTypeConverters* | Whether to load custom type converters by scanning classpath. This is used for backwards compatibility with Camel 2.x. Its recommended to migrate to use fast type converter loading by setting Converter(loader = true) on your custom type converter classes. | false | boolean
-| *camel.main.logDebugMaxChars* | Is used to limit the maximum length of the logging Camel message bodies. If the message body is longer than the limit, the log message is clipped. Use -1 to have unlimited length. Use for example 1000 to log at most 1000 characters. |  | int
-| *camel.main.logExhaustedMessageBody* | Sets whether to log exhausted message body with message history. Default is false. | false | boolean
-| *camel.main.logLanguage* | To configure the language to use for Log EIP. By default, the simple language is used. However, Camel also supports other languages such as groovy. |  | String
-| *camel.main.logMask* | Sets whether log mask is enabled or not. Default is false. | false | boolean
-| *camel.main.logName* | The global name to use for Log EIP The name is default the routeId or the source:line if source location is enabled. You can also specify the name using tokens: $\{class} - the logger class name (org.apache.camel.processor.LogProcessor) $\{contextId} - the camel context id $\{routeId} - the route id $\{groupId} - the route group id $\{nodeId} - the node id $\{nodePrefixId} - the node prefix id $\{source} - the source:line (source location must be enabled) ${source.name} - the source filename (source location must be enabled) ${source.line} - the source line number (source location must be enabled) For example to use the route and node id you can specify the name as: $\{routeId}/$\{nodeId} |  | String
-| *camel.main.mainListenerClasses* | Sets classes names that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | String
-| *camel.main.mainListeners* | Sets main listener objects that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | List
-| *camel.main.mdcLoggingKeysPattern* | Sets the pattern used for determine which custom MDC keys to propagate during message routing when the routing engine continues routing asynchronously for the given message. Setting this pattern to will propagate all custom keys. Or setting the pattern to foo,bar will propagate any keys starting with either foo or bar. Notice that a set of standard Camel MDC keys are always propagated which starts with camel. as key name. The match rules are applied in this order (case insensitive): 1. exact match, returns true 2. wildcard match (pattern ends with a and the name starts with the pattern), returns true 3. regular expression match, returns true 4. otherwise returns false Deprecated, use camel-mdc component instead |  | String
-| *camel.main.messageHistory* | Sets whether message history is enabled or not. Default is false. | false | boolean
-| *camel.main.messageSizeEnabled* | Sets whether message size observation is enabled (default is false). When enabled, Camel will compute the size of message body and headers (in bytes) per endpoint (for both IN and OUT directions) and make this available via JMX MBeans (min/max/mean body size and headers size). | false | boolean
-| *camel.main.modeline* | Whether to support JBang style //DEPS to specify additional dependencies when running Camel CLI | false | boolean
-| *camel.main.name* | Sets the name of the CamelContext. |  | String
-| *camel.main.producerTemplateCacheSize* | Producer template endpoints cache size. | 1000 | int
-| *camel.main.profile* | Camel profile to use when running. The dev profile is for development, which enables a set of additional developer focus functionality, tracing, debugging, and gathering additional runtime statistics that are useful during development. However, those additional features has a slight overhead cost, and are not enabled for production profile. The default profile is prod. |  | String
-| *camel.main.routeFilterExcludePattern* | Used for filtering routes routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
-| *camel.main.routeFilterIncludePattern* | Used for filtering routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
-| *camel.main.routesBuilderClasses* | Sets classes names that implement RoutesBuilder . |  | String
-| *camel.main.routesBuilders* | Sets the RoutesBuilder instances. |  | List
-| *camel.main.routesCollectorEnabled* | Whether the routes collector is enabled or not. When enabled Camel will auto-discover routes (RouteBuilder instances from the registry and also load additional routes from the file system). The routes collector is default enabled. | true | boolean
-| *camel.main.routesCollectorIgnoreLoadingError* | Whether the routes collector should ignore any errors during loading and compiling routes. This is only intended for development or tooling. | false | boolean
-| *camel.main.routesExcludePattern* | Used for exclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to exclude all the routes from a directory whose name contains foo use: &#42;&#42;/foo. |  | String
-| *camel.main.routesIncludePattern* | Used for inclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to include all the routes from a directory whose name contains foo use: &#42;&#42;/foo. | classpath:camel/*,classpath:camel-template/*,classpath:camel-rest/* | String
-| *camel.main.routesReloadDirectory* | Directory to scan for route changes. Camel cannot scan the classpath, so this must be configured to a file directory. Development with Maven as build tool, you can configure the directory to be src/main/resources to scan for Camel routes in XML or YAML files. | src/main/resources/camel | String
-| *camel.main.routesReloadDirectoryRecursive* | Whether the directory to scan should include sub directories. Depending on the number of sub directories, then this can cause the JVM to startup slower as Camel uses the JDK file-watch service to scan for file changes. | false | boolean
-| *camel.main.routesReloadEnabled* | Used for enabling automatic routes reloading. If enabled then Camel will watch for file changes in the given reload directory, and trigger reloading routes if files are changed. | false | boolean
-| *camel.main.routesReloadPattern* | Used for inclusive filtering of routes from directories. Typical used for specifying to accept routes in XML or YAML files, such as .yaml,.xml. Multiple patterns can be specified separated by comma. |  | String
-| *camel.main.routesReloadRemoveAllRoutes* | When reloading routes should all existing routes be stopped and removed. By default, Camel will stop and remove all existing routes before reloading routes. This ensures that only the reloaded routes will be active. If disabled then only routes with the same route id is updated, and any existing routes are continued to run. | true | boolean
-| *camel.main.routesReloadRestartDuration* | Whether to restart max duration when routes are reloaded. For example if max duration is 60 seconds, and a route is reloaded after 25 seconds, then this will restart the count and wait 60 seconds again. | false | boolean
-| *camel.main.shutdownLogInflightExchangesOnTimeout* | Sets whether to log information about the inflight Exchanges which are still running during a shutdown which didn't complete without the given timeout. This requires to enable the option inflightRepositoryBrowseEnabled. | true | boolean
-| *camel.main.shutdownNowOnTimeout* | Sets whether to force shutdown of all consumers when a timeout occurred and thus not all consumers was shutdown within that period. You should have good reasons to set this option to false as it means that the routes keep running and is halted abruptly when CamelContext has been shutdown. | true | boolean
-| *camel.main.shutdownRoutesInReverseOrder* | Sets whether routes should be shutdown in reverse or the same order as they were started. | true | boolean
-| *camel.main.shutdownSuppressLoggingOnTimeout* | Whether Camel should try to suppress logging during shutdown and timeout was triggered, meaning forced shutdown is happening. And during forced shutdown we want to avoid logging errors/warnings et all in the logs as a side-effect of the forced timeout. Notice the suppress is a best effort as there may still be some logs coming from 3rd party libraries and whatnot, which Camel cannot control. This option is default false. | false | boolean
-| *camel.main.shutdownTimeout* | Timeout in seconds to graceful shutdown all the Camel routes. | 45 | int
-| *camel.main.sourceLocationEnabled* | Whether to capture precise source location:line-number for all EIPs in Camel routes. Enabling this will impact parsing Java based routes (also Groovy etc.) on startup as this uses JDK StackTraceElement to calculate the location from the Camel route, which comes with a performance cost. This only impact startup, not the performance of the routes at runtime. | false | boolean
-| *camel.main.startupRecorder* | To use startup recorder for capturing execution time during starting Camel. The recorder can be one of: false (or off), logging, backlog, java-flight-recorder (or jfr). |  | String
-| *camel.main.startupRecorderDir* | Directory to store the recording. By default the current directory will be used. Use false to turn off saving recording to disk. |  | String
-| *camel.main.startupRecorderDuration* | How long time to run the startup recorder. Use 0 (default) to keep the recorder running until the JVM is exited. Use -1 to stop the recorder right after Camel has been started (to only focus on potential Camel startup performance bottlenecks) Use a positive value to keep recording for N seconds. When the recorder is stopped then the recording is auto saved to disk (note: save to disk can be disabled by setting startupRecorderDir to false) |  | long
-| *camel.main.startupRecorderMaxDepth* | To filter our sub steps at a maximum depth. Use -1 for no maximum. Use 0 for no sub steps. Use 1 for max 1 sub step, and so forth. The default is -1. | -1 | int
-| *camel.main.startupRecorderProfile* | To use a specific Java Flight Recorder profile configuration, such as default or profile. The default is default. | default | String
-| *camel.main.startupRecorderRecording* | To enable Java Flight Recorder to start a recording and automatic dump the recording to disk after startup is complete. This requires that camel-jfr is on the classpath, and to enable this option. | false | boolean
-| *camel.main.startupRecorderRuntimeEnabled* | To also instrument the running Camel application, and not only its startup, by emitting Java Flight Recorder events for every exchange, route and processor. This requires that camel-jfr is on the classpath, and to enable this option. The runtime events are only captured while a recording is active. As they are emitted per message they add overhead, so this is turned off by default. | false | boolean
-| *camel.main.startupSummaryLevel* | Controls the level of information logged during startup (and shutdown) of CamelContext. | Default | StartupSummaryLevel
-| *camel.main.streamCachingAllowClasses* | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
-| *camel.main.streamCachingAnySpoolRules* | Sets whether if just any of the org.apache.camel.spi.StreamCachingStrategy.SpoolRule rules returns true then shouldSpoolCache(long) returns true, to allow spooling to disk. If this option is false, then all the org.apache.camel.spi.StreamCachingStrategy.SpoolRule must return true. The default value is false which means that all the rules must return true. | false | boolean
-| *camel.main.streamCachingBufferSize* | Sets the stream caching buffer size to use when allocating in-memory buffers used for in-memory stream caches. The default size is 4096. |  | int
-| *camel.main.streamCachingDenyClasses* | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
-| *camel.main.streamCachingEnabled* | Sets whether stream caching is enabled or not. While stream types (like StreamSource, InputStream and Reader) are commonly used in messaging for performance reasons, they also have an important drawback: they can only be read once. In order to be able to work with message content multiple times, the stream needs to be cached. Streams are cached in memory only (by default). If streamCachingSpoolEnabled=true, then, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is true. | true | boolean
-| *camel.main.streamCachingRemoveSpoolDirectoryWhenStopping* | Whether to remove stream caching temporary directory when stopping. This option is default true. | true | boolean
-| *camel.main.streamCachingSpoolCipher* | Sets a stream caching cipher name to use when spooling to disk to write with encryption. By default the data is not encrypted. |  | String
-| *camel.main.streamCachingSpoolDirectory* | Sets the stream caching spool (temporary) directory to use for overflow and spooling to disk. If no spool directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
-| *camel.main.streamCachingSpoolEnabled* | To enable stream caching spooling to disk. This means, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is false. | false | boolean
-| *camel.main.streamCachingSpoolRules* | Sets custom rules (org.apache.camel.spi.StreamCachingStrategy.SpoolRule) for deciding when to spool to disk. Multiple rules can be separated by comma. |  | String
-| *camel.main.streamCachingSpoolThreshold* | Stream caching threshold in bytes when overflow to disk is activated. The default threshold is 128kb. Use -1 to disable overflow to disk. |  | long
-| *camel.main.streamCachingSpoolUsedHeapMemoryLimit* | Sets what the upper bounds should be when streamCachingSpoolUsedHeapMemoryThreshold is in use. | Max | String
-| *camel.main.streamCachingSpoolUsedHeapMemoryThreshold* | Sets a percentage (1-99) of used heap memory threshold to activate stream caching spooling to disk. |  | int
-| *camel.main.streamCachingStatisticsEnabled* | Sets whether stream caching statistics is enabled. | false | boolean
-| *camel.main.threadNamePattern* | Sets the thread name pattern used for creating the full thread name. The default pattern is: Camel (#camelId#) thread ##counter# - #name# Where #camelId# is the name of the CamelContext. and #counter# is a unique incrementing counter. and #name# is the regular thread name. You can also use #longName# which is the long thread name which can includes endpoint parameters etc. |  | String
-| *camel.main.tracing* | Sets whether tracing is enabled or not. Default is false. | false | boolean
-| *camel.main.tracingLoggingFormat* | To use a custom tracing logging format. The default format (arrow, routeId, label) is: %-4.4s %-12.12s %-33.33s | %-4.4s [%-12.12s] [%-33.33s] | String
-| *camel.main.tracingPattern* | Tracing pattern to match which node EIPs to trace. For example to match all To EIP nodes, use to. The pattern matches by node and route id's Multiple patterns can be separated by comma. |  | String
-| *camel.main.tracingStandby* | Whether to set tracing on standby. If on standby then the tracer is installed and made available. Then the tracer can be enabled later at runtime via JMX or via Tracer#setEnabled(boolean) . | false | boolean
-| *camel.main.tracingTemplates* | Whether tracing should trace inner details from route templates (or kamelets). Turning this on increases the verbosity of tracing by including events from internal routes in the templates or kamelets. Default is false. | false | boolean
-| *camel.main.typeConverterStatisticsEnabled* | Sets whether type converter statistics is enabled. By default the type converter utilization statistics is disabled. Notice: If enabled then there is a slight performance impact under very heavy load. | false | boolean
-| *camel.main.useBreadcrumb* | Set whether breadcrumb is enabled. The default value is false. | false | boolean
-| *camel.main.useDataType* | Whether to enable using data type on Camel messages. Data type are automatic turned on if one ore more routes has been explicit configured with input and output types. Otherwise data type is default off. | false | boolean
-| *camel.main.useMdcLogging* | To turn on MDC logging (deprecated, use camel-mdc component instead) | false | boolean
-| *camel.main.uuidGenerator* | UUID generator to use. default (32 bytes), short (16 bytes), classic (32 bytes or longer), simple (long incrementing counter), off (turned off for exchanges - only intended for performance profiling) | default | String
-| *camel.main.virtualThreadsEnabled* | Whether to enable virtual threads when creating thread pools. When enabled, Camel will use virtual threads instead of platform threads for its thread pools. This can also be enabled via the JVM system property {code camel.threads.virtual.enabled=true} . This option must be read early during bootstrap, so it is set as a system property before thread pools are created. | false | boolean
-| *camel.main.yamlDslCompactNotationWarn* | Whether to log a WARN when YAML DSL routes use compact (shorthand) notation instead of the canonical (explicit/normalized) form. The canonical style is recommended as it is more tooling and AI friendly. Use Camel CLI to normalize existing routes: camel validate normalize &lt;file&gt; | true | boolean
+| `camel.main.additionalSensitiveKeywords` | Camel comes with a default set of sensitive keywords which are automatically masked. This option allows to add additional custom keywords to be masked as well. Multiple keywords can be separated by comma. |  | String
+| `camel.main.allowUseOriginalMessage` | Sets whether to allow access to the original message from Camel's error handler, or from org.apache.camel.spi.UnitOfWork.getOriginalInMessage(). Turning this off can optimize performance, as defensive copy of the original message is not needed. Default is false. | false | boolean
+| `camel.main.autoConfigurationEnabled` | Whether auto configuration of components, dataformats, languages is enabled or not. When enabled the configuration parameters are loaded from the properties component. You can prefix the parameters in the properties file with: - camel.component.name.option1=value1 - camel.component.name.option2=value2 - camel.dataformat.name.option1=value1 - camel.dataformat.name.option2=value2 - camel.language.name.option1=value1 - camel.language.name.option2=value2 Where name is the name of the component, dataformat or language such as seda,direct,jaxb. The auto configuration also works for any options on components that is a complex type (not standard Java type) and there has been an explicit single bean instance registered to the Camel registry via the org.apache.camel.spi.Registry#bind(String,Object) method or by using the org.apache.camel.BindToRegistry annotation style. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationEnvironmentVariablesEnabled` | Whether auto configuration should include OS environment variables as well. When enabled this allows to overrule any configuration using an OS environment variable. For example to set a shutdown timeout of 5 seconds: CAMEL_MAIN_SHUTDOWNTIMEOUT=5. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationFailFast` | Whether auto configuration should fail fast when configuring one ore more properties fails for whatever reason such as a invalid property name, etc. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationLogSummary` | Whether auto configuration should log a summary with the configured properties. This option is default enabled. | true | boolean
+| `camel.main.autoConfigurationSystemPropertiesEnabled` | Whether auto configuration should include JVM system properties as well. When enabled this allows to overrule any configuration using a JVM system property. For example to set a shutdown timeout of 5 seconds: -D camel.main.shutdown-timeout=5. Note that JVM system properties take precedence over OS environment variables. This option is default enabled. | true | boolean
+| `camel.main.autoStartup` | Sets whether the object should automatically start when Camel starts. Important: Currently only routes can be disabled, as CamelContext's are always started. Note: When setting auto startup false on CamelContext then that takes precedence and no routes are started. You would need to start CamelContext explicit using the org.apache.camel.CamelContext.start() method, to start the context, and then you would need to start the routes manually using CamelContext.getRouteController().startRoute(String). Default is true to always start up. | true | boolean
+| `camel.main.autoStartupExcludePattern` | Used for exclusive filtering of routes to not automatically start with Camel starts. The pattern support matching by route id or endpoint urls. Multiple patterns can be specified separated by comma, as example, to exclude all the routes starting from kafka or jms use: kafka,jms. |  | String
+| `camel.main.autowiredEnabled` | Whether autowiring is enabled. This is used for automatic autowiring options (the option must be marked as autowired) by looking up in the registry to find if there is a single instance of matching type, which then gets configured on the component. This can be used for automatic configuring JDBC data sources, JMS connection factories, AWS Clients, etc. Default is true. | true | boolean
+| `camel.main.basePackageScan` | Package name to use as base (offset) for classpath scanning of RouteBuilder , org.apache.camel.TypeConverter , CamelConfiguration classes, and also classes annotated with org.apache.camel.Converter , or org.apache.camel.BindToRegistry . If you are using Spring Boot then it is instead recommended to use Spring Boots component scanning and annotate your route builder classes with Component. In other words only use this for Camel Main in standalone mode. |  | String
+| `camel.main.basePackageScanEnabled` | Whether base package scan is enabled. | true | boolean
+| `camel.main.beanIntrospectionExtendedStatistics` | Sets whether bean introspection uses extended statistics. The default is false. | false | boolean
+| `camel.main.beanIntrospectionLoggingLevel` | Sets the logging level used by bean introspection, logging activity of its usage. The default is TRACE. |  | LoggingLevel
+| `camel.main.beanPostProcessorEnabled` | Can be used to turn off bean post processing. Be careful to turn this off, as this means that beans that use Camel annotations such as org.apache.camel.EndpointInject , org.apache.camel.ProducerTemplate , org.apache.camel.Produce , org.apache.camel.Consume etc will not be injected and in use. Turning this off should only be done if you are sure you do not use any of these Camel features. Not all runtimes allow turning this off. The default value is true (enabled). | true | boolean
+| `camel.main.camelEventsTimestampEnabled` | Whether to include timestamps for all emitted Camel Events. Enabling this allows to know fine-grained at what time each event was emitted, which can be used for reporting to report exactly the time of the events. This is by default false to avoid the overhead of including this information. | false | boolean
+| `camel.main.caseInsensitiveHeaders` | Whether to use case sensitive or insensitive headers. Important: When using case sensitive (this is set to false). Then the map is case sensitive which means headers such as content-type and Content-Type are two different keys which can be a problem for some protocols such as HTTP based, which rely on case insensitive headers. However case sensitive implementations can yield faster performance. Therefore use case sensitive implementation with care. Default is true. | true | boolean
+| `camel.main.cloudPropertiesLocation` | Sets the locations (comma separated values) where to find properties configuration as defined for cloud native environments such as Kubernetes. You should only scan text based mounted configuration. |  | String
+| `camel.main.compileWorkDir` | Work directory for compiler. Can be used to write compiled classes or other resources. |  | String
+| `camel.main.configurationClasses` | Sets classes names that will be used to configure the camel context as example by providing custom beans through org.apache.camel.BindToRegistry annotation. |  | String
+| `camel.main.configurations` | Sets the configuration objects used to configure the camel context. |  | List
+| `camel.main.consumerTemplateCacheSize` | Consumer template endpoints cache size. | 1000 | int
+| `camel.main.contextReloadEnabled` | Used for enabling context reloading. If enabled then Camel allow external systems such as security vaults (AWS secrets manager, etc.) to trigger refreshing Camel by updating property placeholders and reload all existing routes to take changes into effect. | false | boolean
+| `camel.main.description` | Sets the description (intended for humans) of the Camel application. |  | String
+| `camel.main.devConsoleEnabled` | Whether to enable developer console (requires camel-console on classpath). The developer console is only for assisting during development. This is NOT for production usage. | false | boolean
+| `camel.main.dumpRoutes` | If dumping is enabled then Camel will during startup dump all loaded routes (incl rests and route templates) represented as XML, YAML, or Java DSL into the log. This is intended for trouble shooting or to assist during development. Sensitive information that may be configured in the route endpoints could potentially be included in the dump output and is therefore not recommended being used for production usage. This requires to have camel-xml-io/camel-yaml-io/camel-java-io on the classpath to be able to dump the routes as XML/YAML/Java. You can also use JSon which dumps the route structure in JSon. The JSon does not represent Camel DSL but it useful for tooling to understand the structure of the routes and how EIPs are nested together. You can also use png to save route diagrams as PNG image files either all combined in a single file (default camel-route-diagrams.png) or to a given folder, where routes are grouped by source file name(s) and saved as corresponding .png files. This requires to have camel-diagram on the classpath to be able to render PNG diagrams. |  | String
+| `camel.main.dumpRoutesGeneratedIds` | Whether to include auto generated IDs in the dumped output. Default is false. | false | boolean
+| `camel.main.dumpRoutesInclude` | Controls what to include in output for route dumping. Possible values: all, routes, rests, routeConfigurations, routeTemplates, beans, dataFormats. Multiple values can be separated by comma. Default is routes. | routes | String
+| `camel.main.dumpRoutesLog` | Whether to log route dumps to Logger | true | boolean
+| `camel.main.dumpRoutesOutput` | Whether to save route dumps to an output file. If the output is a filename, then all content is saved to this file. If the output is a directory name, then one or more files are saved to the directory, where the names are based on the original source file names, or auto generated names. |  | String
+| `camel.main.dumpRoutesResolvePlaceholders` | Whether to resolve property placeholders in the dumped output. Default is true. | true | boolean
+| `camel.main.dumpRoutesUriAsParameters` | When dumping routes to YAML format, then this option controls whether endpoint URIs should be expanded into a key/value parameters. | false | boolean
+| `camel.main.durationHitExitCode` | Sets the exit code for the application if duration was hit |  | int
+| `camel.main.durationMaxAction` | Controls whether the Camel application should shutdown the JVM, or stop all routes, when duration max is triggered. | shutdown | String
+| `camel.main.durationMaxIdleSeconds` | To specify for how long time in seconds Camel can be idle before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
+| `camel.main.durationMaxMessages` | To specify how many messages to process by Camel before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
+| `camel.main.durationMaxSeconds` | To specify for how long time in seconds to keep running the JVM before automatic terminating the JVM. You can use this to run Camel for a short while. |  | int
+| `camel.main.endpointBridgeErrorHandler` | Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN/ERROR level and ignored. The default value is false. | false | boolean
+| `camel.main.endpointLazyStartProducer` | Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel's routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing. The default value is false. | false | boolean
+| `camel.main.endpointRuntimeStatisticsEnabled` | Sets whether endpoint runtime statistics is enabled (gathers runtime usage of each incoming and outgoing endpoints). The default value is false. | false | boolean
+| `camel.main.exchangeFactory` | Controls whether to pool (reuse) exchanges or create new exchanges (prototype). Using pooled will reduce JVM garbage collection overhead by avoiding to re-create Exchange instances per message each consumer receives. The default is prototype mode. | default | String
+| `camel.main.exchangeFactoryCapacity` | The capacity the pool (for each consumer) uses for storing exchanges. The default capacity is 100. | 100 | int
+| `camel.main.exchangeFactoryStatisticsEnabled` | Configures whether statistics is enabled on exchange factory. | false | boolean
+| `camel.main.extraShutdownTimeout` | Extra timeout in seconds to graceful shutdown Camel. When Camel is shutting down then Camel first shutdown all the routes (shutdownTimeout). Then additional services is shutdown (extraShutdownTimeout). | 15 | int
+| `camel.main.fileConfigurations` | Directory to load additional properties files that contains configurations that takes precedence (except for camel.main.xxx configurations). This can be used to refer to files that may have secret configuration that has been mounted on the file system for containers. You can specify a pattern to load from file-system (not classpath) and a name pattern such as /var/app/secret/.properties, multiple directories can be separated by comma. |  | String
+| `camel.main.globalOptions` | Sets global options that can be referenced in the camel context Important: This has nothing to do with property placeholders, and is just a plain set of key/value pairs which are used to configure global options on CamelContext, such as a maximum debug logging length etc. |  | Map
+| `camel.main.groovyPreloadCompiled` | Whether to preload existing compiled Groovy sources from the compileWorkDir option on startup. This can be enabled to avoid compiling sources that already has been compiled during a build phase. | false | boolean
+| `camel.main.groovyScriptPattern` | Directories to scan for groovy source to be pre-compiled. For example: scripts/.groovy will scan inside the classpath folder scripts for all groovy source files. By default, sources are scanned from the classpath, but you can prefix with file: to use file system. The directories are using Ant-path style pattern, and multiple directories can be specified separated by comma. This requires having camel-groovy JAR on the classpath. | classpath:camel-groovy/*,classpath:camel-groovy-compiled/* | String
+| `camel.main.inflightRepositoryBrowseEnabled` | Sets whether the inflight repository should allow browsing each inflight exchange. This is by default disabled as there is a very slight performance overhead when enabled. | false | boolean
+| `camel.main.javaRoutesExcludePattern` | Used for exclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. For example to exclude all classes starting with Bar use: &#42;&#42;/Bar&#42; To exclude all routes form a specific package use: com/mycompany/bar/&#42; To exclude all routes form a specific package and its sub-packages use double wildcards: com/mycompany/bar/&#42;&#42; And to exclude all routes from two specific packages use: com/mycompany/bar/&#42;,com/mycompany/stuff/&#42; |  | String
+| `camel.main.javaRoutesIncludePattern` | Used for inclusive filtering RouteBuilder classes which are collected from the registry or via classpath scanning. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma. Multiple patterns can be specified separated by comma. For example to include all classes starting with Foo use: &#42;&#42;/Foo To include all routes form a specific package use: com/mycompany/foo/&#42; To include all routes form a specific package and its sub-packages use double wildcards: com/mycompany/foo/&#42;&#42; And to include all routes from two specific packages use: com/mycompany/foo/&#42;,com/mycompany/stuff/&#42; |  | String
+| `camel.main.jmxEnabled` | Enable JMX in your Camel application. | true | boolean
+| `camel.main.jmxManagementMBeansLevel` | Sets the mbeans registration level. The default value is Default. | Default | ManagementMBeansLevel
+| `camel.main.jmxManagementNamePattern` | The naming pattern for creating the CamelContext JMX management name. The default pattern is #name# | #name# | String
+| `camel.main.jmxManagementRegisterRoutesCreateByKamelet` | Whether routes created by Kamelets should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via Kamelets. This is default disabled as a Kamelet is intended as a component (black-box) and its implementation details as Camel route makes the overall management and monitoring of Camel applications more verbose. During development of Kamelets then enabling this will make it possible for developers to do fine-grained performance inspection and identify potential bottlenecks in the Kamelet routes. However, for production usage then keeping this disabled is recommended. | false | boolean
+| `camel.main.jmxManagementRegisterRoutesCreateByTemplate` | Whether routes created by route templates (not Kamelets) should be registered for JMX management. Enabling this allows to have fine-grained monitoring and management of every route created via route templates. This is default enabled (unlike Kamelets) as routes created via templates is regarded as standard routes, and should be available for management and monitoring. | true | boolean
+| `camel.main.jmxManagementStatisticsLevel` | Sets the JMX statistics level, the level can be set to Extended to gather additional information The default value is Default. | Default | ManagementStatisticsLevel
+| `camel.main.jmxUpdateRouteEnabled` | Whether to allow updating routes at runtime via JMX using the ManagedRouteMBean. This is disabled by default, but can be enabled for development and troubleshooting purposes, such as updating routes in an existing running Camel via JMX and other tools. | false | boolean
+| `camel.main.loadHealthChecks` | Whether to load custom health checks by scanning classpath. | false | boolean
+| `camel.main.loadStatisticsEnabled` | Sets whether Camel load (inflight messages, not cpu) statistics is enabled (something like the unix load average). The statistics requires to have camel-management on the classpath as JMX is required. The default value is false. | false | boolean
+| `camel.main.loadTypeConverters` | Whether to load custom type converters by scanning classpath. This is used for backwards compatibility with Camel 2.x. Its recommended to migrate to use fast type converter loading by setting Converter(loader = true) on your custom type converter classes. | false | boolean
+| `camel.main.logDebugMaxChars` | Is used to limit the maximum length of the logging Camel message bodies. If the message body is longer than the limit, the log message is clipped. Use -1 to have unlimited length. Use for example 1000 to log at most 1000 characters. |  | int
+| `camel.main.logExhaustedMessageBody` | Sets whether to log exhausted message body with message history. Default is false. | false | boolean
+| `camel.main.logLanguage` | To configure the language to use for Log EIP. By default, the simple language is used. However, Camel also supports other languages such as groovy. |  | String
+| `camel.main.logMask` | Sets whether log mask is enabled or not. Default is false. | false | boolean
+| `camel.main.logName` | The global name to use for Log EIP The name is default the routeId or the source:line if source location is enabled. You can also specify the name using tokens: $\{class} - the logger class name (org.apache.camel.processor.LogProcessor) $\{contextId} - the camel context id $\{routeId} - the route id $\{groupId} - the route group id $\{nodeId} - the node id $\{nodePrefixId} - the node prefix id $\{source} - the source:line (source location must be enabled) ${source.name} - the source filename (source location must be enabled) ${source.line} - the source line number (source location must be enabled) For example to use the route and node id you can specify the name as: $\{routeId}/$\{nodeId} |  | String
+| `camel.main.mainListenerClasses` | Sets classes names that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | String
+| `camel.main.mainListeners` | Sets main listener objects that will be used for MainListener that makes it possible to do custom logic during starting and stopping camel-main. |  | List
+| `camel.main.mdcLoggingKeysPattern` | Sets the pattern used for determine which custom MDC keys to propagate during message routing when the routing engine continues routing asynchronously for the given message. Setting this pattern to will propagate all custom keys. Or setting the pattern to foo,bar will propagate any keys starting with either foo or bar. Notice that a set of standard Camel MDC keys are always propagated which starts with camel. as key name. The match rules are applied in this order (case insensitive): 1. exact match, returns true 2. wildcard match (pattern ends with a and the name starts with the pattern), returns true 3. regular expression match, returns true 4. otherwise returns false Deprecated, use camel-mdc component instead |  | String
+| `camel.main.messageHistory` | Sets whether message history is enabled or not. Default is false. | false | boolean
+| `camel.main.messageSizeEnabled` | Sets whether message size observation is enabled (default is false). When enabled, Camel will compute the size of message body and headers (in bytes) per endpoint (for both IN and OUT directions) and make this available via JMX MBeans (min/max/mean body size and headers size). | false | boolean
+| `camel.main.modeline` | Whether to support JBang style //DEPS to specify additional dependencies when running Camel CLI | false | boolean
+| `camel.main.name` | Sets the name of the CamelContext. |  | String
+| `camel.main.producerTemplateCacheSize` | Producer template endpoints cache size. | 1000 | int
+| `camel.main.profile` | Camel profile to use when running. The dev profile is for development, which enables a set of additional developer focus functionality, tracing, debugging, and gathering additional runtime statistics that are useful during development. However, those additional features has a slight overhead cost, and are not enabled for production profile. The default profile is prod. |  | String
+| `camel.main.routeFilterExcludePattern` | Used for filtering routes routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
+| `camel.main.routeFilterIncludePattern` | Used for filtering routes matching the given pattern, which follows the following rules: - Match by route id - Match by route input endpoint uri The matching is using exact match, by wildcard and regular expression as documented by PatternHelper#matchPattern(String,String) . For example to only include routes which starts with foo in their route id's, use: include=foo&#42; And to exclude routes which starts from JMS endpoints, use: exclude=jms:&#42; Multiple patterns can be separated by comma, for example to exclude both foo and bar routes, use: exclude=foo&#42;,bar&#42; Exclude takes precedence over include. |  | String
+| `camel.main.routesBuilderClasses` | Sets classes names that implement RoutesBuilder . |  | String
+| `camel.main.routesBuilders` | Sets the RoutesBuilder instances. |  | List
+| `camel.main.routesCollectorEnabled` | Whether the routes collector is enabled or not. When enabled Camel will auto-discover routes (RouteBuilder instances from the registry and also load additional routes from the file system). The routes collector is default enabled. | true | boolean
+| `camel.main.routesCollectorIgnoreLoadingError` | Whether the routes collector should ignore any errors during loading and compiling routes. This is only intended for development or tooling. | false | boolean
+| `camel.main.routesExcludePattern` | Used for exclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to exclude all the routes from a directory whose name contains foo use: &#42;&#42;/foo. |  | String
+| `camel.main.routesIncludePattern` | Used for inclusive filtering of routes from directories. The exclusive filtering takes precedence over inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma, as example, to include all the routes from a directory whose name contains foo use: &#42;&#42;/foo. | classpath:camel/*,classpath:camel-template/*,classpath:camel-rest/* | String
+| `camel.main.routesReloadDirectory` | Directory to scan for route changes. Camel cannot scan the classpath, so this must be configured to a file directory. Development with Maven as build tool, you can configure the directory to be src/main/resources to scan for Camel routes in XML or YAML files. | src/main/resources/camel | String
+| `camel.main.routesReloadDirectoryRecursive` | Whether the directory to scan should include sub directories. Depending on the number of sub directories, then this can cause the JVM to startup slower as Camel uses the JDK file-watch service to scan for file changes. | false | boolean
+| `camel.main.routesReloadEnabled` | Used for enabling automatic routes reloading. If enabled then Camel will watch for file changes in the given reload directory, and trigger reloading routes if files are changed. | false | boolean
+| `camel.main.routesReloadPattern` | Used for inclusive filtering of routes from directories. Typical used for specifying to accept routes in XML or YAML files, such as .yaml,.xml. Multiple patterns can be specified separated by comma. |  | String
+| `camel.main.routesReloadRemoveAllRoutes` | When reloading routes should all existing routes be stopped and removed. By default, Camel will stop and remove all existing routes before reloading routes. This ensures that only the reloaded routes will be active. If disabled then only routes with the same route id is updated, and any existing routes are continued to run. | true | boolean
+| `camel.main.routesReloadRestartDuration` | Whether to restart max duration when routes are reloaded. For example if max duration is 60 seconds, and a route is reloaded after 25 seconds, then this will restart the count and wait 60 seconds again. | false | boolean
+| `camel.main.shutdownLogInflightExchangesOnTimeout` | Sets whether to log information about the inflight Exchanges which are still running during a shutdown which didn't complete without the given timeout. This requires to enable the option inflightRepositoryBrowseEnabled. | true | boolean
+| `camel.main.shutdownNowOnTimeout` | Sets whether to force shutdown of all consumers when a timeout occurred and thus not all consumers was shutdown within that period. You should have good reasons to set this option to false as it means that the routes keep running and is halted abruptly when CamelContext has been shutdown. | true | boolean
+| `camel.main.shutdownRoutesInReverseOrder` | Sets whether routes should be shutdown in reverse or the same order as they were started. | true | boolean
+| `camel.main.shutdownSuppressLoggingOnTimeout` | Whether Camel should try to suppress logging during shutdown and timeout was triggered, meaning forced shutdown is happening. And during forced shutdown we want to avoid logging errors/warnings et all in the logs as a side-effect of the forced timeout. Notice the suppress is a best effort as there may still be some logs coming from 3rd party libraries and whatnot, which Camel cannot control. This option is default false. | false | boolean
+| `camel.main.shutdownTimeout` | Timeout in seconds to graceful shutdown all the Camel routes. | 45 | int
+| `camel.main.sourceLocationEnabled` | Whether to capture precise source location:line-number for all EIPs in Camel routes. Enabling this will impact parsing Java based routes (also Groovy etc.) on startup as this uses JDK StackTraceElement to calculate the location from the Camel route, which comes with a performance cost. This only impact startup, not the performance of the routes at runtime. | false | boolean
+| `camel.main.startupRecorder` | To use startup recorder for capturing execution time during starting Camel. The recorder can be one of: false (or off), logging, backlog, java-flight-recorder (or jfr). |  | String
+| `camel.main.startupRecorderDir` | Directory to store the recording. By default the current directory will be used. Use false to turn off saving recording to disk. |  | String
+| `camel.main.startupRecorderDuration` | How long time to run the startup recorder. Use 0 (default) to keep the recorder running until the JVM is exited. Use -1 to stop the recorder right after Camel has been started (to only focus on potential Camel startup performance bottlenecks) Use a positive value to keep recording for N seconds. When the recorder is stopped then the recording is auto saved to disk (note: save to disk can be disabled by setting startupRecorderDir to false) |  | long
+| `camel.main.startupRecorderMaxDepth` | To filter our sub steps at a maximum depth. Use -1 for no maximum. Use 0 for no sub steps. Use 1 for max 1 sub step, and so forth. The default is -1. | -1 | int
+| `camel.main.startupRecorderProfile` | To use a specific Java Flight Recorder profile configuration, such as default or profile. The default is default. | default | String
+| `camel.main.startupRecorderRecording` | To enable Java Flight Recorder to start a recording and automatic dump the recording to disk after startup is complete. This requires that camel-jfr is on the classpath, and to enable this option. | false | boolean
+| `camel.main.startupRecorderRuntimeEnabled` | To also instrument the running Camel application, and not only its startup, by emitting Java Flight Recorder events for every exchange, route and processor. This requires that camel-jfr is on the classpath, and to enable this option. The runtime events are only captured while a recording is active. As they are emitted per message they add overhead, so this is turned off by default. | false | boolean
+| `camel.main.startupSummaryLevel` | Controls the level of information logged during startup (and shutdown) of CamelContext. | Default | StartupSummaryLevel
+| `camel.main.streamCachingAllowClasses` | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
+| `camel.main.streamCachingAnySpoolRules` | Sets whether if just any of the org.apache.camel.spi.StreamCachingStrategy.SpoolRule rules returns true then shouldSpoolCache(long) returns true, to allow spooling to disk. If this option is false, then all the org.apache.camel.spi.StreamCachingStrategy.SpoolRule must return true. The default value is false which means that all the rules must return true. | false | boolean
+| `camel.main.streamCachingBufferSize` | Sets the stream caching buffer size to use when allocating in-memory buffers used for in-memory stream caches. The default size is 4096. |  | int
+| `camel.main.streamCachingDenyClasses` | To filter stream caching of a given set of allowed/denied classes. By default, all classes that are java.io.InputStream is allowed. Multiple class names can be separated by comma. |  | String
+| `camel.main.streamCachingEnabled` | Sets whether stream caching is enabled or not. While stream types (like StreamSource, InputStream and Reader) are commonly used in messaging for performance reasons, they also have an important drawback: they can only be read once. In order to be able to work with message content multiple times, the stream needs to be cached. Streams are cached in memory only (by default). If streamCachingSpoolEnabled=true, then, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is true. | true | boolean
+| `camel.main.streamCachingRemoveSpoolDirectoryWhenStopping` | Whether to remove stream caching temporary directory when stopping. This option is default true. | true | boolean
+| `camel.main.streamCachingSpoolCipher` | Sets a stream caching cipher name to use when spooling to disk to write with encryption. By default the data is not encrypted. |  | String
+| `camel.main.streamCachingSpoolDirectory` | Sets the stream caching spool (temporary) directory to use for overflow and spooling to disk. If no spool directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
+| `camel.main.streamCachingSpoolEnabled` | To enable stream caching spooling to disk. This means, for large stream messages (over 128 KB by default) will be cached in a temporary file instead, and Camel will handle deleting the temporary file once the cached stream is no longer necessary. Default is false. | false | boolean
+| `camel.main.streamCachingSpoolRules` | Sets custom rules (org.apache.camel.spi.StreamCachingStrategy.SpoolRule) for deciding when to spool to disk. Multiple rules can be separated by comma. |  | String
+| `camel.main.streamCachingSpoolThreshold` | Stream caching threshold in bytes when overflow to disk is activated. The default threshold is 128kb. Use -1 to disable overflow to disk. |  | long
+| `camel.main.streamCachingSpoolUsedHeapMemoryLimit` | Sets what the upper bounds should be when streamCachingSpoolUsedHeapMemoryThreshold is in use. | Max | String
+| `camel.main.streamCachingSpoolUsedHeapMemoryThreshold` | Sets a percentage (1-99) of used heap memory threshold to activate stream caching spooling to disk. |  | int
+| `camel.main.streamCachingStatisticsEnabled` | Sets whether stream caching statistics is enabled. | false | boolean
+| `camel.main.threadNamePattern` | Sets the thread name pattern used for creating the full thread name. The default pattern is: Camel (#camelId#) thread ##counter# - #name# Where #camelId# is the name of the CamelContext. and #counter# is a unique incrementing counter. and #name# is the regular thread name. You can also use #longName# which is the long thread name which can includes endpoint parameters etc. |  | String
+| `camel.main.tracing` | Sets whether tracing is enabled or not. Default is false. | false | boolean
+| `camel.main.tracingLoggingFormat` | To use a custom tracing logging format. The default format (arrow, routeId, label) is: %-4.4s %-12.12s %-33.33s | %-4.4s [%-12.12s] [%-33.33s] | String
+| `camel.main.tracingPattern` | Tracing pattern to match which node EIPs to trace. For example to match all To EIP nodes, use to. The pattern matches by node and route id's Multiple patterns can be separated by comma. |  | String
+| `camel.main.tracingStandby` | Whether to set tracing on standby. If on standby then the tracer is installed and made available. Then the tracer can be enabled later at runtime via JMX or via Tracer#setEnabled(boolean) . | false | boolean
+| `camel.main.tracingTemplates` | Whether tracing should trace inner details from route templates (or kamelets). Turning this on increases the verbosity of tracing by including events from internal routes in the templates or kamelets. Default is false. | false | boolean
+| `camel.main.typeConverterStatisticsEnabled` | Sets whether type converter statistics is enabled. By default the type converter utilization statistics is disabled. Notice: If enabled then there is a slight performance impact under very heavy load. | false | boolean
+| `camel.main.useBreadcrumb` | Set whether breadcrumb is enabled. The default value is false. | false | boolean
+| `camel.main.useDataType` | Whether to enable using data type on Camel messages. Data type are automatic turned on if one ore more routes has been explicit configured with input and output types. Otherwise data type is default off. | false | boolean
+| `camel.main.useMdcLogging` | To turn on MDC logging (deprecated, use camel-mdc component instead) | false | boolean
+| `camel.main.uuidGenerator` | UUID generator to use. default (32 bytes), short (16 bytes), classic (32 bytes or longer), simple (long incrementing counter), off (turned off for exchanges - only intended for performance profiling) | default | String
+| `camel.main.virtualThreadsEnabled` | Whether to enable virtual threads when creating thread pools. When enabled, Camel will use virtual threads instead of platform threads for its thread pools. This can also be enabled via the JVM system property {code camel.threads.virtual.enabled=true} . This option must be read early during bootstrap, so it is set as a system property before thread pools are created. | false | boolean
+| `camel.main.yamlDslCompactNotationWarn` | Whether to log a WARN when YAML DSL routes use compact (shorthand) notation instead of the canonical (explicit/normalized) form. The canonical style is recommended as it is more tooling and AI friendly. Use Camel CLI to normalize existing routes: camel validate normalize &lt;file&gt; | true | boolean
 |===
 
 
@@ -163,13 +163,13 @@ The camel.startupcondition supports 7 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.startupcondition.customClassNames* | A list of custom class names (FQN). Multiple classes can be separated by comma. |  | String
-| *camel.startupcondition.enabled* | To enable using startup conditions | false | boolean
-| *camel.startupcondition.environmentVariableExists* | Wait for an environment variable with the given name to exists before continuing |  | String
-| *camel.startupcondition.fileExists* | Wait for a file with the given name to exists before continuing |  | String
-| *camel.startupcondition.interval* | Interval in millis between checking conditions. | 500 | int
-| *camel.startupcondition.onTimeout* | What action, to do on timeout. fail = do not startup, and throw an exception causing camel to fail stop = do not startup, and stop camel ignore = log a WARN and continue to startup | stop | String
-| *camel.startupcondition.timeout* | Total timeout (in millis) for all startup conditions. | 20000 | int
+| `camel.startupcondition.customClassNames` | A list of custom class names (FQN). Multiple classes can be separated by comma. |  | String
+| `camel.startupcondition.enabled` | To enable using startup conditions | false | boolean
+| `camel.startupcondition.environmentVariableExists` | Wait for an environment variable with the given name to exists before continuing |  | String
+| `camel.startupcondition.fileExists` | Wait for a file with the given name to exists before continuing |  | String
+| `camel.startupcondition.interval` | Interval in millis between checking conditions. | 500 | int
+| `camel.startupcondition.onTimeout` | What action, to do on timeout. fail = do not startup, and throw an exception causing camel to fail stop = do not startup, and stop camel ignore = log a WARN and continue to startup | stop | String
+| `camel.startupcondition.timeout` | Total timeout (in millis) for all startup conditions. | 20000 | int
 |===
 
 
@@ -179,18 +179,18 @@ The camel.routecontroller supports 12 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.routecontroller.backOffDelay* | Backoff delay in millis when restarting a route that failed to startup. | 2000 | long
-| *camel.routecontroller.backOffMaxAttempts* | Backoff maximum number of attempts to restart a route that failed to startup. When this threshold has been exceeded then the controller will give up attempting to restart the route, and the route will remain as stopped. |  | long
-| *camel.routecontroller.backOffMaxDelay* | Backoff maximum delay in millis when restarting a route that failed to startup. |  | long
-| *camel.routecontroller.backOffMaxElapsedTime* | Backoff maximum elapsed time in millis, after which the backoff should be considered exhausted and no more attempts should be made. |  | long
-| *camel.routecontroller.backOffMultiplier* | Backoff multiplier to use for exponential backoff. This is used to extend the delay between restart attempts. |  | double
-| *camel.routecontroller.enabled* | To enable using supervising route controller which allows Camel to start up and then, the controller takes care of starting the routes in a safe manner. This can be used when you want to start up Camel despite a route may otherwise fail fast during startup and cause Camel to fail to start up as well. By delegating the route startup to the supervising route controller, then it manages the startup using a background thread. The controller allows to be configured with various settings to attempt to restart failing routes. | false | boolean
-| *camel.routecontroller.excludeRoutes* | Pattern for filtering routes to be excluded as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to exclude all JMS routes, you can say jms:. And to exclude routes with specific route ids mySpecialRoute,myOtherSpecialRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
-| *camel.routecontroller.includeRoutes* | Pattern for filtering routes to be included as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to include all kafka routes, you can say kafka:. And to include routes with specific route ids myRoute,myOtherRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
-| *camel.routecontroller.initialDelay* | Initial delay in milli seconds before the route controller starts, after CamelContext has been started. |  | long
-| *camel.routecontroller.threadPoolSize* | The number of threads used by the route controller scheduled thread pool that are used for restarting routes. The pool uses 1 thread by default, but you can increase this to allow the controller to concurrently attempt to restart multiple routes in case more than one route has problems starting. | 1 | int
-| *camel.routecontroller.unhealthyOnExhausted* | Whether to mark the route as unhealthy (down) when all restarting attempts (backoff) have failed and the route is not successfully started and the route manager is giving up. If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
-| *camel.routecontroller.unhealthyOnRestarting* | Whether to mark the route as unhealthy (down) when the route failed to initially start, and is being controlled for restarting (backoff). If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
+| `camel.routecontroller.backOffDelay` | Backoff delay in millis when restarting a route that failed to startup. | 2000 | long
+| `camel.routecontroller.backOffMaxAttempts` | Backoff maximum number of attempts to restart a route that failed to startup. When this threshold has been exceeded then the controller will give up attempting to restart the route, and the route will remain as stopped. |  | long
+| `camel.routecontroller.backOffMaxDelay` | Backoff maximum delay in millis when restarting a route that failed to startup. |  | long
+| `camel.routecontroller.backOffMaxElapsedTime` | Backoff maximum elapsed time in millis, after which the backoff should be considered exhausted and no more attempts should be made. |  | long
+| `camel.routecontroller.backOffMultiplier` | Backoff multiplier to use for exponential backoff. This is used to extend the delay between restart attempts. |  | double
+| `camel.routecontroller.enabled` | To enable using supervising route controller which allows Camel to start up and then, the controller takes care of starting the routes in a safe manner. This can be used when you want to start up Camel despite a route may otherwise fail fast during startup and cause Camel to fail to start up as well. By delegating the route startup to the supervising route controller, then it manages the startup using a background thread. The controller allows to be configured with various settings to attempt to restart failing routes. | false | boolean
+| `camel.routecontroller.excludeRoutes` | Pattern for filtering routes to be excluded as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to exclude all JMS routes, you can say jms:. And to exclude routes with specific route ids mySpecialRoute,myOtherSpecialRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
+| `camel.routecontroller.includeRoutes` | Pattern for filtering routes to be included as supervised. The pattern is matching on route id, and endpoint uri for the route. Multiple patterns can be separated by comma. For example to include all kafka routes, you can say kafka:. And to include routes with specific route ids myRoute,myOtherRoute. The pattern supports wildcards and uses the matcher from org.apache.camel.support.PatternHelper#matchPattern. |  | String
+| `camel.routecontroller.initialDelay` | Initial delay in milli seconds before the route controller starts, after CamelContext has been started. |  | long
+| `camel.routecontroller.threadPoolSize` | The number of threads used by the route controller scheduled thread pool that are used for restarting routes. The pool uses 1 thread by default, but you can increase this to allow the controller to concurrently attempt to restart multiple routes in case more than one route has problems starting. | 1 | int
+| `camel.routecontroller.unhealthyOnExhausted` | Whether to mark the route as unhealthy (down) when all restarting attempts (backoff) have failed and the route is not successfully started and the route manager is giving up. If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
+| `camel.routecontroller.unhealthyOnRestarting` | Whether to mark the route as unhealthy (down) when the route failed to initially start, and is being controlled for restarting (backoff). If setting this to false will make health checks ignore this problem and allow to report the Camel application as UP. | true | boolean
 |===
 
 
@@ -200,34 +200,34 @@ The camel.server supports 28 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.server.authenticationEnabled* | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
-| *camel.server.authenticationPath* | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
-| *camel.server.authenticationRealm* | Sets the authentication realm |  | String
-| *camel.server.basicPropertiesFile* | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
-| *camel.server.enabled* | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
-| *camel.server.fileUploadDirectory* | Directory to temporary store file uploads while Camel routes the incoming request. If no directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
-| *camel.server.fileUploadEnabled* | Whether to enable file uploads being supported (such as POST multipart/form-data) and stored into a temporary directory. | true | boolean
-| *camel.server.host* | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
-| *camel.server.jwtAllowMissingIssuerAndAudience* | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the embedded server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
-| *camel.server.jwtAudience* | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
-| *camel.server.jwtIssuer* | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
-| *camel.server.jwtKeystorePassword* | Password from the keystore used for JWT tokens validation. |  | String
-| *camel.server.jwtKeystorePath* | Path to the keystore file used for JWT tokens validation. |  | String
-| *camel.server.jwtKeystoreType* | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
-| *camel.server.maxBodySize* | Maximum HTTP body size the embedded HTTP server can accept. |  | Long
-| *camel.server.mcpEnabled* | Whether to expose ai-tool routes as MCP tools over streamable HTTP. Requires camel-mcp-server on the classpath. By default, the MCP server is not enabled. | false | boolean
-| *camel.server.mcpPath* | HTTP path where the MCP endpoint is served. | /mcp | String
-| *camel.server.mcpServerName* | MCP server name advertised to clients. Defaults to the CamelContext name. |  | String
-| *camel.server.mcpSessionIdleTtl* | Idle TTL in milliseconds for MCP sessions on the Vert.x streamable transport. Sessions with no activity for longer than this interval are evicted. 0 disables idle eviction. | 300000 | long
-| *camel.server.mcpSessionKeepAliveInterval* | Keep-alive ping interval in milliseconds for MCP sessions on the Vert.x streamable transport. Dead sessions are evicted after consecutive ping failures. 0 disables keep-alive pings. | 30000 | long
-| *camel.server.mcpTags* | Comma-separated list of ai-tool tag patterns to expose as MCP tools. Matching is case-insensitive and supports exact match, wildcard prefix ( {code foo} ), and {code } to match all tags. Only tools registered under a matching tag are exposed; the untagged default pool is never exposed. When not set, no tools are exposed. |  | String
-| *camel.server.mcpToolTimeout* | Per-call MCP tool execution timeout in milliseconds. A call exceeding the timeout returns an error result to the MCP client; the underlying route keeps running until it completes on its own. | 20000 | long
-| *camel.server.path* | Context-path to use for embedded HTTP server | / | String
-| *camel.server.port* | Port to use for binding embedded HTTP server. Use 0 to dynamic assign a free random port number. | 8080 | int
-| *camel.server.staticContextPath* | The context-path to use for serving static content. By default, the root path is used. And if there is an index.html page then this is automatically loaded. | / | String
-| *camel.server.staticEnabled* | Whether serving static files is enabled. If enabled then Camel can host html/js and other web files that makes it possible to include small web applications. | false | boolean
-| *camel.server.staticSourceDir* | Additional directory that holds static content when static is enabled. |  | String
-| *camel.server.useGlobalSslContextParameters* | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
+| `camel.server.authenticationEnabled` | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
+| `camel.server.authenticationPath` | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
+| `camel.server.authenticationRealm` | Sets the authentication realm |  | String
+| `camel.server.basicPropertiesFile` | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
+| `camel.server.enabled` | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
+| `camel.server.fileUploadDirectory` | Directory to temporary store file uploads while Camel routes the incoming request. If no directory has been explicit configured, then a temporary directory is created in the java.io.tmpdir directory. |  | String
+| `camel.server.fileUploadEnabled` | Whether to enable file uploads being supported (such as POST multipart/form-data) and stored into a temporary directory. | true | boolean
+| `camel.server.host` | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
+| `camel.server.jwtAllowMissingIssuerAndAudience` | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the embedded server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
+| `camel.server.jwtAudience` | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
+| `camel.server.jwtIssuer` | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
+| `camel.server.jwtKeystorePassword` | Password from the keystore used for JWT tokens validation. |  | String
+| `camel.server.jwtKeystorePath` | Path to the keystore file used for JWT tokens validation. |  | String
+| `camel.server.jwtKeystoreType` | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
+| `camel.server.maxBodySize` | Maximum HTTP body size the embedded HTTP server can accept. |  | Long
+| `camel.server.mcpEnabled` | Whether to expose ai-tool routes as MCP tools over streamable HTTP. Requires camel-mcp-server on the classpath. By default, the MCP server is not enabled. | false | boolean
+| `camel.server.mcpPath` | HTTP path where the MCP endpoint is served. | /mcp | String
+| `camel.server.mcpServerName` | MCP server name advertised to clients. Defaults to the CamelContext name. |  | String
+| `camel.server.mcpSessionIdleTtl` | Idle TTL in milliseconds for MCP sessions on the Vert.x streamable transport. Sessions with no activity for longer than this interval are evicted. 0 disables idle eviction. | 300000 | long
+| `camel.server.mcpSessionKeepAliveInterval` | Keep-alive ping interval in milliseconds for MCP sessions on the Vert.x streamable transport. Dead sessions are evicted after consecutive ping failures. 0 disables keep-alive pings. | 30000 | long
+| `camel.server.mcpTags` | Comma-separated list of ai-tool tag patterns to expose as MCP tools. Matching is case-insensitive and supports exact match, wildcard prefix ( {code foo} ), and {code } to match all tags. Only tools registered under a matching tag are exposed; the untagged default pool is never exposed. When not set, no tools are exposed. |  | String
+| `camel.server.mcpToolTimeout` | Per-call MCP tool execution timeout in milliseconds. A call exceeding the timeout returns an error result to the MCP client; the underlying route keeps running until it completes on its own. | 20000 | long
+| `camel.server.path` | Context-path to use for embedded HTTP server | / | String
+| `camel.server.port` | Port to use for binding embedded HTTP server. Use 0 to dynamic assign a free random port number. | 8080 | int
+| `camel.server.staticContextPath` | The context-path to use for serving static content. By default, the root path is used. And if there is an index.html page then this is automatically loaded. | / | String
+| `camel.server.staticEnabled` | Whether serving static files is enabled. If enabled then Camel can host html/js and other web files that makes it possible to include small web applications. | false | boolean
+| `camel.server.staticSourceDir` | Additional directory that holds static content when static is enabled. |  | String
+| `camel.server.useGlobalSslContextParameters` | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
 |===
 
 
@@ -237,37 +237,37 @@ The camel.management supports 31 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.management.authenticationEnabled* | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
-| *camel.management.authenticationPath* | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
-| *camel.management.authenticationRealm* | Sets the authentication realm |  | String
-| *camel.management.basicPropertiesFile* | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
-| *camel.management.devConsoleEnabled* | Whether to enable developer console (not intended for production use). Dev console must also be enabled on CamelContext. For example by setting camel.context.dev-console=true in application.properties, or via code camelContext.setDevConsole(true); If enabled then you can access a basic developer console on context-path: /q/dev. | false | boolean
-| *camel.management.downloadEnabled* | Whether to enable file download via HTTP. This makes it possible to browse and download resource source files such as Camel XML or YAML routes. Only enable this for development, troubleshooting or special situations for management and monitoring. | false | boolean
-| *camel.management.enabled* | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
-| *camel.management.healthCheckEnabled* | Whether to enable health-check console. If enabled then you can access health-check status on context-path: /observe/health | false | boolean
-| *camel.management.healthPath* | The path endpoint used to expose the health status | /observe/health | String
-| *camel.management.host* | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
-| *camel.management.infoEnabled* | Whether to enable info console. If enabled then you can see some basic Camel information at /observe/info | false | boolean
-| *camel.management.infoPath* | The path endpoint used to expose the info status | /observe/info | String
-| *camel.management.jolokiaEnabled* | Whether to enable jolokia. If enabled then you can access jolokia api on context-path: /observe/jolokia | false | boolean
-| *camel.management.jolokiaPath* | The path endpoint used to expose the jolokia data. | /observe/jolokia | String
-| *camel.management.jwtAllowMissingIssuerAndAudience* | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the management server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
-| *camel.management.jwtAudience* | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
-| *camel.management.jwtIssuer* | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
-| *camel.management.jwtKeystorePassword* | Password from the keystore used for JWT tokens validation. |  | String
-| *camel.management.jwtKeystorePath* | Path to the keystore file used for JWT tokens validation. |  | String
-| *camel.management.jwtKeystoreType* | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
-| *camel.management.mcpEnabled* | Whether to expose dev/diagnostics MCP tools on this management server (requires camel-mcp-server on the classpath). Currently honored only when Camel JBang registers JbangDevMcpMainListener (for example camel run --mcp). For route-based MCP on the main HTTP server in plain camel-main, configure camel.server.mcpEnabled instead. Not intended for production use. | false | boolean
-| *camel.management.mcpPath* | HTTP path where the management MCP endpoint is served. | /mcp | String
-| *camel.management.metricsEnabled* | Whether to enable metrics. If enabled then you can access metrics on context-path: /observe/metrics | false | boolean
-| *camel.management.openapiUiEnabled* | Whether to enable Swagger UI for REST DSL OpenAPI documents. If enabled then you can browse the API at context-path: /q/openapi. The OpenAPI document is expected at openapiUiSpecPath (by default /q/openapi.json from REST DSL apiContextPath ). | false | boolean
-| *camel.management.openapiUiSpecPath* | Path or URL of the OpenAPI document loaded by Swagger UI at /q/openapi. | /q/openapi.json | String
-| *camel.management.path* | Context-path to use for embedded HTTP server | / | String
-| *camel.management.port* | Port to use for binding embedded HTTP management server. Use 0 to dynamic assign a free random port number. | 8080 | int
-| *camel.management.sendEnabled* | Whether to enable sending messages to Camel via HTTP. This makes it possible to use Camel to send messages to Camel endpoint URIs via HTTP. | false | boolean
-| *camel.management.uploadEnabled* | Whether to enable file upload via HTTP (not intended for production use). This functionality is for development to be able to reload Camel routes and code with source changes (if reload is enabled). If enabled then you can upload/delete files via HTTP PUT/DELETE on context-path: /q/upload/\{name}. You must also configure the uploadSourceDir option. | false | boolean
-| *camel.management.uploadSourceDir* | Source directory when upload is enabled. |  | String
-| *camel.management.useGlobalSslContextParameters* | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
+| `camel.management.authenticationEnabled` | Whether to enable HTTP authentication for embedded server (for standalone applications; not Spring Boot or Quarkus). | false | boolean
+| `camel.management.authenticationPath` | Set HTTP url path of embedded server that is protected by authentication configuration. |  | String
+| `camel.management.authenticationRealm` | Sets the authentication realm |  | String
+| `camel.management.basicPropertiesFile` | Name of the file that contains basic authentication info for Vert.x file auth provider. |  | String
+| `camel.management.devConsoleEnabled` | Whether to enable developer console (not intended for production use). Dev console must also be enabled on CamelContext. For example by setting camel.context.dev-console=true in application.properties, or via code camelContext.setDevConsole(true); If enabled then you can access a basic developer console on context-path: /q/dev. | false | boolean
+| `camel.management.downloadEnabled` | Whether to enable file download via HTTP. This makes it possible to browse and download resource source files such as Camel XML or YAML routes. Only enable this for development, troubleshooting or special situations for management and monitoring. | false | boolean
+| `camel.management.enabled` | Whether embedded HTTP server is enabled. By default, the server is not enabled. | false | boolean
+| `camel.management.healthCheckEnabled` | Whether to enable health-check console. If enabled then you can access health-check status on context-path: /observe/health | false | boolean
+| `camel.management.healthPath` | The path endpoint used to expose the health status | /observe/health | String
+| `camel.management.host` | Hostname to use for binding embedded HTTP server | 0.0.0.0 | String
+| `camel.management.infoEnabled` | Whether to enable info console. If enabled then you can see some basic Camel information at /observe/info | false | boolean
+| `camel.management.infoPath` | The path endpoint used to expose the info status | /observe/info | String
+| `camel.management.jolokiaEnabled` | Whether to enable jolokia. If enabled then you can access jolokia api on context-path: /observe/jolokia | false | boolean
+| `camel.management.jolokiaPath` | The path endpoint used to expose the jolokia data. | /observe/jolokia | String
+| `camel.management.jwtAllowMissingIssuerAndAudience` | Whether JWT authentication is allowed to run without an expected issuer or audience. By default the management server fails to start when a JWT keystore is configured but neither jwtIssuer nor jwtAudience is set, because the tokens would only be checked for signature and expiry. Enable this to accept that and validate signature and expiry only. | false | boolean
+| `camel.management.jwtAudience` | Expected JWT audience (aud claim) for token validation. Multiple values can be separated by comma. When set, tokens whose audience does not contain any of the configured values are rejected. |  | String
+| `camel.management.jwtIssuer` | Expected JWT issuer (iss claim) for token validation. When set, tokens whose issuer does not match are rejected. |  | String
+| `camel.management.jwtKeystorePassword` | Password from the keystore used for JWT tokens validation. |  | String
+| `camel.management.jwtKeystorePath` | Path to the keystore file used for JWT tokens validation. |  | String
+| `camel.management.jwtKeystoreType` | Type of the keystore used for JWT tokens validation (jks, pkcs12, etc.). |  | String
+| `camel.management.mcpEnabled` | Whether to expose dev/diagnostics MCP tools on this management server (requires camel-mcp-server on the classpath). Currently honored only when Camel JBang registers JbangDevMcpMainListener (for example camel run --mcp). For route-based MCP on the main HTTP server in plain camel-main, configure camel.server.mcpEnabled instead. Not intended for production use. | false | boolean
+| `camel.management.mcpPath` | HTTP path where the management MCP endpoint is served. | /mcp | String
+| `camel.management.metricsEnabled` | Whether to enable metrics. If enabled then you can access metrics on context-path: /observe/metrics | false | boolean
+| `camel.management.openapiUiEnabled` | Whether to enable Swagger UI for REST DSL OpenAPI documents. If enabled then you can browse the API at context-path: /q/openapi. The OpenAPI document is expected at openapiUiSpecPath (by default /q/openapi.json from REST DSL apiContextPath ). | false | boolean
+| `camel.management.openapiUiSpecPath` | Path or URL of the OpenAPI document loaded by Swagger UI at /q/openapi. | /q/openapi.json | String
+| `camel.management.path` | Context-path to use for embedded HTTP server | / | String
+| `camel.management.port` | Port to use for binding embedded HTTP management server. Use 0 to dynamic assign a free random port number. | 8080 | int
+| `camel.management.sendEnabled` | Whether to enable sending messages to Camel via HTTP. This makes it possible to use Camel to send messages to Camel endpoint URIs via HTTP. | false | boolean
+| `camel.management.uploadEnabled` | Whether to enable file upload via HTTP (not intended for production use). This functionality is for development to be able to reload Camel routes and code with source changes (if reload is enabled). If enabled then you can upload/delete files via HTTP PUT/DELETE on context-path: /q/upload/\{name}. You must also configure the uploadSourceDir option. | false | boolean
+| `camel.management.uploadSourceDir` | Source directory when upload is enabled. |  | String
+| `camel.management.useGlobalSslContextParameters` | Whether to use global SSL configuration for securing the embedded HTTP server. | false | boolean
 |===
 
 
@@ -277,21 +277,21 @@ The camel.debug supports 15 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.debug.bodyIncludeFiles* | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
-| *camel.debug.bodyIncludeStreams* | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
-| *camel.debug.bodyMaxChars* | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
-| *camel.debug.breakpoints* | Allows to pre-configure breakpoints (node ids) to use with debugger on startup. Multiple ids can be separated by comma. Use special value _all_routes_ to add a breakpoint for the first node for every route, in other words this makes it easy to debug from the beginning of every route without knowing the exact node ids. |  | String
-| *camel.debug.enabled* | Enables Debugger in your Camel application. | false | boolean
-| *camel.debug.fallbackTimeout* | Fallback Timeout in seconds (300 seconds as default) when block the message processing in Camel. A timeout used for waiting for a message to arrive at a given breakpoint. | 300 | long
-| *camel.debug.includeException* | Trace messages to include exception if the message failed | true | boolean
-| *camel.debug.includeExchangeProperties* | Whether to include the exchange properties in the traced message | true | boolean
-| *camel.debug.includeExchangeVariables* | Whether to include the exchange variables in the traced message | true | boolean
-| *camel.debug.jmxConnectorEnabled* | Whether to create JMX connector that allows tooling to control the Camel debugger. This is what the IDEA and VSCode tooling is using. | true | boolean
-| *camel.debug.jmxConnectorPort* | Port number to expose a JMX RMI connector for tooling that needs to control the debugger. | 1099 | int
-| *camel.debug.loggingLevel* | The debugger logging level to use when logging activity. | INFO | LoggingLevel
-| *camel.debug.singleStepIncludeStartEnd* | In single step mode, then when the exchange is created and completed, then simulate a breakpoint at start and end, that allows to suspend and watch the incoming/complete exchange at the route (you can see message body as response, failed exception etc). | false | boolean
-| *camel.debug.standby* | To set the debugger in standby mode, where the debugger will be installed by not automatic enabled. The debugger can then later be enabled explicit from Java, JMX or tooling. | false | boolean
-| *camel.debug.waitForAttach* | Whether the debugger should suspend on startup, and wait for a remote debugger to attach. This is what the IDEA and VSCode tooling is using. | false | boolean
+| `camel.debug.bodyIncludeFiles` | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
+| `camel.debug.bodyIncludeStreams` | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
+| `camel.debug.bodyMaxChars` | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
+| `camel.debug.breakpoints` | Allows to pre-configure breakpoints (node ids) to use with debugger on startup. Multiple ids can be separated by comma. Use special value _all_routes_ to add a breakpoint for the first node for every route, in other words this makes it easy to debug from the beginning of every route without knowing the exact node ids. |  | String
+| `camel.debug.enabled` | Enables Debugger in your Camel application. | false | boolean
+| `camel.debug.fallbackTimeout` | Fallback Timeout in seconds (300 seconds as default) when block the message processing in Camel. A timeout used for waiting for a message to arrive at a given breakpoint. | 300 | long
+| `camel.debug.includeException` | Trace messages to include exception if the message failed | true | boolean
+| `camel.debug.includeExchangeProperties` | Whether to include the exchange properties in the traced message | true | boolean
+| `camel.debug.includeExchangeVariables` | Whether to include the exchange variables in the traced message | true | boolean
+| `camel.debug.jmxConnectorEnabled` | Whether to create JMX connector that allows tooling to control the Camel debugger. This is what the IDEA and VSCode tooling is using. | true | boolean
+| `camel.debug.jmxConnectorPort` | Port number to expose a JMX RMI connector for tooling that needs to control the debugger. | 1099 | int
+| `camel.debug.loggingLevel` | The debugger logging level to use when logging activity. | INFO | LoggingLevel
+| `camel.debug.singleStepIncludeStartEnd` | In single step mode, then when the exchange is created and completed, then simulate a breakpoint at start and end, that allows to suspend and watch the incoming/complete exchange at the route (you can see message body as response, failed exception etc). | false | boolean
+| `camel.debug.standby` | To set the debugger in standby mode, where the debugger will be installed by not automatic enabled. The debugger can then later be enabled explicit from Java, JMX or tooling. | false | boolean
+| `camel.debug.waitForAttach` | Whether the debugger should suspend on startup, and wait for a remote debugger to attach. This is what the IDEA and VSCode tooling is using. | false | boolean
 |===
 
 
@@ -301,22 +301,22 @@ The camel.trace supports 16 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.trace.activityEnabled* | Whether activity tracking is enabled. When enabled, the backlog tracer will capture activity data that can be enriched with additional details from tracing (such as span decorator attributes). | false | boolean
-| *camel.trace.activitySize* | Defines how many completed exchange summaries to keep in the activity queue (should be between 1 - 1000). The activity queue captures lightweight metadata (no body or headers) each time an exchange completes a route, providing a rolling window of recent exchange activity. | 100 | int
-| *camel.trace.backlogSize* | Defines how many of the last messages to keep in the tracer (should be between 1 - 1000). | 100 | int
-| *camel.trace.bodyIncludeFiles* | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
-| *camel.trace.bodyIncludeStreams* | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
-| *camel.trace.bodyMaxChars* | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
-| *camel.trace.enabled* | Enables tracer in your Camel application. | false | boolean
-| *camel.trace.includeException* | Trace messages to include exception if the message failed | true | boolean
-| *camel.trace.includeExchangeProperties* | Whether to include the exchange properties in the traced message | true | boolean
-| *camel.trace.includeExchangeVariables* | Whether to include the exchange variables in the traced message | true | boolean
-| *camel.trace.removeOnDump* | Whether all traced messages should be removed when the tracer is dumping. By default, the messages are removed, which means that dumping will not contain previous dumped messages. | true | boolean
-| *camel.trace.standby* | To set the tracer in standby mode, where the tracer will be installed by not automatic enabled. The tracer can then later be enabled explicit from Java, JMX or tooling. | false | boolean
-| *camel.trace.traceFilter* | Filter for tracing messages |  | String
-| *camel.trace.tracePattern* | Filter for tracing by route or node id |  | String
-| *camel.trace.traceRests* | Whether to trace routes that is created from Rest DSL. | true | boolean
-| *camel.trace.traceTemplates* | Whether to trace routes that is created from route templates or kamelets. | false | boolean
+| `camel.trace.activityEnabled` | Whether activity tracking is enabled. When enabled, the backlog tracer will capture activity data that can be enriched with additional details from tracing (such as span decorator attributes). | false | boolean
+| `camel.trace.activitySize` | Defines how many completed exchange summaries to keep in the activity queue (should be between 1 - 1000). The activity queue captures lightweight metadata (no body or headers) each time an exchange completes a route, providing a rolling window of recent exchange activity. | 100 | int
+| `camel.trace.backlogSize` | Defines how many of the last messages to keep in the tracer (should be between 1 - 1000). | 100 | int
+| `camel.trace.bodyIncludeFiles` | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
+| `camel.trace.bodyIncludeStreams` | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
+| `camel.trace.bodyMaxChars` | To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size. | 32768 | int
+| `camel.trace.enabled` | Enables tracer in your Camel application. | false | boolean
+| `camel.trace.includeException` | Trace messages to include exception if the message failed | true | boolean
+| `camel.trace.includeExchangeProperties` | Whether to include the exchange properties in the traced message | true | boolean
+| `camel.trace.includeExchangeVariables` | Whether to include the exchange variables in the traced message | true | boolean
+| `camel.trace.removeOnDump` | Whether all traced messages should be removed when the tracer is dumping. By default, the messages are removed, which means that dumping will not contain previous dumped messages. | true | boolean
+| `camel.trace.standby` | To set the tracer in standby mode, where the tracer will be installed by not automatic enabled. The tracer can then later be enabled explicit from Java, JMX or tooling. | false | boolean
+| `camel.trace.traceFilter` | Filter for tracing messages |  | String
+| `camel.trace.tracePattern` | Filter for tracing by route or node id |  | String
+| `camel.trace.traceRests` | Whether to trace routes that is created from Rest DSL. | true | boolean
+| `camel.trace.traceTemplates` | Whether to trace routes that is created from route templates or kamelets. | false | boolean
 |===
 
 
@@ -326,12 +326,12 @@ The camel.security supports 6 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.security.allowedProperties* | Comma-separated list of property keys to exclude from security policy checks. Use full property paths to allow specific properties regardless of the configured policy. |  | String
-| *camel.security.insecureDevPolicy* | Security policy for development-only features. When set, overrides the global policy for options intended only for development environments. |  | String
-| *camel.security.insecureSerializationPolicy* | Security policy for insecure deserialization configuration. When set, overrides the global policy for options that enable dangerous deserialization of untrusted data. |  | String
-| *camel.security.insecureSslPolicy* | Security policy for insecure SSL/TLS configuration. When set, overrides the global policy for options that disable certificate validation or hostname verification. |  | String
-| *camel.security.policy* | Global security policy applied to all categories unless overridden. Controls how Camel reacts when insecure configuration is detected at startup. | warn | String
-| *camel.security.secretPolicy* | Security policy for plain-text secrets. When set, overrides the global policy for properties that contain sensitive values configured as plain text. |  | String
+| `camel.security.allowedProperties` | Comma-separated list of property keys to exclude from security policy checks. Use full property paths to allow specific properties regardless of the configured policy. |  | String
+| `camel.security.insecureDevPolicy` | Security policy for development-only features. When set, overrides the global policy for options intended only for development environments. |  | String
+| `camel.security.insecureSerializationPolicy` | Security policy for insecure deserialization configuration. When set, overrides the global policy for options that enable dangerous deserialization of untrusted data. |  | String
+| `camel.security.insecureSslPolicy` | Security policy for insecure SSL/TLS configuration. When set, overrides the global policy for options that disable certificate validation or hostname verification. |  | String
+| `camel.security.policy` | Global security policy applied to all categories unless overridden. Controls how Camel reacts when insecure configuration is detected at startup. | warn | String
+| `camel.security.secretPolicy` | Security policy for plain-text secrets. When set, overrides the global policy for properties that contain sensitive values configured as plain text. |  | String
 |===
 
 
@@ -341,34 +341,34 @@ The camel.ssl supports 28 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.ssl.certAlias* | An optional certificate alias to use. This is useful when the keystore has multiple certificates. |  | String
-| *camel.ssl.cipherSuites* | List of TLS/SSL cipher suite algorithm names. Multiple names can be separated by comma. |  | String
-| *camel.ssl.cipherSuitesExclude* | Filters TLS/SSL cipher suites algorithms names. This filter is used for excluding algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.cipherSuitesInclude* | Filters TLS/SSL cipher suites algorithms names. This filter is used for including algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.clientAuthentication* | Sets the configuration for server-side client-authentication requirements | NONE | String
-| *camel.ssl.enabled* | Enables SSL in your Camel application. | false | boolean
-| *camel.ssl.keyManagerAlgorithm* | Algorithm name used for creating the KeyManagerFactory. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
-| *camel.ssl.keyManagerProvider* | To use a specific provider for creating KeyManagerFactory. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.keyStore* | The key store to load. The key store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
-| *camel.ssl.keystorePassword* | Sets the SSL Keystore password. |  | String
-| *camel.ssl.keyStoreProvider* | To use a specific provider for creating KeyStore. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.keyStoreType* | The type of the key store to load. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
-| *camel.ssl.namedGroups* | List of TLS/SSL named groups (key exchange groups). Multiple names can be separated by comma. Named groups control which key exchange algorithms are available during the TLS handshake, including post-quantum hybrid groups such as X25519MLKEM768. |  | String
-| *camel.ssl.namedGroupsExclude* | Filters TLS/SSL named groups. This filter is used for excluding named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.namedGroupsInclude* | Filters TLS/SSL named groups. This filter is used for including named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.provider* | To use a specific provider for creating SSLContext. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.secureRandomAlgorithm* | Algorithm name used for creating the SecureRandom. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
-| *camel.ssl.secureRandomProvider* | To use a specific provider for creating SecureRandom. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
-| *camel.ssl.secureSocketProtocol* | The protocol for the secure sockets created by the SSLContext. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html | TLSv1.3 | String
-| *camel.ssl.selfSigned* | Whether to generate a self-signed certificate for development use when no keystore is configured. This can be used in development environment to easily enable HTTPS without providing a keystore. Do NOT use this in production as the certificate is not trusted and is regenerated on each restart. | false | boolean
-| *camel.ssl.selfSignedKeyType* | The key algorithm to use when generating the self-signed certificate for development use (requires selfSigned to be enabled). Supported values are EC (default, NIST P-256) and RSA (2048-bit). | EC | String
-| *camel.ssl.sessionTimeout* | Timeout in seconds to use for SSLContext. The default is 24 hours. | 86400 | int
-| *camel.ssl.signatureSchemes* | List of TLS/SSL signature schemes. Multiple names can be separated by comma. Signature schemes control which signature algorithms are available during the TLS handshake, including post-quantum signature algorithms such as ML-DSA. |  | String
-| *camel.ssl.signatureSchemesExclude* | Filters TLS/SSL signature schemes. This filter is used for excluding signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.signatureSchemesInclude* | Filters TLS/SSL signature schemes. This filter is used for including signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
-| *camel.ssl.trustAllCertificates* | Allows to trust all SSL certificates without performing certificate validation. This can be used in development environment but may expose the system to security risks. Notice that if the trustAllCertificates option is set to true then the trustStore/trustStorePassword options are not in use. | false | boolean
-| *camel.ssl.trustStore* | The trust store to load. The trust store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
-| *camel.ssl.trustStorePassword* | Sets the SSL Truststore password. |  | String
+| `camel.ssl.certAlias` | An optional certificate alias to use. This is useful when the keystore has multiple certificates. |  | String
+| `camel.ssl.cipherSuites` | List of TLS/SSL cipher suite algorithm names. Multiple names can be separated by comma. |  | String
+| `camel.ssl.cipherSuitesExclude` | Filters TLS/SSL cipher suites algorithms names. This filter is used for excluding algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.cipherSuitesInclude` | Filters TLS/SSL cipher suites algorithms names. This filter is used for including algorithms that matches the naming pattern. Multiple names can be separated by comma. Notice that if the cipherSuites option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.clientAuthentication` | Sets the configuration for server-side client-authentication requirements | NONE | String
+| `camel.ssl.enabled` | Enables SSL in your Camel application. | false | boolean
+| `camel.ssl.keyManagerAlgorithm` | Algorithm name used for creating the KeyManagerFactory. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
+| `camel.ssl.keyManagerProvider` | To use a specific provider for creating KeyManagerFactory. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.keyStore` | The key store to load. The key store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
+| `camel.ssl.keystorePassword` | Sets the SSL Keystore password. |  | String
+| `camel.ssl.keyStoreProvider` | To use a specific provider for creating KeyStore. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.keyStoreType` | The type of the key store to load. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
+| `camel.ssl.namedGroups` | List of TLS/SSL named groups (key exchange groups). Multiple names can be separated by comma. Named groups control which key exchange algorithms are available during the TLS handshake, including post-quantum hybrid groups such as X25519MLKEM768. |  | String
+| `camel.ssl.namedGroupsExclude` | Filters TLS/SSL named groups. This filter is used for excluding named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.namedGroupsInclude` | Filters TLS/SSL named groups. This filter is used for including named groups that match the naming pattern. Multiple names can be separated by comma. Notice that if the namedGroups option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.provider` | To use a specific provider for creating SSLContext. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.secureRandomAlgorithm` | Algorithm name used for creating the SecureRandom. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html |  | String
+| `camel.ssl.secureRandomProvider` | To use a specific provider for creating SecureRandom. The list of available providers returned by java.security.Security.getProviders() or null to use the highest priority provider implementing the secure socket protocol. |  | String
+| `camel.ssl.secureSocketProtocol` | The protocol for the secure sockets created by the SSLContext. See \https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html | TLSv1.3 | String
+| `camel.ssl.selfSigned` | Whether to generate a self-signed certificate for development use when no keystore is configured. This can be used in development environment to easily enable HTTPS without providing a keystore. Do NOT use this in production as the certificate is not trusted and is regenerated on each restart. | false | boolean
+| `camel.ssl.selfSignedKeyType` | The key algorithm to use when generating the self-signed certificate for development use (requires selfSigned to be enabled). Supported values are EC (default, NIST P-256) and RSA (2048-bit). | EC | String
+| `camel.ssl.sessionTimeout` | Timeout in seconds to use for SSLContext. The default is 24 hours. | 86400 | int
+| `camel.ssl.signatureSchemes` | List of TLS/SSL signature schemes. Multiple names can be separated by comma. Signature schemes control which signature algorithms are available during the TLS handshake, including post-quantum signature algorithms such as ML-DSA. |  | String
+| `camel.ssl.signatureSchemesExclude` | Filters TLS/SSL signature schemes. This filter is used for excluding signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.signatureSchemesInclude` | Filters TLS/SSL signature schemes. This filter is used for including signature schemes that match the naming pattern. Multiple names can be separated by comma. Notice that if the signatureSchemes option has been configured then the include/exclude filters are not in use. |  | String
+| `camel.ssl.trustAllCertificates` | Allows to trust all SSL certificates without performing certificate validation. This can be used in development environment but may expose the system to security risks. Notice that if the trustAllCertificates option is set to true then the trustStore/trustStorePassword options are not in use. | false | boolean
+| `camel.ssl.trustStore` | The trust store to load. The trust store is by default loaded from classpath. If you must load from file system, then use file: as prefix. file:nameOfFile (to refer to the file system) classpath:nameOfFile (to refer to the classpath; default) http:uri (to load the resource using HTTP) ref:nameOfBean (to lookup an existing KeyStore instance from the registry, for example for testing and development). |  | String
+| `camel.ssl.trustStorePassword` | Sets the SSL Truststore password. |  | String
 |===
 
 
@@ -378,14 +378,14 @@ The camel.threadpool supports 8 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.threadpool.allowCoreThreadTimeOut* | Sets default whether to allow core threads to timeout | false | Boolean
-| *camel.threadpool.config* | Adds a configuration for a specific thread pool profile (inherits default values) |  | Map
-| *camel.threadpool.keepAliveTime* | Sets the default keep alive time for inactive threads |  | Long
-| *camel.threadpool.maxPoolSize* | Sets the default maximum pool size |  | Integer
-| *camel.threadpool.maxQueueSize* | Sets the default maximum number of tasks in the work queue. Use -1 or an unbounded queue |  | Integer
-| *camel.threadpool.poolSize* | Sets the default core pool size (threads to keep minimum in pool) |  | Integer
-| *camel.threadpool.rejectedPolicy* | Sets the default handler for tasks which cannot be executed by the thread pool. |  | ThreadPoolRejectedPolicy
-| *camel.threadpool.timeUnit* | Sets the default time unit used for keep alive time |  | TimeUnit
+| `camel.threadpool.allowCoreThreadTimeOut` | Sets default whether to allow core threads to timeout | false | Boolean
+| `camel.threadpool.config` | Adds a configuration for a specific thread pool profile (inherits default values) |  | Map
+| `camel.threadpool.keepAliveTime` | Sets the default keep alive time for inactive threads |  | Long
+| `camel.threadpool.maxPoolSize` | Sets the default maximum pool size |  | Integer
+| `camel.threadpool.maxQueueSize` | Sets the default maximum number of tasks in the work queue. Use -1 or an unbounded queue |  | Integer
+| `camel.threadpool.poolSize` | Sets the default core pool size (threads to keep minimum in pool) |  | Integer
+| `camel.threadpool.rejectedPolicy` | Sets the default handler for tasks which cannot be executed by the thread pool. |  | ThreadPoolRejectedPolicy
+| `camel.threadpool.timeUnit` | Sets the default time unit used for keep alive time |  | TimeUnit
 |===
 
 
@@ -395,14 +395,14 @@ The camel.health supports 8 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.health.consumersEnabled* | Whether consumers health check is enabled | true | Boolean
-| *camel.health.enabled* | Whether health check is enabled globally | true | Boolean
-| *camel.health.excludePattern* | Pattern to exclude health checks from being invoked by Camel when checking healths. Multiple patterns can be separated by comma. |  | String
-| *camel.health.exposureLevel* | Sets the level of details to exposure as result of invoking health checks. There are the following levels: full, default, oneline The full level will include all details and status from all the invoked health checks. The default level will report UP if everything is okay, and only include detailed information for health checks that was DOWN. The oneline level will only report either UP or DOWN. | default | String
-| *camel.health.initialState* | The initial state of health-checks (readiness). There are the following states: UP, DOWN, UNKNOWN. By default, the state is DOWN, is regarded as being pessimistic/careful. This means that the overall health checks may report as DOWN during startup and then only if everything is up and running flip to being UP. Setting the initial state to UP, is regarded as being optimistic. This means that the overall health checks may report as UP during startup and then if a consumer or other service is in fact un-healthy, then the health-checks can flip being DOWN. Setting the state to UNKNOWN means that some health-check would be reported in unknown state, especially during early bootstrap where a consumer may not be fully initialized or validated a connection to a remote system. This option allows to pre-configure the state for different modes. | down | String
-| *camel.health.producersEnabled* | Whether producers health check is enabled | false | Boolean
-| *camel.health.registryEnabled* | Whether registry health check is enabled | true | Boolean
-| *camel.health.routesEnabled* | Whether routes health check is enabled | true | Boolean
+| `camel.health.consumersEnabled` | Whether consumers health check is enabled | true | Boolean
+| `camel.health.enabled` | Whether health check is enabled globally | true | Boolean
+| `camel.health.excludePattern` | Pattern to exclude health checks from being invoked by Camel when checking healths. Multiple patterns can be separated by comma. |  | String
+| `camel.health.exposureLevel` | Sets the level of details to exposure as result of invoking health checks. There are the following levels: full, default, oneline The full level will include all details and status from all the invoked health checks. The default level will report UP if everything is okay, and only include detailed information for health checks that was DOWN. The oneline level will only report either UP or DOWN. | default | String
+| `camel.health.initialState` | The initial state of health-checks (readiness). There are the following states: UP, DOWN, UNKNOWN. By default, the state is DOWN, is regarded as being pessimistic/careful. This means that the overall health checks may report as DOWN during startup and then only if everything is up and running flip to being UP. Setting the initial state to UP, is regarded as being optimistic. This means that the overall health checks may report as UP during startup and then if a consumer or other service is in fact un-healthy, then the health-checks can flip being DOWN. Setting the state to UNKNOWN means that some health-check would be reported in unknown state, especially during early bootstrap where a consumer may not be fully initialized or validated a connection to a remote system. This option allows to pre-configure the state for different modes. | down | String
+| `camel.health.producersEnabled` | Whether producers health check is enabled | false | Boolean
+| `camel.health.registryEnabled` | Whether registry health check is enabled | true | Boolean
+| `camel.health.routesEnabled` | Whether routes health check is enabled | true | Boolean
 |===
 
 
@@ -412,37 +412,37 @@ The camel.rest supports 31 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.rest.apiComponent* | Sets the name of the Camel component to use as the REST API (such as swagger or openapi) |  | String
-| *camel.rest.apiContextPath* | Sets a leading API context-path the REST API services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. |  | String
-| *camel.rest.apiContextRouteId* | Sets the route id to use for the route that services the REST API. The route will by default use an auto assigned route id. |  | String
-| *camel.rest.apiHost* | To use a specific hostname for the API documentation (such as swagger or openapi) This can be used to override the generated host with this configured hostname |  | String
-| *camel.rest.apiProperties* | Sets additional options on api level |  | Map
-| *camel.rest.apiVendorExtension* | Whether vendor extension is enabled in the Rest APIs. If enabled then Camel will include additional information as vendor extension (eg keys starting with x-) such as route ids, class names etc. Not all 3rd party API gateways and tools supports vendor-extensions when importing your API docs. | false | boolean
-| *camel.rest.bindingMode* | Sets the binding mode to be used by the REST consumer | RestBindingMode.off | RestBindingMode
-| *camel.rest.bindingPackageScan* | Package name to use as base (offset) for classpath scanning of POJO classes are located when using binding mode is enabled for JSon or XML. Multiple package names can be separated by comma. |  | String
-| *camel.rest.clientRequestValidation* | Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error. | false | boolean
-| *camel.rest.clientResponseValidation* | Whether to check what Camel is returning as response to the client: 1) Status-code and Content-Type matches Rest DSL response messages. 2) Check whether expected headers is included according to the Rest DSL repose message headers. 3) If the response body is JSon then check whether its valid JSon. Returns 500 if validation error detected. | false | boolean
-| *camel.rest.component* | Sets the name of the Camel component to use as the REST consumer |  | String
-| *camel.rest.componentProperties* | Sets additional options on component level |  | Map
-| *camel.rest.consumerProperties* | Sets additional options on consumer level |  | Map
-| *camel.rest.contextPath* | Sets a leading context-path the REST services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. Or for components such as camel-jetty or camel-netty-http that includes a HTTP server. |  | String
-| *camel.rest.corsHeaders* | Sets the CORS headers to use if CORS has been enabled. |  | Map
-| *camel.rest.dataFormatProperties* | Sets additional options on data format level |  | Map
-| *camel.rest.enableCORS* | To specify whether to enable CORS which means Camel will automatic include CORS in the HTTP headers in the response. This option is default false | false | boolean
-| *camel.rest.enableNoContentResponse* | Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false. | false | boolean
-| *camel.rest.endpointProperties* | Sets additional options on endpoint level |  | Map
-| *camel.rest.host* | Sets the hostname to use by the REST consumer |  | String
-| *camel.rest.hostNameResolver* | Sets the resolver to use for resolving hostname | RestHostNameResolver.allLocalIp | RestHostNameResolver
-| *camel.rest.inlineRoutes* | Inline routes in rest-dsl which are linked using direct endpoints. Each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). By inlining (default) allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. If a route is not using direct endpoint then the rest-dsl is not inlined, and will become an individual route. This option is default true. | true | boolean
-| *camel.rest.jsonDataFormat* | Sets a custom json data format to be used Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
-| *camel.rest.port* | Sets the port to use by the REST consumer |  | int
-| *camel.rest.producerApiDoc* | Sets the location of the api document (swagger api) the REST producer will use to validate the REST uri and query parameters are valid accordingly to the api document. This requires adding camel-openapi-java to the classpath, and any miss configuration will let Camel fail on startup and report the error(s). The location of the api document is loaded from classpath by default, but you can use file: or http: to refer to resources to load from file or http url. |  | String
-| *camel.rest.producerComponent* | Sets the name of the Camel component to use as the REST producer |  | String
-| *camel.rest.scheme* | Sets the scheme to use by the REST consumer |  | String
-| *camel.rest.skipBindingOnErrorCode* | Whether to skip binding output if there is a custom HTTP error code, and instead use the response body as-is. This option is default true. | true | boolean
-| *camel.rest.useXForwardHeaders* | Whether to use X-Forward headers to set host etc. for OpenApi. This may be needed in special cases involving reverse-proxy and networking going from HTTP to HTTPS etc. Then the proxy can send X-Forward headers (X-Forwarded-Proto) that influences the host names in the OpenAPI schema that camel-openapi-java generates from Rest DSL routes. | false | boolean
-| *camel.rest.validationLevels* | Sets the client request validation levels when using camel-openapi-validator. |  | Map
-| *camel.rest.xmlDataFormat* | Sets a custom xml data format to be used. Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
+| `camel.rest.apiComponent` | Sets the name of the Camel component to use as the REST API (such as swagger or openapi) |  | String
+| `camel.rest.apiContextPath` | Sets a leading API context-path the REST API services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. |  | String
+| `camel.rest.apiContextRouteId` | Sets the route id to use for the route that services the REST API. The route will by default use an auto assigned route id. |  | String
+| `camel.rest.apiHost` | To use a specific hostname for the API documentation (such as swagger or openapi) This can be used to override the generated host with this configured hostname |  | String
+| `camel.rest.apiProperties` | Sets additional options on api level |  | Map
+| `camel.rest.apiVendorExtension` | Whether vendor extension is enabled in the Rest APIs. If enabled then Camel will include additional information as vendor extension (eg keys starting with x-) such as route ids, class names etc. Not all 3rd party API gateways and tools supports vendor-extensions when importing your API docs. | false | boolean
+| `camel.rest.bindingMode` | Sets the binding mode to be used by the REST consumer | RestBindingMode.off | RestBindingMode
+| `camel.rest.bindingPackageScan` | Package name to use as base (offset) for classpath scanning of POJO classes are located when using binding mode is enabled for JSon or XML. Multiple package names can be separated by comma. |  | String
+| `camel.rest.clientRequestValidation` | Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error. | false | boolean
+| `camel.rest.clientResponseValidation` | Whether to check what Camel is returning as response to the client: 1) Status-code and Content-Type matches Rest DSL response messages. 2) Check whether expected headers is included according to the Rest DSL repose message headers. 3) If the response body is JSon then check whether its valid JSon. Returns 500 if validation error detected. | false | boolean
+| `camel.rest.component` | Sets the name of the Camel component to use as the REST consumer |  | String
+| `camel.rest.componentProperties` | Sets additional options on component level |  | Map
+| `camel.rest.consumerProperties` | Sets additional options on consumer level |  | Map
+| `camel.rest.contextPath` | Sets a leading context-path the REST services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. Or for components such as camel-jetty or camel-netty-http that includes a HTTP server. |  | String
+| `camel.rest.corsHeaders` | Sets the CORS headers to use if CORS has been enabled. |  | Map
+| `camel.rest.dataFormatProperties` | Sets additional options on data format level |  | Map
+| `camel.rest.enableCORS` | To specify whether to enable CORS which means Camel will automatic include CORS in the HTTP headers in the response. This option is default false | false | boolean
+| `camel.rest.enableNoContentResponse` | Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false. | false | boolean
+| `camel.rest.endpointProperties` | Sets additional options on endpoint level |  | Map
+| `camel.rest.host` | Sets the hostname to use by the REST consumer |  | String
+| `camel.rest.hostNameResolver` | Sets the resolver to use for resolving hostname | RestHostNameResolver.allLocalIp | RestHostNameResolver
+| `camel.rest.inlineRoutes` | Inline routes in rest-dsl which are linked using direct endpoints. Each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). By inlining (default) allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. If a route is not using direct endpoint then the rest-dsl is not inlined, and will become an individual route. This option is default true. | true | boolean
+| `camel.rest.jsonDataFormat` | Sets a custom json data format to be used Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
+| `camel.rest.port` | Sets the port to use by the REST consumer |  | int
+| `camel.rest.producerApiDoc` | Sets the location of the api document (swagger api) the REST producer will use to validate the REST uri and query parameters are valid accordingly to the api document. This requires adding camel-openapi-java to the classpath, and any miss configuration will let Camel fail on startup and report the error(s). The location of the api document is loaded from classpath by default, but you can use file: or http: to refer to resources to load from file or http url. |  | String
+| `camel.rest.producerComponent` | Sets the name of the Camel component to use as the REST producer |  | String
+| `camel.rest.scheme` | Sets the scheme to use by the REST consumer |  | String
+| `camel.rest.skipBindingOnErrorCode` | Whether to skip binding output if there is a custom HTTP error code, and instead use the response body as-is. This option is default true. | true | boolean
+| `camel.rest.useXForwardHeaders` | Whether to use X-Forward headers to set host etc. for OpenApi. This may be needed in special cases involving reverse-proxy and networking going from HTTP to HTTPS etc. Then the proxy can send X-Forward headers (X-Forwarded-Proto) that influences the host names in the OpenAPI schema that camel-openapi-java generates from Rest DSL routes. | false | boolean
+| `camel.rest.validationLevels` | Sets the client request validation levels when using camel-openapi-validator. |  | Map
+| `camel.rest.xmlDataFormat` | Sets a custom xml data format to be used. Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance. |  | String
 |===
 
 
@@ -452,19 +452,19 @@ The camel.vault.aws supports 13 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.aws.accessKey* | The AWS access key |  | String
-| *camel.vault.aws.defaultCredentialsProvider* | Define if we want to use the AWS Default Credentials Provider or not | false | boolean
-| *camel.vault.aws.overrideEndpoint* | Set the need for overriding the endpoint. This option needs to be used in combination with the uriEndpointOverride option | false | boolean
-| *camel.vault.aws.profileCredentialsProvider* | Define if we want to use the AWS Profile Credentials Provider or not | false | boolean
-| *camel.vault.aws.profileName* | Define the profile name to use if Profile Credentials Provider is selected |  | String
-| *camel.vault.aws.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in AWS. | false | boolean
-| *camel.vault.aws.refreshPeriod* | The period (millis) between checking AWS for updated secrets. | 30000 | long
-| *camel.vault.aws.region* | The AWS region |  | String
-| *camel.vault.aws.secretKey* | The AWS secret key |  | String
-| *camel.vault.aws.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.aws.sqsQueueUrl* | In case of usage of SQS notification this field will specified the Queue URL to use |  | String
-| *camel.vault.aws.uriEndpointOverride* | Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option |  | String
-| *camel.vault.aws.useSqsNotification* | Whether to use AWS SQS for secrets updates notification, this will require setting up Eventbridge/Cloudtrail/SQS communication | false | boolean
+| `camel.vault.aws.accessKey` | The AWS access key |  | String
+| `camel.vault.aws.defaultCredentialsProvider` | Define if we want to use the AWS Default Credentials Provider or not | false | boolean
+| `camel.vault.aws.overrideEndpoint` | Set the need for overriding the endpoint. This option needs to be used in combination with the uriEndpointOverride option | false | boolean
+| `camel.vault.aws.profileCredentialsProvider` | Define if we want to use the AWS Profile Credentials Provider or not | false | boolean
+| `camel.vault.aws.profileName` | Define the profile name to use if Profile Credentials Provider is selected |  | String
+| `camel.vault.aws.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in AWS. | false | boolean
+| `camel.vault.aws.refreshPeriod` | The period (millis) between checking AWS for updated secrets. | 30000 | long
+| `camel.vault.aws.region` | The AWS region |  | String
+| `camel.vault.aws.secretKey` | The AWS secret key |  | String
+| `camel.vault.aws.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.aws.sqsQueueUrl` | In case of usage of SQS notification this field will specified the Queue URL to use |  | String
+| `camel.vault.aws.uriEndpointOverride` | Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option |  | String
+| `camel.vault.aws.useSqsNotification` | Whether to use AWS SQS for secrets updates notification, this will require setting up Eventbridge/Cloudtrail/SQS communication | false | boolean
 |===
 
 
@@ -474,13 +474,13 @@ The camel.vault.gcp supports 7 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.gcp.projectId* | The GCP Project ID |  | String
-| *camel.vault.gcp.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in GCP. | false | boolean
-| *camel.vault.gcp.refreshPeriod* | The period (millis) between checking Google for updated secrets. | 30000 | long
-| *camel.vault.gcp.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.gcp.serviceAccountKey* | The Service Account Key location |  | String
-| *camel.vault.gcp.subscriptionName* | Define the Google Pubsub subscription Name to be used when checking for updates |  | String
-| *camel.vault.gcp.useDefaultInstance* | Define if we want to use the GCP Client Default Instance or not | false | boolean
+| `camel.vault.gcp.projectId` | The GCP Project ID |  | String
+| `camel.vault.gcp.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in GCP. | false | boolean
+| `camel.vault.gcp.refreshPeriod` | The period (millis) between checking Google for updated secrets. | 30000 | long
+| `camel.vault.gcp.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.gcp.serviceAccountKey` | The Service Account Key location |  | String
+| `camel.vault.gcp.subscriptionName` | Define the Google Pubsub subscription Name to be used when checking for updates |  | String
+| `camel.vault.gcp.useDefaultInstance` | Define if we want to use the GCP Client Default Instance or not | false | boolean
 |===
 
 
@@ -490,18 +490,18 @@ The camel.vault.azure supports 12 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.azure.azureIdentityEnabled* | Whether the Azure Identity Authentication should be used or not. | false | boolean
-| *camel.vault.azure.blobAccessKey* | The Eventhubs Blob Access Key for CheckpointStore purpose |  | String
-| *camel.vault.azure.blobAccountName* | The Eventhubs Blob Account Name for CheckpointStore purpose |  | String
-| *camel.vault.azure.blobContainerName* | The Eventhubs Blob Container Name for CheckpointStore purpose |  | String
-| *camel.vault.azure.clientId* | The client Id for accessing Azure Key Vault |  | String
-| *camel.vault.azure.clientSecret* | The client Secret for accessing Azure Key Vault |  | String
-| *camel.vault.azure.eventhubConnectionString* | The Eventhubs connection String for Key Vault Secret events notifications |  | String
-| *camel.vault.azure.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in Azure. | false | boolean
-| *camel.vault.azure.refreshPeriod* | The period (millis) between checking Azure for updated secrets. | 30000 | long
-| *camel.vault.azure.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.azure.tenantId* | The Tenant Id for accessing Azure Key Vault |  | String
-| *camel.vault.azure.vaultName* | The vault Name in Azure Key Vault |  | String
+| `camel.vault.azure.azureIdentityEnabled` | Whether the Azure Identity Authentication should be used or not. | false | boolean
+| `camel.vault.azure.blobAccessKey` | The Eventhubs Blob Access Key for CheckpointStore purpose |  | String
+| `camel.vault.azure.blobAccountName` | The Eventhubs Blob Account Name for CheckpointStore purpose |  | String
+| `camel.vault.azure.blobContainerName` | The Eventhubs Blob Container Name for CheckpointStore purpose |  | String
+| `camel.vault.azure.clientId` | The client Id for accessing Azure Key Vault |  | String
+| `camel.vault.azure.clientSecret` | The client Secret for accessing Azure Key Vault |  | String
+| `camel.vault.azure.eventhubConnectionString` | The Eventhubs connection String for Key Vault Secret events notifications |  | String
+| `camel.vault.azure.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in Azure. | false | boolean
+| `camel.vault.azure.refreshPeriod` | The period (millis) between checking Azure for updated secrets. | 30000 | long
+| `camel.vault.azure.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.azure.tenantId` | The Tenant Id for accessing Azure Key Vault |  | String
+| `camel.vault.azure.vaultName` | The vault Name in Azure Key Vault |  | String
 |===
 
 
@@ -511,10 +511,10 @@ The camel.vault.kubernetes supports 4 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.kubernetes.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in Kubernetes Cluster. | false | boolean
-| *camel.vault.kubernetes.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.kubernetescm.configmaps* | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
-| *camel.vault.kubernetescm.refreshEnabled* | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
+| `camel.vault.kubernetes.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in Kubernetes Cluster. | false | boolean
+| `camel.vault.kubernetes.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.kubernetescm.configmaps` | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
+| `camel.vault.kubernetescm.refreshEnabled` | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
 |===
 
 
@@ -524,8 +524,8 @@ The camel.vault.kubernetescm supports 2 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.kubernetescm.configmaps* | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
-| *camel.vault.kubernetescm.refreshEnabled* | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
+| `camel.vault.kubernetescm.configmaps` | Specify the configmap names (or pattern) to check for updates. Multiple configmaps can be separated by comma. |  | String
+| `camel.vault.kubernetescm.refreshEnabled` | Whether to automatically reload Camel upon configmaps being updated in Kubernetes Cluster. | false | boolean
 |===
 
 
@@ -535,15 +535,15 @@ The camel.vault.hashicorp supports 9 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.hashicorp.cloud* | Determine if the Hashicorp Vault is deployed on Hashicorp Cloud or not | false | boolean
-| *camel.vault.hashicorp.host* | Host to access hashicorp vault |  | String
-| *camel.vault.hashicorp.namespace* | If the Hashicorp Vault instance is deployed on Hashicorp Cloud, this field will determine the namespace |  | String
-| *camel.vault.hashicorp.port* | Port to access hashicorp vault |  | String
-| *camel.vault.hashicorp.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in Hashicorp Vault. | false | boolean
-| *camel.vault.hashicorp.refreshPeriod* | The period (millis) between checking Hashicorp Vault for updated secrets. | 60000 | long
-| *camel.vault.hashicorp.scheme* | Scheme to access hashicorp vault |  | String
-| *camel.vault.hashicorp.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.hashicorp.token* | Token to access hashicorp vault |  | String
+| `camel.vault.hashicorp.cloud` | Determine if the Hashicorp Vault is deployed on Hashicorp Cloud or not | false | boolean
+| `camel.vault.hashicorp.host` | Host to access hashicorp vault |  | String
+| `camel.vault.hashicorp.namespace` | If the Hashicorp Vault instance is deployed on Hashicorp Cloud, this field will determine the namespace |  | String
+| `camel.vault.hashicorp.port` | Port to access hashicorp vault |  | String
+| `camel.vault.hashicorp.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in Hashicorp Vault. | false | boolean
+| `camel.vault.hashicorp.refreshPeriod` | The period (millis) between checking Hashicorp Vault for updated secrets. | 60000 | long
+| `camel.vault.hashicorp.scheme` | Scheme to access hashicorp vault |  | String
+| `camel.vault.hashicorp.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.hashicorp.token` | Token to access hashicorp vault |  | String
 |===
 
 
@@ -553,16 +553,16 @@ The camel.vault.ibm supports 10 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.ibm.eventStreamBootstrapServers* | Specify the Bootstrap servers for consuming notification on IBM Event Stream. Multiple servers can be separated by comma. |  | String
-| *camel.vault.ibm.eventStreamConsumerPollTimeout* | Specify the Consumer Poll Timeout while consuming from IBM Event Stream Topic | 3000 | long
-| *camel.vault.ibm.eventStreamGroupId* | Specify the Consumer Group ID to access IBM Event Stream |  | String
-| *camel.vault.ibm.eventStreamPassword* | Specify the password to access IBM Event Stream |  | String
-| *camel.vault.ibm.eventStreamTopic* | Specify the topic name for consuming notification on IBM Event Stream |  | String
-| *camel.vault.ibm.eventStreamUsername* | Specify the username to access IBM Event Stream |  | String
-| *camel.vault.ibm.refreshEnabled* | Whether to automatically reload Camel upon secrets being updated in IBM. | false | boolean
-| *camel.vault.ibm.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.ibm.serviceUrl* | Service URL to access IBM Secrets Manager vault |  | String
-| *camel.vault.ibm.token* | Token to access IBM Secrets Manager vault |  | String
+| `camel.vault.ibm.eventStreamBootstrapServers` | Specify the Bootstrap servers for consuming notification on IBM Event Stream. Multiple servers can be separated by comma. |  | String
+| `camel.vault.ibm.eventStreamConsumerPollTimeout` | Specify the Consumer Poll Timeout while consuming from IBM Event Stream Topic | 3000 | long
+| `camel.vault.ibm.eventStreamGroupId` | Specify the Consumer Group ID to access IBM Event Stream |  | String
+| `camel.vault.ibm.eventStreamPassword` | Specify the password to access IBM Event Stream |  | String
+| `camel.vault.ibm.eventStreamTopic` | Specify the topic name for consuming notification on IBM Event Stream |  | String
+| `camel.vault.ibm.eventStreamUsername` | Specify the username to access IBM Event Stream |  | String
+| `camel.vault.ibm.refreshEnabled` | Whether to automatically reload Camel upon secrets being updated in IBM. | false | boolean
+| `camel.vault.ibm.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.ibm.serviceUrl` | Service URL to access IBM Secrets Manager vault |  | String
+| `camel.vault.ibm.token` | Token to access IBM Secrets Manager vault |  | String
 |===
 
 
@@ -572,15 +572,15 @@ The camel.vault.cyberark supports 9 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.vault.cyberark.account* | The CyberArk Conjur account name |  | String
-| *camel.vault.cyberark.apiKey* | The API key for authentication |  | String
-| *camel.vault.cyberark.authToken* | Pre-authenticated token to use |  | String
-| *camel.vault.cyberark.certificatePath* | Path to the SSL certificate for verification |  | String
-| *camel.vault.cyberark.password* | The password for authentication |  | String
-| *camel.vault.cyberark.secrets* | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
-| *camel.vault.cyberark.url* | The CyberArk Conjur instance URL |  | String
-| *camel.vault.cyberark.username* | The username for authentication |  | String
-| *camel.vault.cyberark.verifySsl* | Whether to verify SSL certificates | false | boolean
+| `camel.vault.cyberark.account` | The CyberArk Conjur account name |  | String
+| `camel.vault.cyberark.apiKey` | The API key for authentication |  | String
+| `camel.vault.cyberark.authToken` | Pre-authenticated token to use |  | String
+| `camel.vault.cyberark.certificatePath` | Path to the SSL certificate for verification |  | String
+| `camel.vault.cyberark.password` | The password for authentication |  | String
+| `camel.vault.cyberark.secrets` | Specify the secret names (or pattern) to check for updates. Multiple secrets can be separated by comma. |  | String
+| `camel.vault.cyberark.url` | The CyberArk Conjur instance URL |  | String
+| `camel.vault.cyberark.username` | The username for authentication |  | String
+| `camel.vault.cyberark.verifySsl` | Whether to verify SSL certificates | false | boolean
 |===
 
 
@@ -590,17 +590,17 @@ The camel.opentelemetry supports 11 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.opentelemetry.enabled* | To enable OpenTelemetry | false | boolean
-| *camel.opentelemetry.encoding* | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
-| *camel.opentelemetry.excludePatterns* | Adds an exclude pattern that will disable tracing for Camel messages that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.opentelemetry.instrumentationName* | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
-| *camel.opentelemetry.traceProcessors* | Setting this to true will create new OpenTelemetry Spans for each Camel Processors. Use the excludePattern property to filter out Processors. | false | boolean
-| *camel.opentelemetry2.enabled* | To enable OpenTelemetry 2 | false | boolean
-| *camel.opentelemetry2.encoding* | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
-| *camel.opentelemetry2.excludePatterns* | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.opentelemetry2.includePatterns* | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
-| *camel.opentelemetry2.instrumentationName* | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
-| *camel.opentelemetry2.traceProcessors* | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.opentelemetry.enabled` | To enable OpenTelemetry | false | boolean
+| `camel.opentelemetry.encoding` | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
+| `camel.opentelemetry.excludePatterns` | Adds an exclude pattern that will disable tracing for Camel messages that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.opentelemetry.instrumentationName` | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
+| `camel.opentelemetry.traceProcessors` | Setting this to true will create new OpenTelemetry Spans for each Camel Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.opentelemetry2.enabled` | To enable OpenTelemetry 2 | false | boolean
+| `camel.opentelemetry2.encoding` | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
+| `camel.opentelemetry2.excludePatterns` | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.opentelemetry2.includePatterns` | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
+| `camel.opentelemetry2.instrumentationName` | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
+| `camel.opentelemetry2.traceProcessors` | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
 |===
 
 
@@ -610,12 +610,12 @@ The camel.opentelemetry2 supports 6 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.opentelemetry2.enabled* | To enable OpenTelemetry 2 | false | boolean
-| *camel.opentelemetry2.encoding* | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
-| *camel.opentelemetry2.excludePatterns* | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.opentelemetry2.includePatterns* | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
-| *camel.opentelemetry2.instrumentationName* | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
-| *camel.opentelemetry2.traceProcessors* | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.opentelemetry2.enabled` | To enable OpenTelemetry 2 | false | boolean
+| `camel.opentelemetry2.encoding` | Sets whether the header keys need to be encoded (connector specific) or not. The value is a boolean. Dashes need for instances to be encoded for JMS property keys. | false | boolean
+| `camel.opentelemetry2.excludePatterns` | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.opentelemetry2.includePatterns` | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
+| `camel.opentelemetry2.instrumentationName` | A name uniquely identifying the instrumentation scope, such as the instrumentation library, package, or fully qualified class name. Must not be null. | camel | String
+| `camel.opentelemetry2.traceProcessors` | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
 |===
 
 
@@ -625,11 +625,11 @@ The camel.telemetryDev supports 5 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.telemetryDev.enabled* | To enable TelemetryDev | false | boolean
-| *camel.telemetryDev.excludePatterns* | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
-| *camel.telemetryDev.includePatterns* | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
-| *camel.telemetryDev.traceFormat* | The output format for traces. |  | String
-| *camel.telemetryDev.traceProcessors* | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
+| `camel.telemetryDev.enabled` | To enable TelemetryDev | false | boolean
+| `camel.telemetryDev.excludePatterns` | Sets exclude pattern(s) that will disable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. |  | String
+| `camel.telemetryDev.includePatterns` | Sets include pattern(s) that will explicitly enable tracing for Camel processors that matches the pattern. Multiple patterns can be separated by comma. All processors included by default if nothing is specified. |  | String
+| `camel.telemetryDev.traceFormat` | The output format for traces. |  | String
+| `camel.telemetryDev.traceProcessors` | Setting this to true will create new telemetry spans for each Camel custom Processors. Use the excludePattern property to filter out Processors. | false | boolean
 |===
 
 
@@ -639,9 +639,9 @@ The camel.mdc supports 3 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.mdc.customExchangeHeaders* | Provide the headers you would like to use in the logging. Use &#42; value to include all available headers |  | String
-| *camel.mdc.customExchangeProperties* | Provide the properties you would like to use in the logging. Use &#42; value to include all available properties |  | String
-| *camel.mdc.enabled* | To enable MDC service | false | boolean
+| `camel.mdc.customExchangeHeaders` | Provide the headers you would like to use in the logging. Use &#42; value to include all available headers |  | String
+| `camel.mdc.customExchangeProperties` | Provide the properties you would like to use in the logging. Use &#42; value to include all available properties |  | String
+| `camel.mdc.enabled` | To enable MDC service | false | boolean
 |===
 
 
@@ -651,22 +651,22 @@ The camel.metrics supports 16 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.metrics.baseEndpointURIExchangeEventNotifier* | Whether to use static or dynamic values for Endpoint Name tags in captured metrics. By default, static values are used. When using dynamic tags, then a dynamic to (toD) can compute many different endpoint URIs that, can lead to many tags as the URI is dynamic, so use this with care if setting this option to false. | true | boolean
-| *camel.metrics.binders* | Additional Micrometer binders to include such as jvm-memory, processor, jvm-thread, and so forth. Multiple binders can be separated by comma. The following binders currently is available from Micrometer: class-loader, commons-object-pool2, file-descriptor, hystrix-metrics-binder, jvm-compilation, jvm-gc, jvm-heap-pressure, jvm-info, jvm-memory, jvm-thread, log4j2, logback, processor, uptime |  | String
-| *camel.metrics.clearOnReload* | Clear the captured metrics data when Camel is reloading routes such as when using Camel CLI. | true | boolean
-| *camel.metrics.enabled* | To enable Micrometer metrics. | false | boolean
-| *camel.metrics.enableExchangeEventNotifier* | Set whether to enable the MicrometerExchangeEventNotifier for capturing metrics on exchange processing times. | true | boolean
-| *camel.metrics.enableInstrumentedThreadPoolFactory* | Set whether to gather performance information about Camel Thread Pools by injecting an InstrumentedThreadPoolFactory. | false | boolean
-| *camel.metrics.enableMessageHistory* | Set whether to enable the MicrometerMessageHistoryFactory for capturing metrics on individual route node processing times. Depending on the number of configured route nodes, there is the potential to create a large volume of metrics. Therefore, this option is disabled by default. | false | boolean
-| *camel.metrics.enableRouteEventNotifier* | Set whether to enable the MicrometerRouteEventNotifier for capturing metrics on the total number of routes and total number of routes running. | true | boolean
-| *camel.metrics.enableRoutePolicy* | Set whether to enable the MicrometerRoutePolicyFactory for capturing metrics on route processing times. | true | boolean
-| *camel.metrics.logMetricsOnShutdown* | Log metrics when application is shutting down. (default, false). | false | boolean
-| *camel.metrics.logMetricsOnShutdownFilters* | List of metrics (comma separated) to log when application is shutting down. You can use character to log any metrics containing the wildcard, for example camel.exchanges. (default to all metrics available). |  | String
-| *camel.metrics.namingStrategy* | Controls the name style to use for metrics. Default = uses micrometer naming convention. Legacy = uses the classic naming style (camelCase) | default | String
-| *camel.metrics.path* | The path endpoint used to expose the metrics. | /observe/metrics | String
-| *camel.metrics.routePolicyLevel* | Sets the level of information to capture. all = both context and routes. | all | String
-| *camel.metrics.skipCamelInfo* | Skip the evaluation of app.info metric which contains runtime provider information (default, false). | false | boolean
-| *camel.metrics.textFormatVersion* | The text-format version to use with Prometheus scraping. 0.0.4 = text/plain; version=0.0.4; charset=utf-8 1.0.0 = application/openmetrics-text; version=1.0.0; charset=utf-8 | 0.0.4 | String
+| `camel.metrics.baseEndpointURIExchangeEventNotifier` | Whether to use static or dynamic values for Endpoint Name tags in captured metrics. By default, static values are used. When using dynamic tags, then a dynamic to (toD) can compute many different endpoint URIs that, can lead to many tags as the URI is dynamic, so use this with care if setting this option to false. | true | boolean
+| `camel.metrics.binders` | Additional Micrometer binders to include such as jvm-memory, processor, jvm-thread, and so forth. Multiple binders can be separated by comma. The following binders currently is available from Micrometer: class-loader, commons-object-pool2, file-descriptor, hystrix-metrics-binder, jvm-compilation, jvm-gc, jvm-heap-pressure, jvm-info, jvm-memory, jvm-thread, log4j2, logback, processor, uptime |  | String
+| `camel.metrics.clearOnReload` | Clear the captured metrics data when Camel is reloading routes such as when using Camel CLI. | true | boolean
+| `camel.metrics.enabled` | To enable Micrometer metrics. | false | boolean
+| `camel.metrics.enableExchangeEventNotifier` | Set whether to enable the MicrometerExchangeEventNotifier for capturing metrics on exchange processing times. | true | boolean
+| `camel.metrics.enableInstrumentedThreadPoolFactory` | Set whether to gather performance information about Camel Thread Pools by injecting an InstrumentedThreadPoolFactory. | false | boolean
+| `camel.metrics.enableMessageHistory` | Set whether to enable the MicrometerMessageHistoryFactory for capturing metrics on individual route node processing times. Depending on the number of configured route nodes, there is the potential to create a large volume of metrics. Therefore, this option is disabled by default. | false | boolean
+| `camel.metrics.enableRouteEventNotifier` | Set whether to enable the MicrometerRouteEventNotifier for capturing metrics on the total number of routes and total number of routes running. | true | boolean
+| `camel.metrics.enableRoutePolicy` | Set whether to enable the MicrometerRoutePolicyFactory for capturing metrics on route processing times. | true | boolean
+| `camel.metrics.logMetricsOnShutdown` | Log metrics when application is shutting down. (default, false). | false | boolean
+| `camel.metrics.logMetricsOnShutdownFilters` | List of metrics (comma separated) to log when application is shutting down. You can use character to log any metrics containing the wildcard, for example camel.exchanges. (default to all metrics available). |  | String
+| `camel.metrics.namingStrategy` | Controls the name style to use for metrics. Default = uses micrometer naming convention. Legacy = uses the classic naming style (camelCase) | default | String
+| `camel.metrics.path` | The path endpoint used to expose the metrics. | /observe/metrics | String
+| `camel.metrics.routePolicyLevel` | Sets the level of information to capture. all = both context and routes. | all | String
+| `camel.metrics.skipCamelInfo` | Skip the evaluation of app.info metric which contains runtime provider information (default, false). | false | boolean
+| `camel.metrics.textFormatVersion` | The text-format version to use with Prometheus scraping. 0.0.4 = text/plain; version=0.0.4; charset=utf-8 1.0.0 = application/openmetrics-text; version=1.0.0; charset=utf-8 | 0.0.4 | String
 |===
 
 
@@ -676,17 +676,17 @@ The camel.faulttolerance supports 11 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.faulttolerance.bulkheadEnabled* | Whether bulkhead is enabled or not on the circuit breaker. Default is false. | false | Boolean
-| *camel.faulttolerance.bulkheadMaxConcurrentCalls* | Configures the max amount of concurrent calls the bulkhead will support. Default value is 10. | 10 | Integer
-| *camel.faulttolerance.bulkheadWaitingTaskQueue* | Configures the task queue size for holding waiting tasks to be processed by the bulkhead. Default value is 10. | 10 | Integer
-| *camel.faulttolerance.delay* | Control how long the circuit breaker stays open. The default is 5 seconds. | 5000 | Long
-| *camel.faulttolerance.failureRatio* | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Integer
-| *camel.faulttolerance.requestVolumeThreshold* | Controls the size of the rolling window used when the circuit breaker is closed Default value is 20. | 20 | Integer
-| *camel.faulttolerance.successThreshold* | Controls the number of trial calls which are allowed when the circuit breaker is half-open Default value is 1. | 1 | Integer
-| *camel.faulttolerance.threadOffloadExecutorService* | References a custom thread pool to use when offloading a guarded action to another thread. |  | String
-| *camel.faulttolerance.timeoutDuration* | Configures the thread execution timeout. Default value is 1000 milliseconds. | 1000 | Long
-| *camel.faulttolerance.timeoutEnabled* | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
-| *camel.faulttolerance.typedGuard* | Refers to an existing io.smallrye.faulttolerance.api.TypedGuard instance to lookup and use from the registry. When using this, then any other TypedGuard circuit breaker options are not in use. |  | String
+| `camel.faulttolerance.bulkheadEnabled` | Whether bulkhead is enabled or not on the circuit breaker. Default is false. | false | Boolean
+| `camel.faulttolerance.bulkheadMaxConcurrentCalls` | Configures the max amount of concurrent calls the bulkhead will support. Default value is 10. | 10 | Integer
+| `camel.faulttolerance.bulkheadWaitingTaskQueue` | Configures the task queue size for holding waiting tasks to be processed by the bulkhead. Default value is 10. | 10 | Integer
+| `camel.faulttolerance.delay` | Control how long the circuit breaker stays open. The default is 5 seconds. | 5000 | Long
+| `camel.faulttolerance.failureRatio` | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Integer
+| `camel.faulttolerance.requestVolumeThreshold` | Controls the size of the rolling window used when the circuit breaker is closed Default value is 20. | 20 | Integer
+| `camel.faulttolerance.successThreshold` | Controls the number of trial calls which are allowed when the circuit breaker is half-open Default value is 1. | 1 | Integer
+| `camel.faulttolerance.threadOffloadExecutorService` | References a custom thread pool to use when offloading a guarded action to another thread. |  | String
+| `camel.faulttolerance.timeoutDuration` | Configures the thread execution timeout. Default value is 1000 milliseconds. | 1000 | Long
+| `camel.faulttolerance.timeoutEnabled` | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
+| `camel.faulttolerance.typedGuard` | Refers to an existing io.smallrye.faulttolerance.api.TypedGuard instance to lookup and use from the registry. When using this, then any other TypedGuard circuit breaker options are not in use. |  | String
 |===
 
 
@@ -696,31 +696,31 @@ The camel.resilience4j supports 25 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.resilience4j.asynchronous* | Whether to use asynchronous (non-blocking) processing using Resilience4j's CompletionStage-based decorators. When enabled, the caller thread is released immediately and processing completes asynchronously. | false | Boolean
-| *camel.resilience4j.automaticTransitionFromOpenToHalfOpenEnabled* | Enables automatic transition from OPEN to HALF_OPEN state once the waitDurationInOpenState has passed. | false | Boolean
-| *camel.resilience4j.bulkheadEnabled* | Whether bulkhead is enabled or not on the circuit breaker. | false | Boolean
-| *camel.resilience4j.bulkheadFairCallHandlingEnabled* | Configures whether the bulkhead uses a fair calling strategy. When enabled (default), a fair strategy guarantees the order of incoming requests (FIFO). When disabled, no ordering is guaranteed and may improve throughput. | true | Boolean
-| *camel.resilience4j.bulkheadMaxConcurrentCalls* | Configures the max amount of concurrent calls the bulkhead will support. |  | Integer
-| *camel.resilience4j.bulkheadMaxWaitDuration* | Configures a maximum amount of time which the calling thread will wait to enter the bulkhead. Accepts Camel duration expressions (e.g. 500ms, 1s) or millisecond values. Default is 0 (no waiting). |  | String
-| *camel.resilience4j.circuitBreaker* | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreaker instance to lookup and use from the registry. When using this, then any other circuit breaker options are not in use. |  | String
-| *camel.resilience4j.config* | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreakerConfig instance to lookup and use from the registry. |  | String
-| *camel.resilience4j.failureRateThreshold* | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Float
-| *camel.resilience4j.maxWaitDurationInHalfOpenState* | Configures the maximum wait duration which controls how long the CircuitBreaker should stay in Half Open state, before it switches to open. Value 0 means circuit breaker will wait in half open state until all permitted calls have been completed. Accepts Camel duration expressions (e.g. 10s, 1m) or millisecond values. | 0 | String
-| *camel.resilience4j.micrometerEnabled* | Whether to enable collecting statistics using Micrometer. This requires adding camel-resilience4j-micrometer JAR to the classpath. | false | Boolean
-| *camel.resilience4j.minimumNumberOfCalls* | Configures configures the minimum number of calls which are required (per sliding window period) before the CircuitBreaker can calculate the error rate. For example, if minimumNumberOfCalls is 10, then at least 10 calls must be recorded, before the failure rate can be calculated. If only 9 calls have been recorded the CircuitBreaker will not transition to open even if all 9 calls have failed. Default minimumNumberOfCalls is 100 | 100 | Integer
-| *camel.resilience4j.permittedNumberOfCallsInHalfOpenState* | Configures the number of permitted calls when the CircuitBreaker is half open. The size must be greater than 0. Default size is 10. | 10 | Integer
-| *camel.resilience4j.slidingWindowSize* | Configures the size of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. slidingWindowSize configures the size of the sliding window. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. The slidingWindowSize must be greater than 0. The minimumNumberOfCalls must be greater than 0. If the slidingWindowType is COUNT_BASED, the minimumNumberOfCalls cannot be greater than slidingWindowSize . If the slidingWindowType is TIME_BASED, you can pick whatever you want. Default slidingWindowSize is 100. | 100 | Integer
-| *camel.resilience4j.slidingWindowSynchronizationStrategy* | Configures the synchronization strategy for the sliding window. LOCK_FREE uses a CAS-based lock-free algorithm for better performance under high concurrency. SYNCHRONIZED uses blocking locks with lower memory allocation. | SYNCHRONIZED | String
-| *camel.resilience4j.slidingWindowType* | Configures the type of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. Default slidingWindowType is COUNT_BASED. | COUNT_BASED | String
-| *camel.resilience4j.slowCallDurationThreshold* | Configures the duration threshold above which calls are considered as slow and increase the slow calls percentage. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
-| *camel.resilience4j.slowCallRateThreshold* | Configures a threshold in percentage. The CircuitBreaker considers a call as slow when the call duration is greater than slowCallDurationThreshold(Duration. When the percentage of slow calls is equal or greater the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 100 percentage which means that all recorded calls must be slower than slowCallDurationThreshold. | 100 | Float
-| *camel.resilience4j.throwExceptionWhenHalfOpenOrOpenState* | Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open or open. | false | Boolean
-| *camel.resilience4j.timeoutCancelRunningFuture* | Configures whether cancel is called on the running future. Defaults to true. | true | Boolean
-| *camel.resilience4j.timeoutDuration* | Configures the thread execution timeout. Accepts Camel duration expressions (e.g. 1s, 500ms) or millisecond values. Default value is 1000 millis (1 second). | 1000 | String
-| *camel.resilience4j.timeoutEnabled* | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
-| *camel.resilience4j.timeoutExecutorService* | References to a custom thread pool to use when timeout is enabled (uses ForkJoinPool#commonPool() by default) |  | String
-| *camel.resilience4j.waitDurationInOpenState* | Configures the wait duration which specifies how long the CircuitBreaker should stay open, before it switches to half open. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
-| *camel.resilience4j.writableStackTraceEnabled* | Enables writable stack traces. When set to false, Exception.getStackTrace returns a zero length array. This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls). | false | Boolean
+| `camel.resilience4j.asynchronous` | Whether to use asynchronous (non-blocking) processing using Resilience4j's CompletionStage-based decorators. When enabled, the caller thread is released immediately and processing completes asynchronously. | false | Boolean
+| `camel.resilience4j.automaticTransitionFromOpenToHalfOpenEnabled` | Enables automatic transition from OPEN to HALF_OPEN state once the waitDurationInOpenState has passed. | false | Boolean
+| `camel.resilience4j.bulkheadEnabled` | Whether bulkhead is enabled or not on the circuit breaker. | false | Boolean
+| `camel.resilience4j.bulkheadFairCallHandlingEnabled` | Configures whether the bulkhead uses a fair calling strategy. When enabled (default), a fair strategy guarantees the order of incoming requests (FIFO). When disabled, no ordering is guaranteed and may improve throughput. | true | Boolean
+| `camel.resilience4j.bulkheadMaxConcurrentCalls` | Configures the max amount of concurrent calls the bulkhead will support. |  | Integer
+| `camel.resilience4j.bulkheadMaxWaitDuration` | Configures a maximum amount of time which the calling thread will wait to enter the bulkhead. Accepts Camel duration expressions (e.g. 500ms, 1s) or millisecond values. Default is 0 (no waiting). |  | String
+| `camel.resilience4j.circuitBreaker` | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreaker instance to lookup and use from the registry. When using this, then any other circuit breaker options are not in use. |  | String
+| `camel.resilience4j.config` | Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreakerConfig instance to lookup and use from the registry. |  | String
+| `camel.resilience4j.failureRateThreshold` | Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage. | 50 | Float
+| `camel.resilience4j.maxWaitDurationInHalfOpenState` | Configures the maximum wait duration which controls how long the CircuitBreaker should stay in Half Open state, before it switches to open. Value 0 means circuit breaker will wait in half open state until all permitted calls have been completed. Accepts Camel duration expressions (e.g. 10s, 1m) or millisecond values. | 0 | String
+| `camel.resilience4j.micrometerEnabled` | Whether to enable collecting statistics using Micrometer. This requires adding camel-resilience4j-micrometer JAR to the classpath. | false | Boolean
+| `camel.resilience4j.minimumNumberOfCalls` | Configures configures the minimum number of calls which are required (per sliding window period) before the CircuitBreaker can calculate the error rate. For example, if minimumNumberOfCalls is 10, then at least 10 calls must be recorded, before the failure rate can be calculated. If only 9 calls have been recorded the CircuitBreaker will not transition to open even if all 9 calls have failed. Default minimumNumberOfCalls is 100 | 100 | Integer
+| `camel.resilience4j.permittedNumberOfCallsInHalfOpenState` | Configures the number of permitted calls when the CircuitBreaker is half open. The size must be greater than 0. Default size is 10. | 10 | Integer
+| `camel.resilience4j.slidingWindowSize` | Configures the size of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. slidingWindowSize configures the size of the sliding window. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. The slidingWindowSize must be greater than 0. The minimumNumberOfCalls must be greater than 0. If the slidingWindowType is COUNT_BASED, the minimumNumberOfCalls cannot be greater than slidingWindowSize . If the slidingWindowType is TIME_BASED, you can pick whatever you want. Default slidingWindowSize is 100. | 100 | Integer
+| `camel.resilience4j.slidingWindowSynchronizationStrategy` | Configures the synchronization strategy for the sliding window. LOCK_FREE uses a CAS-based lock-free algorithm for better performance under high concurrency. SYNCHRONIZED uses blocking locks with lower memory allocation. | SYNCHRONIZED | String
+| `camel.resilience4j.slidingWindowType` | Configures the type of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. Default slidingWindowType is COUNT_BASED. | COUNT_BASED | String
+| `camel.resilience4j.slowCallDurationThreshold` | Configures the duration threshold above which calls are considered as slow and increase the slow calls percentage. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
+| `camel.resilience4j.slowCallRateThreshold` | Configures a threshold in percentage. The CircuitBreaker considers a call as slow when the call duration is greater than slowCallDurationThreshold(Duration. When the percentage of slow calls is equal or greater the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 100 percentage which means that all recorded calls must be slower than slowCallDurationThreshold. | 100 | Float
+| `camel.resilience4j.throwExceptionWhenHalfOpenOrOpenState` | Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open or open. | false | Boolean
+| `camel.resilience4j.timeoutCancelRunningFuture` | Configures whether cancel is called on the running future. Defaults to true. | true | Boolean
+| `camel.resilience4j.timeoutDuration` | Configures the thread execution timeout. Accepts Camel duration expressions (e.g. 1s, 500ms) or millisecond values. Default value is 1000 millis (1 second). | 1000 | String
+| `camel.resilience4j.timeoutEnabled` | Whether timeout is enabled or not on the circuit breaker. Default is false. | false | Boolean
+| `camel.resilience4j.timeoutExecutorService` | References to a custom thread pool to use when timeout is enabled (uses ForkJoinPool#commonPool() by default) |  | String
+| `camel.resilience4j.waitDurationInOpenState` | Configures the wait duration which specifies how long the CircuitBreaker should stay open, before it switches to half open. Accepts Camel duration expressions (e.g. 60s, 1m) or millisecond values. Default value is 60 seconds. | 60s | String
+| `camel.resilience4j.writableStackTraceEnabled` | Enables writable stack traces. When set to false, Exception.getStackTrace returns a zero length array. This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls). | false | Boolean
 |===
 
 
@@ -730,11 +730,11 @@ The camel.lra supports 5 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.lra.coordinatorContextPath* | The context-path for the LRA coordinator. Is default /lra-coordinator | /lra-coordinator | String
-| *camel.lra.coordinatorUrl* | The URL for the LRA coordinator service that orchestrates the transactions |  | String
-| *camel.lra.enabled* | To enable Saga LRA | false | boolean
-| *camel.lra.localParticipantContextPath* | The context-path for the local participant. Is default /lra-participant | /lra-participant | String
-| *camel.lra.localParticipantUrl* | The URL for the local participant |  | String
+| `camel.lra.coordinatorContextPath` | The context-path for the LRA coordinator. Is default /lra-coordinator | /lra-coordinator | String
+| `camel.lra.coordinatorUrl` | The URL for the LRA coordinator service that orchestrates the transactions |  | String
+| `camel.lra.enabled` | To enable Saga LRA | false | boolean
+| `camel.lra.localParticipantContextPath` | The context-path for the local participant. Is default /lra-participant | /lra-participant | String
+| `camel.lra.localParticipantUrl` | The URL for the local participant |  | String
 |===
 
 
@@ -744,14 +744,14 @@ The camel.errorRegistry supports 8 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.errorRegistry.bodyIncludeFiles* | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
-| *camel.errorRegistry.bodyIncludeStreams* | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
-| *camel.errorRegistry.bodyMaxChars* | To limit the message body to a maximum size in the captured error data. Use 0 or negative value to use unlimited size. | 32768 | int
-| *camel.errorRegistry.enabled* | Whether the error registry is enabled to capture errors during message routing. | false | boolean
-| *camel.errorRegistry.includeExchangeProperties* | Whether to include the exchange properties in the captured error data. | true | boolean
-| *camel.errorRegistry.includeExchangeVariables* | Whether to include the exchange variables in the captured error data. | true | boolean
-| *camel.errorRegistry.maximumEntries* | The maximum number of error entries to keep in the registry. When the limit is exceeded, the oldest entries are evicted. | 100 | int
-| *camel.errorRegistry.timeToLiveSeconds* | The time-to-live in seconds for error entries. Entries older than this are evicted. The default value is 0 (disabled). | 0 | int
+| `camel.errorRegistry.bodyIncludeFiles` | Whether to include the message body of file based messages. The overhead is that the file content has to be read from the file. | true | boolean
+| `camel.errorRegistry.bodyIncludeStreams` | Whether to include the message body of stream based messages. If enabled then beware the stream may not be re-readable later. See more about Stream Caching. | false | boolean
+| `camel.errorRegistry.bodyMaxChars` | To limit the message body to a maximum size in the captured error data. Use 0 or negative value to use unlimited size. | 32768 | int
+| `camel.errorRegistry.enabled` | Whether the error registry is enabled to capture errors during message routing. | false | boolean
+| `camel.errorRegistry.includeExchangeProperties` | Whether to include the exchange properties in the captured error data. | true | boolean
+| `camel.errorRegistry.includeExchangeVariables` | Whether to include the exchange variables in the captured error data. | true | boolean
+| `camel.errorRegistry.maximumEntries` | The maximum number of error entries to keep in the registry. When the limit is exceeded, the oldest entries are evicted. | 100 | int
+| `camel.errorRegistry.timeToLiveSeconds` | The time-to-live in seconds for error entries. Entries older than this are evicted. The default value is 0 (disabled). | 0 | int
 |===
 
 
@@ -761,16 +761,16 @@ The camel.cluster.file supports 10 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.file.acquireLockDelay* | The time to wait before starting to try to acquire the cluster lock. Note that if FileLockClusterService determines no cluster members are running or cannot reliably determine the cluster state, the initial delay is computed from the acquireLockInterval. | 1 | long
-| *camel.cluster.file.acquireLockDelayUnit* | The time unit for the acquireLockDelay | SECONDS | TimeUnit
-| *camel.cluster.file.acquireLockInterval* | The time to wait between attempts to try to acquire the cluster lock evaluated using wall-clock time. All cluster members must use the same value so leadership checks and leader liveness detection remain consistent. | 10 | long
-| *camel.cluster.file.acquireLockIntervalUnit* | The time unit for the acquireLockInterval | SECONDS | TimeUnit
-| *camel.cluster.file.clusterDataTaskMaxAttempts* | Sets how many times a cluster data task will run, counting both the first execution and subsequent retries in case of failure or timeout. The default is 5 attempts. This can be useful when the cluster data root is on network based file storage, where I/O operations may occasionally block for long or unpredictable periods. | 5 | int
-| *camel.cluster.file.clusterDataTaskTimeout* | Sets the timeout for a cluster data task (reading or writing cluster data). The default is 10 seconds. Timeouts are useful when the cluster data root is on network storage, where I/O operations may occasionally block for long or unpredictable periods. | 10 | long
-| *camel.cluster.file.clusterDataTaskTimeoutUnit* | The time unit for the clusterDataTaskTimeoutUnit | SECONDS | TimeUnit
-| *camel.cluster.file.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.file.heartbeatTimeoutMultiplier* | Multiplier applied to the cluster leader acquireLockInterval to determine how long followers should wait before considering the leader stale. For example, if the leader updates its heartbeat every 2 seconds and the heartbeatTimeoutMultiplier is 3, followers will tolerate up to 2s * 3 = 6s of silence before declaring the leader unavailable. | 5 | int
-| *camel.cluster.file.root* | The root file path |  | String
+| `camel.cluster.file.acquireLockDelay` | The time to wait before starting to try to acquire the cluster lock. Note that if FileLockClusterService determines no cluster members are running or cannot reliably determine the cluster state, the initial delay is computed from the acquireLockInterval. | 1 | long
+| `camel.cluster.file.acquireLockDelayUnit` | The time unit for the acquireLockDelay | SECONDS | TimeUnit
+| `camel.cluster.file.acquireLockInterval` | The time to wait between attempts to try to acquire the cluster lock evaluated using wall-clock time. All cluster members must use the same value so leadership checks and leader liveness detection remain consistent. | 10 | long
+| `camel.cluster.file.acquireLockIntervalUnit` | The time unit for the acquireLockInterval | SECONDS | TimeUnit
+| `camel.cluster.file.clusterDataTaskMaxAttempts` | Sets how many times a cluster data task will run, counting both the first execution and subsequent retries in case of failure or timeout. The default is 5 attempts. This can be useful when the cluster data root is on network based file storage, where I/O operations may occasionally block for long or unpredictable periods. | 5 | int
+| `camel.cluster.file.clusterDataTaskTimeout` | Sets the timeout for a cluster data task (reading or writing cluster data). The default is 10 seconds. Timeouts are useful when the cluster data root is on network storage, where I/O operations may occasionally block for long or unpredictable periods. | 10 | long
+| `camel.cluster.file.clusterDataTaskTimeoutUnit` | The time unit for the clusterDataTaskTimeoutUnit | SECONDS | TimeUnit
+| `camel.cluster.file.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.file.heartbeatTimeoutMultiplier` | Multiplier applied to the cluster leader acquireLockInterval to determine how long followers should wait before considering the leader stale. For example, if the leader updates its heartbeat every 2 seconds and the heartbeatTimeoutMultiplier is 3, followers will tolerate up to 2s * 3 = 6s of silence before declaring the leader unavailable. | 5 | int
+| `camel.cluster.file.root` | The root file path |  | String
 |===
 
 
@@ -780,21 +780,21 @@ The camel.cluster.kubernetes supports 15 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.kubernetes.clusterLabels* | Labels used to identify the members of the cluster. |  | Map
-| *camel.cluster.kubernetes.configuration* | To use an existing configuration for Kubernetes |  | KubernetesConfiguration
-| *camel.cluster.kubernetes.connectionTimeout* | Connection timeout in milliseconds to use when making requests to the Kubernetes API server. |  | Integer
-| *camel.cluster.kubernetes.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.kubernetes.groupName* | Name of the lock group (or namespace according to the Camel cluster convention) within the chosen ConfigMap. |  | String
-| *camel.cluster.kubernetes.jitterFactor* | A jitter factor to apply in order to prevent all pods to call Kubernetes APIs in the same instant. | 1.2 | double
-| *camel.cluster.kubernetes.kubernetesResourceName* | Name of the resource used for locking (or prefix, in case multiple ones are used). | leaders | String
-| *camel.cluster.kubernetes.kubernetesResourcesNamespace* | Kubernetes namespace containing the pods and the ConfigMap used for locking. |  | String
-| *camel.cluster.kubernetes.leaseDurationMillis* | The default duration of the lease for the current leader. | 15000 | long
-| *camel.cluster.kubernetes.leaseResourceType* | Kubernetes resource type used to hold the leases. | Lease | LeaseResourceType
-| *camel.cluster.kubernetes.masterUrl* | URL to a remote Kubernetes API server. This should only be used when your Camel application is connecting from outside Kubernetes. If you run your Camel application inside Kubernetes, then you can use local or client as the URL to tell Camel to run in local mode. If you connect remotely to Kubernetes, then you may also need some of the many other configuration options for secured connection with certificates, etc. |  | String
-| *camel.cluster.kubernetes.namespace* | Kubernetes namespace |  | String
-| *camel.cluster.kubernetes.podName* | Name of the current pod (defaults to host name). |  | String
-| *camel.cluster.kubernetes.renewDeadlineMillis* | The deadline after which the leader must stop its services because it may have lost the leadership. | 10000 | long
-| *camel.cluster.kubernetes.retryPeriodMillis* | The time between two subsequent attempts to check and acquire the leadership. It is randomized using the jitter factor. | 2000 | long
+| `camel.cluster.kubernetes.clusterLabels` | Labels used to identify the members of the cluster. |  | Map
+| `camel.cluster.kubernetes.configuration` | To use an existing configuration for Kubernetes |  | KubernetesConfiguration
+| `camel.cluster.kubernetes.connectionTimeout` | Connection timeout in milliseconds to use when making requests to the Kubernetes API server. |  | Integer
+| `camel.cluster.kubernetes.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.kubernetes.groupName` | Name of the lock group (or namespace according to the Camel cluster convention) within the chosen ConfigMap. |  | String
+| `camel.cluster.kubernetes.jitterFactor` | A jitter factor to apply in order to prevent all pods to call Kubernetes APIs in the same instant. | 1.2 | double
+| `camel.cluster.kubernetes.kubernetesResourceName` | Name of the resource used for locking (or prefix, in case multiple ones are used). | leaders | String
+| `camel.cluster.kubernetes.kubernetesResourcesNamespace` | Kubernetes namespace containing the pods and the ConfigMap used for locking. |  | String
+| `camel.cluster.kubernetes.leaseDurationMillis` | The default duration of the lease for the current leader. | 15000 | long
+| `camel.cluster.kubernetes.leaseResourceType` | Kubernetes resource type used to hold the leases. | Lease | LeaseResourceType
+| `camel.cluster.kubernetes.masterUrl` | URL to a remote Kubernetes API server. This should only be used when your Camel application is connecting from outside Kubernetes. If you run your Camel application inside Kubernetes, then you can use local or client as the URL to tell Camel to run in local mode. If you connect remotely to Kubernetes, then you may also need some of the many other configuration options for secured connection with certificates, etc. |  | String
+| `camel.cluster.kubernetes.namespace` | Kubernetes namespace |  | String
+| `camel.cluster.kubernetes.podName` | Name of the current pod (defaults to host name). |  | String
+| `camel.cluster.kubernetes.renewDeadlineMillis` | The deadline after which the leader must stop its services because it may have lost the leadership. | 10000 | long
+| `camel.cluster.kubernetes.retryPeriodMillis` | The time between two subsequent attempts to check and acquire the leadership. It is randomized using the jitter factor. | 2000 | long
 |===
 
 
@@ -804,18 +804,18 @@ The camel.cluster.zookeeper supports 12 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.zookeeper.basePath* | The base path to store in ZooKeeper |  | String
-| *camel.cluster.zookeeper.connectTimeout* | Connect timeout (millis) | 15000 | long
-| *camel.cluster.zookeeper.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.zookeeper.id* | Node id |  | String
-| *camel.cluster.zookeeper.maxCloseWait* | Time to wait (millis) during close to join background threads | 1000 | long
-| *camel.cluster.zookeeper.namespace* | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace |  | String
-| *camel.cluster.zookeeper.nodes* | The Zookeeper server hosts (multiple servers can be separated by comma) |  | String
-| *camel.cluster.zookeeper.reconnectBaseSleepTime* | Initial amount of time (millis) to wait between retries | 1000 | long
-| *camel.cluster.zookeeper.reconnectMaxRetries* | Max number of times to retry | 3 | int
-| *camel.cluster.zookeeper.reconnectMaxSleepTime* | Max time (millis) to sleep on each retry |  | long
-| *camel.cluster.zookeeper.retryPolicy* | To use a custom retry policy implementation |  | RetryPolicy
-| *camel.cluster.zookeeper.sessionTimeout* | Session timeout (millis) | 60000 | long
+| `camel.cluster.zookeeper.basePath` | The base path to store in ZooKeeper |  | String
+| `camel.cluster.zookeeper.connectTimeout` | Connect timeout (millis) | 15000 | long
+| `camel.cluster.zookeeper.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.zookeeper.id` | Node id |  | String
+| `camel.cluster.zookeeper.maxCloseWait` | Time to wait (millis) during close to join background threads | 1000 | long
+| `camel.cluster.zookeeper.namespace` | ZooKeeper namespace. If a namespace is set here, all paths will get pre-pended with the namespace |  | String
+| `camel.cluster.zookeeper.nodes` | The Zookeeper server hosts (multiple servers can be separated by comma) |  | String
+| `camel.cluster.zookeeper.reconnectBaseSleepTime` | Initial amount of time (millis) to wait between retries | 1000 | long
+| `camel.cluster.zookeeper.reconnectMaxRetries` | Max number of times to retry | 3 | int
+| `camel.cluster.zookeeper.reconnectMaxSleepTime` | Max time (millis) to sleep on each retry |  | long
+| `camel.cluster.zookeeper.retryPolicy` | To use a custom retry policy implementation |  | RetryPolicy
+| `camel.cluster.zookeeper.sessionTimeout` | Session timeout (millis) | 60000 | long
 |===
 
 
@@ -825,23 +825,23 @@ The camel.cluster.consul supports 17 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.consul.aclToken* | Sets the ACL token to be used with Consul |  | String
-| *camel.cluster.consul.blockSeconds* | The second to wait for a watch event, default 10 seconds | 10 | int
-| *camel.cluster.consul.configuration* | To use an existing configuration |  | ConsulClusterConfiguration
-| *camel.cluster.consul.connectTimeout* | Connect timeout in millis |  | int
-| *camel.cluster.consul.datacenter* | The data center |  | String
-| *camel.cluster.consul.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.consul.id* | Client id registered as _consul.service.registry.id |  | String
-| *camel.cluster.consul.password* | Sets the password to be used for basic authentication |  | String
-| *camel.cluster.consul.readTimeout* | Read timeout in millis |  | int
-| *camel.cluster.consul.rootPath* | The Consul cluster root directory path | /camel | String
-| *camel.cluster.consul.sessionLockDelay* | Session lock delay in seconds | 5 | int
-| *camel.cluster.consul.sessionRefreshInterval* | Session refresh interval in seconds | 5 | int
-| *camel.cluster.consul.sessionTtl* | Session time to live in seconds | 60 | int
-| *camel.cluster.consul.sslContextParameters* | SSL configuration for advanced security configuration |  | SSLContextParameters
-| *camel.cluster.consul.url* | The Consul agent URL |  | String
-| *camel.cluster.consul.userName* | Sets the username to be used for basic authentication |  | String
-| *camel.cluster.consul.writeTimeout* | Write timeout in mills |  | int
+| `camel.cluster.consul.aclToken` | Sets the ACL token to be used with Consul |  | String
+| `camel.cluster.consul.blockSeconds` | The second to wait for a watch event, default 10 seconds | 10 | int
+| `camel.cluster.consul.configuration` | To use an existing configuration |  | ConsulClusterConfiguration
+| `camel.cluster.consul.connectTimeout` | Connect timeout in millis |  | int
+| `camel.cluster.consul.datacenter` | The data center |  | String
+| `camel.cluster.consul.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.consul.id` | Client id registered as _consul.service.registry.id |  | String
+| `camel.cluster.consul.password` | Sets the password to be used for basic authentication |  | String
+| `camel.cluster.consul.readTimeout` | Read timeout in millis |  | int
+| `camel.cluster.consul.rootPath` | The Consul cluster root directory path | /camel | String
+| `camel.cluster.consul.sessionLockDelay` | Session lock delay in seconds | 5 | int
+| `camel.cluster.consul.sessionRefreshInterval` | Session refresh interval in seconds | 5 | int
+| `camel.cluster.consul.sessionTtl` | Session time to live in seconds | 60 | int
+| `camel.cluster.consul.sslContextParameters` | SSL configuration for advanced security configuration |  | SSLContextParameters
+| `camel.cluster.consul.url` | The Consul agent URL |  | String
+| `camel.cluster.consul.userName` | Sets the username to be used for basic authentication |  | String
+| `camel.cluster.consul.writeTimeout` | Write timeout in mills |  | int
 |===
 
 
@@ -851,11 +851,11 @@ The camel.cluster.jgroups-raft supports 5 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.jgroups-raft.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.jgroups-raft.id* | Unique Raft id |  | String
-| *camel.cluster.jgroups-raft.jgroupsClusterName* | The name of the cluster | jgroupsraft-master | String
-| *camel.cluster.jgroups-raft.jgroupsConfig* | The path to the JGroups Raft configuration | raft.xml | String
-| *camel.cluster.jgroups-raft.raftHandle* | To use a custom RaftHandler |  | RaftHandle
+| `camel.cluster.jgroups-raft.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.jgroups-raft.id` | Unique Raft id |  | String
+| `camel.cluster.jgroups-raft.jgroupsClusterName` | The name of the cluster | jgroupsraft-master | String
+| `camel.cluster.jgroups-raft.jgroupsConfig` | The path to the JGroups Raft configuration | raft.xml | String
+| `camel.cluster.jgroups-raft.raftHandle` | To use a custom RaftHandler |  | RaftHandle
 |===
 
 
@@ -865,22 +865,22 @@ The camel.cluster.infinispan supports 16 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.cluster.infinispan.cacheContainer* | Specifies the cache Container to connect |  | RemoteCacheManager
-| *camel.cluster.infinispan.cacheContainerConfiguration* | The CacheContainer configuration. Used if the cacheContainer is not defined. |  | Configuration
-| *camel.cluster.infinispan.configuration* | To use an existing configuration |  | InfinispanRemoteClusterConfiguration
-| *camel.cluster.infinispan.configurationProperties* | Implementation specific properties for the CacheManager |  | Map
-| *camel.cluster.infinispan.configurationUri* | An implementation specific URI for the CacheManager |  | String
-| *camel.cluster.infinispan.enabled* | Whether to enable this cluster service. | true | boolean
-| *camel.cluster.infinispan.hosts* | Specifies the host of the cache on Infinispan instance. Multiple hosts can be separated by semicolon. |  | String
-| *camel.cluster.infinispan.id* | Node id |  | String
-| *camel.cluster.infinispan.lifespan* | The lifespan of the cache entry for the local cluster member registered to the inventory | 30 | long
-| *camel.cluster.infinispan.lifespanTimeUnit* | The TimeUnit of the lifespan | SECONDS | TimeUnit
-| *camel.cluster.infinispan.password* | Define the password to access the infinispan instance |  | String
-| *camel.cluster.infinispan.saslMechanism* | Define the SASL Mechanism to access the infinispan instance |  | String
-| *camel.cluster.infinispan.secure* | Define if we are connecting to a secured Infinispan instance | false | boolean
-| *camel.cluster.infinispan.securityRealm* | Define the security realm to access the infinispan instance |  | String
-| *camel.cluster.infinispan.securityServerName* | Define the security server name to access the infinispan instance |  | String
-| *camel.cluster.infinispan.username* | Define the username to access the infinispan instance |  | String
+| `camel.cluster.infinispan.cacheContainer` | Specifies the cache Container to connect |  | RemoteCacheManager
+| `camel.cluster.infinispan.cacheContainerConfiguration` | The CacheContainer configuration. Used if the cacheContainer is not defined. |  | Configuration
+| `camel.cluster.infinispan.configuration` | To use an existing configuration |  | InfinispanRemoteClusterConfiguration
+| `camel.cluster.infinispan.configurationProperties` | Implementation specific properties for the CacheManager |  | Map
+| `camel.cluster.infinispan.configurationUri` | An implementation specific URI for the CacheManager |  | String
+| `camel.cluster.infinispan.enabled` | Whether to enable this cluster service. | true | boolean
+| `camel.cluster.infinispan.hosts` | Specifies the host of the cache on Infinispan instance. Multiple hosts can be separated by semicolon. |  | String
+| `camel.cluster.infinispan.id` | Node id |  | String
+| `camel.cluster.infinispan.lifespan` | The lifespan of the cache entry for the local cluster member registered to the inventory | 30 | long
+| `camel.cluster.infinispan.lifespanTimeUnit` | The TimeUnit of the lifespan | SECONDS | TimeUnit
+| `camel.cluster.infinispan.password` | Define the password to access the infinispan instance |  | String
+| `camel.cluster.infinispan.saslMechanism` | Define the SASL Mechanism to access the infinispan instance |  | String
+| `camel.cluster.infinispan.secure` | Define if we are connecting to a secured Infinispan instance | false | boolean
+| `camel.cluster.infinispan.securityRealm` | Define the security realm to access the infinispan instance |  | String
+| `camel.cluster.infinispan.securityServerName` | Define the security server name to access the infinispan instance |  | String
+| `camel.cluster.infinispan.username` | Define the username to access the infinispan instance |  | String
 |===
 // main options: END
 

--- a/docs/user-manual/modules/ROOT/pages/camel-jbang-configuration.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-jbang-configuration.adoc
@@ -9,59 +9,59 @@ The camel.jbang supports 53 options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===
 | Name | Description | Default | Type
-| *camel.jbang.camel-version* | The version of Apache Camel to use |  | String
-| *camel.jbang.camelSpringBootVersion* | To use a custom Camel version when running or export to Spring Boot |  | String
-| *camel.jbang.camelWrapper* | Include Camel Wrapper scripts in the exported project for version pinning | false | boolean
-| *camel.jbang.classpathFiles* | Additional files to add to classpath (Use commas to separate multiple files). |  | String
-| *camel.jbang.compileWorkDir* | Work directory for compiler. Can be used to write compiled classes or other resources. | .camel-jbang/compile | String
-| *camel.jbang.console* | Developer console at /q/dev on local HTTP server (port 8080 by default) | false | boolean
-| *camel.jbang.dependencies* | Additional dependencies (Use commas to separate multiple dependencies). |  | String
-| *camel.jbang.dependencies.main* | Additional dependencies for Camel Main runtime only |  | String
-| *camel.jbang.dependencies.quarkus* | Additional dependencies for Quarkus runtime only |  | String
-| *camel.jbang.dependencies.spring-boot* | Additional dependencies for Spring Boot runtime only |  | String
-| *camel.jbang.download* | Whether to allow automatic downloading JAR dependencies (over the internet) | true | boolean
-| *camel.jbang.excludes* | Exclude files by name or pattern (Use commas to separate multiple files) |  | String
-| *camel.jbang.exportDir* | Directory where the project will be exported | . | String
-| *camel.jbang.fresh* | Whether to force using fresh (i.e. non-cached) resources | false | boolean
-| *camel.jbang.gav* | Maven coordinate (groupId:artifactId:version) |  | String
-| *camel.jbang.groovyFiles* | Additional groovy source files to export to src/main/resources/camel-groovy directory (Use commas to separate multiple files) |  | String
-| *camel.jbang.health* | Health check at /observe/health on local HTTP server (port 8080 by default) | false | boolean
-| *camel.jbang.ignoreLoadingError* | Whether to ignore route loading and compilation errors (use this with care!) | false | boolean
-| *camel.jbang.javaVersion* | Java version | 21 | String
-| *camel.jbang.jfr* | Enables Java Flight Recorder saving recording to disk on exit | false | boolean
-| *camel.jbang.jfr-profile* | Java Flight Recorder profile to use (such as default or profile) | default | String
-| *camel.jbang.jib-maven-plugin-version* | Version to use for jib-maven-plugin when exporting the application | 3.5.2 | String
-| *camel.jbang.jkube-maven-plugin-version* | Version to use for jkube-maven-plugin if exporting to camel-main and have Kubernetes enabled (jkube.xxx options) | 1.20.0 | String
-| *camel.jbang.jkubeFiles* | Resource YAML fragments for Kubernetes using Eclipse JKube tool (Use commas to separate multiple files). |  | String
-| *camel.jbang.kameletsVersion* | Apache Camel Kamelets version. By default the Kamelets are the same version as Camel. |  | String
-| *camel.jbang.lazyBean* | Whether to use lazy bean initialization (can help with complex classloading issues) | false | boolean
-| *camel.jbang.localKameletDir* | Local file directory for loading custom Kamelets |  | String
-| *camel.jbang.maven-apache-snapshot-enabled* | Whether downloading JARs from ASF Maven Snapshot repository is enabled | true | boolean
-| *camel.jbang.maven-central-enabled* | Whether downloading JARs from Maven Central repository is enabled | true | boolean
-| *camel.jbang.maven-settings* | Optional location of Maven settings.xml file to configure servers, repositories, mirrors, and proxies. If set to false, not even the default /.m2/settings.xml will be used. |  | String
-| *camel.jbang.maven-settings-security* | Optional location of Maven settings-security.xml file to decrypt Maven Settings (settings.xml) file |  | String
-| *camel.jbang.mavenWrapper* | Include Maven Wrapper files in the exported project | true | boolean
-| *camel.jbang.mcp* | Embed dev/diagnostics MCP tools on the local HTTP management server (/mcp by default) | false | boolean
-| *camel.jbang.metrics* | Metrics (Micrometer and Prometheus) at /observe/metrics on local HTTP server (port 8080 by default) when running standalone Camel | false | boolean
-| *camel.jbang.openApi* | File name of open-api spec file (JSON or YAML) to generate routes from the swagger/openapi API spec file. |  | String
-| *camel.jbang.openapiUi* | Swagger UI for REST OpenAPI at /q/openapi on local HTTP server (port 8080 by default) | false | boolean
-| *camel.jbang.packageScanJars* | Whether to automatic package scan JARs for custom Spring or Quarkus beans making them available for Camel CLI | false | boolean
-| *camel.jbang.parentPom* | Parent POM coordinate (groupId:artifactId:version) to use in the exported project |  | String
-| *camel.jbang.prompt* | Allow user to type in required parameters in prompt if not present in application | false | boolean
-| *camel.jbang.quarkusArtifactId* | artifactId of Quarkus Platform BOM |  | String
-| *camel.jbang.quarkusExtensionRegistryBaseUri* | The base URI of Quarkus Extension Registry |  | String
-| *camel.jbang.quarkusGroupId* | groupId of Quarkus Platform BOM |  | String
-| *camel.jbang.quarkusVersion* | version of Quarkus Platform BOM |  | String
-| *camel.jbang.readmeFiles* | README files included with the integration (Use commas to separate multiple files) |  | String
-| *camel.jbang.repos* | Additional Maven repositories for download on-demand (Use commas to separate multiple repositories) |  | String
-| *camel.jbang.resourceDirs* | Additional resource directories to include recursively, preserving directory structure (Use commas to separate multiple directories) |  | String
-| *camel.jbang.runtime* | Which runtime to use (camel-main, spring-boot, quarkus) |  | String
-| *camel.jbang.scriptFiles* | Additional shell script files to export to src/main/scripts directory |  | String
-| *camel.jbang.sourceDir* | Source directory for dynamically loading Camel file(s) to run. When using this, then files cannot be specified at the same time. |  | String
-| *camel.jbang.springBootVersion* | Spring Boot version |  | String
-| *camel.jbang.stub* | Stubs all the matching endpoint with the given component name or pattern. Multiple names can be separated by comma. (all = stub all endpoints, remote = stub only remote components). |  | String
-| *camel.jbang.tlsFiles* | Additional SSL/TLS files to export to src/main/tls directory |  | String
-| *camel.jbang.verbose* | Verbose output of startup activity (dependency resolution and downloading | false | boolean
+| `camel.jbang.camel-version` | The version of Apache Camel to use |  | String
+| `camel.jbang.camelSpringBootVersion` | To use a custom Camel version when running or export to Spring Boot |  | String
+| `camel.jbang.camelWrapper` | Include Camel Wrapper scripts in the exported project for version pinning | false | boolean
+| `camel.jbang.classpathFiles` | Additional files to add to classpath (Use commas to separate multiple files). |  | String
+| `camel.jbang.compileWorkDir` | Work directory for compiler. Can be used to write compiled classes or other resources. | .camel-jbang/compile | String
+| `camel.jbang.console` | Developer console at /q/dev on local HTTP server (port 8080 by default) | false | boolean
+| `camel.jbang.dependencies` | Additional dependencies (Use commas to separate multiple dependencies). |  | String
+| `camel.jbang.dependencies.main` | Additional dependencies for Camel Main runtime only |  | String
+| `camel.jbang.dependencies.quarkus` | Additional dependencies for Quarkus runtime only |  | String
+| `camel.jbang.dependencies.spring-boot` | Additional dependencies for Spring Boot runtime only |  | String
+| `camel.jbang.download` | Whether to allow automatic downloading JAR dependencies (over the internet) | true | boolean
+| `camel.jbang.excludes` | Exclude files by name or pattern (Use commas to separate multiple files) |  | String
+| `camel.jbang.exportDir` | Directory where the project will be exported | . | String
+| `camel.jbang.fresh` | Whether to force using fresh (i.e. non-cached) resources | false | boolean
+| `camel.jbang.gav` | Maven coordinate (groupId:artifactId:version) |  | String
+| `camel.jbang.groovyFiles` | Additional groovy source files to export to src/main/resources/camel-groovy directory (Use commas to separate multiple files) |  | String
+| `camel.jbang.health` | Health check at /observe/health on local HTTP server (port 8080 by default) | false | boolean
+| `camel.jbang.ignoreLoadingError` | Whether to ignore route loading and compilation errors (use this with care!) | false | boolean
+| `camel.jbang.javaVersion` | Java version | 21 | String
+| `camel.jbang.jfr` | Enables Java Flight Recorder saving recording to disk on exit | false | boolean
+| `camel.jbang.jfr-profile` | Java Flight Recorder profile to use (such as default or profile) | default | String
+| `camel.jbang.jib-maven-plugin-version` | Version to use for jib-maven-plugin when exporting the application | 3.5.2 | String
+| `camel.jbang.jkube-maven-plugin-version` | Version to use for jkube-maven-plugin if exporting to camel-main and have Kubernetes enabled (jkube.xxx options) | 1.20.0 | String
+| `camel.jbang.jkubeFiles` | Resource YAML fragments for Kubernetes using Eclipse JKube tool (Use commas to separate multiple files). |  | String
+| `camel.jbang.kameletsVersion` | Apache Camel Kamelets version. By default the Kamelets are the same version as Camel. |  | String
+| `camel.jbang.lazyBean` | Whether to use lazy bean initialization (can help with complex classloading issues) | false | boolean
+| `camel.jbang.localKameletDir` | Local file directory for loading custom Kamelets |  | String
+| `camel.jbang.maven-apache-snapshot-enabled` | Whether downloading JARs from ASF Maven Snapshot repository is enabled | true | boolean
+| `camel.jbang.maven-central-enabled` | Whether downloading JARs from Maven Central repository is enabled | true | boolean
+| `camel.jbang.maven-settings` | Optional location of Maven settings.xml file to configure servers, repositories, mirrors, and proxies. If set to false, not even the default /.m2/settings.xml will be used. |  | String
+| `camel.jbang.maven-settings-security` | Optional location of Maven settings-security.xml file to decrypt Maven Settings (settings.xml) file |  | String
+| `camel.jbang.mavenWrapper` | Include Maven Wrapper files in the exported project | true | boolean
+| `camel.jbang.mcp` | Embed dev/diagnostics MCP tools on the local HTTP management server (/mcp by default) | false | boolean
+| `camel.jbang.metrics` | Metrics (Micrometer and Prometheus) at /observe/metrics on local HTTP server (port 8080 by default) when running standalone Camel | false | boolean
+| `camel.jbang.openApi` | File name of open-api spec file (JSON or YAML) to generate routes from the swagger/openapi API spec file. |  | String
+| `camel.jbang.openapiUi` | Swagger UI for REST OpenAPI at /q/openapi on local HTTP server (port 8080 by default) | false | boolean
+| `camel.jbang.packageScanJars` | Whether to automatic package scan JARs for custom Spring or Quarkus beans making them available for Camel CLI | false | boolean
+| `camel.jbang.parentPom` | Parent POM coordinate (groupId:artifactId:version) to use in the exported project |  | String
+| `camel.jbang.prompt` | Allow user to type in required parameters in prompt if not present in application | false | boolean
+| `camel.jbang.quarkusArtifactId` | artifactId of Quarkus Platform BOM |  | String
+| `camel.jbang.quarkusExtensionRegistryBaseUri` | The base URI of Quarkus Extension Registry |  | String
+| `camel.jbang.quarkusGroupId` | groupId of Quarkus Platform BOM |  | String
+| `camel.jbang.quarkusVersion` | version of Quarkus Platform BOM |  | String
+| `camel.jbang.readmeFiles` | README files included with the integration (Use commas to separate multiple files) |  | String
+| `camel.jbang.repos` | Additional Maven repositories for download on-demand (Use commas to separate multiple repositories) |  | String
+| `camel.jbang.resourceDirs` | Additional resource directories to include recursively, preserving directory structure (Use commas to separate multiple directories) |  | String
+| `camel.jbang.runtime` | Which runtime to use (camel-main, spring-boot, quarkus) |  | String
+| `camel.jbang.scriptFiles` | Additional shell script files to export to src/main/scripts directory |  | String
+| `camel.jbang.sourceDir` | Source directory for dynamically loading Camel file(s) to run. When using this, then files cannot be specified at the same time. |  | String
+| `camel.jbang.springBootVersion` | Spring Boot version |  | String
+| `camel.jbang.stub` | Stubs all the matching endpoint with the given component name or pattern. Multiple names can be separated by comma. (all = stub all endpoints, remote = stub only remote components). |  | String
+| `camel.jbang.tlsFiles` | Additional SSL/TLS files to export to src/main/tls directory |  | String
+| `camel.jbang.verbose` | Verbose output of startup activity (dependency resolution and downloading | false | boolean
 |===
 // jbang options: END
 

--- a/tooling/maven/camel-package-maven-plugin/src/main/resources/jbang-options.mvel
+++ b/tooling/maven/camel-package-maven-plugin/src/main/resources/jbang-options.mvel
@@ -20,5 +20,5 @@ The @{group.name} supports @{options.size()} options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===@comment{ Render table cells. If description contains newline, prefix cell with `a`, so the content is rendered with formatting. }
 | Name | Description | Default | Type
-@foreach{row : options}| *@{row.name}* @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
+@foreach{row : options}| `@{row.name}` @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===

--- a/tooling/maven/camel-package-maven-plugin/src/main/resources/main-options.mvel
+++ b/tooling/maven/camel-package-maven-plugin/src/main/resources/main-options.mvel
@@ -20,5 +20,5 @@ The @{group.name} supports @{options.size()} options, which are listed below.
 [width="100%",cols="2,5,^1,2",options="header"]
 |===@comment{ Render table cells. If description contains newline, prefix cell with `a`, so the content is rendered with formatting. }
 | Name | Description | Default | Type
-@foreach{row : options}| *@{row.name}* @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
+@foreach{row : options}| `@{row.name}` @{row.description.?contains("\n") ? "a" : ""}| @{util.escape(row.description)} | @{row.getShortDefaultValue(20)} | @{row.getShortJavaType()}
 @end{}|===


### PR DESCRIPTION
## Backport of #26341

Cherry-pick of 156a1b58a9212a89c2cffeb53236ccdbd1ce3a4c to camel-4.22.x.
Conflicts resolved automatically by backport bot agent.