### PR TITLE
CAMEL-24692: camel-catalog - validate simple/groovy with property placeholders as operands

### DIFF
--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1250,6 +1250,64 @@ public class CamelCatalogTest {
     }
 
     @Test
+    public void testPredicatePlaceholderAsOperand() {
+        // CAMEL-24692: a placeholder used as a bare operand of a binary operator is valid at runtime,
+        // as the placeholder is resolved before the predicate is parsed
+        LanguageValidationResult result = catalog.validateLanguagePredicate(null, "simple", "${body} >= {{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("${body} >= {{hot.threshold}}", result.getText());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${header.level} == {{level}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} in {{list}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} range {{range}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} regex {{pattern}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        // the placeholder can also be the entire predicate
+        result = catalog.validateLanguagePredicate(null, "simple", "{{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("{{hot.threshold}}", result.getText());
+    }
+
+    @Test
+    public void testPredicateMultiplePlaceholders() {
+        // CAMEL-24692: each placeholder must be replaced on its own and not as one greedy match
+        LanguageValidationResult result
+                = catalog.validateLanguagePredicate(null, "simple", "${body} == {{a}} && ${header.x} == {{b}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("${body} == {{a}} && ${header.x} == {{b}}", result.getText());
+
+        // mixing a quoted and a bare placeholder
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} == '{{a}}' && ${body} != {{b}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        // and the placeholders must be restored in the error message
+        result = catalog.validateLanguagePredicate(null, "simple", "${bdy} == {{a}} && ${header.x} == {{b}}");
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("{{a}}"), result.getError());
+        assertTrue(result.getError().contains("{{b}}"), result.getError());
+    }
+
+    @Test
+    public void testExpressionPlaceholder() {
+        LanguageValidationResult result = catalog.validateLanguageExpression(null, "simple", "{{greeting}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("{{greeting}}", result.getText());
+
+        result = catalog.validateLanguageExpression(null, "simple", "Hello {{name}} how are you");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguageExpression(null, "simple", "${body} and {{suffix}}");
+        assertTrue(result.isSuccess(), result.getError());
+    }
+
+    @Test
     public void testValidateLanguage() {
         LanguageValidationResult result = catalog.validateLanguageExpression(null, "simple", "${body}");
         assertTrue(result.isSuccess());
@@ -1341,6 +1399,21 @@ public class CamelCatalogTest {
         assertEquals(code, result.getText());
         assertEquals(23, result.getIndex());
         assertEquals("Unexpected input: '*' @ line 2, column 11.", result.getShortError());
+    }
+
+    @Test
+    public void testValidateGroovyLanguagePlaceholder() {
+        // CAMEL-24692: the groovy validation uses the same placeholder replacement as simple
+        LanguageValidationResult result
+                = catalog.validateLanguageExpression(null, "groovy", "request.body >= {{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("request.body >= {{hot.threshold}}", result.getText());
+
+        result = catalog.validateLanguageExpression(null, "groovy", "{{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguageExpression(null, "groovy", "request.body == '{{name}}'");
+        assertTrue(result.isSuccess(), result.getError());
     }
 
     @Test

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
@@ -1380,16 +1380,85 @@ public abstract class AbstractCamelCatalog {
                 || key.startsWith("camel.rest.");
     }
 
+    /**
+     * Replaces property placeholders with a dummy value so the text can be parsed by the language parsers.
+     *
+     * The placeholders cannot be resolved during validation as we do not run the actual Camel application with the
+     * property placeholders setup, and the languages are parsed after the placeholders have been resolved at runtime.
+     *
+     * A placeholder that is already inside a quoted literal is replaced by <tt>{{XXX}}</tt> to <tt>~^XXX^~</tt>, and
+     * otherwise by <tt>{{XXX}}</tt> to <tt>'~XXX~'</tt>. The quotes are needed because the languages do not accept a
+     * bare unquoted literal as operand, such as in <tt>${body} >= {{threshold}}</tt>. Both dummies have the same length
+     * as the placeholder they replace, so the position reported in a parser error still points at the same location in
+     * the original text.
+     *
+     * @param  text the text
+     * @return      the text with the property placeholders replaced by a dummy value
+     * @see         #restorePropertyPlaceholders(String)
+     */
+    private static String dummyPropertyPlaceholders(String text) {
+        if (text == null || !text.contains("{{")) {
+            return text;
+        }
+
+        StringBuilder sb = new StringBuilder(text.length());
+        // the quote character we are currently inside, or 0 when not inside a quoted literal
+        char quote = 0;
+        int i = 0;
+        while (i < text.length()) {
+            char ch = text.charAt(i);
+            if (ch == '\\' && i < text.length() - 1) {
+                // escaped character, so copy as-is
+                sb.append(ch).append(text.charAt(i + 1));
+                i += 2;
+                continue;
+            }
+            if (quote == 0 && (ch == '\'' || ch == '"')) {
+                quote = ch;
+            } else if (quote == ch) {
+                quote = 0;
+            } else if (ch == '{' && i < text.length() - 1 && text.charAt(i + 1) == '{') {
+                int end = text.indexOf("}}", i + 2);
+                if (end != -1) {
+                    String key = text.substring(i + 2, end);
+                    if (quote != 0 || key.indexOf('\'') != -1) {
+                        // already inside a quoted literal, or the key has a single quote that would break the literal
+                        sb.append("~^").append(key).append("^~");
+                    } else {
+                        sb.append("'~").append(key).append("~'");
+                    }
+                    i = end + 2;
+                    continue;
+                }
+            }
+            sb.append(ch);
+            i++;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Reverses {@link #dummyPropertyPlaceholders(String)} so an error message refers to the property placeholders the
+     * user actually wrote.
+     *
+     * @param  text the text
+     * @return      the text with the dummy values replaced by the property placeholders
+     */
+    private static String restorePropertyPlaceholders(String text) {
+        if (text == null) {
+            return null;
+        }
+        // reverse ~^XXX^~ first as it may be surrounded by the quotes the other dummy also uses
+        String answer = text.replaceAll("~\\^(.+?)\\^~", "{{$1}}");
+        return answer.replaceAll("'~(.+?)~'", "{{$1}}");
+    }
+
     private LanguageValidationResult doValidateSimple(ClassLoader classLoader, String simple, boolean predicate) {
         if (classLoader == null) {
             classLoader = getClass().getClassLoader();
         }
 
-        // if there are {{ }}} property placeholders then we need to resolve them to something else
-        // as the simple parse cannot resolve them before parsing as we dont run the actual Camel application
-        // with property placeholders setup so we need to dummy this by replace the {{ }} to something else
-        // therefore we use a more unlikely character: {{XXX}} to ~^XXX^~
-        String resolved = simple.replaceAll("\\{\\{(.+)\\}\\}", "~^$1^~");
+        String resolved = dummyPropertyPlaceholders(simple);
 
         LanguageValidationResult answer = new LanguageValidationResult(simple);
 
@@ -1426,9 +1495,8 @@ public abstract class AbstractCamelCatalog {
 
             if (cause != null) {
 
-                // reverse ~^XXX^~ back to {{XXX}}
-                String errMsg = cause.getMessage();
-                errMsg = errMsg.replaceAll("\\~\\^(.+)\\^\\~", "{{$1}}");
+                // reverse the dummy placeholders back to {{XXX}}
+                String errMsg = restorePropertyPlaceholders(cause.getMessage());
 
                 answer.setError(errMsg);
 
@@ -1485,11 +1553,7 @@ public abstract class AbstractCamelCatalog {
             classLoader = getClass().getClassLoader();
         }
 
-        // if there are {{ }}} property placeholders then we need to resolve them to something else
-        // as the simple parse cannot resolve them before parsing as we dont run the actual Camel application
-        // with property placeholders setup so we need to dummy this by replace the {{ }} to something else
-        // therefore we use a more unlikely character: {{XXX}} to ~^XXX^~
-        String resolved = groovy.replaceAll("\\{\\{(.+)\\}\\}", "~^$1^~");
+        String resolved = dummyPropertyPlaceholders(groovy);
 
         LanguageValidationResult answer = new LanguageValidationResult(groovy);
 
@@ -1526,9 +1590,8 @@ public abstract class AbstractCamelCatalog {
 
             if (cause != null) {
 
-                // reverse ~^XXX^~ back to {{XXX}}
-                String errMsg = cause.getMessage();
-                errMsg = errMsg.replaceAll("\\~\\^(.+)\\^\\~", "{{$1}}");
+                // reverse the dummy placeholders back to {{XXX}}
+                String errMsg = restorePropertyPlaceholders(cause.getMessage());
 
                 answer.setError(errMsg);
 


### PR DESCRIPTION
Fixes [CAMEL-24692](https://issues.apache.org/jira/browse/CAMEL-24692).

## Problem

`AbstractCamelCatalog` substitutes `{{key}}` with `~^key^~` before handing the text to the Simple and Groovy parsers, so a property placeholder can be parsed without a running `CamelContext`. That works when the placeholder sits inside quotes or free text, but `~^key^~` is an *unquoted literal*, and `SimplePredicateParser.binaryOperator()` only accepts a quoted literal, a `${...}` function, or a numeric/boolean/null value as the right hand side. So these valid predicates were rejected:

```
${body} >= {{hot.threshold}}    -> Binary operator >= does not support token ^ at location 12
${header.level} == {{level}}    -> Binary operator == does not support token ^ at location 20
{{hot.threshold}}               -> Unexpected token ~ at location 0
```

They are valid at runtime: `ExpressionReifier.createPredicate()` calls `parseString(definition.getExpression())`, which resolves the property placeholders, **before** `language.createPredicate(exp)`. The Simple parser never sees `{{ }}`.

This produced false positives in the `camel:validate` Maven goal (`ValidateMojo`) and in the Camel TUI save-time validation.

## Fix

Replace a placeholder that is **not already inside a quoted literal** with `'~key~'`, which parses as a quoted literal in every operand position. A placeholder already inside quotes keeps the existing `~^key^~` form, so `${body} contains '{{danger}}'` is unaffected.

Both dummies are exactly the same length as the `{{key}}` they replace, so the position reported in a parser error still points at the same location in the original text and no index remapping is needed.

A second, independent bug is fixed at the same time: the regex was greedy, so several placeholders in one expression collapsed into a single match, both when substituting and when restoring them in the error message:

```
input:  ${body} == {{a}} && ${header.x} == {{b}}
before: ${body} == ~^a}} && ${header.x} == {{b^~
after:  ${body} == '~a~' && ${header.x} == '~b~'
```

The two near-duplicate copies of this logic in `doValidateSimple` and `doValidateGroovy` are now a shared pair of helpers.

## Groovy

`doValidateGroovy` carried the same substitution and failed the same way, verified against the real parser:

```
request.body >= {{hot.threshold}}  -> MultipleCompilationErrorsException
{{hot.threshold}}                  -> MultipleCompilationErrorsException
request.body == '{{name}}'         -> OK
```

## Testing

Four new tests in `CamelCatalogTest` covering bare operands (including `in` / `range` / `regex`, which need a `Literal` and so rule out a numeric dummy), whole-predicate placeholders, multiple and mixed quoted/unquoted placeholders plus error-message restoration, expression-position placeholders, and the Groovy equivalents.

The pre-existing `testPredicatePlaceholder`, which pins the quoted case and the `'{{danger}}'` error reversal, still passes.

The candidate substitutions were checked against the real `SimpleLanguage` parser before settling on this one, including `'foo{{name}}bar'` (placeholder mid-quote), `"{{name}}"`, `${header.{{headerName}}}`, and ternaries.

> Note: `CamelCatalogTest` has 4 unrelated failures on my machine (`testComponentAliases`, `testSuggestComponentNames`, `testSuggestComponentNamesDedupesAlternativeSchemes`, `devConsolesOpenApiSpec`). I reproduced all four on a clean tree at the same base commit, so they pre-date this change and look like a stale local `.m2`.

---
_Claude Code on behalf of davsclaus_
