### PR TITLE
chore(camel-test-infra-minio): pull MinIO test image from quay.io

### DIFF
--- a/test-infra/camel-test-infra-minio/src/main/resources/org/apache/camel/test/infra/minio/services/container.properties
+++ b/test-infra/camel-test-infra-minio/src/main/resources/org/apache/camel/test/infra/minio/services/container.properties
@@ -14,5 +14,5 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-minio.container=mirror.gcr.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
+minio.container=quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
 minio.container.version.exclude=edge,latest,cicd


### PR DESCRIPTION
# Description

Every `camel-minio` integration test currently fails in `@BeforeAll` because the MinIO test container can no longer be pulled:

```
MinioComponentIT.<beforeAll> » ContainerFetch Can't get Docker image:
  mirror.gcr.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
Caused by: NotFoundException: Status 404: manifest for
  mirror.gcr.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1 not found: manifest unknown
```

Seen on #26357 ([job log](https://github.com/apache/camel/actions/runs/34722196557/job/103630006129)). That PR's changes are unrelated; it only reached `camel-minio` because it touches `camel-package-maven-plugin`, which pulls the whole reactor into the incremental build. Any PR whose incremental build reaches `camel-minio` will hit the same failure, on `main` and on the maintenance branches.

**Root cause:** the `minio/minio` repository is gone from Docker Hub (`hub.docker.com/v2/repositories/minio/minio` returns 404). `mirror.gcr.io` is a pull-through cache of Docker Hub, so it now returns `manifest unknown` too.

**Fix:** keep the same tag but pull it from `quay.io`, where MinIO still publishes it:

| Registry | `minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1` |
|---|---|
| Docker Hub | 404 (repository removed) |
| `mirror.gcr.io` | 404 |
| `quay.io` | available: `linux/amd64`, `linux/arm64`, `linux/ppc64le` |

`s390x` is not published, but `camel-minio` already sets `skipITs.s390x=true`, so no pom changes are needed. `check-container-versions.py` has a dedicated Quay.io client, so automated tag bumps keep working (and resume working, since they were querying the removed Docker Hub repository).

**Testing:** ran `mvn verify -pl components/camel-minio` locally (linux/arm64 Docker) against the rebuilt `camel-test-infra-minio`: 3 unit tests and 13 integration tests across 7 IT classes passed, 0 failures, 0 skipped. I confirmed the container under test was `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1` and that no `mirror.gcr.io` copy was cached locally.

Once merged, this should be backported to `camel-4.22.x` so #26357 (and any other 4.22.x PR that builds `camel-minio`) can go green.

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [ ] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

No JIRA: this is a one-line test-infra/CI fix, in the same style as the earlier `chore(camel-test-infra-minio)` image bumps (#20404).

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.
- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

Not run from the root. Only a `container.properties` value changed, so no generated sources are affected; `camel-test-infra-minio` and `camel-minio` were built and verified individually.

# AI-assisted contributions

- [x] If this PR includes AI-generated code, commits have proper co-authorship attribution (e.g., `Co-authored-by` trailers) and the PR description identifies the AI tool used.

The commit carries the operator's Claude Code attribution marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Adriano Machado (@ammachado)

_This was generated by an AI agent and may contain inaccuracies. Please verify before relying on it._
