### PR TITLE
CAMEL-24539: docs - add the camel-openai note to the 4.22.1 upgrade guide

### DIFF
--- a/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
+++ b/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_22.adoc
@@ -42,6 +42,7 @@ It is unset by default, which keeps the previous behaviour of accepting any path
 Additionally, a local input path that does not exist is now reported as a `File not found` `IOException`
 before Docling is invoked. Previously the size check silently skipped a path that resolved to nothing and
 the failure surfaced later, from the Docling process or API call.
+
 === camel-dynamic-router
 
 The `dynamic-router-control` endpoint no longer takes the subscription `predicate`, or the
@@ -219,6 +220,21 @@ Documents carrying an internal DTD subset still parse.
 To restore the previous behaviour and allow external entity resolution, set the new
 `allowExternalEntities` option to `true` on the data format or on the endpoint
 (`smooks:config.xml?allowExternalEntities=true`).
+
+=== camel-openai
+
+When `storeFullResponse=true`, the embeddings and audio operations now store their full SDK response
+under an operation-specific exchange property instead of the chat-completion property `CamelOpenAIResponse`.
+That property is typed as the chat-completion response (`com.openai.models.chat.completions.ChatCompletion`),
+so a downstream reader that expected that type received an incompatible object.
+
+* embeddings now use `CamelOpenAIEmbeddingsResponse` (`com.openai.models.embeddings.CreateEmbeddingResponse`).
+* audio transcription now uses `CamelOpenAIAudioTranscriptionResponse` (`com.openai.models.audio.transcriptions.TranscriptionCreateResponse`).
+* audio translation now uses `CamelOpenAIAudioTranslationResponse` (`com.openai.models.audio.translations.TranslationCreateResponse`).
+
+A route that reads the full embeddings or audio response from `CamelOpenAIResponse` must switch to the
+matching property. The chat-completion and responses operations are unchanged.
+
 == Upgrading Camel 4.21 to 4.22
 
 === camel-tika
@@ -1360,6 +1376,7 @@ on the bytes of a non-ASCII payload and make verification fail.
 already UTF-8 (JEP 400), so this is a no-op there; on Java 17 with a non-UTF-8 default, the
 signature of a non-ASCII `String` payload changes. Binary bodies (`byte[]`, `InputStream`) are
 unaffected, as they are signed byte-for-byte.
+
 === camel-sql - Schema-qualified aggregation repository names
 
 The table-name validation in `JdbcAggregationRepository` now accepts schema-qualified names


### PR DESCRIPTION
## Doc sync follow-up to #26347

CAMEL-24539 was backported to `camel-4.22.x` in #26347, so **4.22.1 is the first release to carry it**.
On `main`, though, the upgrade note only exists in `camel-4x-upgrade-guide-4_23.adoc` — the original
PR (#26110) targeted `main` and filed it under 4.23. Since the `4_XX` guides on `main` are the canonical
history across all release lines, `4_22.adoc` was left out of sync with what 4.22.1 actually ships.

This adds the `camel-openai` section to the *Upgrading from 4.22.0 to 4.22.1* block.

### Two deliberate choices

* **The `4_23.adoc` entry stays.** I checked all 10 existing 4.22.1 entries on `main` — every one of them
  also appears in `4_23.adoc`, so duplication is the established convention here, not drift.
* **The wording follows the branch, not `4_23.adoc`.** The 4.23 text closes with *"The chat-completion,
  responses, moderation and image operations are unchanged"*, but the moderation and image operations
  don't exist on 4.22.x — they were added later on `main`. This entry lists only chat-completion and
  responses.

### Drive-by, easy to drop

While inserting the section I hit a pre-existing AsciiDoc bug at the insertion point: `== Upgrading Camel
4.21 to 4.22` had no blank line before it, so Asciidoctor folds the heading into the preceding paragraph
instead of rendering it. An audit of the file turned up two more (`=== camel-dynamic-router`,
`=== camel-sql - Schema-qualified aggregation repository names`). All three are fixed here — three blank
lines, no text changes. Happy to split these out if you'd rather keep this PR to the sync alone.

I diffed the full 4.22.1 section between `main` and `camel-4.22.x`: `camel-openai` was the only heading
present on the branch and missing from `main`, so this closes the gap rather than patching one instance of
a wider problem.

_Claude Code on behalf of @davsclaus_
