### PR TITLE
CAMEL-24697: camel-yaml-dsl - schema must accept inheritErrorHandler and the resequence expression wrapper; jaxb needs a contextPath in the docs

### DIFF
--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/marshal-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/marshal-eip.adoc
@@ -39,9 +39,9 @@ Java::
 [source,java]
 ----
 from("file:inbox/xml")
-  .unmarshal().jaxb()
+  .unmarshal().jaxb("com.acme.order")
   .to("bean:validateOrder")
-  .marshal().jaxb()
+  .marshal().jaxb("com.acme.order")
   .to("jms:queue:order");
 ----
 
@@ -51,9 +51,9 @@ XML::
 ----
 <route>
   <from uri="file:inbox/xml"/>
-  <unmarshal><jaxb/></unmarshal>
+  <unmarshal><jaxb contextPath="com.acme.order"/></unmarshal>
   <to uri="bean:validateOrder"/>
-  <marshal><jaxb/></marshal>
+  <marshal><jaxb contextPath="com.acme.order"/></marshal>
   <to uri="jms:queue:order"/>
 </route>
 ----
@@ -67,11 +67,13 @@ YAML::
       uri: file:inbox/xml
       steps:
         - unmarshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: bean:validateOrder
         - marshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: jms:queue:order
 ----

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/unmarshal-eip.adoc
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/docs/unmarshal-eip.adoc
@@ -40,9 +40,9 @@ Java::
 [source,java]
 ----
 from("file:inbox/xml")
-  .unmarshal().jaxb()
+  .unmarshal().jaxb("com.acme.order")
   .to("bean:validateOrder")
-  .marshal().jaxb()
+  .marshal().jaxb("com.acme.order")
   .to("jms:queue:order");
 ----
 
@@ -52,9 +52,9 @@ XML::
 ----
 <route>
   <from uri="file:inbox/xml"/>
-  <unmarshal><jaxb/></unmarshal>
+  <unmarshal><jaxb contextPath="com.acme.order"/></unmarshal>
   <to uri="bean:validateOrder"/>
-  <marshal><jaxb/></marshal>
+  <marshal><jaxb contextPath="com.acme.order"/></marshal>
   <to uri="jms:queue:order"/>
 </route>
 ----
@@ -68,11 +68,13 @@ YAML::
       uri: file:inbox/xml
       steps:
         - unmarshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: bean:validateOrder
         - marshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: jms:queue:order
 ----
@@ -119,7 +121,8 @@ YAML::
       steps:
         - unmarshal:
             allowNullBody: "true"
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: bean:validateOrder
 ----

--- a/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camelYamlDsl-model.json
+++ b/catalog/camel-catalog/src/generated/resources/org/apache/camel/catalog/schemas/camelYamlDsl-model.json
@@ -1871,6 +1871,17 @@
         "index" : 4,
         "group" : "common"
       }, {
+        "name" : "inheritErrorHandler",
+        "type" : "boolean",
+        "description" : "Whether to inherit Camel error handling during circuit breaker. By default, Camel error handler is turned off.",
+        "title" : "Inherit Error Handler",
+        "default" : "false",
+        "displayName" : "Inherit Error Handler",
+        "kind" : "attribute",
+        "index" : 5,
+        "group" : "advanced",
+        "label" : "advanced"
+      }, {
         "name" : "resilience4jConfiguration",
         "type" : "object",
         "ref" : "resilience4jConfiguration",
@@ -16338,6 +16349,17 @@
         "kind" : "attribute",
         "index" : 4,
         "group" : "common"
+      }, {
+        "name" : "inheritErrorHandler",
+        "type" : "boolean",
+        "description" : "Whether to inherit the error handler. If turned off, the load balancer will fail over immediately on an error instead of waiting for Camel error handler to exhaust retries.",
+        "title" : "Inherit Error Handler",
+        "default" : "true",
+        "displayName" : "Inherit Error Handler",
+        "kind" : "attribute",
+        "index" : 5,
+        "group" : "advanced",
+        "label" : "advanced"
       } ]
     },
     "randomLoadBalancer" : {

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/marshal-eip.adoc
@@ -39,9 +39,9 @@ Java::
 [source,java]
 ----
 from("file:inbox/xml")
-  .unmarshal().jaxb()
+  .unmarshal().jaxb("com.acme.order")
   .to("bean:validateOrder")
-  .marshal().jaxb()
+  .marshal().jaxb("com.acme.order")
   .to("jms:queue:order");
 ----
 
@@ -51,9 +51,9 @@ XML::
 ----
 <route>
   <from uri="file:inbox/xml"/>
-  <unmarshal><jaxb/></unmarshal>
+  <unmarshal><jaxb contextPath="com.acme.order"/></unmarshal>
   <to uri="bean:validateOrder"/>
-  <marshal><jaxb/></marshal>
+  <marshal><jaxb contextPath="com.acme.order"/></marshal>
   <to uri="jms:queue:order"/>
 </route>
 ----
@@ -67,11 +67,13 @@ YAML::
       uri: file:inbox/xml
       steps:
         - unmarshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: bean:validateOrder
         - marshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: jms:queue:order
 ----

--- a/core/camel-core-engine/src/main/docs/modules/eips/pages/unmarshal-eip.adoc
+++ b/core/camel-core-engine/src/main/docs/modules/eips/pages/unmarshal-eip.adoc
@@ -40,9 +40,9 @@ Java::
 [source,java]
 ----
 from("file:inbox/xml")
-  .unmarshal().jaxb()
+  .unmarshal().jaxb("com.acme.order")
   .to("bean:validateOrder")
-  .marshal().jaxb()
+  .marshal().jaxb("com.acme.order")
   .to("jms:queue:order");
 ----
 
@@ -52,9 +52,9 @@ XML::
 ----
 <route>
   <from uri="file:inbox/xml"/>
-  <unmarshal><jaxb/></unmarshal>
+  <unmarshal><jaxb contextPath="com.acme.order"/></unmarshal>
   <to uri="bean:validateOrder"/>
-  <marshal><jaxb/></marshal>
+  <marshal><jaxb contextPath="com.acme.order"/></marshal>
   <to uri="jms:queue:order"/>
 </route>
 ----
@@ -68,11 +68,13 @@ YAML::
       uri: file:inbox/xml
       steps:
         - unmarshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: bean:validateOrder
         - marshal:
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: jms:queue:order
 ----
@@ -119,7 +121,8 @@ YAML::
       steps:
         - unmarshal:
             allowNullBody: "true"
-            jaxb: {}
+            jaxb:
+              contextPath: com.acme.order
         - to:
             uri: bean:validateOrder
 ----

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-maven-plugin/src/main/java/org/apache/camel/maven/dsl/yaml/GenerateYamlSchemaMojo.java
@@ -288,22 +288,8 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
                 // this is an internal name
                 continue;
             }
-            // we want to skip inheritErrorHandler which is only applicable for the load-balancer
-            boolean skip = false;
-            if (propertyName.equals("inheritErrorHandler")) {
-                skip = true;
-                Optional<AnnotationValue> av = annotationValue(info, YAML_TYPE_ANNOTATION, "nodes");
-                if (av.isPresent()) {
-                    String[] sn = av.get().asStringArray();
-                    for (String n : sn) {
-                        if ("load-balance".equals(n) || "loadBalance".equals(n)) {
-                            skip = false;
-                            break;
-                        }
-                    }
-                }
-            }
             // we want to skip pattern from wiretap
+            boolean skip = false;
             if (propertyName.equals("pattern")) {
                 Optional<AnnotationValue> av = annotationValue(info, YAML_TYPE_ANNOTATION, "nodes");
                 if (av.isPresent()) {
@@ -352,6 +338,39 @@ public class GenerateYamlSchemaMojo extends GenerateYamlSupportMojo {
             // demanding all of them at once instead of exactly one.
             if (propertyRequired && StringUtils.isEmpty(propertyOneOf)) {
                 definition.withArray("required").add(propertyName);
+            }
+        }
+        oneOfGroups.values().forEach(this::completeNegation);
+    }
+
+    /**
+     * A oneOf group gets a "not" branch (see {@link #makeOptional}) as soon as one of its alternatives is optional,
+     * which makes the group as a whole optional. That branch must then exclude every alternative of the group,
+     * including the required ones, otherwise choosing a required alternative matches both the alternative and the "not"
+     * branch and the oneOf fails with "2 are valid". The expression of resequence is such a case: the inline languages
+     * are optional (they come from __extends), but the "expression" wrapper is required.
+     */
+    private void completeNegation(ObjectNode group) {
+        ArrayNode oneOf = group.withArray("oneOf");
+        ObjectNode negation = StreamSupport.stream(oneOf.spliterator(), false)
+                .map(ObjectNode.class::cast)
+                .filter(entry -> entry.has("not"))
+                .findAny()
+                .orElse(null);
+        if (negation == null) {
+            return;
+        }
+        ArrayNode excluded = negation.withObject("/not").withArray("anyOf");
+        Set<String> excludedNames = new HashSet<>();
+        excluded.forEach(entry -> entry.path("required").forEach(name -> excludedNames.add(name.asText())));
+        for (JsonNode entry : oneOf) {
+            if (entry.has("not") || !entry.has("required")) {
+                continue;
+            }
+            for (JsonNode name : entry.get("required")) {
+                if (excludedNames.add(name.asText())) {
+                    excluded.addObject().withArray("required").add(name.asText());
+                }
             }
         }
     }

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/java/org/apache/camel/dsl/yaml/validator/YamlValidatorSchemaGroupsTest.java
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/java/org/apache/camel/dsl/yaml/validator/YamlValidatorSchemaGroupsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.dsl.yaml.validator;
+
+import java.io.File;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CAMEL-24697: the generated schema must accept what the runtime accepts for oneOf groups with a required alternative,
+ * and for the inheritErrorHandler option of circuitBreaker and failoverLoadBalancer.
+ */
+public class YamlValidatorSchemaGroupsTest {
+
+    private static YamlValidator validator;
+    private static JsonNode definitions;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        validator = new YamlValidator();
+        validator.init();
+        try (var is = YamlValidator.class.getResourceAsStream("/schema/camelYamlDsl.json")) {
+            definitions = new ObjectMapper().readTree(is).path("items").path("definitions");
+        }
+    }
+
+    @Test
+    public void testExpressionWrapperMatchesOneBranch() throws Exception {
+        List<Error> report = validator.validate(new File("src/test/resources/oneof-group-expression-wrapper.yaml"));
+        Assertions.assertTrue(report.isEmpty(), "Expected no errors but got: " + messages(report));
+    }
+
+    @Test
+    public void testRequiredAlternativeIsExcludedFromNotBranch() {
+        // resequence and setHeaders entries have a required expression; with the "expression:" wrapper the
+        // "not" branch of the group must not match as well, so it has to list "expression" too
+        for (String name : List.of("org.apache.camel.model.ResequenceDefinition",
+                "org.apache.camel.model.PropertyExpressionDefinition")) {
+            JsonNode group = definitions.path(name).path("anyOf").get(0).path("oneOf");
+            JsonNode not = null;
+            for (JsonNode branch : group) {
+                if (branch.has("not")) {
+                    not = branch.path("not").path("anyOf");
+                }
+            }
+            Assertions.assertNotNull(not, name + " should have a not branch");
+            boolean excluded = false;
+            for (JsonNode entry : not) {
+                if (entry.path("required").toString().contains("\"expression\"")) {
+                    excluded = true;
+                }
+            }
+            Assertions.assertTrue(excluded, name + " not branch should exclude expression");
+        }
+    }
+
+    @Test
+    public void testDataFormatGroupStillRequiresADataFormat() throws Exception {
+        // marshal has no optional alternative, so it must not gain a "not" branch that would allow marshal: {}
+        List<Error> report = validator.validate(new File("src/test/resources/marshal-without-dataformat.yaml"));
+        Assertions.assertFalse(report.isEmpty(), "marshal without a data format should not validate");
+    }
+
+    @Test
+    public void testInheritErrorHandler() throws Exception {
+        List<Error> report = validator.validate(new File("src/test/resources/inherit-error-handler.yaml"));
+        Assertions.assertTrue(report.isEmpty(), "Expected no errors but got: " + messages(report));
+    }
+
+    private static List<String> messages(List<Error> report) {
+        return report.stream().map(Error::getMessage).toList();
+    }
+}

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/inherit-error-handler.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/inherit-error-handler.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# inheritErrorHandler is a property of circuitBreaker and of failoverLoadBalancer (CAMEL-24697)
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - circuitBreaker:
+            inheritErrorHandler: true
+            steps:
+              - to:
+                  uri: mock:a
+        - loadBalance:
+            failoverLoadBalancer:
+              inheritErrorHandler: false
+              maximumFailoverAttempts: "10"
+              roundRobin: true
+            steps:
+              - to:
+                  uri: mock:b
+              - to:
+                  uri: mock:c

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/marshal-without-dataformat.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/marshal-without-dataformat.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# marshal requires a data format; the schema must not accept an empty marshal
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - marshal: {}
+        - to:
+            uri: mock:result

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/oneof-group-expression-wrapper.yaml
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl-validator/src/test/resources/oneof-group-expression-wrapper.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The expression of setHeaders/setVariables entries and of resequence is a required member of a oneOf group.
+# The "expression:" wrapper form must match exactly one branch of that group (CAMEL-24697).
+- route:
+    from:
+      uri: direct:start
+      steps:
+        - setHeaders:
+            headers:
+              - name: foo
+                expression:
+                  simple: "${body}"
+              - name: bar
+                constant: "bar"
+        - resequence:
+            expression:
+              simple: "${header.seqnum}"
+            batchConfig:
+              batchSize: 300
+              batchTimeout: "4000"
+            steps:
+              - to:
+                  uri: mock:result

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl-canonical.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl-canonical.json
@@ -872,6 +872,12 @@
             "title" : "Id",
             "description" : "The id of this node"
           },
+          "inheritErrorHandler" : {
+            "type" : "boolean",
+            "title" : "Inherit Error Handler",
+            "description" : "Whether to inherit Camel error handling during circuit breaker. By default, Camel error handler is turned off.",
+            "default" : false
+          },
           "note" : {
             "type" : "string",
             "title" : "Note",
@@ -10855,6 +10861,12 @@
             "type" : "string",
             "title" : "Id",
             "description" : "The id of this node"
+          },
+          "inheritErrorHandler" : {
+            "type" : "boolean",
+            "title" : "Inherit Error Handler",
+            "description" : "Whether to inherit the error handler. If turned off, the load balancer will fail over immediately on an error instead of waiting for Camel error handler to exhaust retries.",
+            "default" : true
           },
           "maximumFailoverAttempts" : {
             "type" : "string",

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl-model.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl-model.json
@@ -1871,6 +1871,17 @@
         "index" : 4,
         "group" : "common"
       }, {
+        "name" : "inheritErrorHandler",
+        "type" : "boolean",
+        "description" : "Whether to inherit Camel error handling during circuit breaker. By default, Camel error handler is turned off.",
+        "title" : "Inherit Error Handler",
+        "default" : "false",
+        "displayName" : "Inherit Error Handler",
+        "kind" : "attribute",
+        "index" : 5,
+        "group" : "advanced",
+        "label" : "advanced"
+      }, {
         "name" : "resilience4jConfiguration",
         "type" : "object",
         "ref" : "resilience4jConfiguration",
@@ -16338,6 +16349,17 @@
         "kind" : "attribute",
         "index" : 4,
         "group" : "common"
+      }, {
+        "name" : "inheritErrorHandler",
+        "type" : "boolean",
+        "description" : "Whether to inherit the error handler. If turned off, the load balancer will fail over immediately on an error instead of waiting for Camel error handler to exhaust retries.",
+        "title" : "Inherit Error Handler",
+        "default" : "true",
+        "displayName" : "Inherit Error Handler",
+        "kind" : "attribute",
+        "index" : 5,
+        "group" : "advanced",
+        "label" : "advanced"
       } ]
     },
     "randomLoadBalancer" : {

--- a/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
+++ b/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl.json
@@ -1033,6 +1033,12 @@
             "title" : "Id",
             "description" : "The id of this node"
           },
+          "inheritErrorHandler" : {
+            "type" : "boolean",
+            "title" : "Inherit Error Handler",
+            "description" : "Whether to inherit Camel error handling during circuit breaker. By default, Camel error handler is turned off.",
+            "default" : false
+          },
           "note" : {
             "type" : "string",
             "title" : "Note",
@@ -4811,6 +4817,8 @@
           }, {
             "not" : {
               "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
                 "required" : [ "constant" ]
               }, {
                 "required" : [ "datasonnet" ]
@@ -5516,6 +5524,8 @@
           }, {
             "not" : {
               "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
                 "required" : [ "constant" ]
               }, {
                 "required" : [ "datasonnet" ]
@@ -14774,6 +14784,12 @@
             "type" : "string",
             "title" : "Id",
             "description" : "The id of this node"
+          },
+          "inheritErrorHandler" : {
+            "type" : "boolean",
+            "title" : "Inherit Error Handler",
+            "description" : "Whether to inherit the error handler. If turned off, the load balancer will fail over immediately on an error instead of waiting for Camel error handler to exhaust retries.",
+            "default" : true
           },
           "maximumFailoverAttempts" : {
             "type" : "string",


### PR DESCRIPTION
## Summary

[CAMEL-24697](https://issues.apache.org/jira/browse/CAMEL-24697), split out of CAMEL-24693: three cases where `camel validate yaml` rejected EIP documentation examples that the runtime accepts, or where the docs showed a form the runtime does not accept.

### 1. `inheritErrorHandler` on `circuitBreaker` and `failoverLoadBalancer`

`GenerateYamlSchemaMojo` skipped `inheritErrorHandler` for every definition except one whose `@YamlType` nodes contain `loadBalance`. `LoadBalanceDefinition` does not declare the option at all, so that branch never fired. The only two definitions that do declare it are `CircuitBreakerDefinition` and `FailoverLoadBalancerDefinition`, which are exactly the ones the EIP docs use it on, and the generated `ModelDeserializers` already accept it there. The skip is removed; the schema gains the two boolean properties.

### 2. `resequence` with the `expression:` wrapper matched two oneOf branches

Every expression-carrying EIP gets a oneOf group with the inline language form, a `not` branch that excludes all alternatives, and the `expression:` wrapper. The `not` branch was built from `makeOptional`, which is only called for optional alternatives. The expression of `ResequenceDefinition` (and of `PropertyExpressionDefinition`, the entries of setHeaders/setVariables) is `required = true`, so it was missing from the exclusion list and the wrapper form matched both the `not` branch and the wrapper branch.

The generator now runs a post-pass over each oneOf group: if the group has a `not` branch, that branch is completed with every alternative of the group. Groups without an optional alternative, such as the data formats of `marshal` / `unmarshal`, have no `not` branch and are unchanged, so `marshal: {}` is still rejected. The schema diff is the two added `"required": ["expression"]` entries, nothing else.

For resequence this was masked most of the time: its two oneOf groups (expression, batchConfig/streamConfig) are joined with `anyOf`, so the failure only surfaced when the config group also failed, e.g. on `batchTimeout: 4000` (integer where the schema says string). That is why 8 of the 11 resequence examples failed and 3 passed. The `anyOf` join is pre-existing and left alone here, since Kaoto and other consumers parse the `anyOf`/`oneOf` shape; noted on the JIRA as a follow-up.

### 3. `jaxb` needs a `contextPath`

`JaxbDataFormat.contextPath` is `required = true` in the model and `use="required"` in the XSD, but the marshal and unmarshal EIP pages showed `.jaxb()`, `<jaxb/>` and `jaxb: {}` with no context path. The runtime only falls back to an empty `JAXBContext` in that case, which cannot marshal anything, so the docs were wrong rather than the schema. All three DSL tabs on both pages now pass a context path. Catalog doc mirror regenerated.

## Verification

- New `YamlValidatorSchemaGroupsTest` in camel-yaml-dsl-validator covers the three cases (wrapper form with a required expression, the exclusion list of resequence and setHeaders entries, `marshal: {}` still rejected, `inheritErrorHandler` on both definitions). The `inheritErrorHandler` resource fails against the schema on `main`.
- camel-yaml-dsl-validator: 33 tests pass. camel-yaml-dsl-maven-plugin tests pass.
- With the rebuilt schema, all 11 resequence doc examples and the marshal/unmarshal examples validate with `camel validate yaml`. The only remaining messages on the fault-tolerance, resilience4j and failoverLoadBalancer pages are scalar-type ones (`inheritErrorHandler: "true"` and friends), which is CAMEL-24694 / #26351.

## Note for #26351 (CAMEL-24694)

Once both are merged, `YamlValidator.isRuntimeAcceptedScalar` must not accept a property placeholder at `circuitBreaker.inheritErrorHandler` or `failoverLoadBalancer.inheritErrorHandler`: both are still converted eagerly with `Boolean.valueOf` while deserializing (CAMEL-24696), so a placeholder there silently evaluates to `false`. Whichever of the two PRs merges second should carry that exclusion.

No upgrade guide entry: the schema only gains properties, and no existing valid document becomes invalid.

_Claude Code on behalf of davsclaus_

🤖 Generated with [Claude Code](https://claude.com/claude-code)