### PR TITLE
chore(deps): Upgrade Netty to 4.2.18.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -399,7 +399,7 @@
         <narayana-version>7.3.4.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>6.2.0</neo4j-version>
-        <netty-version>4.2.17.Final</netty-version>
+        <netty-version>4.2.18.Final</netty-version>
         <networknt-json-schema-validator-version>2.0.1</networknt-json-schema-validator-version>
         <nimbus-jose-jwt>10.9.1</nimbus-jose-jwt>
         <olingo2-version>2.0.13</olingo2-version>


### PR DESCRIPTION
Backport of #26345 to `camel-4.22.x`.

Upgrades Netty from `4.2.17.Final` to `4.2.18.Final` (released 2026-09-09).

### Why

This is a **bug-fix and security release**. The Netty team lists 30 reported vulnerabilities fixed across the HTTP/1.1, HTTP/2, HTTP/3, SMTP, STOMP, MQTT, Redis, memcache, HAProxy and OCSP modules — request/response smuggling, improper header and certificate validation, unbounded resource usage and memory leaks. No CVE ids were assigned in time for the release ("due to overwhelming strain on the CVE infrastructure"), so the advisories are published without them.

Release notes: https://netty.io/news/2026/09/09/4-2-18-Final.html

### Behaviour changes called out by upstream

* **HTTP/2 header _value_ validation is now enabled by default** (previously opt-in). Both name and value validation are now on by default.
* **QUIC now requires an `X509ExtendedTrustManager`** when hostname verification is enabled — previously verification was silently skipped with a plain `X509TrustManager`, now it throws.

### Note on the cherry-pick

The cherry-pick needed a trivial context conflict resolution: `camel-4.22.x` carries `neoscada-version` and `neo4j-version 6.2.0` on the adjacent lines. Only the `netty-version` line is changed here — the resulting diff is the same one-line bump as on `main`.

### Testing

`mvn verify` was run on `main` for the two directly affected modules (`camel-netty`: 125 tests, `camel-netty-http`: 274 tests, all green). The change is identical here.

---
_Claude Code on behalf of davsclaus_
