### PR TITLE
chore(deps): Upgrade Netty to 4.2.18.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -405,7 +405,7 @@
         <mybatis-version>3.5.19</mybatis-version>
         <narayana-version>7.3.4.Final</narayana-version>
         <neo4j-version>6.2.1</neo4j-version>
-        <netty-version>4.2.17.Final</netty-version>
+        <netty-version>4.2.18.Final</netty-version>
         <networknt-json-schema-validator-version>2.0.1</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.9.1</nimbus-jose-jwt>
         <olingo2-version>2.0.13</olingo2-version>


### PR DESCRIPTION
Upgrades Netty from `4.2.17.Final` to `4.2.18.Final` (released 2026-09-09).

### Why

This is a **bug-fix and security release**. The Netty team lists 30 reported vulnerabilities fixed across the HTTP/1.1, HTTP/2, HTTP/3, SMTP, STOMP, MQTT, Redis, memcache, HAProxy and OCSP modules — request/response smuggling, improper header and certificate validation, unbounded resource usage and memory leaks. No CVE ids were assigned in time for the release ("due to overwhelming strain on the CVE infrastructure"), so the advisories are published without them.

Release notes: https://netty.io/news/2026/09/09/4-2-18-Final.html

### Behaviour changes called out by upstream

* **HTTP/2 header _value_ validation is now enabled by default** (previously opt-in). Both name and value validation are now on by default.
* **QUIC now requires an `X509ExtendedTrustManager`** when hostname verification is enabled — previously verification was silently skipped with a plain `X509TrustManager`, now it throws.

Neither affects Camel's own code, but the HTTP/2 default may be visible to users of `camel-netty-http` / `camel-grpc` sending non-conforming header values. Happy to add an upgrade-guide note if reviewers think it warrants one.

### Testing

`mvn verify` run locally on the two directly affected modules:

* `components/camel-netty` — 125 tests, 0 failures
* `components/camel-netty-http` — 274 tests, 0 failures

---
_Claude Code on behalf of davsclaus_
