### PR TITLE
CAMEL-24693: docs - write the EIP YAML examples for circuit breaker, load balancer, doCatch and aggregate in the YAML DSL shape

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/circuitBreaker-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/circuitBreaker-eip.adoc
@@ -86,12 +86,12 @@ YAML::
             steps:
               - to:
                   uri: http://fooservice.com/slow
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/customLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/customLoadBalancer-eip.adoc
@@ -70,9 +70,9 @@ YAML::
         name: start
       steps:
         - loadBalance:
+            customLoadBalancer:
+              ref: myBalancer
             steps:
-              - customLoadBalancer:
-                  ref: myBalancer
               - to:
                   uri: seda:x
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/doTry-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/doTry-eip.adoc
@@ -176,11 +176,11 @@ YAML::
                   exception:
                     - java.io.IOException
                     - java.lang.IllegalStateException
+                  onWhen:
+                    expression:
+                      simple:
+                        expression: "${exception.message} contains 'Damn'"
                   steps:
-                    - onWhen:
-                        expression:
-                          simple:
-                            expression: "${exception.message} contains 'Damn'"
                     - to:
                         uri: mock:catch
               - doCatch:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/failoverLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/failoverLoadBalancer-eip.adoc
@@ -64,8 +64,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer: {}
             steps:
-              - failoverLoadBalancer: {}
               - to:
                   uri: http:service1
               - to:
@@ -133,11 +133,11 @@ In XML and YAML DSL it is easier.
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer:
+              inheritErrorHandler: "false"
+              maximumFailoverAttempts: 10
+              roundRobin: "true"
             steps:
-              - failoverLoadBalancer:
-                  inheritErrorHandler: "false"
-                  maximumFailoverAttempts: 10
-                  roundRobin: "true"
               - to:
                   uri: http:service1
               - to:
@@ -207,12 +207,12 @@ In XML and YAML DSL it is easier.
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer:
+              inheritErrorHandler: "false"
+              sticky: "true"
+              maximumFailoverAttempts: 10
+              roundRobin: "true"
             steps:
-              - failoverLoadBalancer:
-                  inheritErrorHandler: "false"
-                  sticky: "true"
-                  maximumFailoverAttempts: 10
-                  roundRobin: "true"
               - to:
                   uri: http:service1
               - to:
@@ -270,11 +270,11 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer:
+              exception:
+                - java.io.IOException
+                - org.apache.camel.http.base.HttpOperationFailedException
             steps:
-              - failoverLoadBalancer:
-                  exception:
-                    - java.io.IOException
-                    - org.apache.camel.http.base.HttpOperationFailedException
               - to:
                   uri: http:service1
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/fault-tolerance-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/fault-tolerance-eip.adoc
@@ -68,12 +68,12 @@ YAML::
             steps:
               - to:
                   uri: http://fooservice.com/faulty
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----
@@ -136,10 +136,10 @@ YAML::
       uri: direct:start
       steps:
         - circuitBreaker:
+            faultToleranceConfiguration:
+              timeoutDuration: 2000
+              timeoutEnabled: "true"
             steps:
-              - faultToleranceConfiguration:
-                  timeoutDuration: 2000
-                  timeoutEnabled: "true"
               - log:
                   message: "Fault Tolerance processing start: ${threadName}"
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/keyValueRepository.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/keyValueRepository.adoc
@@ -1120,8 +1120,8 @@ XML DSL::
 ----
 <route>
   <from uri="direct:start"/>
-  <aggregate strategyRef="groupedBodyStrategy"
-             aggregationRepositoryRef="aggregationRepo"
+  <aggregate aggregationStrategy="groupedBodyStrategy"
+             aggregationRepository="aggregationRepo"
              completionSize="10">
     <correlationExpression>
       <header>orderId</header>
@@ -1141,7 +1141,7 @@ YAML DSL::
       - aggregate:
           correlationExpression:
             header: orderId
-          strategyRef: groupedBodyStrategy
+          aggregationStrategy: groupedBodyStrategy
           aggregationRepository: aggregationRepo
           completionSize: 10
           steps:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/randomLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/randomLoadBalancer-eip.adoc
@@ -65,8 +65,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            randomLoadBalancer: {}
             steps:
-              - randomLoadBalancer: {}
               - to:
                   uri: seda:x
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/resilience4j-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/resilience4j-eip.adoc
@@ -68,12 +68,12 @@ YAML::
             steps:
               - to:
                   uri: http://fooservice.com/faulty
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----
@@ -136,10 +136,10 @@ YAML::
       uri: direct:start
       steps:
         - circuitBreaker:
+            resilience4jConfiguration:
+              timeoutDuration: 2000
+              timeoutEnabled: "true"
             steps:
-              - resilience4jConfiguration:
-                  timeoutDuration: 2000
-                  timeoutEnabled: "true"
               - log:
                   message: "Resilience processing start: ${threadName}"
               - to:
@@ -212,19 +212,19 @@ YAML::
       uri: direct:start
       steps:
         - circuitBreaker:
+            resilience4jConfiguration:
+              asynchronous: "true"
+              timeoutDuration: 2000
+              timeoutEnabled: "true"
             steps:
-              - resilience4jConfiguration:
-                  asynchronous: "true"
-                  timeoutDuration: 2000
-                  timeoutEnabled: "true"
               - to:
                   uri: http://fooservice.com/faulty
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/roundRobinLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/roundRobinLoadBalancer-eip.adoc
@@ -66,8 +66,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            roundRobinLoadBalancer: {}
             steps:
-              - roundRobinLoadBalancer: {}
               - to:
                   uri: seda:x
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/stickyLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/stickyLoadBalancer-eip.adoc
@@ -69,11 +69,11 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            stickyLoadBalancer:
+              correlationExpression:
+                header:
+                  expression: myKey
             steps:
-              - stickyLoadBalancer:
-                  correlationExpression:
-                    header:
-                      expression: myKey
               - to:
                   uri: seda:x
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/topicLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/topicLoadBalancer-eip.adoc
@@ -65,8 +65,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            topicLoadBalancer: {}
             steps:
-              - topicLoadBalancer: {}
               - to:
                   uri: seda:x
               - to:

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/weightedLoadBalancer-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/weightedLoadBalancer-eip.adoc
@@ -67,9 +67,9 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            weightedLoadBalancer:
+              distributionRatio: "4,2,1"
             steps:
-              - weightedLoadBalancer:
-                  distributionRatio: "4,2,1"
               - to:
                   uri: seda:x
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/circuitBreaker-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/circuitBreaker-eip.adoc
@@ -86,12 +86,12 @@ YAML::
             steps:
               - to:
                   uri: http://fooservice.com/slow
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/customLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/customLoadBalancer-eip.adoc
@@ -70,9 +70,9 @@ YAML::
         name: start
       steps:
         - loadBalance:
+            customLoadBalancer:
+              ref: myBalancer
             steps:
-              - customLoadBalancer:
-                  ref: myBalancer
               - to:
                   uri: seda:x
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/doTry-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/doTry-eip.adoc
@@ -176,11 +176,11 @@ YAML::
                   exception:
                     - java.io.IOException
                     - java.lang.IllegalStateException
+                  onWhen:
+                    expression:
+                      simple:
+                        expression: "${exception.message} contains 'Damn'"
                   steps:
-                    - onWhen:
-                        expression:
-                          simple:
-                            expression: "${exception.message} contains 'Damn'"
                     - to:
                         uri: mock:catch
               - doCatch:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/failoverLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/failoverLoadBalancer-eip.adoc
@@ -64,8 +64,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer: {}
             steps:
-              - failoverLoadBalancer: {}
               - to:
                   uri: http:service1
               - to:
@@ -133,11 +133,11 @@ In XML and YAML DSL it is easier.
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer:
+              inheritErrorHandler: "false"
+              maximumFailoverAttempts: 10
+              roundRobin: "true"
             steps:
-              - failoverLoadBalancer:
-                  inheritErrorHandler: "false"
-                  maximumFailoverAttempts: 10
-                  roundRobin: "true"
               - to:
                   uri: http:service1
               - to:
@@ -207,12 +207,12 @@ In XML and YAML DSL it is easier.
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer:
+              inheritErrorHandler: "false"
+              sticky: "true"
+              maximumFailoverAttempts: 10
+              roundRobin: "true"
             steps:
-              - failoverLoadBalancer:
-                  inheritErrorHandler: "false"
-                  sticky: "true"
-                  maximumFailoverAttempts: 10
-                  roundRobin: "true"
               - to:
                   uri: http:service1
               - to:
@@ -270,11 +270,11 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            failoverLoadBalancer:
+              exception:
+                - java.io.IOException
+                - org.apache.camel.http.base.HttpOperationFailedException
             steps:
-              - failoverLoadBalancer:
-                  exception:
-                    - java.io.IOException
-                    - org.apache.camel.http.base.HttpOperationFailedException
               - to:
                   uri: http:service1
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/fault-tolerance-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/fault-tolerance-eip.adoc
@@ -68,12 +68,12 @@ YAML::
             steps:
               - to:
                   uri: http://fooservice.com/faulty
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----
@@ -136,10 +136,10 @@ YAML::
       uri: direct:start
       steps:
         - circuitBreaker:
+            faultToleranceConfiguration:
+              timeoutDuration: 2000
+              timeoutEnabled: "true"
             steps:
-              - faultToleranceConfiguration:
-                  timeoutDuration: 2000
-                  timeoutEnabled: "true"
               - log:
                   message: "Fault Tolerance processing start: ${threadName}"
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/keyValueRepository.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/keyValueRepository.adoc
@@ -1120,8 +1120,8 @@ XML DSL::
 ----
 <route>
   <from uri="direct:start"/>
-  <aggregate strategyRef="groupedBodyStrategy"
-             aggregationRepositoryRef="aggregationRepo"
+  <aggregate aggregationStrategy="groupedBodyStrategy"
+             aggregationRepository="aggregationRepo"
              completionSize="10">
     <correlationExpression>
       <header>orderId</header>
@@ -1141,7 +1141,7 @@ YAML DSL::
       - aggregate:
           correlationExpression:
             header: orderId
-          strategyRef: groupedBodyStrategy
+          aggregationStrategy: groupedBodyStrategy
           aggregationRepository: aggregationRepo
           completionSize: 10
           steps:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/randomLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/randomLoadBalancer-eip.adoc
@@ -65,8 +65,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            randomLoadBalancer: {}
             steps:
-              - randomLoadBalancer: {}
               - to:
                   uri: seda:x
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/resilience4j-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/resilience4j-eip.adoc
@@ -68,12 +68,12 @@ YAML::
             steps:
               - to:
                   uri: http://fooservice.com/faulty
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----
@@ -136,10 +136,10 @@ YAML::
       uri: direct:start
       steps:
         - circuitBreaker:
+            resilience4jConfiguration:
+              timeoutDuration: 2000
+              timeoutEnabled: "true"
             steps:
-              - resilience4jConfiguration:
-                  timeoutDuration: 2000
-                  timeoutEnabled: "true"
               - log:
                   message: "Resilience processing start: ${threadName}"
               - to:
@@ -212,19 +212,19 @@ YAML::
       uri: direct:start
       steps:
         - circuitBreaker:
+            resilience4jConfiguration:
+              asynchronous: "true"
+              timeoutDuration: 2000
+              timeoutEnabled: "true"
             steps:
-              - resilience4jConfiguration:
-                  asynchronous: "true"
-                  timeoutDuration: 2000
-                  timeoutEnabled: "true"
               - to:
                   uri: http://fooservice.com/faulty
-              - onFallback:
-                  steps:
-                    - transform:
-                        expression:
-                          constant:
-                            expression: Fallback message
+            onFallback:
+              steps:
+                - transform:
+                    expression:
+                      constant:
+                        expression: Fallback message
         - to:
             uri: mock:result
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/roundRobinLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/roundRobinLoadBalancer-eip.adoc
@@ -66,8 +66,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            roundRobinLoadBalancer: {}
             steps:
-              - roundRobinLoadBalancer: {}
               - to:
                   uri: seda:x
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/stickyLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/stickyLoadBalancer-eip.adoc
@@ -69,11 +69,11 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            stickyLoadBalancer:
+              correlationExpression:
+                header:
+                  expression: myKey
             steps:
-              - stickyLoadBalancer:
-                  correlationExpression:
-                    header:
-                      expression: myKey
               - to:
                   uri: seda:x
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/topicLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/topicLoadBalancer-eip.adoc
@@ -65,8 +65,8 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            topicLoadBalancer: {}
             steps:
-              - topicLoadBalancer: {}
               - to:
                   uri: seda:x
               - to:

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/weightedLoadBalancer-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/weightedLoadBalancer-eip.adoc
@@ -67,9 +67,9 @@ YAML::
       uri: direct:start
       steps:
         - loadBalance:
+            weightedLoadBalancer:
+              distributionRatio: "4,2,1"
             steps:
-              - weightedLoadBalancer:
-                  distributionRatio: "4,2,1"
               - to:
                   uri: seda:x
               - to:


### PR DESCRIPTION
## Summary

First step of [CAMEL-24693](https://issues.apache.org/jira/browse/CAMEL-24693): fix the EIP documentation YAML examples that the YAML DSL runtime rejects, so they can later ship as validated samples in camel-catalog.

18 YAML examples on 12 EIP pages were written in the XML child shape, with `onFallback`, `resilience4jConfiguration`, `faultToleranceConfiguration`, `onWhen` and the `*LoadBalancer` element placed inside `steps`. The YAML DSL deserializer rejects that:

```
Error constructing YAML node id: org.apache.camel.model.ProcessorDefinition
```

Each is now a property of its parent (`circuitBreaker`, `doCatch`, `loadBalance`), which is the form the generated `ModelDeserializers` and the JSON schema accept, and the form the camel-yaml-dsl tests use:

```yaml
- loadBalance:
    failoverLoadBalancer:
      maximumFailoverAttempts: 10
      roundRobin: "true"
    steps:
      - to:
          uri: http:service1
```

The aggregate example on the KeyValueRepository page used the Camel 3 `strategyRef` and `aggregationRepositoryRef` attribute names in both the XML and the YAML tab; both are now `aggregationStrategy` and `aggregationRepository`.

## Pages

circuitBreaker, resilience4j, fault-tolerance, doTry, keyValueRepository, customLoadBalancer, failoverLoadBalancer, randomLoadBalancer, roundRobinLoadBalancer, stickyLoadBalancer, topicLoadBalancer, weightedLoadBalancer. The catalog doc mirror under `catalog/camel-catalog/src/generated` is regenerated.

## Verification

- Before: all 18 examples fail `CamelYamlParser` (camel-yaml-dsl-validator) at deserialization.
- After: all 18 load and start in a `CamelContext` with camel-resilience4j and camel-http-base on the classpath.
- `camel validate yaml` no longer reports any structural error on these pages. The remaining messages are the scalar-type cases handled by CAMEL-24694 (#26351) and the schema gaps now tracked in [CAMEL-24697](https://issues.apache.org/jira/browse/CAMEL-24697) (`inheritErrorHandler` on `circuitBreaker` / `failoverLoadBalancer`, resequence `expression:` oneOf, jaxb `contextPath`).

Docs only, no code change.

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)