### PR TITLE
CAMEL-24692: camel-jbang-plugin-tui - narrow the simple validation placeholder workaround

### DIFF
--- a/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
+++ b/catalog/camel-catalog/src/test/java/org/apache/camel/catalog/CamelCatalogTest.java
@@ -1250,6 +1250,64 @@ public class CamelCatalogTest {
     }
 
     @Test
+    public void testPredicatePlaceholderAsOperand() {
+        // CAMEL-24692: a placeholder used as a bare operand of a binary operator is valid at runtime,
+        // as the placeholder is resolved before the predicate is parsed
+        LanguageValidationResult result = catalog.validateLanguagePredicate(null, "simple", "${body} >= {{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("${body} >= {{hot.threshold}}", result.getText());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${header.level} == {{level}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} in {{list}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} range {{range}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} regex {{pattern}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        // the placeholder can also be the entire predicate
+        result = catalog.validateLanguagePredicate(null, "simple", "{{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("{{hot.threshold}}", result.getText());
+    }
+
+    @Test
+    public void testPredicateMultiplePlaceholders() {
+        // CAMEL-24692: each placeholder must be replaced on its own and not as one greedy match
+        LanguageValidationResult result
+                = catalog.validateLanguagePredicate(null, "simple", "${body} == {{a}} && ${header.x} == {{b}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("${body} == {{a}} && ${header.x} == {{b}}", result.getText());
+
+        // mixing a quoted and a bare placeholder
+        result = catalog.validateLanguagePredicate(null, "simple", "${body} == '{{a}}' && ${body} != {{b}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        // and the placeholders must be restored in the error message
+        result = catalog.validateLanguagePredicate(null, "simple", "${bdy} == {{a}} && ${header.x} == {{b}}");
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("{{a}}"), result.getError());
+        assertTrue(result.getError().contains("{{b}}"), result.getError());
+    }
+
+    @Test
+    public void testExpressionPlaceholder() {
+        LanguageValidationResult result = catalog.validateLanguageExpression(null, "simple", "{{greeting}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("{{greeting}}", result.getText());
+
+        result = catalog.validateLanguageExpression(null, "simple", "Hello {{name}} how are you");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguageExpression(null, "simple", "${body} and {{suffix}}");
+        assertTrue(result.isSuccess(), result.getError());
+    }
+
+    @Test
     public void testValidateLanguage() {
         LanguageValidationResult result = catalog.validateLanguageExpression(null, "simple", "${body}");
         assertTrue(result.isSuccess());
@@ -1341,6 +1399,21 @@ public class CamelCatalogTest {
         assertEquals(code, result.getText());
         assertEquals(23, result.getIndex());
         assertEquals("Unexpected input: '*' @ line 2, column 11.", result.getShortError());
+    }
+
+    @Test
+    public void testValidateGroovyLanguagePlaceholder() {
+        // CAMEL-24692: the groovy validation uses the same placeholder replacement as simple
+        LanguageValidationResult result
+                = catalog.validateLanguageExpression(null, "groovy", "request.body >= {{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals("request.body >= {{hot.threshold}}", result.getText());
+
+        result = catalog.validateLanguageExpression(null, "groovy", "{{hot.threshold}}");
+        assertTrue(result.isSuccess(), result.getError());
+
+        result = catalog.validateLanguageExpression(null, "groovy", "request.body == '{{name}}'");
+        assertTrue(result.isSuccess(), result.getError());
     }
 
     @Test

--- a/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
+++ b/core/camel-core-catalog/src/main/java/org/apache/camel/catalog/impl/AbstractCamelCatalog.java
@@ -1380,16 +1380,85 @@ public abstract class AbstractCamelCatalog {
                 || key.startsWith("camel.rest.");
     }
 
+    /**
+     * Replaces property placeholders with a dummy value so the text can be parsed by the language parsers.
+     *
+     * The placeholders cannot be resolved during validation as we do not run the actual Camel application with the
+     * property placeholders setup, and the languages are parsed after the placeholders have been resolved at runtime.
+     *
+     * A placeholder that is already inside a quoted literal is replaced by <tt>{{XXX}}</tt> to <tt>~^XXX^~</tt>, and
+     * otherwise by <tt>{{XXX}}</tt> to <tt>'~XXX~'</tt>. The quotes are needed because the languages do not accept a
+     * bare unquoted literal as operand, such as in <tt>${body} >= {{threshold}}</tt>. Both dummies have the same length
+     * as the placeholder they replace, so the position reported in a parser error still points at the same location in
+     * the original text.
+     *
+     * @param  text the text
+     * @return      the text with the property placeholders replaced by a dummy value
+     * @see         #restorePropertyPlaceholders(String)
+     */
+    private static String dummyPropertyPlaceholders(String text) {
+        if (text == null || !text.contains("{{")) {
+            return text;
+        }
+
+        StringBuilder sb = new StringBuilder(text.length());
+        // the quote character we are currently inside, or 0 when not inside a quoted literal
+        char quote = 0;
+        int i = 0;
+        while (i < text.length()) {
+            char ch = text.charAt(i);
+            if (ch == '\\' && i < text.length() - 1) {
+                // escaped character, so copy as-is
+                sb.append(ch).append(text.charAt(i + 1));
+                i += 2;
+                continue;
+            }
+            if (quote == 0 && (ch == '\'' || ch == '"')) {
+                quote = ch;
+            } else if (quote == ch) {
+                quote = 0;
+            } else if (ch == '{' && i < text.length() - 1 && text.charAt(i + 1) == '{') {
+                int end = text.indexOf("}}", i + 2);
+                if (end != -1) {
+                    String key = text.substring(i + 2, end);
+                    if (quote != 0 || key.indexOf('\'') != -1) {
+                        // already inside a quoted literal, or the key has a single quote that would break the literal
+                        sb.append("~^").append(key).append("^~");
+                    } else {
+                        sb.append("'~").append(key).append("~'");
+                    }
+                    i = end + 2;
+                    continue;
+                }
+            }
+            sb.append(ch);
+            i++;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Reverses {@link #dummyPropertyPlaceholders(String)} so an error message refers to the property placeholders the
+     * user actually wrote.
+     *
+     * @param  text the text
+     * @return      the text with the dummy values replaced by the property placeholders
+     */
+    private static String restorePropertyPlaceholders(String text) {
+        if (text == null) {
+            return null;
+        }
+        // reverse ~^XXX^~ first as it may be surrounded by the quotes the other dummy also uses
+        String answer = text.replaceAll("~\\^(.+?)\\^~", "{{$1}}");
+        return answer.replaceAll("'~(.+?)~'", "{{$1}}");
+    }
+
     private LanguageValidationResult doValidateSimple(ClassLoader classLoader, String simple, boolean predicate) {
         if (classLoader == null) {
             classLoader = getClass().getClassLoader();
         }
 
-        // if there are {{ }}} property placeholders then we need to resolve them to something else
-        // as the simple parse cannot resolve them before parsing as we dont run the actual Camel application
-        // with property placeholders setup so we need to dummy this by replace the {{ }} to something else
-        // therefore we use a more unlikely character: {{XXX}} to ~^XXX^~
-        String resolved = simple.replaceAll("\\{\\{(.+)\\}\\}", "~^$1^~");
+        String resolved = dummyPropertyPlaceholders(simple);
 
         LanguageValidationResult answer = new LanguageValidationResult(simple);
 
@@ -1426,9 +1495,8 @@ public abstract class AbstractCamelCatalog {
 
             if (cause != null) {
 
-                // reverse ~^XXX^~ back to {{XXX}}
-                String errMsg = cause.getMessage();
-                errMsg = errMsg.replaceAll("\\~\\^(.+)\\^\\~", "{{$1}}");
+                // reverse the dummy placeholders back to {{XXX}}
+                String errMsg = restorePropertyPlaceholders(cause.getMessage());
 
                 answer.setError(errMsg);
 
@@ -1485,11 +1553,7 @@ public abstract class AbstractCamelCatalog {
             classLoader = getClass().getClassLoader();
         }
 
-        // if there are {{ }}} property placeholders then we need to resolve them to something else
-        // as the simple parse cannot resolve them before parsing as we dont run the actual Camel application
-        // with property placeholders setup so we need to dummy this by replace the {{ }} to something else
-        // therefore we use a more unlikely character: {{XXX}} to ~^XXX^~
-        String resolved = groovy.replaceAll("\\{\\{(.+)\\}\\}", "~^$1^~");
+        String resolved = dummyPropertyPlaceholders(groovy);
 
         LanguageValidationResult answer = new LanguageValidationResult(groovy);
 
@@ -1526,9 +1590,8 @@ public abstract class AbstractCamelCatalog {
 
             if (cause != null) {
 
-                // reverse ~^XXX^~ back to {{XXX}}
-                String errMsg = cause.getMessage();
-                errMsg = errMsg.replaceAll("\\~\\^(.+)\\^\\~", "{{$1}}");
+                // reverse the dummy placeholders back to {{XXX}}
+                String errMsg = restorePropertyPlaceholders(cause.getMessage());
 
                 answer.setError(errMsg);
 

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceEditAssist.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/main/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceEditAssist.java
@@ -1617,8 +1617,8 @@ final class SourceEditAssist {
             if (simpleText == null || simpleText.isEmpty()) {
                 continue;
             }
-            // Skip placeholder-only expressions
-            if (simpleText.startsWith("{{") && simpleText.endsWith("}}")) {
+            // Skip what the catalog cannot validate because a placeholder is unresolved
+            if (hasPlaceholderAsLogicalOperand(simpleText)) {
                 continue;
             }
 
@@ -1644,6 +1644,55 @@ final class SourceEditAssist {
             }
         }
         return errors;
+    }
+
+    /**
+     * Whether the text uses a property placeholder as an operand of a logical operator, such as
+     * <tt>{{enabled}} && ${body} > 10</tt>.
+     *
+     * A placeholder can expand to an entire predicate, which the catalog cannot know as it validates without a running
+     * Camel application. The catalog substitutes a placeholder with a dummy value, which is what an operand of a binary
+     * operator needs, but a logical operator needs a predicate on either side. Validating those would report an error
+     * for a route that is perfectly valid at runtime, so they are skipped.
+     */
+    static boolean hasPlaceholderAsLogicalOperand(String text) {
+        if (text == null || !text.contains("{{")) {
+            return false;
+        }
+
+        // split into the operands of the logical operators, ignoring any quoted literal
+        List<String> operands = new ArrayList<>();
+        char quote = 0;
+        int start = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (quote == 0 && (ch == '\'' || ch == '"')) {
+                quote = ch;
+            } else if (quote == ch) {
+                quote = 0;
+            } else if (quote == 0 && i < text.length() - 1) {
+                char next = text.charAt(i + 1);
+                if (ch == '&' && next == '&' || ch == '|' && next == '|') {
+                    operands.add(text.substring(start, i));
+                    i++;
+                    start = i + 1;
+                }
+            }
+        }
+        if (operands.isEmpty()) {
+            // no logical operator so the placeholders are all used as a value which the catalog can validate
+            return false;
+        }
+        operands.add(text.substring(start));
+
+        for (String operand : operands) {
+            String s = operand.trim();
+            // is the operand nothing but a single placeholder
+            if (s.startsWith("{{") && s.endsWith("}}") && s.indexOf("}}") == s.length() - 2) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static String findParentEip(String[] lines, int lineIdx, int lineIndent) {

--- a/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceEditAssistValidateTest.java
+++ b/dsl/camel-jbang/camel-jbang-plugin-tui/src/test/java/org/apache/camel/dsl/jbang/core/commands/tui/SourceEditAssistValidateTest.java
@@ -80,4 +80,48 @@ class SourceEditAssistValidateTest {
         assertTrue(SourceEditAssist.isValidatableFile("routes.YAML"));
         assertFalse(SourceEditAssist.isValidatableFile("Foo.java"));
     }
+
+    @Test
+    void placeholderAsOperandIsValidated() {
+        // CAMEL-24692: the catalog can validate these now, so they must no longer be skipped
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand("{{hot.threshold}}"));
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand("${body} >= {{hot.threshold}}"));
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand("{{a}} == {{b}}"));
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand("${body} >= {{t}} && ${body} < {{u}}"));
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand("${body} == 'abc'"));
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand(null));
+    }
+
+    @Test
+    void placeholderAsLogicalOperandIsSkipped() {
+        // a placeholder can expand to an entire predicate which the catalog cannot know
+        assertTrue(SourceEditAssist.hasPlaceholderAsLogicalOperand("{{a}} && {{b}}"));
+        assertTrue(SourceEditAssist.hasPlaceholderAsLogicalOperand("${body} > 1 && {{flag}}"));
+        assertTrue(SourceEditAssist.hasPlaceholderAsLogicalOperand("{{flag}} || ${body} > 1"));
+        // a logical operator inside a quoted literal is not an operator
+        assertFalse(SourceEditAssist.hasPlaceholderAsLogicalOperand("${body} == '{{a}} && {{b}}'"));
+    }
+
+    @Test
+    void placeholderPredicateIsNotReportedAsError() {
+        List<String> errors = assist().validateSource("placeholder.camel.yaml", """
+                - route:
+                    id: placeholder
+                    from:
+                      uri: timer:tick
+                      steps:
+                        - choice:
+                            when:
+                              - simple: "${body} >= {{hot.threshold}}"
+                                steps:
+                                  - log:
+                                      message: "hot"
+                              - simple: "{{enabled}} && ${body} > 1"
+                                steps:
+                                  - log:
+                                      message: "on"
+                """);
+
+        assertTrue(errors.stream().noneMatch(e -> e.contains("Simple syntax error")), String.valueOf(errors));
+    }
 }


### PR DESCRIPTION
Follow-up to #26349 — **stacked on top of it**, so this PR targets `fix/CAMEL-24692` and should be merged after it. Part of [CAMEL-24692](https://issues.apache.org/jira/browse/CAMEL-24692).

## Background

The TUI save-time validation carried a workaround for the catalog bug fixed in #26349:

```java
// Skip placeholder-only expressions
if (simpleText.startsWith("{{") && simpleText.endsWith("}}")) {
    continue;
}
```

The obvious follow-up was to delete it. **That turns out not to be safe**, so this PR narrows it instead.

## Why it cannot just be removed

A property placeholder can expand to an entire *predicate*, not just a value. The catalog substitutes a placeholder with a dummy value, which is what an operand of a binary operator needs, but a logical operator needs a predicate on either side. So these still fail validation, checked against the catalog built from #26349:

```
{{a}} && {{b}}            -> Logical operator && does not support left hand side token '
{{a}} and {{b}}           -> Unexpected token a
```

Those are false positives: at runtime the placeholders resolve first, so `{{enabled}} && ${body} > 1` is a perfectly valid route. Deleting the guard would reintroduce exactly the class of false positive CAMEL-24692 is about.

## What this PR does

Replaces the shape-based guard with a check for the one case the catalog genuinely cannot model — a placeholder used as an operand of a logical operator. The new guard is **narrower in one direction and wider in the other**:

- Expressions that are merely placeholder-valued are now validated instead of skipped, so real errors in them get caught. `{{a}} =!= {{b}}` was silently ignored before.
- It also covers a case the old guard missed. `${body} > 1 && {{flag}}` does not start with `{{`, so it was never skipped and was already reported as a false error, independently of CAMEL-24692.

| expression | before | after |
|---|---|---|
| `{{hot.threshold}}` | skipped | validated (passes) |
| `${body} >= {{hot.threshold}}` | validated (false error) | validated (passes) |
| `{{a}} =!= {{b}}` | skipped (real error hidden) | validated (error reported) |
| `{{a}} && {{b}}` | skipped | skipped |
| `${body} > 1 && {{flag}}` | validated (false error) | skipped |

The operand split ignores quoted literals, so a `&&` inside a string is not treated as an operator.

## Testing

Three new tests in `SourceEditAssistValidateTest`: one pinning what must now be validated, one pinning what must still be skipped (including the quoted-literal case), and an end-to-end one running `validateSource` over a YAML route that uses both placeholder shapes under `choice`/`when`. 7/7 pass in that class.

---
_Claude Code on behalf of davsclaus_
